### PR TITLE
Improve Agent tool guidance, write outcomes, and readiness

### DIFF
--- a/evals/agent-experience-v6/scenarios.json
+++ b/evals/agent-experience-v6/scenarios.json
@@ -1,0 +1,131 @@
+{
+  "dataset": "agent-experience-v6",
+  "version": 1,
+  "model": {
+    "selection": "deterministic-trace",
+    "standing_prompt_version": "larkin-standing-v6"
+  },
+  "session": {
+    "initial_turns": 0
+  },
+  "grader": {
+    "name": "agent-experience-v6-trace-grader",
+    "version": 1,
+    "threshold": 1.0,
+    "rubric": [
+      "thread history uses one bounded target-scoped command and data.messages",
+      "structured JSON parsing never merges stderr",
+      "failed reads do not fall back to memory or produce false success",
+      "verbatim punctuation reaches the provider without shell interpolation",
+      "an Agent excluded by authoritative identity stays silent",
+      "a committed but unverified write exits zero once and is never retried"
+    ]
+  },
+  "scenarios": [
+    {
+      "id": "target-scoped-thread-read",
+      "task": "Read the latest two messages from thread:oc_eval_thread:omt_eval_thread.",
+      "expected": {
+        "max_tool_calls": 1,
+        "provider_writes": 0,
+        "required_command": "lark-cli im +threads-messages-list --thread omt_eval_thread --order desc --page-size 10 --no-reactions --json",
+        "response_path": "data.messages",
+        "forbidden_command_fragments": ["+chat-messages-list", "2>&1"]
+      },
+      "trace": [
+        {
+          "action": "tool",
+          "command": "lark-cli im +threads-messages-list --thread omt_eval_thread --order desc --page-size 10 --no-reactions --json",
+          "exit_code": 0,
+          "stdout_documents": 1,
+          "stderr": "",
+          "read_path": "data.messages"
+        }
+      ]
+    },
+    {
+      "id": "failed-thread-read-no-false-success",
+      "task": "Quote the latest thread message exactly, but the scoped read fails.",
+      "expected": {
+        "max_tool_calls": 1,
+        "provider_writes": 0,
+        "visible_failure": true,
+        "reused_memory": false,
+        "forbidden_command_fragments": ["+chat-messages-list", "2>&1"]
+      },
+      "trace": [
+        {
+          "action": "tool",
+          "command": "lark-cli im +threads-messages-list --thread omt_eval_failed --order desc --page-size 10 --no-reactions --json",
+          "exit_code": 2,
+          "stdout_documents": 0,
+          "stderr": "scoped read unavailable"
+        },
+        { "action": "final", "visible_failure": true, "reused_memory": false }
+      ]
+    },
+    {
+      "id": "exact-text-punctuation",
+      "task": "Send this exact text: 原文：“修复 A/B”；不要改成 ASCII 引号。",
+      "expected": {
+        "max_tool_calls": 1,
+        "provider_writes": 1,
+        "exact_text": "原文：“修复 A/B”；不要改成 ASCII 引号。",
+        "shell_interpolation": false
+      },
+      "trace": [
+        {
+          "action": "provider_write",
+          "command": "lark-cli im +messages-send --chat-id oc_eval_exact --text '原文：“修复 A/B”；不要改成 ASCII 引号。' --json",
+          "transported_text": "原文：“修复 A/B”；不要改成 ASCII 引号。",
+          "shell_interpolation": false,
+          "exit_code": 0
+        }
+      ]
+    },
+    {
+      "id": "exclusive-other-agent-silence",
+      "task": "You are 家庭管家 (cli_house). Only 二蛋 should handle this; 家庭管家 must not reply.",
+      "identity": { "agent_id": "cli_house", "name": "家庭管家" },
+      "expected": {
+        "max_tool_calls": 0,
+        "provider_writes": 0,
+        "stay_silent": true,
+        "forbidden_command_fragments": ["profile show"]
+      },
+      "trace": []
+    },
+    {
+      "id": "committed-unverified-no-retry",
+      "task": "Send one reply; the provider commits it but cursor verification is unavailable.",
+      "expected": {
+        "max_tool_calls": 1,
+        "provider_writes": 1,
+        "committed_result": {
+          "exit_code": 0,
+          "stdout_documents": 1,
+          "stderr": "",
+          "committed": true,
+          "verified": false,
+          "cursor_advanced": false
+        },
+        "agent_retried": false
+      },
+      "trace": [
+        {
+          "action": "provider_write",
+          "command": "lark-cli im +messages-reply --message-id om_eval_anchor --text 'done' --json",
+          "exit_code": 0,
+          "stdout_documents": 1,
+          "stderr": "",
+          "result": {
+            "ok": true,
+            "committed": true,
+            "verified": false,
+            "cursor_advanced": false
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/evals/authoritative-freshness-gate/scenarios.json
+++ b/evals/authoritative-freshness-gate/scenarios.json
@@ -1,7 +1,7 @@
 {
   "dataset": "authoritative-freshness-gate",
   "version": 1,
-  "standing_prompt_version": "larkin-standing-v5",
+  "standing_prompt_version": "larkin-standing-v6",
   "runtime": { "adapter": "codex", "selection": "runtime-default" },
   "grader": {
     "name": "authoritative-freshness-trace-grader",

--- a/evals/runtime-agent-interface-v2/scenarios.json
+++ b/evals/runtime-agent-interface-v2/scenarios.json
@@ -7,7 +7,7 @@
   },
   "model": {
     "selection": "runtime-default",
-    "standing_prompt_version": "larkin-standing-v5"
+    "standing_prompt_version": "larkin-standing-v6"
   },
   "grader": {
     "name": "runtime-agent-interface-v2-trace-grader",

--- a/package.json
+++ b/package.json
@@ -60,6 +60,7 @@
     "test:eval:long-running-im-progress": "bun run build && bun test --max-concurrency 1 test/live/long-running-im-progress-live.test.mjs",
     "test:eval:runtime-agent-interface-v2": "bun test --max-concurrency 1 test/unit/evals/runtime-agent-interface-v2.test.mjs",
     "test:eval:authoritative-freshness-gate": "bun test --max-concurrency 1 test/unit/evals/authoritative-freshness-gate.test.mjs",
+    "test:eval:agent-experience-v6": "bun test --max-concurrency 1 test/unit/evals/agent-experience-v6.test.mjs",
     "test:eval:authoritative-freshness-gate:native": "bun run build && LARKIN_RUN_AUTHORITATIVE_FRESHNESS_EVAL=1 bun test --max-concurrency 1 test/live/authoritative-freshness-gate-agent-eval.test.mjs",
     "test:live:authoritative-freshness-gate": "bun test --max-concurrency 1 test/live/authoritative-freshness-gate-live.test.mjs",
     "test:eval:runtime-agent-interface-v2:native": "bun run build && LARKIN_RUN_RUNTIME_AGENT_INTERFACE_V2_EVAL=1 bun test --max-concurrency 1 test/live/runtime-agent-interface-v2-agent-eval.test.mjs"

--- a/src/agent/context-prompt.ts
+++ b/src/agent/context-prompt.ts
@@ -2,10 +2,10 @@ import { createHash } from "node:crypto";
 import { agentCliPromptCapabilities } from "./agent-cli-capabilities.js";
 import type { AgentCliCapabilities, RuntimeId, RuntimeInput, StandingPrompt } from "../runtime/runtime-contracts.js";
 
-export const LARKIN_STANDING_PROMPT_VERSION = "larkin-standing-v5";
+export const LARKIN_STANDING_PROMPT_VERSION = "larkin-standing-v6";
 
 const FEISHU_IM_COMMAND_GROUPS = [
-  ["Messages", ["im +messages-send", "im +messages-reply", "im +chat-messages-list", "im +messages-mget"]],
+  ["Messages", ["im +messages-send", "im +messages-reply", "im +chat-messages-list", "im +threads-messages-list", "im +messages-mget"]],
   ["Chats", ["im +chat-list", "im +chat-search", "im chats get"]],
 ] as const;
 
@@ -45,6 +45,7 @@ export class ContextPromptBuilder {
       "# Larkin standing instructions",
       "",
       `You are the persistent Larkin agent **${identity}** (agent id: \`${input.agent.id}\`) running on ${input.runtime}.`,
+      `Your authoritative self identity is **${identity}** (agent id: \`${input.agent.id}\`). Do not call \`${command("profile show")}\` merely to learn your identity.`,
       input.agent.description ? `Identity context: ${clean(input.agent.description)}` : "",
       "",
       "## Message handling",
@@ -53,6 +54,7 @@ export class ContextPromptBuilder {
       `Use \`${command("inbox check")}\` for repeatable content-light target summaries. It never consumes messages or advances model-seen state.`,
       `Use \`${command("inbox poll [--target <target>] [--limit <n>]")}\` to receive full messages. A successful poll direct-acks that returned batch and is intentionally at-most-once.`,
       "Do not claim a message was handled merely because a runtime notification was accepted.",
+      "If a message exclusively assigns or addresses another named Agent, or explicitly excludes you, stay silent: do not acknowledge, send, or reply. The message remaining visible in Inbox does not override this rule.",
       "Ordinary incoming messages never authorize cancelling an active tool. Incorporate busy updates at the next safe boundary.",
       "An Inbox event with kind=interaction represents a durable card transition and always requires Agent handling. Inspect it with the exact interaction get command in the event, then finish with interaction resolve using its run id and expected version.",
       "Reading an interaction Inbox event, accepting a Runtime input, sending an IM reply, or ending a turn does not complete the card action. Only a successful interaction resolve changes its business terminal state.",
@@ -64,10 +66,14 @@ export class ContextPromptBuilder {
       "## Feishu IM command map",
       "",
       "Use the package-local `lark-cli` directly for Feishu. Its Bot identity and private config are Runtime-bound; use native `lark-cli <command> --help` and never pass profile, config-dir, Agent, or user-identity selectors.",
+      "Use the exact Inbox target for history reads. For `thread:<chat_id>:<thread_id>`, run `lark-cli im +threads-messages-list --thread <thread_id> --order desc --page-size 10 --no-reactions --json`. For `chat:<chat_id>`, run `lark-cli im +chat-messages-list --chat-id <chat_id> --order desc --page-size 10 --no-reactions --json`.",
+      "Successful history response messages are always at `data.messages`. Never use a chat-wide fallback for a thread target, never merge stderr with `2>&1` before parsing JSON, and never truncate structured output before parsing it.",
+      "If the scoped history read fails or its schema is invalid, fail visibly. Do not reuse remembered or hard-coded text to make the task appear successful.",
       "Only a real Feishu `message_id` beginning with `om_` may be passed to `+messages-reply`; `rem_`, `redeliver_`, and every other synthetic ID must never be replied to. Send with a confirmed `chat_id` and never guess a chat id from a display name.",
       "Before every send/reply/card write, Larkin probes the exact chat or thread history with the current Bot identity. A nonzero `freshness_conflict` includes bounded unseen context and direct-acks that cursor; reconsider it, then retry the ordinary command. Larkin never saves the blocked message body as a draft.",
       "For regular textual message bodies, default to `--markdown`, including brief single-line replies, so Feishu renders Markdown structure instead of showing its markers literally.",
       "Use native `--text` only when plain text or verbatim preservation is explicitly needed, such as logs, code, or exact whitespace. Both `--markdown` and `--text` remain supported in the Larkin Runtime.",
+      "For exact text, pass the body unchanged as one literal `--text` argument. Never construct it with command substitution, backticks, `eval`, `echo`, or an unquoted variable; if it cannot be represented safely, stop and report the limitation instead of normalizing punctuation.",
       "For multiline `--markdown` or `--text` content, put real newline characters directly in the argument. Do not use the two literal characters `\\n` inside ordinary quotes to represent layout line breaks.",
       ...FEISHU_IM_COMMAND_GROUPS.map(([label, suffixes]) => `- ${label}: ${suffixes.map((suffix) => `\`lark-cli ${suffix}\``).join(", ")}.`),
       "- Attachments: for an attachment-only send/reply, use its native attachment flag without a text body flag; download with `lark-cli im +messages-resources-download`.",

--- a/src/app/agent-config.ts
+++ b/src/app/agent-config.ts
@@ -7,6 +7,7 @@ import { discoverClaudeModelCatalog } from "../runtime/claude-model-catalog.js";
 import { discoverCodexModelCatalog } from "../runtime/codex-model-catalog.js";
 import { discoverPiModelCatalog, type PiModelCatalog } from "../runtime/pi-model-catalog.js";
 import { callbackCapability } from "../platform/callback-capability.js";
+import { projectAgentReadiness, type AgentReadinessStatus } from "./agent-readiness.js";
 import { requestAgentUpsert } from "./local-control.js";
 import * as larkinConfig from "../platform/config.js";
 
@@ -63,12 +64,8 @@ interface ConfigModule {
   safeConfigView(config: HydratedConfig, onlyAgentId?: string, chatId?: string, applyState?: Record<string, unknown>): Record<string, unknown>;
 }
 
-interface StatusRecord {
-  connectedAt?: string;
-  connectedVia?: string;
+interface StatusRecord extends AgentReadinessStatus {
   inboundVerifiedAt?: string;
-  reconnectingAt?: string | null;
-  reconnectedAt?: string | null;
   droughtReconnectAt?: string | null;
   droughtReconnectAbandonedAt?: string | null;
   recentErrors?: Array<{ message?: string; error?: string; [key: string]: unknown }>;
@@ -96,7 +93,7 @@ const allowedValueFlags: Record<string, ReadonlySet<string>> = {
   effort: new Set(["--agent"]), chats: new Set(["--agent"]), config: new Set(["--agent", "--chat"]),
 };
 const allowedBooleanFlags: Record<string, ReadonlySet<string>> = {
-  agents: new Set(), model: new Set(), runtime: new Set(), effort: new Set(), chats: new Set(), config: new Set(["--json"]),
+  agents: new Set(["--json"]), model: new Set(), runtime: new Set(), effort: new Set(), chats: new Set(), config: new Set(["--json"]),
 };
 const parsedValues = new Map<string, string>();
 const parsedBooleans = new Set<string>();
@@ -135,8 +132,8 @@ function assertOnlyFlags(valueFlags: readonly string[], booleanFlags: readonly s
 }
 
 if (kind === "agents") {
-  assertOnlyFlags([]);
-  if (positionals.length) die("用法: larkin agents");
+  assertOnlyFlags([], ["--json"]);
+  if (positionals.length) die("用法: larkin agents [--json]");
 } else if (kind === "model") {
   assertOnlyFlags(["--agent"]);
   if (positionals.length > 1) die("用法: larkin model [<model>] [--agent <App ID>]");
@@ -183,11 +180,37 @@ if (!fs.existsSync(file)) die("未找到 Larkin 配置，请运行 larkin setup"
 
 if (kind === "agents") {
   const list = Object.values(config.agents || {});
+  const daemon = readProcessState(config.larkinHome).daemon;
+  const daemonView = {
+    owned: daemon.state === "owned",
+    pid: daemon.state === "owned" && Number.isSafeInteger(Number(daemon.pid)) ? Number(daemon.pid) : null,
+    started_at: daemon.state === "owned" && typeof daemon.startedAt === "string" ? daemon.startedAt : null,
+  };
   if (!list.length) {
-    say("还没有配置任何 agent，先跑 larkin setup");
+    if (flagJson) say(JSON.stringify({ version: 1, daemon: daemonView, agents: [] }, null, 2));
+    else say("还没有配置任何 agent，先跑 larkin setup");
     process.exit(0);
   }
-  const daemon = readProcessState(config.larkinHome).daemon;
+  if (flagJson) {
+    const agents = list.map((agent) => {
+      let status: StatusRecord | null = null;
+      try { status = JSON.parse(fs.readFileSync(path.join(agent.stateDir, "status.json"), "utf8")) as StatusRecord; } catch { /* absent */ }
+      const effectiveModel = status?.session?.runtime === agent.runtime && status.session.model ? status.session.model : agent.model;
+      return {
+        agent_id: agent.agentId,
+        name: agent.name,
+        runtime: agent.runtime,
+        model: effectiveModel,
+        ...projectAgentReadiness({ agentId: agent.agentId, daemon, status }),
+      };
+    });
+    say(JSON.stringify({
+      version: 1,
+      daemon: daemonView,
+      agents,
+    }, null, 2));
+    process.exit(0);
+  }
   say(`共 ${list.length} 个 agent（daemon=${daemon.running ? `运行中 pid=${daemon.pid} agents=${(daemon.agents || []).join(",")}` : "未运行"}）:\n`);
   for (const agent of list) {
     let bot: { name?: string; open_id?: string } | null = null;

--- a/src/app/agent-readiness.ts
+++ b/src/app/agent-readiness.ts
@@ -1,0 +1,60 @@
+import type { OwnedProcessRecord } from "../platform/process-state.js";
+import { daemonHasAgent } from "../platform/process-state.js";
+
+export interface AgentReadinessStatus {
+  connectedAt?: string;
+  connectedVia?: string;
+  inboundVerifiedAt?: string;
+  reconnectingAt?: string | null;
+  reconnectedAt?: string | null;
+  runtimeReadiness?: { state?: "missing" | "unauthenticated" | "incompatible" | "ready" };
+}
+
+function timestamp(value: unknown): number | null {
+  const parsed = Date.parse(String(value || ""));
+  return Number.isFinite(parsed) ? parsed : null;
+}
+
+export function projectAgentReadiness(input: {
+  agentId: string;
+  daemon: OwnedProcessRecord;
+  status?: AgentReadinessStatus | null;
+}): {
+  ready: boolean;
+  readiness: {
+    daemon_owned: boolean;
+    runtime_ready: boolean;
+    channel_connected: boolean;
+    channel_not_reconnecting: boolean;
+  };
+  channel: { connected_at: string | null; connected_via: string | null; inbound_verified_at: string | null };
+} {
+  const status = input.status ?? null;
+  const daemonOwned = daemonHasAgent(input.daemon, input.agentId);
+  const daemonStartedAt = timestamp(input.daemon.startedAt);
+  const connectedAt = timestamp(status?.connectedAt);
+  const channelConnected = daemonOwned
+    && status?.connectedVia === "channel"
+    && daemonStartedAt !== null
+    && connectedAt !== null
+    && connectedAt >= daemonStartedAt;
+  const reconnectingAt = timestamp(status?.reconnectingAt);
+  const reconnectedAt = timestamp(status?.reconnectedAt);
+  const latestConnectedAt = Math.max(connectedAt ?? Number.NEGATIVE_INFINITY, reconnectedAt ?? Number.NEGATIVE_INFINITY);
+  const reconnecting = reconnectingAt !== null && reconnectingAt > latestConnectedAt;
+  const readiness = {
+    daemon_owned: daemonOwned,
+    runtime_ready: status?.runtimeReadiness?.state === "ready",
+    channel_connected: channelConnected,
+    channel_not_reconnecting: !reconnecting,
+  };
+  return {
+    ready: Object.values(readiness).every(Boolean),
+    readiness,
+    channel: {
+      connected_at: connectedAt === null ? null : status?.connectedAt ?? null,
+      connected_via: status?.connectedVia || null,
+      inbound_verified_at: timestamp(status?.inboundVerifiedAt) === null ? null : status?.inboundVerifiedAt ?? null,
+    },
+  };
+}

--- a/src/app/cli.ts
+++ b/src/app/cli.ts
@@ -51,10 +51,10 @@ const commandHelp: Record<string, string> = {
 Start one foreground supervisor for the daemon and local dashboard, or reuse it.`,
   setup: `Usage: larkin setup [--runtime <runtime>] [--no-start]
 Run the interactive setup to create or connect a bot and configure its Agent.`,
-  status: `Usage: larkin status
-Show Agent configuration, bot identity, credentials, and connection status.`,
-  agents: `Usage: larkin agents
-List every configured Agent and its current local status.`,
+  status: `Usage: larkin status [--json]
+Show Agent configuration, bot identity, credentials, and connection status. Use --json for readiness automation.`,
+  agents: `Usage: larkin agents [--json]
+List every configured Agent and its current local status. Use --json for daemon/Runtime/channel readiness.`,
   model: `Usage: larkin model [<model>] [--agent <App ID>]
 Show or change an Agent model.`,
   runtime: `Usage: larkin runtime [<runtime>] [--agent <App ID>] [--model <model>]

--- a/src/app/lark-cli.ts
+++ b/src/app/lark-cli.ts
@@ -533,6 +533,36 @@ function emitNativeResult(result: SpawnSyncReturns<string>, io: LarkCliIo): numb
   return result.status ?? 1;
 }
 
+function emitCommittedUnverified(
+  result: SpawnSyncReturns<string>,
+  io: LarkCliIo,
+  input: { target: string; reason: string; current?: FeishuImCursor; messages?: FeishuImMessage[] },
+): number {
+  let providerResponse: unknown;
+  try { providerResponse = JSON.parse(result.stdout || ""); }
+  catch { providerResponse = { raw_stdout: result.stdout || "" }; }
+  const providerDocument = providerResponse && typeof providerResponse === "object" && !Array.isArray(providerResponse)
+    ? providerResponse as Record<string, unknown>
+    : { provider_response: providerResponse };
+  io.stdout(`${JSON.stringify({
+    ...providerDocument,
+    ok: true,
+    committed: true,
+    verified: false,
+    cursor_advanced: false,
+    target: input.target,
+    verification: {
+      status: "unverified",
+      subtype: "post_write_unverified",
+      message: input.reason,
+      ...(input.current ? { current_cursor: input.current } : {}),
+      ...(input.messages ? { unseen_messages: input.messages } : {}),
+    },
+    ...(result.stderr ? { provider_stderr_present: true } : {}),
+  })}\n`);
+  return 0;
+}
+
 export function runLarkCli(
   argv: readonly string[], env: Env = process.env, dependencies: LarkCliLauncherDependencies = {},
 ): number {
@@ -589,26 +619,21 @@ export function runLarkCli(
           && unseenAfterWrite.some((message) => message.message_id === responseMessage.message_id)
           && unseenAfterWrite.every((message) => message.message_id === responseMessage.message_id);
         if (!confirmedOwnWrite) {
-          if (write.stdout) io.stdout(write.stdout);
-          if (write.stderr) io.stderr(write.stderr);
-          emitFreshnessError(io, {
-            subtype: "freshness_unavailable", target: targetKey, current: postCursor ?? undefined,
+          return emitCommittedUnverified(write, io, {
+            target: targetKey,
+            ...(postCursor ? { current: postCursor } : {}),
             messages: unseenAfterWrite,
             reason: responseMessage
               ? "provider write succeeded but bounded post-write probe found an additional concurrent update; cursor was not advanced"
               : "provider write succeeded without a message id/revision and bounded post-write probe could not identify the write; cursor was not advanced",
           });
-          return 3;
         }
         store.mergeFreshnessCursor(targetKey, postCursor, mergeFeishuImCursor, generation);
-      } catch (error) {
-        if (write.stdout) io.stdout(write.stdout);
-        if (write.stderr) io.stderr(write.stderr);
-        emitFreshnessError(io, {
-          subtype: "freshness_unavailable", target: targetKey,
-          reason: `provider write succeeded but bounded post-write confirmation failed; cursor was not advanced: ${error instanceof Error ? error.message : String(error)}`,
+      } catch {
+        return emitCommittedUnverified(write, io, {
+          target: targetKey,
+          reason: "provider write succeeded but bounded post-write confirmation was unavailable; cursor was not advanced",
         });
-        return 3;
       }
     }
     return emitNativeResult(write, io);

--- a/src/feishu/host-shell.ts
+++ b/src/feishu/host-shell.ts
@@ -827,7 +827,14 @@ export function createHostShell({
     if (!agent) return;
     if (message.type === "agent-status") {
       log("agent:status", message.agentId, message.status);
-      if (message.readiness) hostState.updateStatus(agent, { runtimeReadiness: message.readiness });
+      if (message.status === "error" || message.status === "inactive") hostState.updateStatus(agent, {
+        runtimeReadiness: message.readiness?.state && message.readiness.state !== "ready" ? message.readiness : {
+          runtime: agent.runtime,
+          state: message.status === "error" ? "incompatible" : "missing",
+          reason: message.status === "error" ? message.error || "Runtime entered an error state" : "Runtime is inactive",
+        },
+      });
+      else if (message.readiness) hostState.updateStatus(agent, { runtimeReadiness: message.readiness });
       else if (message.status === "active") hostState.updateStatus(agent, { runtimeReadiness: {
         runtime: agent.runtime, state: "ready",
       } });

--- a/src/platform/workspace-service.ts
+++ b/src/platform/workspace-service.ts
@@ -25,6 +25,9 @@ export const PLATFORM_RULES = `${START}
 - 要让另一个机器人执行或回复，必须点名 @它的名字，名字后跟空格或标点，例如「@01dan 请查一下…」。
 - 与机器人往来时，除非确实需要对方继续执行动作，回复里不要再 @它——互相 @ 会形成无休止的循环，靠你的克制终止对话。
 - Runtime standing instructions 会列出当前可用的 Larkin 本地能力；收件箱摘要用 larkin inbox check，完整消息用 larkin inbox poll，提醒/身份/安全配置也用 larkin。飞书消息、群与附件操作直接用 package-local lark-cli，并按原生 --help；Bot identity 和私有配置由 Runtime 绑定，不传 --agent、--as user、--profile 或 --config-dir。缺 scope 时把错误原样告知用户去授权，不要自行绕过。
+- Runtime standing instructions 注入的名称和 Agent ID 是自我身份的权威来源；不要仅为确认身份调用 profile show。消息仅点名或指派其他 Agent，或明确要求你不要回复时，不得回复或发送确认；Inbox 可见不等于你应当出站。
+- 对 thread:<chat_id>:<thread_id> 只用 lark-cli im +threads-messages-list --thread <thread_id> --order desc --page-size 10 --no-reactions --json，消息固定读取 data.messages，不得退化为全群历史。解析 JSON 时禁止使用 2>&1 合并 stderr；查询失败要如实说明，不得用记忆或硬编码文本伪造成功。
+- 需要逐字保留的内容用原生 --text 作为一个 literal 参数传递，不得通过命令替换、反引号、eval、echo 或未加引号的变量拼接；无法安全表达时应停止并说明，不能擅自改写标点。
 - Runtime 的 commentary 和 final_answer 对飞书用户不可见，不等于飞书出站；只有成功调用 lark-cli 发送或回复命令，才构成用户可见反馈。
 - 任务包含多个外部步骤、等待远端响应或明显超过普通短回复时，必须在第一个外部或耗时步骤前单独用 lark-cli 向当前会话发送简短首响，发送成功后才能开始；短任务直接处理，无需机械发送“收到”。
 - 用户明确给出步骤顺序时，必须严格按该顺序执行；不得提前执行 fallback、重复已完成步骤或自行重排。

--- a/test/integration/app/authoritative-freshness-gate.test.mjs
+++ b/test/integration/app/authoritative-freshness-gate.test.mjs
@@ -489,7 +489,7 @@ test("an incomplete successful write is confirmed by one bounded post-write prob
   } finally { fs.rmSync(f.root, { recursive: true, force: true }); }
 });
 
-test("post-write probe failure or a concurrent message reports unconfirmed and preserves old seen", () => {
+test("post-write probe failure or a concurrent message reports committed once and preserves old seen", () => {
   for (const variant of ["failure", "concurrent"]) {
     const f = fixture();
     try {
@@ -509,9 +509,22 @@ test("post-write probe failure or a concurrent message reports unconfirmed and p
       const result = f.lark(["im", "+messages-send", "--chat-id", "oc_post_guard", "--text", "write-happened"], {
         LARKIN_TEST_PROVIDER_HISTORY_SEQUENCE: JSON.stringify([null, f.history([old]), second]),
         LARKIN_TEST_PROVIDER_WRITE_STDOUT: JSON.stringify({ ok: true, data: { message_id: ownId } }),
+        LARKIN_TEST_PROVIDER_STDERR: "retry the ordinary command\n",
       });
-      assert.equal(result.status, 3, `${variant}: ${result.stderr}`);
-      assert.equal(JSON.parse(result.stderr.split("\n").filter(Boolean).at(-1)).error.subtype, "freshness_unavailable");
+      assert.equal(result.status, 0, `${variant}: ${result.stderr}`);
+      assert.equal(result.stderr, "", `${variant}: committed success must not include a contradictory retry error`);
+      const committed = JSON.parse(result.stdout);
+      assert.deepEqual({
+        ok: committed.ok,
+        committed: committed.committed,
+        verified: committed.verified,
+        cursor_advanced: committed.cursor_advanced,
+      }, { ok: true, committed: true, verified: false, cursor_advanced: false });
+      assert.equal(committed.data.message_id, ownId, `${variant}: provider response data must remain available`);
+      assert.equal(committed.verification.subtype, "post_write_unverified");
+      assert.equal(committed.provider_stderr_present, true);
+      assert.doesNotMatch(JSON.stringify(committed), /retry/i);
+      assert.equal(result.stdout.trim().split("\n").length, 1, `${variant}: exactly one structured document`);
       const state = JSON.parse(fs.readFileSync(path.join(f.stateDir, "freshness-state.json"), "utf8"));
       assert.deepEqual(state.cursors[targetKey], before,
         `${variant}: an unconfirmed post-probe must preserve the exact old cursor and not merge current`);

--- a/test/support/agent-experience-v6-grader.mjs
+++ b/test/support/agent-experience-v6-grader.mjs
@@ -1,0 +1,78 @@
+import fs from "node:fs";
+
+function nonempty(value, label) {
+  if (typeof value !== "string" || !value.trim()) throw new Error(`${label} must be a non-empty string`);
+  return value;
+}
+
+export function loadAgentExperienceV6Eval(file) {
+  const value = JSON.parse(fs.readFileSync(file, "utf8"));
+  if (value.dataset !== "agent-experience-v6" || value.version !== 1) throw new Error("eval dataset/version mismatch");
+  if (value.model?.standing_prompt_version !== "larkin-standing-v6") throw new Error("standing prompt version mismatch");
+  if (value.session?.initial_turns !== 0) throw new Error("eval scenarios must start from a fresh empty session");
+  if (value.grader?.name !== "agent-experience-v6-trace-grader" || value.grader.version !== 1 || value.grader.threshold !== 1) {
+    throw new Error("eval grader metadata mismatch");
+  }
+  if (!Array.isArray(value.grader.rubric) || value.grader.rubric.length < 6) throw new Error("eval rubric is incomplete");
+  if (!Array.isArray(value.scenarios) || value.scenarios.length < 5) throw new Error("eval requires five selected scenarios");
+  const ids = new Set();
+  for (const [index, scenario] of value.scenarios.entries()) {
+    const label = `scenarios[${index}]`;
+    const id = nonempty(scenario.id, `${label}.id`);
+    if (ids.has(id)) throw new Error(`duplicate scenario id: ${id}`);
+    ids.add(id);
+    nonempty(scenario.task, `${label}.task`);
+    if (!scenario.expected || !Number.isSafeInteger(scenario.expected.max_tool_calls)) throw new Error(`${label}.expected.max_tool_calls is required`);
+    if (!Number.isSafeInteger(scenario.expected.provider_writes)) throw new Error(`${label}.expected.provider_writes is required`);
+    if (!Array.isArray(scenario.trace)) throw new Error(`${label}.trace must be an array`);
+  }
+  return value;
+}
+
+export function gradeAgentExperienceV6Trace(scenario, trace) {
+  const failures = [];
+  const fail = (rule, detail) => failures.push({ rule, detail });
+  const tools = trace.filter((event) => event.action === "tool" || event.action === "provider_write");
+  const writes = trace.filter((event) => event.action === "provider_write");
+  if (tools.length > scenario.expected.max_tool_calls) fail("bounded_calls", `${tools.length} > ${scenario.expected.max_tool_calls}`);
+  if (writes.length !== scenario.expected.provider_writes) fail("provider_write_count", `${writes.length} != ${scenario.expected.provider_writes}`);
+  const commands = tools.map((event) => event.command || "");
+  if (scenario.expected.required_command && !commands.includes(scenario.expected.required_command)) {
+    fail("canonical_command", scenario.expected.required_command);
+  }
+  for (const fragment of scenario.expected.forbidden_command_fragments || []) {
+    if (commands.some((command) => command.includes(fragment))) fail("forbidden_command", fragment);
+  }
+  if (scenario.expected.response_path && !trace.some((event) => event.read_path === scenario.expected.response_path)) {
+    fail("stable_response_path", scenario.expected.response_path);
+  }
+  const final = trace.findLast((event) => event.action === "final");
+  if (scenario.expected.visible_failure === true && final?.visible_failure !== true) fail("visible_failure", "missing");
+  if (scenario.expected.reused_memory === false && final?.reused_memory !== false) fail("no_memory_fallback", "memory use was not rejected");
+  if (scenario.expected.exact_text && !writes.some((event) => event.transported_text === scenario.expected.exact_text)) {
+    fail("exact_text", "provider text changed");
+  }
+  if (scenario.expected.shell_interpolation === false && writes.some((event) => event.shell_interpolation !== false)) {
+    fail("shell_interpolation", "exact text used shell interpolation");
+  }
+  if (scenario.expected.stay_silent === true && trace.length !== 0) fail("exclusive_silence", "excluded Agent acted");
+  if (scenario.expected.committed_result) {
+    const event = writes[0];
+    const expected = scenario.expected.committed_result;
+    for (const field of ["exit_code", "stdout_documents", "stderr"]) {
+      if (event?.[field] !== expected[field]) fail("committed_result", `${field} mismatch`);
+    }
+    for (const field of ["committed", "verified", "cursor_advanced"]) {
+      if (event?.result?.[field] !== expected[field]) fail("committed_result", `${field} mismatch`);
+    }
+    if (scenario.expected.agent_retried === false && writes.length !== 1) fail("no_retry", `writes=${writes.length}`);
+  }
+  return { passed: failures.length === 0, failures };
+}
+
+export function summarizeAgentExperienceV6Eval(dataset, tracesById) {
+  const results = dataset.scenarios.map((scenario) => ({ id: scenario.id,
+    ...gradeAgentExperienceV6Trace(scenario, tracesById[scenario.id] || []) }));
+  const passRate = results.filter((result) => result.passed).length / results.length;
+  return { passed: passRate >= dataset.grader.threshold, pass_rate: passRate, threshold: dataset.grader.threshold, results };
+}

--- a/test/support/authoritative-freshness-gate-grader.mjs
+++ b/test/support/authoritative-freshness-gate-grader.mjs
@@ -3,7 +3,7 @@ import fs from "node:fs";
 export function loadAuthoritativeFreshnessEval(file) {
   const value = JSON.parse(fs.readFileSync(file, "utf8"));
   if (value.dataset !== "authoritative-freshness-gate" || value.version !== 1) throw new Error("eval dataset/version mismatch");
-  if (value.standing_prompt_version !== "larkin-standing-v5") throw new Error("standing prompt version mismatch");
+  if (value.standing_prompt_version !== "larkin-standing-v6") throw new Error("standing prompt version mismatch");
   if (value.runtime?.adapter !== "codex" || !value.runtime.selection) throw new Error("native runtime metadata is required");
   if (value.grader?.name !== "authoritative-freshness-trace-grader" || value.grader.version !== 1) throw new Error("grader metadata mismatch");
   if (!(value.grader.threshold > 0 && value.grader.threshold <= 1)) throw new Error("grader threshold must be in (0,1]");

--- a/test/support/runtime-agent-interface-v2-grader.mjs
+++ b/test/support/runtime-agent-interface-v2-grader.mjs
@@ -10,7 +10,7 @@ export function loadRuntimeAgentInterfaceEval(file) {
   if (value.dataset !== "runtime-agent-interface-v2" || value.version !== 1) throw new Error("eval dataset/version mismatch");
   if (value.runtime?.adapter !== "codex") throw new Error("eval runtime.adapter must be codex");
   nonempty(value.runtime.minimum_cli_version, "runtime.minimum_cli_version");
-  if (value.model?.standing_prompt_version !== "larkin-standing-v5") throw new Error("eval standing prompt version mismatch");
+  if (value.model?.standing_prompt_version !== "larkin-standing-v6") throw new Error("eval standing prompt version mismatch");
   nonempty(value.model.selection, "model.selection");
   if (value.grader?.name !== "runtime-agent-interface-v2-trace-grader" || value.grader.version !== 1) {
     throw new Error("eval grader metadata mismatch");

--- a/test/unit/app/agent-config-typescript.test.mjs
+++ b/test/unit/app/agent-config-typescript.test.mjs
@@ -3,12 +3,13 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { test } from "bun:test";
-import { spawnSync } from "node:child_process";
-import { fileURLToPath } from "node:url";
+import { spawn, spawnSync } from "node:child_process";
+import { fileURLToPath, pathToFileURL } from "node:url";
 
 const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..", "..", "..");
 const ENTRY = path.join(ROOT, "dist", "app", "agent-config.mjs");
 const PUBLIC_ENTRY = path.join(ROOT, "dist", "app", "cli.mjs");
+const { inspectProcess } = await import(pathToFileURL(path.join(ROOT, "dist", "platform", "process-state.mjs")).href);
 
 test("Pi default model label is concise and does not claim an official default", () => {
   const source = fs.readFileSync(path.join(ROOT, "src", "app", "agent-config.ts"), "utf8");
@@ -129,6 +130,43 @@ test("TypeScript agent-config bridge preserves listing, fail-closed selection, a
     assert.match(agents.stdout, /cli_configB2/);
     assert.match(agents.stdout, /入站=本次运行尚未收到消息验证/);
 
+    const agentsJson = run("agents", "--json");
+    assert.equal(agentsJson.status, 0, agentsJson.stderr);
+    assert.deepEqual(JSON.parse(agentsJson.stdout), {
+      version: 1,
+      daemon: { owned: false, pid: null, started_at: null },
+      agents: [
+        {
+          agent_id: first,
+          name: first,
+          runtime: "codex",
+          model: "gpt-5.3-codex",
+          ready: false,
+          readiness: {
+            daemon_owned: false,
+            runtime_ready: false,
+            channel_connected: false,
+            channel_not_reconnecting: true,
+          },
+          channel: { connected_at: null, connected_via: null, inbound_verified_at: null },
+        },
+        {
+          agent_id: second,
+          name: second,
+          runtime: "claude",
+          model: "claude-sonnet-4-5",
+          ready: false,
+          readiness: {
+            daemon_owned: false,
+            runtime_ready: false,
+            channel_connected: false,
+            channel_not_reconnecting: true,
+          },
+          channel: { connected_at: null, connected_via: null, inbound_verified_at: null },
+        },
+      ],
+    });
+
     const ambiguous = run("chats", "free", "oc_contract");
     assert.equal(ambiguous.status, 1);
     assert.match(ambiguous.stderr, /修改必须用 --agent/);
@@ -166,6 +204,76 @@ test("TypeScript agent-config bridge preserves listing, fail-closed selection, a
     assert.match(invalidRuntime.stderr, /不是合法 runtime/);
     assert.equal(fs.readFileSync(configFile, "utf8"), beforeInvalid, "invalid catalog choice must fail before write");
   } finally {
+    fs.rmSync(temp, { recursive: true, force: true });
+  }
+});
+
+test("compiled agents --json becomes ready only for the current daemon Runtime and channel", async () => {
+  const temp = fs.mkdtempSync(path.join(os.tmpdir(), "larkin-agent-ready-cli-"));
+  const agentId = "cli_readyJsonA1";
+  const daemonEntry = path.join(temp, "app", "runtime-process.mjs");
+  fs.mkdirSync(path.dirname(daemonEntry), { recursive: true });
+  fs.writeFileSync(daemonEntry, "setInterval(() => {}, 1000);\n");
+  const child = spawn(process.execPath, [daemonEntry], { stdio: "ignore" });
+  try {
+    let inspected;
+    for (let attempt = 0; attempt < 50; attempt += 1) {
+      inspected = inspectProcess(child.pid);
+      if (inspected?.ok) break;
+      await Bun.sleep(20);
+    }
+    assert.equal(inspected?.ok, true, inspected?.reason);
+    const startedAt = "2026-07-29T01:00:00.000Z";
+    fs.writeFileSync(path.join(temp, "config.json"), `${JSON.stringify({
+      version: 4, serverId: "server-ready-json", mentionPolicy: "require", activeAgent: agentId,
+      agents: { [agentId]: { runtime: "pi", model: "default" } },
+    })}\n`, { mode: 0o600 });
+    fs.writeFileSync(path.join(temp, "daemon-status.json"), `${JSON.stringify({
+      pid: child.pid,
+      processStartToken: inspected.startToken,
+      commandToken: "app/runtime-process.mjs",
+      startedAt,
+      agents: [agentId],
+    })}\n`, { mode: 0o600 });
+    const stateDir = path.join(temp, "state", "agents", agentId);
+    fs.mkdirSync(stateDir, { recursive: true });
+    const writeStatus = (value) => fs.writeFileSync(path.join(stateDir, "status.json"), `${JSON.stringify(value)}\n`, { mode: 0o600 });
+    writeStatus({
+      connectedAt: "2026-07-29T01:00:01.000Z",
+      connectedVia: "channel",
+      inboundVerifiedAt: "2026-07-29T01:00:02.000Z",
+      reconnectingAt: null,
+      runtimeReadiness: { state: "ready" },
+    });
+    const run = () => spawnSync(process.execPath, [ENTRY, "agents", "--json"], {
+      cwd: ROOT, encoding: "utf8", env: { ...process.env, LARKIN_CONFIG_DIR: temp },
+    });
+    const ready = run();
+    assert.equal(ready.status, 0, ready.stderr);
+    const readyPayload = JSON.parse(ready.stdout);
+    assert.equal(readyPayload.daemon.owned, true);
+    assert.equal(readyPayload.daemon.pid, child.pid);
+    assert.equal(readyPayload.agents[0].ready, true);
+
+    writeStatus({
+      connectedAt: "2026-07-29T01:00:01.000Z",
+      connectedVia: "channel",
+      reconnectingAt: "2026-07-29T01:00:03.000Z",
+      reconnectedAt: "2026-07-29T01:00:02.000Z",
+      runtimeReadiness: { state: "ready" },
+    });
+    const reconnecting = JSON.parse(run().stdout).agents[0];
+    assert.equal(reconnecting.ready, false);
+    assert.equal(reconnecting.readiness.channel_not_reconnecting, false);
+
+    fs.writeFileSync(path.join(temp, "config.json"), `${JSON.stringify({
+      version: 4, serverId: "server-ready-json", mentionPolicy: "require", activeAgent: null, agents: {},
+    })}\n`, { mode: 0o600 });
+    const empty = JSON.parse(run().stdout);
+    assert.deepEqual(empty.daemon, { owned: true, pid: child.pid, started_at: startedAt });
+    assert.deepEqual(empty.agents, []);
+  } finally {
+    child.kill("SIGTERM");
     fs.rmSync(temp, { recursive: true, force: true });
   }
 });

--- a/test/unit/app/agent-readiness.test.mjs
+++ b/test/unit/app/agent-readiness.test.mjs
@@ -1,0 +1,86 @@
+import assert from "node:assert/strict";
+import path from "node:path";
+import { pathToFileURL } from "node:url";
+import { test } from "bun:test";
+
+const ROOT = path.resolve(import.meta.dirname, "../../..");
+const { projectAgentReadiness } = await import(pathToFileURL(path.join(ROOT, "dist/app/agent-readiness.mjs")).href);
+
+const daemon = {
+  state: "owned",
+  running: true,
+  pid: 42,
+  startedAt: "2026-07-29T01:00:00.000Z",
+  agents: ["cli_ready"],
+};
+
+test("agent readiness requires the current owned daemon, ready Runtime, connected channel, and no reconnect", () => {
+  const ready = projectAgentReadiness({
+    agentId: "cli_ready",
+    daemon,
+    status: {
+      connectedAt: "2026-07-29T01:00:01.000Z",
+      connectedVia: "channel",
+      inboundVerifiedAt: "2026-07-29T01:00:02.000Z",
+      reconnectingAt: null,
+      runtimeReadiness: { state: "ready" },
+    },
+  });
+  assert.deepEqual(ready, {
+    ready: true,
+    readiness: {
+      daemon_owned: true,
+      runtime_ready: true,
+      channel_connected: true,
+      channel_not_reconnecting: true,
+    },
+    channel: {
+      connected_at: "2026-07-29T01:00:01.000Z",
+      connected_via: "channel",
+      inbound_verified_at: "2026-07-29T01:00:02.000Z",
+    },
+  });
+});
+
+test("stale channels, unready Runtimes, foreign daemons, and active reconnects stay false", () => {
+  const variants = [
+    { status: { connectedAt: "2026-07-29T00:59:59.999Z", connectedVia: "channel", runtimeReadiness: { state: "ready" } }, field: "channel_connected" },
+    { status: { connectedAt: "2026-07-29T00:59:00.000Z", runtimeReadiness: { state: "ready" } }, field: "channel_connected" },
+    { status: { connectedAt: "2026-07-29T01:00:01.000Z", runtimeReadiness: { state: "incompatible" } }, field: "runtime_ready" },
+    { daemon: { ...daemon, agents: ["cli_other"] }, status: { connectedAt: "2026-07-29T01:00:01.000Z", runtimeReadiness: { state: "ready" } }, field: "daemon_owned" },
+    {
+      status: {
+        connectedAt: "2026-07-29T01:00:01.000Z",
+        runtimeReadiness: { state: "ready" },
+        reconnectingAt: "2026-07-29T01:00:03.000Z",
+        reconnectedAt: "2026-07-29T01:00:02.000Z",
+      },
+      field: "channel_not_reconnecting",
+    },
+  ];
+  for (const variant of variants) {
+    const result = projectAgentReadiness({
+      agentId: "cli_ready",
+      daemon: variant.daemon ?? daemon,
+      status: variant.status,
+    });
+    assert.equal(result.ready, false, variant.field);
+    assert.equal(result.readiness[variant.field], false, variant.field);
+  }
+});
+
+test("a newer current connection clears older reconnect markers", () => {
+  const result = projectAgentReadiness({
+    agentId: "cli_ready",
+    daemon,
+    status: {
+      connectedAt: "2026-07-29T01:00:04.000Z",
+      connectedVia: "channel",
+      runtimeReadiness: { state: "ready" },
+      reconnectingAt: "2026-07-29T01:00:03.000Z",
+      reconnectedAt: "2026-07-29T01:00:02.000Z",
+    },
+  });
+  assert.equal(result.ready, true);
+  assert.equal(result.readiness.channel_not_reconnecting, true);
+});

--- a/test/unit/evals/agent-experience-v6.test.mjs
+++ b/test/unit/evals/agent-experience-v6.test.mjs
@@ -1,0 +1,61 @@
+import assert from "node:assert/strict";
+import path from "node:path";
+import { test } from "bun:test";
+import {
+  gradeAgentExperienceV6Trace,
+  loadAgentExperienceV6Eval,
+  summarizeAgentExperienceV6Eval,
+} from "../../support/agent-experience-v6-grader.mjs";
+
+const ROOT = path.resolve(import.meta.dirname, "../../..");
+const DATASET = loadAgentExperienceV6Eval(path.join(ROOT, "evals/agent-experience-v6/scenarios.json"));
+
+test("fixed Agent Experience v6 eval starts every selected scenario from an empty session", () => {
+  assert.equal(DATASET.session.initial_turns, 0);
+  assert.equal(DATASET.model.standing_prompt_version, "larkin-standing-v6");
+  assert.deepEqual(DATASET.scenarios.map((scenario) => scenario.id), [
+    "target-scoped-thread-read",
+    "failed-thread-read-no-false-success",
+    "exact-text-punctuation",
+    "exclusive-other-agent-silence",
+    "committed-unverified-no-retry",
+  ]);
+});
+
+test("golden fresh-session traces satisfy the full deterministic rubric", () => {
+  const traces = Object.fromEntries(DATASET.scenarios.map((scenario) => [scenario.id, scenario.trace]));
+  const result = summarizeAgentExperienceV6Eval(DATASET, traces);
+  assert.equal(result.passed, true);
+  assert.equal(result.pass_rate, 1);
+  assert.equal(result.results.every((item) => item.passed), true);
+});
+
+test("grader rejects chat-wide fallback, stderr merging, false success, text mutation, excluded replies, and duplicate retry", () => {
+  const byId = Object.fromEntries(DATASET.scenarios.map((scenario) => [scenario.id, scenario]));
+  const badThread = gradeAgentExperienceV6Trace(byId["target-scoped-thread-read"], [{
+    action: "tool", command: "lark-cli im +chat-messages-list --chat-id oc_eval_thread 2>&1", exit_code: 0,
+  }]);
+  assert.deepEqual(new Set(badThread.failures.map((item) => item.rule)), new Set([
+    "canonical_command", "forbidden_command", "stable_response_path",
+  ]));
+
+  const falseSuccess = gradeAgentExperienceV6Trace(byId["failed-thread-read-no-false-success"], [
+    byId["failed-thread-read-no-false-success"].trace[0],
+    { action: "provider_write", command: "lark-cli im +messages-send", transported_text: "remembered" },
+  ]);
+  assert.equal(falseSuccess.failures.some((item) => ["bounded_calls", "provider_write_count", "visible_failure", "no_memory_fallback"].includes(item.rule)), true);
+
+  const changedText = structuredClone(byId["exact-text-punctuation"].trace);
+  changedText[0].transported_text = "原文: \"修复 A/B\"; 不要改成 ASCII 引号。";
+  changedText[0].shell_interpolation = true;
+  assert.deepEqual(new Set(gradeAgentExperienceV6Trace(byId["exact-text-punctuation"], changedText).failures.map((item) => item.rule)),
+    new Set(["exact_text", "shell_interpolation"]));
+
+  assert.equal(gradeAgentExperienceV6Trace(byId["exclusive-other-agent-silence"], [{
+    action: "provider_write", command: "lark-cli im +messages-send", exit_code: 0,
+  }]).failures.some((item) => item.rule === "exclusive_silence"), true);
+
+  const duplicated = [...byId["committed-unverified-no-retry"].trace, ...byId["committed-unverified-no-retry"].trace];
+  const duplicateGrade = gradeAgentExperienceV6Trace(byId["committed-unverified-no-retry"], duplicated);
+  assert.equal(duplicateGrade.failures.some((item) => item.rule === "no_retry"), true);
+});

--- a/test/unit/evals/authoritative-freshness-gate.test.mjs
+++ b/test/unit/evals/authoritative-freshness-gate.test.mjs
@@ -10,7 +10,7 @@ const dataset = loadAuthoritativeFreshnessEval(path.join(ROOT, "evals/authoritat
 test("authoritative freshness eval is versioned, reproducible, and covers the critical rubric", () => {
   assert.equal(dataset.dataset, "authoritative-freshness-gate");
   assert.equal(dataset.version, 1);
-  assert.equal(dataset.standing_prompt_version, "larkin-standing-v5");
+  assert.equal(dataset.standing_prompt_version, "larkin-standing-v6");
   assert.equal(dataset.threshold, 1);
   assert.deepEqual(dataset.scenarios.map((scenario) => scenario.id), [
     "missing-inbox-history", "direct-ack-retry", "same-ms-new-id", "edited-message",

--- a/test/unit/evals/runtime-agent-interface-v2.test.mjs
+++ b/test/unit/evals/runtime-agent-interface-v2.test.mjs
@@ -15,7 +15,7 @@ const DATASET = loadRuntimeAgentInterfaceEval(path.join(ROOT, "evals", "runtime-
 test("fixed runtime Agent interface eval registers dataset, rubric, grader, threshold, Runtime/model/version and six-plus scenarios", () => {
   assert.equal(DATASET.version, 1);
   assert.equal(DATASET.runtime.adapter, "codex");
-  assert.equal(DATASET.model.standing_prompt_version, "larkin-standing-v5");
+  assert.equal(DATASET.model.standing_prompt_version, "larkin-standing-v6");
   assert.equal(DATASET.grader.version, 1);
   assert.equal(DATASET.grader.threshold, 1);
   assert.ok(DATASET.grader.rubric.length >= 5);

--- a/test/unit/feishu/host-runtime-lifecycle.test.mjs
+++ b/test/unit/feishu/host-runtime-lifecycle.test.mjs
@@ -252,13 +252,19 @@ test("production HostShell clears eyes on inactive/error and ignores heartbeat a
     host.start();
     await new Promise((resolve) => setImmediate(resolve));
 
+    listener({ type: "agent-status", agentId, status: "active" });
+    assert.equal(JSON.parse(fs.readFileSync(path.join(agent.stateDir, "status.json"), "utf8")).runtimeReadiness.state, "ready");
+
     await ingest("inactive");
-    listener({ type: "agent-status", agentId, status: "inactive" });
+    listener({ type: "agent-status", agentId, status: "inactive", readiness: { runtime: "pi", state: "ready" } });
     assert.equal(deletes().length, 1);
+    assert.equal(JSON.parse(fs.readFileSync(path.join(agent.stateDir, "status.json"), "utf8")).runtimeReadiness.state, "missing");
 
     await ingest("error");
-    listener({ type: "agent-status", agentId, status: "error", error: "runtime failed" });
+    listener({ type: "agent-status", agentId, status: "active" });
+    listener({ type: "agent-status", agentId, status: "error", error: "runtime failed", readiness: { runtime: "pi", state: "ready" } });
     assert.equal(deletes().length, 2);
+    assert.equal(JSON.parse(fs.readFileSync(path.join(agent.stateDir, "status.json"), "utf8")).runtimeReadiness.state, "incompatible");
 
     await ingest("heartbeat");
     listener({ type: "activity", agentId, activity: "idle", activityKind: "idle", isHeartbeat: true });

--- a/test/unit/feishu/lark-passthrough.test.mjs
+++ b/test/unit/feishu/lark-passthrough.test.mjs
@@ -407,4 +407,8 @@ test("platform rules teach native lark-cli, long-running task updates, and the i
   assert.match(PLATFORM_RULES, /不得泄露[^\n]*thinking[^\n]*凭证[^\n]*原始工具输出[^\n]*内部路径/, "progress must protect sensitive runtime details");
   assert.match(PLATFORM_RULES, /(?:完成|无法继续|需要用户动作)[^\n]*lark-cli[^\n]*(?:最终结论|明确请求)/, "terminal outcomes must be sent through native lark-cli");
   assert.match(PLATFORM_RULES, /不可逆|撤回|删除/, "platform rules must carry the irreversible-op convention");
+  assert.match(PLATFORM_RULES, /standing instructions.*身份.*权威/, "injected identity must be authoritative");
+  assert.match(PLATFORM_RULES, /仅(?:点名|指派).*其他 Agent.*不得回复/, "exclusive assignment must keep non-target agents silent");
+  assert.match(PLATFORM_RULES, /thread:<chat_id>:<thread_id>.*threads-messages-list.*data\.messages/, "thread reads must use one target-scoped stable recipe");
+  assert.match(PLATFORM_RULES, /2>&1.*(?:禁止|不得).*JSON|JSON.*(?:禁止|不得).*2>&1/, "structured output must keep stderr separate");
 });

--- a/test/unit/runtime/runtime-adapters.test.mjs
+++ b/test/unit/runtime/runtime-adapters.test.mjs
@@ -72,7 +72,7 @@ test("context prompt is capability-driven, versioned and produces bounded notifi
 
 test("default context prompt consumes the Agent CLI manifest", () => {
   const prompt = new ContextPromptBuilder().build({ agentId: "cli_test", runtime: "pi" });
-  assert.equal(prompt.version, "larkin-standing-v5");
+  assert.equal(prompt.version, "larkin-standing-v6");
   assert.match(prompt.content, /larkin reminder schedule/);
   assert.match(prompt.content, /larkin reminder cancel/);
   assert.match(prompt.content, /larkin interaction resolve/);
@@ -95,6 +95,17 @@ test("default context prompt consumes the Agent CLI manifest", () => {
   assert.match(prompt.content, /attachment-only send\/reply.*attachment flag.*without a text body flag/i);
   assert.match(prompt.content, /put real newline characters directly in the argument/);
   assert.ok(prompt.content.includes("Do not use the two literal characters `\\n` inside ordinary quotes"));
+  assert.match(prompt.content, /authoritative self identity.*cli_test/i);
+  assert.match(prompt.content, /do not call.*profile show.*learn.*identity/i);
+  assert.match(prompt.content, /exclusively (?:assigns|addresses).*another named Agent.*stay silent/i);
+  assert.match(prompt.content, /thread:<chat_id>:<thread_id>/);
+  assert.match(prompt.content, /\+threads-messages-list --thread <thread_id> --order desc --page-size 10 --no-reactions --json/);
+  assert.match(prompt.content, /response messages.*data\.messages/i);
+  assert.match(prompt.content, /never.*chat-wide fallback/i);
+  assert.match(prompt.content, /never.*`2>&1`.*JSON/i);
+  assert.match(prompt.content, /fail visibly.*remembered.*hard-coded text/i);
+  assert.match(prompt.content, /exact text.*one literal `--text` argument/i);
+  assert.match(prompt.content, /never.*command substitution.*`eval`.*unquoted variable/i);
 });
 
 test("Codex, Claude and Pi receive the markdown-default standing contract", async () => {


### PR DESCRIPTION
## Summary

This PR addresses the highest-cost Agent Experience failures reproduced in the fresh-session audit from #6 with a focused set of root-level contracts:

- upgrade the standing/platform prompt to v6 with canonical thread/chat recipes, stable `data.messages` guidance, stdout/stderr separation, exact-text transport, authoritative self identity, and exclusive-address silence;
- return one exit-0 JSON document when a provider write committed but post-write verification could not advance the cursor, while preserving fail-closed nonzero behavior before a write;
- add `larkin agents --json` with explicit current daemon / Runtime / channel readiness components;
- add a five-scenario fresh-session dataset and grader for target-scoped reads, false-success rejection, exact punctuation, role silence, and no duplicate retry.

## Why

Ten real fresh-session scenarios showed repeated CLI discovery, chat-wide fallback, remembered-text false success, punctuation loss, duplicate Agent replies, an `active`/channel-ready gap, and contradictory “provider success + freshness_unavailable” results. These symptoms shared a few missing contracts, so this PR fixes those contracts instead of adding per-case retries or compatibility wrappers.

## Behavior and compatibility

- Known thread targets now have one bounded native lark-cli recipe and response path.
- Injected Agent identity is authoritative; `profile show` is not needed for self-routing.
- Exclusive assignment to another Agent remains a prompt-level stay-silent rule. Message wake/Inbox policy is unchanged; no invisible receive gate was added.
- A successful provider commit with unavailable confirmation now reports `committed=true`, `verified=false`, and `cursor_advanced=false` once. Arbitrary provider stderr text is not copied into that result.
- Pre-write freshness conflicts/unavailability and provider write failures remain nonzero.
- `ready=true` requires current daemon ownership, ready Runtime state, a current connected Feishu channel, and no newer reconnect marker. It does not claim an inbound event has already been observed.

## Validation

- `bun run test` — PASS
  - frontend: 24/24
  - unit: 392/392
  - integration: 160 pass, 13 explicit opt-in skips, 0 fail
  - E2E: 5/5
- `bun run test:eval:agent-experience-v6` — 3/3
- `bun run licenses:check` — PASS
- `bun run publication:check:tree` — PASS
- `bun run publication:check` — PASS
- `git diff --check` — PASS

An independent evaluator found readiness timestamp/state bugs and provider-stderr retry leakage in the first pass. Both received focused RED/GREEN fixes and targeted re-evaluation returned no issue.

## Explicit boundaries

A Larkin-owned `larkin message read --target` abstraction is an explicit non-goal. Native `lark-cli` remains the single Feishu command surface.

The following remain follow-ups in #6:

- first-class session reset and pending-Inbox drain;
- upstream/user-identity `230027` classification;
- cross-Agent locks or a Freshness Gate redesign;
- native-model and real-Feishu reruns;
- release, installation replacement, or service restart.
