### PR TITLE
fix(inbox): prevent partial poll backlog from being stranded

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -35,4 +35,6 @@ Never commit credentials, tokens, private keys, local configuration, user data, 
 
 Contributions intentionally submitted for inclusion are licensed under Apache-2.0 as described by the repository `LICENSE` and its contribution terms.
 
+Owner policy: every bugfix or feature delivery must increment the version in `package.json` before merge. Unless the Owner explicitly selects a minor or major increment, default to exactly one patch increment. If the delivery already includes the required increment relative to its base, do not increment it again in a release-only follow-up. This policy does not authorize creating or publishing a tag or GitHub Release.
+
 Release tags use `vX.Y.Z`, must exactly match the version in `package.json`, and must point to a commit already contained in `main`. Version changes and release tags are explicit maintainer actions; do not create, move, or replace a release tag as part of an ordinary contribution.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "larkin",
-  "version": "0.2.33",
+  "version": "0.2.34",
   "private": true,
   "larkinPackageRole": "development-source-checkout",
   "packageManager": "bun@1.3.14",

--- a/src/agent/agent-state-store.ts
+++ b/src/agent/agent-state-store.ts
@@ -85,6 +85,7 @@ export interface InboxPollResult<T> {
   envelopes: T[];
   consumedDeliveryIds: string[];
   seenThroughSeq: number | null;
+  pendingCount: number;
 }
 
 interface InboxTargetState {
@@ -641,7 +642,12 @@ export class AgentStateStore {
         if (envelopes.length < limit && (!options.target || options.target === selectedTarget)) envelopes.push(row);
         else remaining.push(row);
       }
-      if (!envelopes.length) return { envelopes, consumedDeliveryIds: [], seenThroughSeq: null };
+      const pendingCount = remaining.reduce((count, row) => {
+        if (!options.target) return count + 1;
+        const rowTarget = typeof row.target === "string" ? row.target : targetKeyOfInboxEnvelope(row);
+        return count + (rowTarget === options.target ? 1 : 0);
+      }, 0);
+      if (!envelopes.length) return { envelopes, consumedDeliveryIds: [], seenThroughSeq: null, pendingCount };
       const messageIds = new Set(envelopes.flatMap((row) => {
         if (!row || typeof row !== "object") return [];
         const messageId = (row as Record<string, unknown>).message_id;
@@ -677,7 +683,7 @@ export class AgentStateStore {
       }
       this.replaceInboxUnlocked(remaining);
       this.writeJson("inboxState", state);
-      return { envelopes, consumedDeliveryIds, seenThroughSeq };
+      return { envelopes, consumedDeliveryIds, seenThroughSeq, pendingCount };
     });
   }
 

--- a/src/app/agent-cli.ts
+++ b/src/app/agent-cli.ts
@@ -489,7 +489,10 @@ export function runAgentCli(
           env.LARKIN_RUNTIME_OBSERVATION_GENERATION || "external");
       }
       const projected = projectInboxEvents(polled.envelopes);
+      const hasMore = polled.pendingCount > 0;
       emitJson(io, { version: 2, delivery: "direct_ack", at_most_once: true, ...projected,
+        pending_count: polled.pendingCount, has_more: hasMore,
+        ...(hasMore ? { next_action: "Continue polling the same Inbox scope until has_more is false." } : {}),
         seen_through_seq: polled.seenThroughSeq, consumed_delivery_ids: polled.consumedDeliveryIds });
       return 0;
     }

--- a/src/runtime/runtime-host.ts
+++ b/src/runtime/runtime-host.ts
@@ -225,6 +225,70 @@ export function createRuntimeHost(options: {
     }
   };
 
+  const TURN_END_RETRY_REASON = "runtime turn ended before Inbox consumption was observed";
+
+  /**
+   * Runtime acceptance acknowledges only the notification. At the safe turn
+   * boundary, canonical Inbox presence decides whether that same delivery
+   * identity must become retryable again. The Inbox rows and ledger update are
+   * observed under one transaction so a concurrent poll cannot be overwritten.
+   */
+  const reconcileAcceptedAtTurnEnd = (agent: ManagedAgent): void => {
+    const store = agent.stateStore;
+    if (!store?.readNdjson) {
+      reconcileExternalConsumption(agent);
+      for (const record of agent.records.values()) {
+        if (record.status !== "accepted") continue;
+        emit({ type: "delivery", agentId: agent.config.agentId, deliveryId: record.deliveryId,
+          messageId: record.messageId, status: "deferred", reason: TURN_END_RETRY_REASON });
+      }
+      return;
+    }
+    const consumed: DeliveryRecord[] = [];
+    const deferred: DeliveryRecord[] = [];
+    try {
+      store.withInboxTransaction(() => {
+        const inboxIds = new Set(store.readNdjson!<Record<string, unknown>>("inbox").flatMap((row) =>
+          typeof row?.message_id === "string" ? [row.message_id] : []));
+        const disk = store.readJson<DeliveryFile>("runtimeDeliveries", { version: 1, records: [] });
+        let changed = false;
+        const pendingUpdates: DeliveryRecord[] = [];
+        const records = disk.records.map((candidate) => {
+          const current = agent.records.get(candidate.deliveryId);
+          if (!current) return candidate;
+          if (candidate.status === "consumed") {
+            if (current.status !== "consumed") {
+              agent.records.set(candidate.deliveryId, candidate);
+              consumed.push(candidate);
+            }
+            return candidate;
+          }
+          if (current.status !== "accepted" || candidate.status !== "accepted" || !inboxIds.has(candidate.messageId)) {
+            return candidate;
+          }
+          const next: DeliveryRecord = { ...candidate, status: "pending", updatedAt: now(),
+            reason: TURN_END_RETRY_REASON, retryable: true };
+          changed = true;
+          pendingUpdates.push(next);
+          return next;
+        });
+        if (changed) {
+          store.writeJson("runtimeDeliveries", { ...disk, records });
+          for (const next of pendingUpdates) {
+            agent.records.set(next.deliveryId, next);
+            deferred.push(next);
+          }
+        }
+      });
+    } catch (error) {
+      log("turn-end Inbox reconciliation failed", String(error));
+      return;
+    }
+    emitConsumed(agent, consumed);
+    for (const record of deferred) emit({ type: "delivery", agentId: agent.config.agentId,
+      deliveryId: record.deliveryId, messageId: record.messageId, status: "deferred", reason: TURN_END_RETRY_REASON });
+  };
+
   // Production callers persist the canonical Inbox before calling deliver(). If a
   // concurrent drain wins between that append and ledger creation, close only the
   // record created/observed by this call under the same Inbox lock.
@@ -417,12 +481,7 @@ export function createRuntimeHost(options: {
       agent.turnInProgress = false;
       agent.busy = false;
       emit({ type: "activity", agentId: agent.config.agentId, activity: "idle", activityKind: "idle", detailKind: "turn_ended" });
-      reconcileExternalConsumption(agent);
-      for (const record of agent.records.values()) {
-        if (record.status !== "accepted") continue;
-        emit({ type: "delivery", agentId: agent.config.agentId, deliveryId: record.deliveryId,
-          messageId: record.messageId, status: "deferred", reason: "runtime turn ended before Inbox consumption was observed" });
-      }
+      reconcileAcceptedAtTurnEnd(agent);
       if (recoveredAuthentication) {
         agent.authFailureActive = false;
         const prior = agent.readiness;

--- a/test/e2e/runtime-production-mock-e2e.test.mjs
+++ b/test/e2e/runtime-production-mock-e2e.test.mjs
@@ -244,19 +244,38 @@ for (const runtime of ["codex", "claude", "pi"]) {
       assert.equal(store.readNdjson("inbox").length, 2, "check must not consume the batch");
 
       stdout = ""; stderr = "";
-      const pollCode = runAgentCli(["inbox", "poll", "--target", target], runtimeEnv, {
+      const pollCode = runAgentCli(["inbox", "poll", "--target", target, "--limit", "1"], runtimeEnv, {
         stateStore: store, io: { stdout: (text) => { stdout += text; }, stderr: (text) => { stderr += text; } },
       });
       assert.equal(pollCode, 0, stderr);
-      const drained = JSON.parse(stdout);
-      assert.equal(drained.delivery, "direct_ack");
-      assert.equal(drained.at_most_once, true);
-      assert.equal(drained.events.length, 2);
+      const partial = JSON.parse(stdout);
+      assert.equal(partial.delivery, "direct_ack");
+      assert.equal(partial.at_most_once, true);
+      assert.equal(partial.events.length, 1);
+      assert.equal(partial.pending_count, 1);
+      assert.equal(partial.has_more, true);
       assert.deepEqual(
-        Object.fromEntries(["chat_id", "message_id", "thread_id", "sender_id", "content"].map((key) => [key, drained.events[0][key]])),
+        Object.fromEntries(["chat_id", "message_id", "thread_id", "sender_id", "content"].map((key) => [key, partial.events[0][key]])),
         { chat_id: `oc_${runtime}`, message_id: `om_${runtime}_1`, thread_id: null, sender_id: "ou_sender", content: "first" },
       );
-      assert.deepEqual(new Set(drained.consumed_delivery_ids), new Set([session.prompts[0].inputId, session.busyInputs[0].inputId]));
+      assert.deepEqual(partial.consumed_delivery_ids, [session.prompts[0].inputId]);
+
+      session.emit({ type: "turn-end", turnId: `${runtime}-turn` });
+      await new Promise((resolve) => setImmediate(resolve));
+      assert.equal(session.prompts.length, 2, "partial consumption schedules another production Runtime wake");
+      assert.equal(session.prompts[1].inputId, session.busyInputs[0].inputId, "the replacement wake retains delivery identity");
+      session.emit({ type: "turn-start", turnId: `${runtime}-rewake` });
+
+      stdout = ""; stderr = "";
+      const finalPollCode = runAgentCli(["inbox", "poll", "--target", target], runtimeEnv, {
+        stateStore: store, io: { stdout: (text) => { stdout += text; }, stderr: (text) => { stderr += text; } },
+      });
+      assert.equal(finalPollCode, 0, stderr);
+      const drained = JSON.parse(stdout);
+      assert.deepEqual(drained.events.map((event) => event.message_id), [`om_${runtime}_2`]);
+      assert.equal(drained.pending_count, 0);
+      assert.equal(drained.has_more, false);
+      assert.deepEqual(drained.consumed_delivery_ids, [session.busyInputs[0].inputId]);
       guardedStdout = ""; guardedStderr = "";
       assert.equal(runLarkCli(sendArgv, runtimeEnv, guardedDependencies), 0, guardedStderr);
       assert.equal(sent.length, 1, "the provider is called once after the target is current");
@@ -269,10 +288,11 @@ for (const runtime of ["codex", "claude", "pi"]) {
       await new Promise((resolve) => setTimeout(resolve, 300));
       assert.equal(runtimeEvents.filter((event) => event.type === "delivery" && event.status === "consumed").length, 2);
 
-      session.emit({ type: "turn-end", turnId: `${runtime}-turn` });
+      session.emit({ type: "turn-end", turnId: `${runtime}-rewake` });
       await new Promise((resolve) => setImmediate(resolve));
+      assert.equal(session.prompts.length, 2, "draining the replacement turn must not create another wake");
       const status = store.readJson("status", {});
-      assert.equal(status.session.turns, 1);
+      assert.equal(status.session.turns, 2);
       assert.equal(status.lastActivity.state, "idle");
       if (runtime === "pi") {
         await hostShell.ingest(agentId, { chat_id: "oc_pi", chat_type: "p2p", sender_id: "ou_sender", message_id: "om_pi_auth",

--- a/test/integration/app/runtime-agent-interface-v2-freshness.test.mjs
+++ b/test/integration/app/runtime-agent-interface-v2-freshness.test.mjs
@@ -25,7 +25,9 @@ test("Inbox check remains content-light while poll is bounded, target-local, and
       agents: { [agentId]: { runtime: "pi", model: "default" } },
     })}\n`, { mode: 0o600 });
     fs.writeFileSync(inbox, [
-      { message_id: "om_a", chat_id: "oc_a", content: "secret-a", create_time: "100" },
+      { message_id: "om_a1", chat_id: "oc_a", content: "secret-a1", create_time: "100" },
+      { message_id: "om_a2", chat_id: "oc_a", content: "secret-a2", create_time: "101" },
+      { message_id: "om_a3", chat_id: "oc_a", content: "secret-a3", create_time: "102" },
       { message_id: "om_b", chat_id: "oc_b", content: "secret-b", create_time: "200" },
     ].map((row) => JSON.stringify(row)).join("\n") + "\n", { mode: 0o600 });
     const run = (argv) => spawnSync(process.execPath, [AGENT_CLI, ...argv], {
@@ -34,11 +36,29 @@ test("Inbox check remains content-light while poll is bounded, target-local, and
     const check = run(["inbox", "check"]);
     assert.equal(check.status, 0);
     assert.equal(check.stdout.includes("secret-"), false);
-    const poll = run(["inbox", "poll", "--target", "chat:oc_a", "--limit", "1"]);
-    assert.equal(poll.status, 0, poll.stderr);
-    const value = JSON.parse(poll.stdout);
-    assert.equal(value.delivery, "direct_ack");
-    assert.deepEqual(value.events.map((event) => event.message_id), ["om_a"]);
+    const firstPoll = run(["inbox", "poll", "--target", "chat:oc_a", "--limit", "1"]);
+    assert.equal(firstPoll.status, 0, firstPoll.stderr);
+    const first = JSON.parse(firstPoll.stdout);
+    assert.equal(first.delivery, "direct_ack");
+    assert.deepEqual(first.events.map((event) => event.message_id), ["om_a1"]);
+    assert.equal(first.pending_count, 2);
+    assert.equal(first.has_more, true);
+    assert.match(first.next_action, /Continue polling the same Inbox scope until has_more is false/);
+
+    const second = JSON.parse(run(["inbox", "poll", "--target", "chat:oc_a", "--limit", "1"]).stdout);
+    assert.deepEqual(second.events.map((event) => event.message_id), ["om_a2"]);
+    assert.equal(second.pending_count, 1);
+    assert.equal(second.has_more, true);
+
+    const third = JSON.parse(run(["inbox", "poll", "--target", "chat:oc_a", "--limit", "1"]).stdout);
+    assert.deepEqual(third.events.map((event) => event.message_id), ["om_a3"]);
+    assert.equal(third.pending_count, 0);
+    assert.equal(third.has_more, false);
+
+    const empty = JSON.parse(run(["inbox", "poll", "--target", "chat:oc_a", "--limit", "1"]).stdout);
+    assert.deepEqual(empty.events, [], "a retried poll must not replay direct-acked bodies");
+    assert.equal(empty.pending_count, 0);
+    assert.equal(empty.has_more, false);
     assert.equal(fs.readFileSync(inbox, "utf8").includes("om_b"), true);
   } finally { fs.rmSync(root, { recursive: true, force: true }); }
 });

--- a/test/unit/app/agent-cli.test.mjs
+++ b/test/unit/app/agent-cli.test.mjs
@@ -318,6 +318,9 @@ test("inbox check is repeatable and content-light while poll direct-acks a bound
     assert.equal(polled.at_most_once, true);
     assert.equal(polled.events.length, 1);
     assert.equal(polled.events[0].content, "secret body");
+    assert.equal(polled.pending_count, 1);
+    assert.equal(polled.has_more, true);
+    assert.match(polled.next_action, /Continue polling the same Inbox scope until has_more is false/);
     assert.equal(polled.seen_through_seq, 1);
     assert.deepEqual(f.store.readNdjson("inbox").map((row) => row.message_id), ["om_2", "om_other"]);
     const deliveries = f.store.readJson("runtimeDeliveries", null);
@@ -327,9 +330,26 @@ test("inbox check is repeatable and content-light while poll direct-acks a bound
     });
     assert.equal(deliveries.records[1].status, "pending");
     assert.equal(JSON.parse(f.run(["inbox", "check"]).stdout).targets.find((row) => row.target === "chat:oc_1").pending_count, 1);
-    assert.equal(JSON.parse(f.run(["inbox", "poll", "--target", "chat:oc_1"]).stdout).events[0].message_id, "om_2");
-    assert.deepEqual(JSON.parse(f.run(["inbox", "poll", "--target", "chat:oc_1"]).stdout).events, []);
+    const finalPoll = JSON.parse(f.run(["inbox", "poll", "--target", "chat:oc_1"]).stdout);
+    assert.equal(finalPoll.events[0].message_id, "om_2");
+    assert.equal(finalPoll.pending_count, 0);
+    assert.equal(finalPoll.has_more, false);
+    assert.equal("next_action" in finalPoll, false);
+    const emptyPoll = JSON.parse(f.run(["inbox", "poll", "--target", "chat:oc_1"]).stdout);
+    assert.deepEqual(emptyPoll.events, []);
+    assert.equal(emptyPoll.pending_count, 0);
+    assert.equal(emptyPoll.has_more, false);
     assert.deepEqual(f.store.readNdjson("inbox").map((row) => row.message_id), ["om_other"], "unrelated target must remain pending");
+
+    f.store.appendNdjson("inbox", { message_id: "om_other_2", chat_id: "oc_3", content: "another target" });
+    const globalPartial = JSON.parse(f.run(["inbox", "poll", "--limit", "1"]).stdout);
+    assert.deepEqual(globalPartial.events.map((row) => row.message_id), ["om_other"]);
+    assert.equal(globalPartial.pending_count, 1, "an unscoped poll counts all remaining consumable rows");
+    assert.equal(globalPartial.has_more, true);
+    const globalFinal = JSON.parse(f.run(["inbox", "poll", "--limit", "1"]).stdout);
+    assert.deepEqual(globalFinal.events.map((row) => row.message_id), ["om_other_2"]);
+    assert.equal(globalFinal.pending_count, 0);
+    assert.equal(globalFinal.has_more, false);
 
     fs.writeFileSync(f.store.paths.inbox, '{"message_id":"om_bad"}\nnot-json\n');
     const deliveryBytes = fs.readFileSync(f.store.paths.runtimeDeliveries, "utf8");

--- a/test/unit/runtime/runtime-host.test.mjs
+++ b/test/unit/runtime/runtime-host.test.mjs
@@ -244,6 +244,96 @@ test("delivery ownership, dedupe and correlation survive recreation and reach co
   } finally { fs.rmSync(root, { recursive: true, force: true }); }
 });
 
+test("turn end re-wakes only accepted canonical rows left by a partial poll, including arrivals during the turn", async () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "larkin-runtime-partial-rewake-"));
+  const agentId = "cli_partialRewakeA1";
+  const store = createAgentStateStore(root, agentId);
+  const session = new FakeSession();
+  const host = createRuntimeHost({
+    adapterFor: () => ({ id: "codex", capabilities: {}, async createSession() { return session; } }),
+    promptBuilder: new ContextPromptBuilder(),
+    stateStoreFor: () => store,
+  });
+  const config = { agentId, name: agentId, runtime: "codex", model: "g", workspaceDir: path.join(root, "agents", agentId), stateDir: store.paths.root };
+  try {
+    await host.start([config]);
+    const target = "chat:oc_partial";
+    const receipts = [];
+    for (const messageId of ["om_partial_1", "om_partial_2", "om_partial_3"]) {
+      store.appendNdjson("inbox", { message_id: messageId, target, content: messageId });
+      receipts.push(await host.deliver(agentId, { message_id: messageId, target }));
+    }
+    session.emit({ type: "turn-start", turnId: "turn-partial" });
+    const first = store.pollInbox({ target, limit: 1 });
+    assert.deepEqual(first.envelopes.map((row) => row.message_id), ["om_partial_1"]);
+    assert.equal(first.pendingCount, 2);
+
+    store.appendNdjson("inbox", { message_id: "om_partial_4", target, content: "arrived during turn" });
+    receipts.push(await host.deliver(agentId, { message_id: "om_partial_4", target }));
+    session.emit({ type: "turn-end", turnId: "turn-partial" });
+    await new Promise((resolve) => setImmediate(resolve));
+
+    assert.equal(session.prompts.length, 2, "remaining canonical rows schedule one replacement wake at the safe boundary");
+    assert.equal(session.prompts[1].inputId, receipts[1].deliveryId, "retry preserves the oldest unconsumed delivery identity");
+    assert.deepEqual(store.readNdjson("inbox").map((row) => row.message_id), ["om_partial_2", "om_partial_3", "om_partial_4"]);
+    const statusesAfterRetry = Object.fromEntries(store.readJson("runtimeDeliveries", { records: [] }).records
+      .map((record) => [record.messageId, record.status]));
+    assert.deepEqual(statusesAfterRetry, {
+      om_partial_1: "consumed",
+      om_partial_2: "accepted",
+      om_partial_3: "pending",
+      om_partial_4: "pending",
+    });
+
+    const drained = store.pollInbox({ target });
+    assert.deepEqual(drained.envelopes.map((row) => row.message_id), ["om_partial_2", "om_partial_3", "om_partial_4"]);
+    assert.equal(drained.pendingCount, 0);
+    assert.equal(drained.envelopes.some((row) => row.message_id === "om_partial_1"), false, "the direct-acked body is never replayed");
+    session.emit({ type: "turn-start", turnId: "turn-drained" });
+    session.emit({ type: "turn-end", turnId: "turn-drained" });
+    await new Promise((resolve) => setImmediate(resolve));
+    assert.equal(session.prompts.length, 2, "a fully drained target produces no replacement wake");
+    assert.equal(store.readJson("runtimeDeliveries", { records: [] }).records.every((record) => record.status === "consumed"), true);
+  } finally {
+    await host.shutdown("partial re-wake test complete");
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("turn end retries an accepted wake when the Agent never polls without advancing the Inbox cursor", async () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "larkin-runtime-no-poll-rewake-"));
+  const agentId = "cli_noPollRewakeA1";
+  const store = createAgentStateStore(root, agentId);
+  const session = new FakeSession();
+  const events = [];
+  const host = createRuntimeHost({
+    adapterFor: () => ({ id: "codex", capabilities: {}, async createSession() { return session; } }),
+    promptBuilder: new ContextPromptBuilder(),
+    stateStoreFor: () => store,
+  });
+  host.subscribe((event) => events.push(event));
+  try {
+    await host.start([{ agentId, name: agentId, runtime: "codex", model: "g", workspaceDir: path.join(root, "agents", agentId), stateDir: store.paths.root }]);
+    const target = "chat:oc_no_poll";
+    store.appendNdjson("inbox", { message_id: "om_no_poll", target, content: "still pending" });
+    const receipt = await host.deliver(agentId, { message_id: "om_no_poll", target });
+    const stateBefore = store.readJson("inboxState", {});
+    session.emit({ type: "turn-start", turnId: "turn-no-poll" });
+    session.emit({ type: "turn-end", turnId: "turn-no-poll" });
+    await new Promise((resolve) => setImmediate(resolve));
+
+    assert.equal(session.prompts.length, 2);
+    assert.equal(session.prompts[1].inputId, receipt.deliveryId);
+    assert.deepEqual(store.readNdjson("inbox").map((row) => row.message_id), ["om_no_poll"]);
+    assert.deepEqual(store.readJson("inboxState", {}), stateBefore, "re-waking alone must not advance model-seen state");
+    assert.ok(events.some((event) => event.type === "delivery" && event.deliveryId === receipt.deliveryId
+      && event.status === "deferred" && /before Inbox consumption/.test(event.reason)));
+  } finally {
+    await host.shutdown("no-poll re-wake test complete");
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});
+
 test("startup migration consumes orphan synthetic active deliveries but never guesses for real om_ messages", async () => {
   const root = fs.mkdtempSync(path.join(os.tmpdir(), "larkin-runtime-synthetic-migration-"));
   const agentId = "cli_migrateA1";


### PR DESCRIPTION
## What changed

- Return authoritative `pending_count` and truthful `has_more` from the same Inbox transaction that direct-acks a poll batch.
- Add conditional `next_action` guidance so Agents keep polling the same scope while backlog remains.
- Reconcile accepted Runtime deliveries at turn end against the canonical Inbox, transition only still-unconsumed rows back to retryable `pending`, and preserve the original delivery/input identity.
- Expand unit, integration, and production Mock E2E coverage for partial drain, no poll, arrival during a turn, no replay, and fully drained silence.
- Bump the source version from `0.2.33` to `0.2.34`.
- Add an Owner policy to `AGENTS.md`: every bugfix/feature delivery increments `package.json` before merge; default to one patch increment unless the Owner selects minor/major, do not double-bump an already-versioned delivery, and do not infer tag/Release authorization.

## Why

Runtime acceptance acknowledges the wake notification, not consumption of every referenced Inbox row. Previously a bounded poll hard-coded `has_more=false`, while turn-end reconciliation emitted a deferred event without changing accepted deliveries back to a retryable state. Remaining rows could therefore stay durable but never be re-signalled.

The version/policy update makes the repository's delivery rule explicit and keeps this bugfix's source version aligned with the installed implementation.

## Impact

Partial polls now expose exact remaining backlog and continue to wake the Agent until the canonical Inbox is drained. Returned message bodies remain direct-acked and at-most-once; already consumed rows are never replayed. Fully drained targets produce no replacement wake.

The merged source and local replacement will report `0.2.34`. This PR does not create a release tag or publish a GitHub Release.

## Validation

- Versioning tests: 4 passed, 0 failed; exact version `0.2.34`.
- Focused Inbox/Runtime/integration/Mock E2E matrix: 49 passed, 0 failed.
- Full `bun run test`: integration 167 passed + 14 intentional skips; E2E 5 passed; no failures.
- `bun run typecheck`
- `bun run build`
- `bun run licenses:check`
- `bun run publication:check:tree`
- Full history publication check passed on the implementation executor's 300-second retry (260 files, 82 refs, 7,334 objects).
- `git diff --check`
- Independent evaluator found no blocking or important issue; the updated exact-head GitHub `source-checks` remains the merge gate.

No real Feishu traffic, release/tag publication, session reset, or configuration mutation was performed.

Fixes #14