### PR TITLE
Add public contribution workflows

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,80 @@
+name: Bug report
+description: Report a reproducible problem in Larkin
+title: "[Bug]: "
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for reporting a problem. Search existing issues first.
+        Do not include credentials, private messages, user data, or exploit details. Report vulnerabilities through the private security link in the issue chooser.
+  - type: textarea
+    id: problem
+    attributes:
+      label: What happened?
+      description: Describe the observed behavior and its user impact.
+      placeholder: A concise description of the problem and when it occurs.
+    validations:
+      required: true
+  - type: textarea
+    id: reproduction
+    attributes:
+      label: Reproduction
+      description: Provide the smallest safe sequence that reproduces the problem.
+      placeholder: |
+        1. Configure ...
+        2. Run ...
+        3. Observe ...
+    validations:
+      required: true
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behavior
+      description: What should have happened instead?
+    validations:
+      required: true
+  - type: dropdown
+    id: area
+    attributes:
+      label: Affected area
+      options:
+        - Setup or onboarding
+        - Runtime host or sessions
+        - Feishu messaging or cards
+        - Dashboard
+        - CLI or configuration
+        - Packaging or release
+        - Other
+    validations:
+      required: true
+  - type: input
+    id: version
+    attributes:
+      label: Larkin version or commit
+      placeholder: v0.2.32 or caaf292
+    validations:
+      required: true
+  - type: input
+    id: environment
+    attributes:
+      label: Environment
+      description: Include OS, architecture, agent runtime, and Bun version when relevant.
+      placeholder: macOS 15 arm64, Codex, Bun 1.3.14
+    validations:
+      required: true
+  - type: textarea
+    id: diagnostics
+    attributes:
+      label: Redacted diagnostics
+      description: Include only the smallest useful logs or screenshots after removing secrets and private data.
+  - type: checkboxes
+    id: acknowledgements
+    attributes:
+      label: Checklist
+      options:
+        - label: I searched existing issues for the same problem.
+          required: true
+        - label: I removed credentials, private messages, user data, and other sensitive information.
+          required: true
+        - label: This is not a vulnerability or other security-sensitive disclosure.
+          required: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Report a security vulnerability
+    url: https://github.com/eddiearc/larkin/security/advisories/new
+    about: Privately report vulnerabilities or security-sensitive details.
+  - name: Contribution guide
+    url: https://github.com/eddiearc/larkin/blob/main/CONTRIBUTING.md
+    about: Read the issue-first policy and development workflow before contributing.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,65 @@
+name: Feature request
+description: Propose a user-facing capability or substantial change
+title: "[Feature]: "
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Non-trivial changes are issue-first. Please align the problem and intended direction with maintainers before implementation.
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem or opportunity
+      description: What user problem should Larkin solve, and who experiences it?
+    validations:
+      required: true
+  - type: textarea
+    id: outcome
+    attributes:
+      label: Desired outcome
+      description: Describe observable behavior and success without prescribing unnecessary implementation details.
+    validations:
+      required: true
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed direction
+      description: Share a possible approach, public interface, or workflow if you have one.
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: What existing workflow or narrower solution did you consider?
+  - type: textarea
+    id: scope
+    attributes:
+      label: Scope and compatibility
+      description: Note affected runtimes, platforms, configuration, permissions, persistence, or release behavior.
+    validations:
+      required: true
+  - type: textarea
+    id: validation
+    attributes:
+      label: Validation ideas
+      description: Which user-visible scenarios would demonstrate that the change works?
+  - type: dropdown
+    id: contribution
+    attributes:
+      label: Are you willing to contribute an implementation after alignment?
+      options:
+        - "Yes"
+        - "No"
+        - Maybe
+    validations:
+      required: true
+  - type: checkboxes
+    id: acknowledgements
+    attributes:
+      label: Checklist
+      options:
+        - label: I searched existing issues and did not find an equivalent proposal.
+          required: true
+        - label: I will wait for maintainer alignment before implementing this non-trivial change.
+          required: true
+        - label: This request contains no credentials, private user data, or vulnerability details.
+          required: true

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,34 @@
+## Summary
+
+<!-- What changed, why it matters, and the user or developer impact. -->
+
+## Related issue
+
+<!-- Use "Closes #123" for non-trivial changes aligned in an issue. -->
+
+Closes #
+
+<!-- For an allowed direct PR, replace the line above with "Small-change exemption:" and explain why an issue was unnecessary. -->
+
+## Scope
+
+- In scope:
+- Out of scope:
+- Compatibility or migration impact:
+
+## Validation
+
+<!-- List the exact commands/scenarios and actual results. Remove checks that genuinely do not apply and explain why. -->
+
+- [ ] Relevant focused tests pass.
+- [ ] `bun run build` passes.
+- [ ] `bun run test` passes.
+- [ ] `bun run licenses:check` passes.
+- [ ] `bun run publication:check:tree` passes.
+- [ ] `git diff --check` passes.
+
+## Safety and publication
+
+- [ ] This change contains no credentials, private messages, user data, private filesystem paths, generated `dist/`, or release artifacts.
+- [ ] Security-sensitive details, if any, were reported privately rather than included in this PR.
+- [ ] I did not create, move, or replace a release tag as part of this ordinary contribution.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,15 +1,48 @@
 # Contributing to Larkin
 
-Keep changes focused and update the closest tests when behavior changes. Before submitting a change, run:
+Thank you for helping improve Larkin. Search the
+[issue tracker](https://github.com/eddiearc/larkin/issues) before starting work
+so that related reports and decisions stay in one place.
+
+## When to open an issue first
+
+Open an issue and wait for maintainer alignment before implementing a
+non-trivial change. This includes new features, user-visible behavior changes,
+architecture or dependency changes, permission or persistence changes, release
+changes, and work that touches a security boundary. Describe the problem,
+expected behavior, scope, and the smallest useful validation plan. An issue is
+alignment on the problem and intended direction, not a guarantee that a
+particular implementation will be accepted.
+
+You may open a pull request directly for typo and documentation fixes, narrowly
+scoped test improvements, or obvious low-risk bug fixes. Explain the small-change
+exemption in the pull request instead of creating a ceremonial issue.
+
+Do not report vulnerabilities or include credentials, private messages, user
+data, or exploit details in a public issue. Follow [SECURITY.md](./SECURITY.md)
+and use GitHub private vulnerability reporting.
+
+## Development workflow
+
+1. Fork the repository and create a focused branch from the latest `main`.
+2. Make one cohesive change and update the closest tests when behavior changes.
+3. Run the relevant focused test first, then the repository checks below.
+4. Open a pull request, link the aligned issue when one is required, and record
+   the commands and actual results used for validation.
+
+Before submitting a change, run:
 
 ```bash
 bun install --frozen-lockfile
 bun run build
-bun test
+bun run test
 bun run licenses:check
 bun run publication:check:tree
 ```
 
-Do not commit credentials, local configuration, user data, generated `dist/`, or release artifacts. Report security vulnerabilities according to [SECURITY.md](./SECURITY.md), not through the public issue tracker.
+Keep pull requests reviewable and avoid unrelated refactors. Do not commit
+credentials, local configuration, user data, generated `dist/`, dependency
+directories, caches, or release artifacts. Maintainers may close proposals that
+conflict with the product boundary or cannot be maintained safely.
 
 By intentionally submitting a contribution for inclusion in Larkin, you agree that it is licensed under the repository's [Apache License 2.0](./LICENSE), as described in section 5 of that license.

--- a/evals/public-contribution-governance/scenarios.json
+++ b/evals/public-contribution-governance/scenarios.json
@@ -1,0 +1,81 @@
+{
+  "dataset": "public-contribution-governance",
+  "version": 1,
+  "subject": {
+    "kind": "repository-policy",
+    "policy_version": "larkin-public-contribution-v1"
+  },
+  "grader": {
+    "name": "public-contribution-governance-artifact-grader",
+    "version": 1,
+    "threshold": 1.0,
+    "rubric": [
+      "small low-risk changes can use a direct pull request without a ceremonial issue",
+      "non-trivial behavior and feature work waits for issue alignment",
+      "permission, persistence, dependency, and release changes are issue-first",
+      "security-sensitive reports are routed to private vulnerability reporting",
+      "pull requests link an issue or explain the small-change exemption and record validation",
+      "contributions preserve publication, secret, generated-output, and release-tag boundaries"
+    ]
+  },
+  "scenarios": [
+    {
+      "id": "small-doc-fix-direct-pr",
+      "prompt": "Fix a typo in the README without changing behavior.",
+      "expected_route": "direct-pr",
+      "assertions": [
+        { "file": "CONTRIBUTING.md", "pattern": "may open a pull request directly[\\s\\S]*typo and documentation fixes" },
+        { "file": ".github/pull_request_template.md", "pattern": "Small-change exemption" }
+      ]
+    },
+    {
+      "id": "feature-issue-first",
+      "prompt": "Add a new user-visible Runtime capability.",
+      "expected_route": "issue-first",
+      "assertions": [
+        { "file": "CONTRIBUTING.md", "pattern": "Open an issue and wait for maintainer alignment[\\s\\S]*new features[\\s\\S]*user-visible behavior changes" },
+        { "file": ".github/ISSUE_TEMPLATE/feature_request.yml", "pattern": "wait for maintainer alignment before implementing" }
+      ]
+    },
+    {
+      "id": "boundary-change-issue-first",
+      "prompt": "Change dependencies, permissions, persistence, or release behavior.",
+      "expected_route": "issue-first",
+      "assertions": [
+        { "file": "CONTRIBUTING.md", "pattern": "dependency changes, permission or persistence changes, release\\s+changes" },
+        { "file": ".github/ISSUE_TEMPLATE/feature_request.yml", "pattern": "configuration, permissions, persistence, or release behavior" }
+      ]
+    },
+    {
+      "id": "vulnerability-private",
+      "prompt": "Report a vulnerability with exploit details.",
+      "expected_route": "private-security",
+      "assertions": [
+        { "file": "SECURITY.md", "pattern": "private vulnerability reporting" },
+        { "file": ".github/ISSUE_TEMPLATE/config.yml", "pattern": "security/advisories/new" },
+        { "file": ".github/ISSUE_TEMPLATE/bug_report.yml", "pattern": "This is not a vulnerability" }
+      ]
+    },
+    {
+      "id": "reviewable-pr-evidence",
+      "prompt": "Submit an aligned implementation for review.",
+      "expected_route": "pull-request",
+      "assertions": [
+        { "file": ".github/pull_request_template.md", "pattern": "Closes #" },
+        { "file": ".github/pull_request_template.md", "pattern": "bun run test" },
+        { "file": ".github/pull_request_template.md", "pattern": "publication:check:tree" },
+        { "file": "CONTRIBUTING.md", "pattern": "commands and actual results used for validation" }
+      ]
+    },
+    {
+      "id": "publication-and-release-safety",
+      "prompt": "Prepare an ordinary contribution without publishing a release.",
+      "expected_route": "pull-request",
+      "assertions": [
+        { "file": ".github/pull_request_template.md", "pattern": "no credentials[\\s\\S]*generated `dist/`[\\s\\S]*release artifacts" },
+        { "file": ".github/pull_request_template.md", "pattern": "did not create, move, or replace a release tag" },
+        { "file": "CONTRIBUTING.md", "pattern": "dependency[\\s\\S]*caches[\\s\\S]*release artifacts" }
+      ]
+    }
+  ]
+}

--- a/package.json
+++ b/package.json
@@ -61,6 +61,8 @@
     "test:eval:runtime-agent-interface-v2": "bun test --max-concurrency 1 test/unit/evals/runtime-agent-interface-v2.test.mjs",
     "test:eval:authoritative-freshness-gate": "bun test --max-concurrency 1 test/unit/evals/authoritative-freshness-gate.test.mjs",
     "test:eval:agent-experience-v6": "bun test --max-concurrency 1 test/unit/evals/agent-experience-v6.test.mjs",
+    "test:eval:public-contribution-governance": "bun test --max-concurrency 1 test/unit/evals/public-contribution-governance.test.mjs",
+    "test:live:public-contribution-governance": "bun test --max-concurrency 1 test/live/public-contribution-governance-live.test.mjs",
     "test:eval:authoritative-freshness-gate:native": "bun run build && LARKIN_RUN_AUTHORITATIVE_FRESHNESS_EVAL=1 bun test --max-concurrency 1 test/live/authoritative-freshness-gate-agent-eval.test.mjs",
     "test:live:authoritative-freshness-gate": "bun test --max-concurrency 1 test/live/authoritative-freshness-gate-live.test.mjs",
     "test:eval:runtime-agent-interface-v2:native": "bun run build && LARKIN_RUN_RUNTIME_AGENT_INTERFACE_V2_EVAL=1 bun test --max-concurrency 1 test/live/runtime-agent-interface-v2-agent-eval.test.mjs"

--- a/scripts/check-publication.mjs
+++ b/scripts/check-publication.mjs
@@ -7,7 +7,10 @@ import { LARK_CLI_NATIVE_SHA256, LARK_CLI_VERSION, larkCliTarget } from "./relea
 
 const DEFAULT_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
 const REQUIRED = ["README.md", "AGENTS.md", "LICENSE", "SECURITY.md", "CONTRIBUTING.md"];
-const ALLOWED_MARKDOWN = new Set(["README.md", "AGENTS.md", "SECURITY.md", "CONTRIBUTING.md"]);
+const ALLOWED_MARKDOWN = new Set([
+  "README.md", "AGENTS.md", "SECURITY.md", "CONTRIBUTING.md",
+  ".github/pull_request_template.md",
+]);
 const isAscii = (value) => /^[\x00-\x7f]*$/.test(value);
 
 function parseArguments(argv) {

--- a/test/integration/build/publication-boundary.test.mjs
+++ b/test/integration/build/publication-boundary.test.mjs
@@ -413,6 +413,26 @@ test("tree scan rejects internal documentation paths and non-allowlisted Markdow
   }
 });
 
+test("tree scan allows only the approved GitHub pull request Markdown template", () => {
+  const root = fixture();
+  try {
+    const approved = ".github/pull_request_template.md";
+    const rejected = ".github/README.md";
+    for (const [relative, contents] of [[approved, "## Summary\n"], [rejected, "# Internal\n"]]) {
+      const absolute = path.join(root, relative);
+      fs.mkdirSync(path.dirname(absolute), { recursive: true });
+      fs.writeFileSync(absolute, contents);
+      git(root, "add", relative);
+    }
+    const result = runCheck(root, "--tree-only");
+    assert.equal(result.status, 1, result.stderr || result.stdout);
+    assert.doesNotMatch(result.stderr, /pull_request_template\.md/);
+    assert.match(result.stderr, /\.github\/README\.md: Markdown file is outside the publication allowlist/);
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});
+
 test("default scan covers reachable history, commit messages, paths, and refs", () => {
   const root = fixture();
   try {

--- a/test/live/public-contribution-governance-live.test.mjs
+++ b/test/live/public-contribution-governance-live.test.mjs
@@ -1,0 +1,47 @@
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import { test } from "bun:test";
+
+const ENABLED = process.env.LARKIN_RUN_PUBLIC_CONTRIBUTION_GOVERNANCE_LIVE === "1";
+const REPOSITORY = process.env.LARKIN_GITHUB_REPOSITORY || "eddiearc/larkin";
+const SKIP_REASON = "set LARKIN_RUN_PUBLIC_CONTRIBUTION_GOVERNANCE_LIVE=1 with authenticated gh after merge";
+
+function api(path) {
+  const result = spawnSync("gh", ["api", path], { encoding: "utf8" });
+  assert.equal(result.status, 0, result.stderr || result.stdout);
+  return JSON.parse(result.stdout);
+}
+
+function defaultBranchContent(relative) {
+  const value = api(`repos/${REPOSITORY}/contents/${relative}?ref=main`);
+  assert.equal(value.encoding, "base64", `${relative} must be a regular default-branch file`);
+  return Buffer.from(value.content, "base64").toString("utf8");
+}
+
+test.skipIf(!ENABLED)(`public GitHub contribution workflow is installed and protected (${SKIP_REASON})`, () => {
+  const repository = api(`repos/${REPOSITORY}`);
+  assert.equal(repository.private, false);
+  assert.equal(repository.default_branch, "main");
+  assert.equal(repository.has_issues, true);
+
+  const expected = new Map([
+    [".github/ISSUE_TEMPLATE/bug_report.yml", /This is not a vulnerability/],
+    [".github/ISSUE_TEMPLATE/feature_request.yml", /wait for maintainer alignment/],
+    [".github/ISSUE_TEMPLATE/config.yml", /security\/advisories\/new/],
+    [".github/pull_request_template.md", /Small-change exemption/],
+    ["CONTRIBUTING.md", /Open an issue and wait for maintainer alignment/],
+  ]);
+  for (const [file, pattern] of expected) assert.match(defaultBranchContent(file), pattern, file);
+
+  const privateReporting = api(`repos/${REPOSITORY}/private-vulnerability-reporting`);
+  assert.equal(privateReporting.enabled, true);
+
+  const protection = api(`repos/${REPOSITORY}/branches/main/protection`);
+  assert.equal(protection.required_status_checks.strict, true);
+  assert.equal(protection.required_status_checks.contexts.includes("source-checks"), true);
+  assert.equal(protection.enforce_admins.enabled, true);
+  assert.equal(protection.required_pull_request_reviews.required_approving_review_count, 0);
+  assert.equal(protection.required_conversation_resolution.enabled, true);
+  assert.equal(protection.allow_force_pushes.enabled, false);
+  assert.equal(protection.allow_deletions.enabled, false);
+});

--- a/test/support/public-contribution-governance-grader.mjs
+++ b/test/support/public-contribution-governance-grader.mjs
@@ -1,0 +1,55 @@
+import fs from "node:fs";
+import path from "node:path";
+
+function nonempty(value, label) {
+  if (typeof value !== "string" || !value.trim()) throw new Error(`${label} must be a non-empty string`);
+  return value;
+}
+
+export function loadPublicContributionGovernanceEval(file) {
+  const value = JSON.parse(fs.readFileSync(file, "utf8"));
+  if (value.dataset !== "public-contribution-governance" || value.version !== 1) throw new Error("eval dataset/version mismatch");
+  if (value.subject?.kind !== "repository-policy" || value.subject?.policy_version !== "larkin-public-contribution-v1") {
+    throw new Error("eval subject metadata mismatch");
+  }
+  if (value.grader?.name !== "public-contribution-governance-artifact-grader" || value.grader.version !== 1 || value.grader.threshold !== 1) {
+    throw new Error("eval grader metadata mismatch");
+  }
+  if (!Array.isArray(value.grader.rubric) || value.grader.rubric.length < 6) throw new Error("eval rubric is incomplete");
+  if (!Array.isArray(value.scenarios) || value.scenarios.length < 6) throw new Error("eval requires six scenarios");
+  const ids = new Set();
+  for (const [index, scenario] of value.scenarios.entries()) {
+    const label = `scenarios[${index}]`;
+    const id = nonempty(scenario.id, `${label}.id`);
+    if (ids.has(id)) throw new Error(`duplicate scenario id: ${id}`);
+    ids.add(id);
+    nonempty(scenario.prompt, `${label}.prompt`);
+    nonempty(scenario.expected_route, `${label}.expected_route`);
+    if (!Array.isArray(scenario.assertions) || scenario.assertions.length === 0) throw new Error(`${label}.assertions is required`);
+    for (const assertion of scenario.assertions) {
+      nonempty(assertion.file, `${label}.assertions[].file`);
+      nonempty(assertion.pattern, `${label}.assertions[].pattern`);
+      if (path.isAbsolute(assertion.file) || assertion.file.split("/").includes("..")) throw new Error(`${label} has an unsafe artifact path`);
+      new RegExp(assertion.pattern, "i");
+    }
+  }
+  return value;
+}
+
+export function gradePublicContributionScenario(root, scenario) {
+  const failures = [];
+  for (const assertion of scenario.assertions) {
+    const file = path.join(root, assertion.file);
+    let content = "";
+    try { content = fs.readFileSync(file, "utf8"); }
+    catch { failures.push({ rule: "artifact_available", file: assertion.file }); continue; }
+    if (!new RegExp(assertion.pattern, "i").test(content)) failures.push({ rule: "required_policy_evidence", file: assertion.file });
+  }
+  return { id: scenario.id, route: scenario.expected_route, passed: failures.length === 0, failures };
+}
+
+export function summarizePublicContributionGovernanceEval(root, dataset) {
+  const results = dataset.scenarios.map((scenario) => gradePublicContributionScenario(root, scenario));
+  const passRate = results.filter((result) => result.passed).length / results.length;
+  return { passed: passRate >= dataset.grader.threshold, pass_rate: passRate, threshold: dataset.grader.threshold, results };
+}

--- a/test/unit/evals/public-contribution-governance.test.mjs
+++ b/test/unit/evals/public-contribution-governance.test.mjs
@@ -1,0 +1,52 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { test } from "bun:test";
+import {
+  gradePublicContributionScenario,
+  loadPublicContributionGovernanceEval,
+  summarizePublicContributionGovernanceEval,
+} from "../../support/public-contribution-governance-grader.mjs";
+
+const ROOT = path.resolve(import.meta.dirname, "../../..");
+const DATASET = loadPublicContributionGovernanceEval(path.join(ROOT, "evals/public-contribution-governance/scenarios.json"));
+
+test("public contribution governance eval is versioned with a complete fixed rubric", () => {
+  assert.equal(DATASET.subject.policy_version, "larkin-public-contribution-v1");
+  assert.equal(DATASET.grader.version, 1);
+  assert.equal(DATASET.grader.threshold, 1);
+  assert.deepEqual(DATASET.scenarios.map((scenario) => scenario.id), [
+    "small-doc-fix-direct-pr", "feature-issue-first", "boundary-change-issue-first",
+    "vulnerability-private", "reviewable-pr-evidence", "publication-and-release-safety",
+  ]);
+});
+
+test("repository contribution artifacts pass every registered governance scenario", () => {
+  const result = summarizePublicContributionGovernanceEval(ROOT, DATASET);
+  assert.equal(result.passed, true, JSON.stringify(result.results));
+  assert.equal(result.pass_rate, 1);
+  assert.equal(result.results.every((item) => item.passed), true);
+});
+
+test("grader rejects a missing issue-first rule and public vulnerability routing", () => {
+  const temp = fs.mkdtempSync(path.join(os.tmpdir(), "larkin-governance-eval-"));
+  try {
+    for (const scenario of DATASET.scenarios) {
+      for (const assertion of scenario.assertions) {
+        const source = path.join(ROOT, assertion.file);
+        const destination = path.join(temp, assertion.file);
+        fs.mkdirSync(path.dirname(destination), { recursive: true });
+        if (!fs.existsSync(destination)) fs.copyFileSync(source, destination);
+      }
+    }
+    fs.writeFileSync(path.join(temp, "CONTRIBUTING.md"), "Open a pull request directly for every change.\n");
+    fs.writeFileSync(path.join(temp, ".github/ISSUE_TEMPLATE/config.yml"), "blank_issues_enabled: true\n");
+    const feature = DATASET.scenarios.find((scenario) => scenario.id === "feature-issue-first");
+    const security = DATASET.scenarios.find((scenario) => scenario.id === "vulnerability-private");
+    assert.equal(gradePublicContributionScenario(temp, feature).passed, false);
+    assert.equal(gradePublicContributionScenario(temp, security).passed, false);
+  } finally {
+    fs.rmSync(temp, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
## Summary

- define when non-trivial contributions require issue alignment and when a direct PR is appropriate
- add structured bug and feature Issue forms plus private-security and contribution links
- add a pull request template covering scope, validation, publication, and release safety
- correct the contributor test entry point from `bun test` to the package-orchestrated `bun run test`
- add a versioned six-scenario governance eval with a deterministic rubric and 100% threshold
- add focused publication allowlist coverage and a default-skip real GitHub API E2E for post-merge enforcement

## Related issue

Small-change exemption: this repository-governance change was explicitly aligned with the owner outside the public issue tracker before implementation.

## Impact

Public contributors receive a clear issue-first workflow, structured intake, and a reproducible PR checklist. Vulnerability reports are routed away from public Issues.

## Validation

- PASS: all three Issue-form/config YAML files parse successfully
- PASS: focused publication boundary suite (21/21), including positive and negative PR-template allowlist coverage
- PASS: `bun run test:eval:public-contribution-governance` (3/3; 6/6 scenarios at threshold 1.0; negative mutations rejected)
- PASS: default-safe E2E entry (1 skipped unless explicitly enabled after merge)
- PASS: `bun run publication:check:tree` (252 files, 0 violations)
- PASS: `bun run licenses:check` (86 runtime package versions)
- PASS: `git diff --check`
- PASS before the local environment-specific failure: typecheck, build, and frontend tests (24/24)
- LOCAL LIMITATION: `bun run test` reached an unchanged process-lock test that rejected the local `bun.exe` command marker; the same base SHA has green hosted `source-checks`, and this PR's hosted run is the merge gate

## Safety

No runtime source, credentials, generated `dist`, release artifacts, dependency graph, version, or release tag changed.
