### PR TITLE
Release v0.2.33

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "larkin",
-  "version": "0.2.32",
+  "version": "0.2.33",
   "private": true,
   "larkinPackageRole": "development-source-checkout",
   "packageManager": "bun@1.3.14",


### PR DESCRIPTION
## Summary

- bump Larkin from `0.2.32` to `0.2.33`
- publish the already-merged Agent-bound official CLI workspace delivery as a distinct formal version

This PR changes only `package.json.version`. It does not build or publish release artifacts; PR and `main` run source checks only. After this exact head passes and merges, an annotated `v0.2.33` tag on the resulting `main` commit will trigger the tag-only release workflow.

## Validation

- version RED on 0.2.32 and GREEN on 0.2.33
- `bun install --frozen-lockfile`
- `bun run test`: 24 frontend, 404 unit, 167 integration with 14 expected skips, 5 E2E passed
- `bun run licenses:check`
- `bun run publication:check:tree`
- `bun run publication:check`
- `git diff --check`
- local `darwin-arm64` release build, codesign verification, checksum and release smoke passed

Formal publication and local installation remain gated on the merged main commit, matching annotated tag, successful four-platform workflow, and published checksum verification.
