### PR TITLE
Release v0.2.31

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "larkin",
-  "version": "0.2.30",
+  "version": "0.2.31",
   "private": true,
   "larkinPackageRole": "development-source-checkout",
   "packageManager": "bun@1.3.14",


### PR DESCRIPTION
## Summary

- bump the explicit Larkin version from `0.2.30` to `0.2.31`
- prepare the merged Runtime Agent Interface v2 and release-CI fixes for tag publication

## Validation

- `bun run release:check-version v0.2.31`
- `bun run test` (382 unit, 144 integration, 5 E2E passed; 13 opt-in tests skipped)
- `bun run licenses:check`
- `bun run publication:check:tree`
- `bun run publication:check`
- darwin-arm64 release build and smoke (`version=0.2.31`, Dashboard HTTP 200)

After this PR is merged and main checks pass, the annotated `v0.2.31` tag will trigger the protected Publish release workflow.