### PR TITLE
Release v0.2.32

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "larkin",
-  "version": "0.2.31",
+  "version": "0.2.32",
   "private": true,
   "larkinPackageRole": "development-source-checkout",
   "packageManager": "bun@1.3.14",


### PR DESCRIPTION
## Summary

- bump the formal Larkin version from 0.2.31 to 0.2.32
- publish the already-merged Agent Experience remediation under a unique release version
- keep product code and locked dependencies unchanged

## Validation

- bun run release:check-version v0.2.32
- bun run test: 24 frontend, 392 unit, 160 integration, 5 E2E passed
- bun run licenses:check
- bun run publication:check:tree
- bun run publication:check
- clean darwin-arm64 standalone build and release smoke

After merge, an annotated v0.2.32 tag will trigger the existing tag-only Publish release workflow.