### PR TITLE
Add reliable Agent session reset

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "larkin",
-  "version": "0.2.37",
+  "version": "0.2.38",
   "private": true,
   "larkinPackageRole": "development-source-checkout",
   "packageManager": "bun@1.3.14",

--- a/src/agent/transport-business-context.ts
+++ b/src/agent/transport-business-context.ts
@@ -38,6 +38,28 @@ interface ChatMeta extends JsonObject { name: string; chat_mode: string; chat_ty
 interface FeishuReplyContext extends ReplyContext { thread_id?: string; chat_id?: string }
 interface AppInfo { name: string | null; description: string | null; avatarUrl: string | null }
 
+export function formatFeishuError(error: LarkError | null | undefined, grantLink: string | null = null): string | null {
+  if (!error) return null;
+  const parts: string[] = [];
+  if (error.message) parts.push(error.message);
+  if (error.missing_scopes?.length) parts.push(`missing_scopes: ${error.missing_scopes.join(", ")}`);
+  const tag = [error.type, error.subtype].filter(Boolean).join("/");
+  const meta = [tag, error.code != null ? `code ${error.code}` : "", error.log_id ? `log_id ${error.log_id}` : ""].filter(Boolean).join(" | ");
+  if (meta) parts.push(`(${meta})`);
+  let output = `飞书接口报错：${parts.join("　")}`;
+  const isScope = error.code !== 230027
+    && (error.subtype === "app_scope_not_applied" || error.code === 99991672 || Boolean(error.missing_scopes?.length));
+  if (error.code === 230027) {
+    output += "\n\n[系统提示] 请检查 bot/app 是否已加入目标 chat/thread（membership），并确认该目标允许当前 app 执行操作（target authorization）；这不是 OAuth scope apply 错误。";
+  }
+  if (isScope) {
+    output += grantLink
+      ? `\n\n授权链接（请 app owner 本人打开确认，约50分钟内有效，确认后即生效）：\n${grantLink}`
+      : "\n\n[系统提示] 当前没有可用的授权链接。请勿自行拼造或猜测任何 scope-apply / 开发者后台链接（那类链接对本应用无效）。只需如实说明缺少上述 scope、需有开发者后台权限者去补充；有可用链接时系统会在此处给出。";
+  }
+  return output;
+}
+
 export function createTransportBusinessContext(env: Env = process.env) {
   const { config } = larkinConfig.loadConfig(env);
   const selectedAgent = larkinConfig.selectAgent(config, env);
@@ -249,23 +271,7 @@ export function createTransportBusinessContext(env: Env = process.env) {
     } catch { return null; }
   };
   const feishuError = (result: LarkResult | null): string | null => {
-    const error = result?.error;
-    if (!error) return null;
-    const parts: string[] = [];
-    if (error.message) parts.push(error.message);
-    if (error.missing_scopes?.length) parts.push(`missing_scopes: ${error.missing_scopes.join(", ")}`);
-    const tag = [error.type, error.subtype].filter(Boolean).join("/");
-    const meta = [tag, error.code != null ? `code ${error.code}` : "", error.log_id ? `log_id ${error.log_id}` : ""].filter(Boolean).join(" | ");
-    if (meta) parts.push(`(${meta})`);
-    let output = `飞书接口报错：${parts.join("　")}`;
-    const isScope = error.subtype === "app_scope_not_applied" || error.code === 99991672 || error.code === 230027 || Boolean(error.missing_scopes?.length);
-    if (isScope) {
-      const link = liveGrantLink();
-      output += link
-        ? `\n\n授权链接（请 app owner 本人打开确认，约50分钟内有效，确认后即生效）：\n${link}`
-        : "\n\n[系统提示] 当前没有可用的授权链接。请勿自行拼造或猜测任何 scope-apply / 开发者后台链接（那类链接对本应用无效）。只需如实说明缺少上述 scope、需有开发者后台权限者去补充；有可用链接时系统会在此处给出。";
-    }
-    return output;
+    return formatFeishuError(result?.error, liveGrantLink());
   };
   const query = (requestPath: string, name: string): string | null => {
     try { return new URL(`http://x${requestPath.startsWith("/") ? requestPath : `/${requestPath}`}`).searchParams.get(name); }

--- a/src/app/binary-entry.ts
+++ b/src/app/binary-entry.ts
@@ -19,6 +19,7 @@ async function dispatchInternal(mode: InternalMode, rest: string[]): Promise<voi
     case "lark-cli": process.exitCode = await (await import("./lark-cli.js")).runLarkCliProcess(rest, process.env); return;
     case "runtime-model-directory": await (await import("./runtime-model-directory.js")).main(); return;
     case "agent-config": await import("./agent-config.js"); return;
+    case "session-cli": await (await import("./session-cli.js")).main(rest, process.env); return;
     case "lark": await import("./lark.js"); return;
     case "dashboard": await import("./dashboard.js"); return;
     case "bot-register": await (await import("../setup/bot-register.js")).main(); return;

--- a/src/app/cli.ts
+++ b/src/app/cli.ts
@@ -78,7 +78,7 @@ Examples:
   larkin config mention chat oc_x free --agent cli_x
 
 Credentials, internal paths, serverId, activeAgent, and raw config are never exposed here.`,
-  session: `Usage: larkin session reset --agent <App ID> --json [--wait-ready <seconds>] [--operation-id <id>]
+  session: `Usage: larkin session reset --agent <App ID> --json [--wait-ready <seconds>]
 Atomically replace one idle, zero-backlog Agent Runtime session through authenticated local control.`,
 };
 

--- a/src/app/cli.ts
+++ b/src/app/cli.ts
@@ -37,6 +37,7 @@ const routes: Record<string, Route> = {
   effort: ["agent-config", "effort"],
   chats: ["agent-config", "chats"],
   config: ["agent-config", "config"],
+  session: ["session-cli"],
 };
 const runtimeAgentAuthority = typeof process.env.LARKIN_AGENT_ID === "string"
   && process.env.LARKIN_AGENT_ID.trim().length > 0;
@@ -77,6 +78,8 @@ Examples:
   larkin config mention chat oc_x free --agent cli_x
 
 Credentials, internal paths, serverId, activeAgent, and raw config are never exposed here.`,
+  session: `Usage: larkin session reset --agent <App ID> --json [--wait-ready <seconds>] [--operation-id <id>]
+Atomically replace one idle, zero-backlog Agent Runtime session through authenticated local control.`,
 };
 
 if (command === "--version" || command === "-V") {
@@ -121,6 +124,7 @@ Usage: larkin <command>
   effort [<level>] Show or set the reasoning effort; use clear to restore the default
   chats            List known chats; use free/strict <oc_id> to configure mention requirements
   config           Inspect effective config/source, edit mention inheritance, or explicitly apply runtime changes
+  session reset    Replace one idle, zero-backlog Agent Runtime session for a fresh scenario
   <lark-cli 命令组>  im/docs/wiki/drive 等 lark-cli 命令原样转发，机器人身份已锁定（如 larkin im +chat-list）
 Getting started:
   First-time setup: larkin setup

--- a/src/app/internal-command.ts
+++ b/src/app/internal-command.ts
@@ -6,6 +6,7 @@ export const INTERNAL_MODES = [
   "run",
   "setup",
   "agent-config",
+  "session-cli",
   "lark",
   "runtime-process",
   "dashboard",

--- a/src/app/local-control.ts
+++ b/src/app/local-control.ts
@@ -8,16 +8,19 @@ import { readProcessState } from "../platform/process-state.js";
 import { currentProcessMetadata } from "../platform/process-inspect.cjs";
 import { processCommandToken } from "./internal-command.js";
 
-export interface AgentUpsertRequest { operationId: string; agentId: string; authorization: string; operation?: "session-reset"; waitReadyMs?: number }
+export interface AgentUpsertRequest { operationId: string; agentId: string; authorization: string }
 export type AgentUpsertOperation = Pick<AgentUpsertRequest, "operationId" | "agentId">;
-export interface AgentUpsertResponse { ok: boolean; operationId: string; agentId: string; error?: string; readiness?: RuntimeReadiness }
+export interface AgentUpsertResponse { ok: boolean; operationId: string; agentId: string; code?: string; error?: string; readiness?: RuntimeReadiness }
 export interface DashboardRecoveryResponse { ok: boolean; operationId: string; state?: string; error?: string }
 export interface SessionResetResponse {
-  ok: boolean; operationId: string; agentId: string; code?: string; error?: string;
-  resetCommitted: boolean | null; generationChanged: boolean; sessionChanged: boolean; turns: number;
+  ok: boolean; agentId: string; code?: string; error?: string;
+  resetCommitted: boolean; generationChanged: boolean; sessionChanged: boolean; turns: number;
   runtimeReady: boolean; channelConnected: boolean; reconnecting: boolean; pendingCount: number;
   readyForFreshScenario: boolean; inboundObserved: false; readiness?: RuntimeReadiness;
 }
+interface SessionResetControlRequest { operation: "session-reset"; agentId: string; authorization: string; waitReadyMs?: number }
+type AgentControlRequest = AgentUpsertRequest | SessionResetControlRequest;
+type AgentControlPayload = Omit<AgentUpsertRequest, "authorization"> | Omit<SessionResetControlRequest, "authorization">;
 
 interface ProcessBinding { pid: number; processStartToken: string }
 interface SocketBinding { device: string; inode: string; owner: string; changeTimeNs: string }
@@ -87,17 +90,42 @@ function assertSecureRoot(root: string): void {
       || (stat.mode & 0o077) !== 0) throw new Error("Larkin config root 必须由当前用户拥有且不可被其他用户访问");
 }
 
-function parseRequest(line: string): AgentUpsertRequest {
-  const value = JSON.parse(line) as Partial<AgentUpsertRequest>;
-  if (!OPERATION_ID.test(String(value.operationId || "")) || !AGENT_ID.test(String(value.agentId || ""))
-      || !AUTHORIZATION.test(String(value.authorization || ""))) {
+function removeLegacyResetLedger(larkinHome: string): void {
+  const file = path.join(path.resolve(larkinHome), "daemon-control-operations.json");
+  let stat: fs.Stats;
+  try { stat = fs.lstatSync(file); }
+  catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") return;
+    throw error;
+  }
+  if (!stat.isFile() || stat.isSymbolicLink()
+      || (typeof process.getuid === "function" && stat.uid !== process.getuid()) || (stat.mode & 0o077) !== 0) {
+    throw new Error("legacy daemon control operation ledger 不安全");
+  }
+  fs.unlinkSync(file);
+}
+
+function parseRequest(line: string): AgentControlRequest {
+  const value = JSON.parse(line) as Partial<AgentUpsertRequest & SessionResetControlRequest>;
+  if (!AGENT_ID.test(String(value.agentId || "")) || !AUTHORIZATION.test(String(value.authorization || ""))) {
+    throw new Error("invalid agent control request");
+  }
+  if (value.operation === "session-reset") {
+    if (value.waitReadyMs !== undefined && (!Number.isSafeInteger(value.waitReadyMs) || value.waitReadyMs < 0 || value.waitReadyMs > 300_000)) {
+      throw new Error("invalid session reset waitReadyMs");
+    }
+    if (Object.keys(value).some((key) => !["agentId", "authorization", "operation", "waitReadyMs"].includes(key))) {
+      throw new Error("session reset control request 包含未知字段");
+    }
+    return value as SessionResetControlRequest;
+  }
+  if (value.operation !== undefined || !OPERATION_ID.test(String(value.operationId || ""))) {
     throw new Error("invalid agent upsert request");
   }
-  if (value.operation !== undefined && value.operation !== "session-reset") throw new Error("invalid agent control operation");
-  if (value.waitReadyMs !== undefined && (!Number.isSafeInteger(value.waitReadyMs) || value.waitReadyMs < 0 || value.waitReadyMs > 300_000)) {
+  if (value.waitReadyMs !== undefined) {
     throw new Error("invalid session reset waitReadyMs");
   }
-  if (Object.keys(value).some((key) => !["operationId", "agentId", "authorization", "operation", "waitReadyMs"].includes(key))) {
+  if (Object.keys(value).some((key) => !["operationId", "agentId", "authorization"].includes(key))) {
     throw new Error("agent control request 包含未知字段");
   }
   return value as AgentUpsertRequest;
@@ -411,83 +439,29 @@ export function createAgentControlServer({
   upsert,
   resetSession,
   maxRememberedOperations = 256,
-  maxRememberedResetOperations = 256,
-  operationLedgerWrite = atomicWritePrivateJson,
 }: {
   larkinHome: string;
   authorityToken: string;
   upsert(request: AgentUpsertOperation): Promise<void>;
-  resetSession?(request: AgentUpsertOperation & { waitReadyMs: number }): Promise<SessionResetResponse>;
+  resetSession?(request: { agentId: string; waitReadyMs: number }): Promise<SessionResetResponse>;
   maxRememberedOperations?: number;
-  maxRememberedResetOperations?: number;
-  operationLedgerWrite?: (file: string, value: unknown) => void;
 }): { start(): Promise<void>; close(): Promise<void> } {
   let socket = "";
   let socketRoot = "";
   let socketIdentity: SocketBinding | null = null;
-  type ControlOperation = "upsert" | "session-reset";
-  type Remembered = { agentId: string; operation: ControlOperation; response: AgentUpsertResponse | SessionResetResponse };
-  type DurableReset = { agentId: string; operation: "session-reset"; state: "intent" | "terminal"; response?: SessionResetResponse };
-  const completed = new Map<string, Remembered>();
-  const durableResets = new Map<string, DurableReset>();
-  const inFlight = new Map<string, { agentId: string; operation: ControlOperation; response: Promise<AgentUpsertResponse | SessionResetResponse> }>();
+  const completed = new Map<string, AgentUpsertResponse>();
+  const inFlight = new Map<string, { agentId: string; response: Promise<AgentUpsertResponse> }>();
+  const resetInFlight = new Map<string, Promise<SessionResetResponse>>();
   const agentQueues = new Map<string, Promise<unknown>>();
-  const operationsFile = path.join(path.resolve(larkinHome), "daemon-control-operations.json");
-  const loadCompleted = (): void => {
-    let parsed: { version?: unknown; records?: unknown };
-    try {
-      const stat = fs.lstatSync(operationsFile);
-      if (!stat.isFile() || stat.isSymbolicLink()
-          || (typeof process.getuid === "function" && stat.uid !== process.getuid()) || (stat.mode & 0o077) !== 0) {
-        throw new Error("daemon control operation ledger 不安全");
-      }
-      parsed = JSON.parse(fs.readFileSync(operationsFile, "utf8")) as { version?: unknown; records?: unknown };
-    } catch (error) {
-      if ((error as NodeJS.ErrnoException).code === "ENOENT") return;
-      throw error;
-    }
-    if (parsed.version !== 1 || !Array.isArray(parsed.records)) throw new Error("daemon control operation ledger 无效");
-    for (const raw of parsed.records.slice(-maxRememberedResetOperations)) {
-      if (!raw || typeof raw !== "object" || Array.isArray(raw)) throw new Error("daemon control operation ledger 无效");
-      const record = raw as { operationId?: unknown; agentId?: unknown; operation?: unknown; state?: unknown; response?: unknown };
-      if (!OPERATION_ID.test(String(record.operationId || "")) || !AGENT_ID.test(String(record.agentId || ""))
-          || record.operation !== "session-reset" || !["intent", "terminal"].includes(String(record.state || ""))
-          || (record.state === "terminal" && (!record.response || typeof record.response !== "object" || Array.isArray(record.response)))) {
-        throw new Error("daemon control operation ledger 无效");
-      }
-      const operationId = String(record.operationId);
-      const durable: DurableReset = { agentId: String(record.agentId), operation: "session-reset",
-        state: record.state as "intent" | "terminal", ...(record.response ? { response: record.response as SessionResetResponse } : {}) };
-      durableResets.set(operationId, durable);
-      if (durable.state === "terminal" && durable.response) completed.set(operationId, {
-        agentId: durable.agentId, operation: "session-reset", response: durable.response,
-      });
-    }
-  };
-  const persistDurableResets = (records = durableResets): void => operationLedgerWrite(operationsFile, { version: 1,
-    records: [...records].map(([operationId, record]) => ({ operationId, ...record })) });
-  const unknownOutcome = (operationId: string, agentId: string): SessionResetResponse => ({
-    ok: false, operationId, agentId, code: "operation_outcome_unknown",
-    error: "reset intent exists without a durable terminal result; inspect current Agent readiness before choosing a new operation id",
-    resetCommitted: null, generationChanged: false, sessionChanged: false, turns: 0,
-    runtimeReady: false, channelConnected: false, reconnecting: false, pendingCount: 0,
-    readyForFreshScenario: false, inboundObserved: false,
+  const upsertConflict = (operationId: string, agentId: string): AgentUpsertResponse => ({
+    ok: false, operationId, agentId, code: "operation_conflict", error: "operationId 已绑定其他 Agent 或操作",
   });
-  const operationConflict = (operationId: string, agentId: string,
-    operation: ControlOperation): AgentUpsertResponse | SessionResetResponse => {
-    const base = { ok: false, operationId, agentId, code: "operation_conflict",
-      error: "operationId 已绑定其他 Agent 或操作" };
-    if (operation !== "session-reset") return base;
-    return { ...base, resetCommitted: false, generationChanged: false, sessionChanged: false, turns: 0,
-      runtimeReady: false, channelConnected: false, reconnecting: false, pendingCount: 0,
-      readyForFreshScenario: false, inboundObserved: false };
-  };
   let server: net.Server | null = null;
   return {
     async start(): Promise<void> {
       fs.mkdirSync(larkinHome, { recursive: true, mode: 0o700 });
       assertSecureRoot(larkinHome);
-      loadCompleted();
+      removeLegacyResetLedger(larkinHome);
       const authority = secureAuthority(larkinHome);
       if (!sameSecret(authority.token, authorityToken)) throw new Error("daemon control authorization 不匹配");
       const supervisor = readProcessState(larkinHome).supervisor;
@@ -514,128 +488,94 @@ export function createAgentControlServer({
           const line = input.slice(0, newline);
           input = "";
           void (async () => {
-            let request: AgentUpsertRequest;
+            let request: AgentControlRequest;
             try { request = parseRequest(line); }
             catch (error) {
-              connection.end(`${JSON.stringify({ ok: false, operationId: "invalid", agentId: "invalid", error: (error as Error).message })}\n`);
+              connection.end(`${JSON.stringify({ ok: false, agentId: "invalid", error: (error as Error).message })}\n`);
               return;
             }
             try {
               const live = assertLiveAuthority(larkinHome, authorityToken);
               if (!sameSecret(live.token, request.authorization)) throw new Error("unauthorized control request");
             } catch {
-              connection.end(`${JSON.stringify({ ok: false, operationId: request.operationId, agentId: request.agentId,
-                error: "unauthorized control request" })}\n`);
+              connection.end(`${JSON.stringify({ ok: false, ...("operation" in request ? {} : { operationId: request.operationId }),
+                agentId: request.agentId, error: "unauthorized control request" })}\n`);
               return;
             }
-            const requestedOperation: ControlOperation = request.operation ?? "upsert";
-            const replay = completed.get(request.operationId);
+            if ("operation" in request) {
+              const resetRequest = request;
+              let operation = resetInFlight.get(resetRequest.agentId);
+              if (!operation) {
+                const executeReset = async (): Promise<SessionResetResponse> => {
+                  try {
+                    if (!resetSession) throw new Error("session reset control unavailable");
+                    return await resetSession({ agentId: resetRequest.agentId, waitReadyMs: resetRequest.waitReadyMs ?? 30_000 });
+                  } catch (error) {
+                    const code = typeof (error as { code?: unknown }).code === "string"
+                      ? String((error as { code: string }).code)
+                      : error instanceof RuntimePrerequisiteError && error.readiness.state === "unavailable"
+                        ? "runtime_unavailable" : "reset_refused";
+                    return { ok: false, agentId: resetRequest.agentId, code,
+                      error: error instanceof Error ? error.message : String(error), resetCommitted: false,
+                      generationChanged: false, sessionChanged: false, turns: 0, runtimeReady: false,
+                      channelConnected: false, reconnecting: false,
+                      pendingCount: Number((error as { pendingCount?: unknown }).pendingCount) || 0,
+                      readyForFreshScenario: false, inboundObserved: false,
+                      ...(error instanceof RuntimePrerequisiteError ? { readiness: error.readiness } : {}) };
+                  }
+                };
+                const prior = agentQueues.get(resetRequest.agentId) ?? Promise.resolve();
+                const executing = prior.catch(() => {}).then(executeReset);
+                let queued: Promise<SessionResetResponse>;
+                queued = executing.finally(() => {
+                  if (agentQueues.get(resetRequest.agentId) === queued) agentQueues.delete(resetRequest.agentId);
+                  if (resetInFlight.get(resetRequest.agentId) === queued) resetInFlight.delete(resetRequest.agentId);
+                });
+                agentQueues.set(resetRequest.agentId, queued);
+                resetInFlight.set(resetRequest.agentId, queued);
+                operation = queued;
+              }
+              const response = await operation;
+              connection.end(`${JSON.stringify(response)}\n`);
+              return;
+            }
+            const upsertRequest = request;
+            const replay = completed.get(upsertRequest.operationId);
             if (replay) {
-              if (replay.agentId !== request.agentId || replay.operation !== requestedOperation) {
-                connection.end(`${JSON.stringify(operationConflict(request.operationId, request.agentId, requestedOperation))}\n`);
-                return;
-              }
-              connection.end(`${JSON.stringify(replay.response)}\n`);
+              connection.end(`${JSON.stringify(replay.agentId === upsertRequest.agentId
+                ? replay : upsertConflict(upsertRequest.operationId, upsertRequest.agentId))}\n`);
               return;
             }
-            const existing = inFlight.get(request.operationId);
-            if (existing && (existing.agentId !== request.agentId || existing.operation !== requestedOperation)) {
-              connection.end(`${JSON.stringify(operationConflict(request.operationId, request.agentId, requestedOperation))}\n`);
+            const existing = inFlight.get(upsertRequest.operationId);
+            if (existing && existing.agentId !== upsertRequest.agentId) {
+              connection.end(`${JSON.stringify(upsertConflict(upsertRequest.operationId, upsertRequest.agentId))}\n`);
               return;
             }
-            if (requestedOperation === "session-reset") {
-              const durable = durableResets.get(request.operationId);
-              if (durable) {
-                if (durable.agentId !== request.agentId) {
-                  connection.end(`${JSON.stringify(operationConflict(request.operationId, request.agentId, requestedOperation))}\n`);
-                  return;
-                }
-                connection.end(`${JSON.stringify(durable.state === "terminal" && durable.response
-                  ? durable.response : unknownOutcome(request.operationId, request.agentId))}\n`);
-                return;
-              }
-              const candidateResets = new Map(durableResets);
-              while (candidateResets.size >= maxRememberedResetOperations) {
-                const terminal = [...candidateResets].find(([, record]) => record.state === "terminal");
-                if (!terminal) {
-                  connection.end(`${JSON.stringify({ ...unknownOutcome(request.operationId, request.agentId),
-                    resetCommitted: false, code: "operation_ledger_full", error: "reset operation ledger is full of unresolved intents" })}\n`);
-                  return;
-                }
-                candidateResets.delete(terminal[0]);
-              }
-              candidateResets.set(request.operationId, { agentId: request.agentId, operation: "session-reset", state: "intent" });
-              try { persistDurableResets(candidateResets); }
-              catch (error) {
-                connection.end(`${JSON.stringify({ ...unknownOutcome(request.operationId, request.agentId), resetCommitted: false,
-                  code: "operation_intent_persist_failed", error: error instanceof Error ? error.message : String(error) })}\n`);
-                return;
-              }
-              for (const operationId of durableResets.keys()) {
-                if (!candidateResets.has(operationId)) completed.delete(operationId);
-              }
-              durableResets.clear();
-              for (const [operationId, record] of candidateResets) durableResets.set(operationId, record);
-            }
-            const execute = async (): Promise<AgentUpsertResponse | SessionResetResponse> => {
+            const execute = async (): Promise<AgentUpsertResponse> => {
               try {
-                if (request.operation === "session-reset") {
-                  if (!resetSession) throw new Error("session reset control unavailable");
-                  return await resetSession({ operationId: request.operationId, agentId: request.agentId, waitReadyMs: request.waitReadyMs ?? 30_000 });
-                }
-                await upsert({ operationId: request.operationId, agentId: request.agentId });
-                return { ok: true, operationId: request.operationId, agentId: request.agentId };
+                await upsert({ operationId: upsertRequest.operationId, agentId: upsertRequest.agentId });
+                return { ok: true, operationId: upsertRequest.operationId, agentId: upsertRequest.agentId };
               } catch (error) {
-                if (request.operation === "session-reset") {
-                  const code = typeof (error as { code?: unknown }).code === "string"
-                    ? String((error as { code: string }).code)
-                    : error instanceof RuntimePrerequisiteError && error.readiness.state === "unavailable"
-                      ? "runtime_unavailable" : "reset_refused";
-                  return { ok: false, operationId: request.operationId, agentId: request.agentId, code,
-                    error: error instanceof Error ? error.message : String(error), resetCommitted: false,
-                    generationChanged: false, sessionChanged: false, turns: 0, runtimeReady: false,
-                    channelConnected: false, reconnecting: false,
-                    pendingCount: Number((error as { pendingCount?: unknown }).pendingCount) || 0,
-                    readyForFreshScenario: false, inboundObserved: false,
-                    ...(error instanceof RuntimePrerequisiteError ? { readiness: error.readiness } : {}) };
-                }
-                return { ok: false, operationId: request.operationId, agentId: request.agentId,
+                return { ok: false, operationId: upsertRequest.operationId, agentId: upsertRequest.agentId,
                   error: error instanceof Error ? error.message : String(error),
                   ...(error instanceof RuntimePrerequisiteError ? { readiness: error.readiness } : {}) };
               }
             };
             let operation = existing?.response;
             if (!operation) {
-              const prior = agentQueues.get(request.agentId) ?? Promise.resolve();
+              const prior = agentQueues.get(upsertRequest.agentId) ?? Promise.resolve();
               operation = prior.catch(() => {}).then(execute);
               const queued = operation.finally(() => {
-                if (agentQueues.get(request.agentId) === queued) agentQueues.delete(request.agentId);
+                if (agentQueues.get(upsertRequest.agentId) === queued) agentQueues.delete(upsertRequest.agentId);
               });
-              agentQueues.set(request.agentId, queued);
-              inFlight.set(request.operationId, { agentId: request.agentId, operation: requestedOperation, response: operation });
+              agentQueues.set(upsertRequest.agentId, queued);
+              inFlight.set(upsertRequest.operationId, { agentId: upsertRequest.agentId, response: operation });
             }
             const response = await operation;
-            inFlight.delete(request.operationId);
-            let finalResponse = response;
-            if (requestedOperation === "session-reset") {
-              const resetResponse = response as SessionResetResponse;
-              durableResets.set(request.operationId, { agentId: request.agentId, operation: "session-reset",
-                state: "terminal", response: resetResponse });
-              try { persistDurableResets(); }
-              catch (error) {
-                durableResets.set(request.operationId, { agentId: request.agentId, operation: "session-reset", state: "intent" });
-                finalResponse = { ...resetResponse, ok: false, readyForFreshScenario: false,
-                  code: "operation_result_persist_failed",
-                  error: `reset result could not be persisted: ${error instanceof Error ? error.message : String(error)}` };
-              }
-            }
-            completed.set(request.operationId, { agentId: request.agentId, operation: requestedOperation, response: finalResponse });
-            while ([...completed.values()].filter((record) => record.operation === "upsert").length > maxRememberedOperations) {
-              const oldestUpsert = [...completed].find(([, record]) => record.operation === "upsert");
-              if (!oldestUpsert) break;
-              completed.delete(oldestUpsert[0]);
-            }
-            connection.end(`${JSON.stringify(finalResponse)}\n`);
+            inFlight.delete(upsertRequest.operationId);
+            completed.set(upsertRequest.operationId, response);
+            while (completed.size > maxRememberedOperations) completed.delete(completed.keys().next().value as string);
+            connection.end(`${JSON.stringify(response)}\n`);
           })();
         });
       });
@@ -718,16 +658,12 @@ export async function requestDashboardRecovery({
 
 async function requestAgentControl<T>({
   larkinHome,
-  agentId,
-  operationId = crypto.randomUUID(),
   timeoutMs = 30_000,
-  request = {},
+  request,
 }: {
   larkinHome: string;
-  agentId: string;
-  operationId?: string;
   timeoutMs?: number;
-  request?: Pick<AgentUpsertRequest, "operation" | "waitReadyMs">;
+  request: AgentControlPayload;
 }): Promise<T> {
   const { supervisor, daemon } = readProcessState(larkinHome);
   if (supervisor.state !== "owned") throw new Error(`supervisor control ownership=${supervisor.state}（${supervisor.reason}）`);
@@ -745,7 +681,7 @@ async function requestAgentControl<T>({
     let input = "";
     client.setEncoding("utf8");
     client.once("error", (error) => { clearTimeout(timer); reject(error); });
-    client.once("connect", () => client.write(`${JSON.stringify({ operationId, agentId, authorization: authority.token, ...request })}\n`));
+    client.once("connect", () => client.write(`${JSON.stringify({ ...request, authorization: authority.token })}\n`));
     client.on("data", (chunk) => {
       input += chunk;
       const newline = input.indexOf("\n");
@@ -764,25 +700,23 @@ export async function requestAgentUpsert(input: {
   operationId?: string;
   timeoutMs?: number;
 }): Promise<AgentUpsertResponse> {
-  return requestAgentControl<AgentUpsertResponse>(input);
+  return requestAgentControl<AgentUpsertResponse>({ larkinHome: input.larkinHome, timeoutMs: input.timeoutMs,
+    request: { operationId: input.operationId ?? crypto.randomUUID(), agentId: input.agentId } });
 }
 
 export async function requestSessionReset({
   larkinHome,
   agentId,
-  operationId = crypto.randomUUID(),
   waitReadyMs = 30_000,
 }: {
   larkinHome: string;
   agentId: string;
-  operationId?: string;
   waitReadyMs?: number;
 }): Promise<SessionResetResponse> {
-  const response = await requestAgentControl<SessionResetResponse>({
-    larkinHome, agentId, operationId, timeoutMs: Math.max(1_000, waitReadyMs + 1_000),
-    request: { operation: "session-reset", waitReadyMs },
+  return requestAgentControl<SessionResetResponse>({
+    larkinHome, timeoutMs: Math.max(1_000, waitReadyMs + 1_000),
+    request: { operation: "session-reset", agentId, waitReadyMs },
   });
-  return response;
 }
 
 export function cleanupStaleAgentControlSocket(larkinHome: string, expectedToken: string): "removed" | "absent" {

--- a/src/app/local-control.ts
+++ b/src/app/local-control.ts
@@ -8,10 +8,16 @@ import { readProcessState } from "../platform/process-state.js";
 import { currentProcessMetadata } from "../platform/process-inspect.cjs";
 import { processCommandToken } from "./internal-command.js";
 
-export interface AgentUpsertRequest { operationId: string; agentId: string; authorization: string }
+export interface AgentUpsertRequest { operationId: string; agentId: string; authorization: string; operation?: "session-reset"; waitReadyMs?: number }
 export type AgentUpsertOperation = Pick<AgentUpsertRequest, "operationId" | "agentId">;
 export interface AgentUpsertResponse { ok: boolean; operationId: string; agentId: string; error?: string; readiness?: RuntimeReadiness }
 export interface DashboardRecoveryResponse { ok: boolean; operationId: string; state?: string; error?: string }
+export interface SessionResetResponse {
+  ok: boolean; operationId: string; agentId: string; code?: string; error?: string;
+  resetCommitted: boolean | null; generationChanged: boolean; sessionChanged: boolean; turns: number;
+  runtimeReady: boolean; channelConnected: boolean; reconnecting: boolean; pendingCount: number;
+  readyForFreshScenario: boolean; inboundObserved: false; readiness?: RuntimeReadiness;
+}
 
 interface ProcessBinding { pid: number; processStartToken: string }
 interface SocketBinding { device: string; inode: string; owner: string; changeTimeNs: string }
@@ -87,8 +93,12 @@ function parseRequest(line: string): AgentUpsertRequest {
       || !AUTHORIZATION.test(String(value.authorization || ""))) {
     throw new Error("invalid agent upsert request");
   }
-  if (Object.keys(value).some((key) => !["operationId", "agentId", "authorization"].includes(key))) {
-    throw new Error("agent upsert request 只允许 operationId/agentId/authorization");
+  if (value.operation !== undefined && value.operation !== "session-reset") throw new Error("invalid agent control operation");
+  if (value.waitReadyMs !== undefined && (!Number.isSafeInteger(value.waitReadyMs) || value.waitReadyMs < 0 || value.waitReadyMs > 300_000)) {
+    throw new Error("invalid session reset waitReadyMs");
+  }
+  if (Object.keys(value).some((key) => !["operationId", "agentId", "authorization", "operation", "waitReadyMs"].includes(key))) {
+    throw new Error("agent control request 包含未知字段");
   }
   return value as AgentUpsertRequest;
 }
@@ -399,24 +409,85 @@ export function createAgentControlServer({
   larkinHome,
   authorityToken,
   upsert,
+  resetSession,
   maxRememberedOperations = 256,
+  maxRememberedResetOperations = 256,
+  operationLedgerWrite = atomicWritePrivateJson,
 }: {
   larkinHome: string;
   authorityToken: string;
   upsert(request: AgentUpsertOperation): Promise<void>;
+  resetSession?(request: AgentUpsertOperation & { waitReadyMs: number }): Promise<SessionResetResponse>;
   maxRememberedOperations?: number;
+  maxRememberedResetOperations?: number;
+  operationLedgerWrite?: (file: string, value: unknown) => void;
 }): { start(): Promise<void>; close(): Promise<void> } {
   let socket = "";
   let socketRoot = "";
   let socketIdentity: SocketBinding | null = null;
-  const completed = new Map<string, AgentUpsertResponse>();
-  const inFlight = new Map<string, { agentId: string; response: Promise<AgentUpsertResponse> }>();
+  type ControlOperation = "upsert" | "session-reset";
+  type Remembered = { agentId: string; operation: ControlOperation; response: AgentUpsertResponse | SessionResetResponse };
+  type DurableReset = { agentId: string; operation: "session-reset"; state: "intent" | "terminal"; response?: SessionResetResponse };
+  const completed = new Map<string, Remembered>();
+  const durableResets = new Map<string, DurableReset>();
+  const inFlight = new Map<string, { agentId: string; operation: ControlOperation; response: Promise<AgentUpsertResponse | SessionResetResponse> }>();
   const agentQueues = new Map<string, Promise<unknown>>();
+  const operationsFile = path.join(path.resolve(larkinHome), "daemon-control-operations.json");
+  const loadCompleted = (): void => {
+    let parsed: { version?: unknown; records?: unknown };
+    try {
+      const stat = fs.lstatSync(operationsFile);
+      if (!stat.isFile() || stat.isSymbolicLink()
+          || (typeof process.getuid === "function" && stat.uid !== process.getuid()) || (stat.mode & 0o077) !== 0) {
+        throw new Error("daemon control operation ledger 不安全");
+      }
+      parsed = JSON.parse(fs.readFileSync(operationsFile, "utf8")) as { version?: unknown; records?: unknown };
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code === "ENOENT") return;
+      throw error;
+    }
+    if (parsed.version !== 1 || !Array.isArray(parsed.records)) throw new Error("daemon control operation ledger 无效");
+    for (const raw of parsed.records.slice(-maxRememberedResetOperations)) {
+      if (!raw || typeof raw !== "object" || Array.isArray(raw)) throw new Error("daemon control operation ledger 无效");
+      const record = raw as { operationId?: unknown; agentId?: unknown; operation?: unknown; state?: unknown; response?: unknown };
+      if (!OPERATION_ID.test(String(record.operationId || "")) || !AGENT_ID.test(String(record.agentId || ""))
+          || record.operation !== "session-reset" || !["intent", "terminal"].includes(String(record.state || ""))
+          || (record.state === "terminal" && (!record.response || typeof record.response !== "object" || Array.isArray(record.response)))) {
+        throw new Error("daemon control operation ledger 无效");
+      }
+      const operationId = String(record.operationId);
+      const durable: DurableReset = { agentId: String(record.agentId), operation: "session-reset",
+        state: record.state as "intent" | "terminal", ...(record.response ? { response: record.response as SessionResetResponse } : {}) };
+      durableResets.set(operationId, durable);
+      if (durable.state === "terminal" && durable.response) completed.set(operationId, {
+        agentId: durable.agentId, operation: "session-reset", response: durable.response,
+      });
+    }
+  };
+  const persistDurableResets = (records = durableResets): void => operationLedgerWrite(operationsFile, { version: 1,
+    records: [...records].map(([operationId, record]) => ({ operationId, ...record })) });
+  const unknownOutcome = (operationId: string, agentId: string): SessionResetResponse => ({
+    ok: false, operationId, agentId, code: "operation_outcome_unknown",
+    error: "reset intent exists without a durable terminal result; inspect current Agent readiness before choosing a new operation id",
+    resetCommitted: null, generationChanged: false, sessionChanged: false, turns: 0,
+    runtimeReady: false, channelConnected: false, reconnecting: false, pendingCount: 0,
+    readyForFreshScenario: false, inboundObserved: false,
+  });
+  const operationConflict = (operationId: string, agentId: string,
+    operation: ControlOperation): AgentUpsertResponse | SessionResetResponse => {
+    const base = { ok: false, operationId, agentId, code: "operation_conflict",
+      error: "operationId 已绑定其他 Agent 或操作" };
+    if (operation !== "session-reset") return base;
+    return { ...base, resetCommitted: false, generationChanged: false, sessionChanged: false, turns: 0,
+      runtimeReady: false, channelConnected: false, reconnecting: false, pendingCount: 0,
+      readyForFreshScenario: false, inboundObserved: false };
+  };
   let server: net.Server | null = null;
   return {
     async start(): Promise<void> {
       fs.mkdirSync(larkinHome, { recursive: true, mode: 0o700 });
       assertSecureRoot(larkinHome);
+      loadCompleted();
       const authority = secureAuthority(larkinHome);
       if (!sameSecret(authority.token, authorityToken)) throw new Error("daemon control authorization 不匹配");
       const supervisor = readProcessState(larkinHome).supervisor;
@@ -457,26 +528,77 @@ export function createAgentControlServer({
                 error: "unauthorized control request" })}\n`);
               return;
             }
+            const requestedOperation: ControlOperation = request.operation ?? "upsert";
             const replay = completed.get(request.operationId);
             if (replay) {
-              if (replay.agentId !== request.agentId) {
-                connection.end(`${JSON.stringify({ ...replay, ok: false, error: "operationId 已绑定其他 Agent" })}\n`);
+              if (replay.agentId !== request.agentId || replay.operation !== requestedOperation) {
+                connection.end(`${JSON.stringify(operationConflict(request.operationId, request.agentId, requestedOperation))}\n`);
                 return;
               }
-              connection.end(`${JSON.stringify(replay)}\n`);
+              connection.end(`${JSON.stringify(replay.response)}\n`);
               return;
             }
             const existing = inFlight.get(request.operationId);
-            if (existing && existing.agentId !== request.agentId) {
-              connection.end(`${JSON.stringify({ ok: false, operationId: request.operationId, agentId: request.agentId,
-                error: "operationId 已绑定其他 Agent" })}\n`);
+            if (existing && (existing.agentId !== request.agentId || existing.operation !== requestedOperation)) {
+              connection.end(`${JSON.stringify(operationConflict(request.operationId, request.agentId, requestedOperation))}\n`);
               return;
             }
-            const execute = async (): Promise<AgentUpsertResponse> => {
+            if (requestedOperation === "session-reset") {
+              const durable = durableResets.get(request.operationId);
+              if (durable) {
+                if (durable.agentId !== request.agentId) {
+                  connection.end(`${JSON.stringify(operationConflict(request.operationId, request.agentId, requestedOperation))}\n`);
+                  return;
+                }
+                connection.end(`${JSON.stringify(durable.state === "terminal" && durable.response
+                  ? durable.response : unknownOutcome(request.operationId, request.agentId))}\n`);
+                return;
+              }
+              const candidateResets = new Map(durableResets);
+              while (candidateResets.size >= maxRememberedResetOperations) {
+                const terminal = [...candidateResets].find(([, record]) => record.state === "terminal");
+                if (!terminal) {
+                  connection.end(`${JSON.stringify({ ...unknownOutcome(request.operationId, request.agentId),
+                    resetCommitted: false, code: "operation_ledger_full", error: "reset operation ledger is full of unresolved intents" })}\n`);
+                  return;
+                }
+                candidateResets.delete(terminal[0]);
+              }
+              candidateResets.set(request.operationId, { agentId: request.agentId, operation: "session-reset", state: "intent" });
+              try { persistDurableResets(candidateResets); }
+              catch (error) {
+                connection.end(`${JSON.stringify({ ...unknownOutcome(request.operationId, request.agentId), resetCommitted: false,
+                  code: "operation_intent_persist_failed", error: error instanceof Error ? error.message : String(error) })}\n`);
+                return;
+              }
+              for (const operationId of durableResets.keys()) {
+                if (!candidateResets.has(operationId)) completed.delete(operationId);
+              }
+              durableResets.clear();
+              for (const [operationId, record] of candidateResets) durableResets.set(operationId, record);
+            }
+            const execute = async (): Promise<AgentUpsertResponse | SessionResetResponse> => {
               try {
+                if (request.operation === "session-reset") {
+                  if (!resetSession) throw new Error("session reset control unavailable");
+                  return await resetSession({ operationId: request.operationId, agentId: request.agentId, waitReadyMs: request.waitReadyMs ?? 30_000 });
+                }
                 await upsert({ operationId: request.operationId, agentId: request.agentId });
                 return { ok: true, operationId: request.operationId, agentId: request.agentId };
               } catch (error) {
+                if (request.operation === "session-reset") {
+                  const code = typeof (error as { code?: unknown }).code === "string"
+                    ? String((error as { code: string }).code)
+                    : error instanceof RuntimePrerequisiteError && error.readiness.state === "unavailable"
+                      ? "runtime_unavailable" : "reset_refused";
+                  return { ok: false, operationId: request.operationId, agentId: request.agentId, code,
+                    error: error instanceof Error ? error.message : String(error), resetCommitted: false,
+                    generationChanged: false, sessionChanged: false, turns: 0, runtimeReady: false,
+                    channelConnected: false, reconnecting: false,
+                    pendingCount: Number((error as { pendingCount?: unknown }).pendingCount) || 0,
+                    readyForFreshScenario: false, inboundObserved: false,
+                    ...(error instanceof RuntimePrerequisiteError ? { readiness: error.readiness } : {}) };
+                }
                 return { ok: false, operationId: request.operationId, agentId: request.agentId,
                   error: error instanceof Error ? error.message : String(error),
                   ...(error instanceof RuntimePrerequisiteError ? { readiness: error.readiness } : {}) };
@@ -490,13 +612,30 @@ export function createAgentControlServer({
                 if (agentQueues.get(request.agentId) === queued) agentQueues.delete(request.agentId);
               });
               agentQueues.set(request.agentId, queued);
-              inFlight.set(request.operationId, { agentId: request.agentId, response: operation });
+              inFlight.set(request.operationId, { agentId: request.agentId, operation: requestedOperation, response: operation });
             }
             const response = await operation;
             inFlight.delete(request.operationId);
-            completed.set(request.operationId, response);
-            while (completed.size > maxRememberedOperations) completed.delete(completed.keys().next().value as string);
-            connection.end(`${JSON.stringify(response)}\n`);
+            let finalResponse = response;
+            if (requestedOperation === "session-reset") {
+              const resetResponse = response as SessionResetResponse;
+              durableResets.set(request.operationId, { agentId: request.agentId, operation: "session-reset",
+                state: "terminal", response: resetResponse });
+              try { persistDurableResets(); }
+              catch (error) {
+                durableResets.set(request.operationId, { agentId: request.agentId, operation: "session-reset", state: "intent" });
+                finalResponse = { ...resetResponse, ok: false, readyForFreshScenario: false,
+                  code: "operation_result_persist_failed",
+                  error: `reset result could not be persisted: ${error instanceof Error ? error.message : String(error)}` };
+              }
+            }
+            completed.set(request.operationId, { agentId: request.agentId, operation: requestedOperation, response: finalResponse });
+            while ([...completed.values()].filter((record) => record.operation === "upsert").length > maxRememberedOperations) {
+              const oldestUpsert = [...completed].find(([, record]) => record.operation === "upsert");
+              if (!oldestUpsert) break;
+              completed.delete(oldestUpsert[0]);
+            }
+            connection.end(`${JSON.stringify(finalResponse)}\n`);
           })();
         });
       });
@@ -577,17 +716,19 @@ export async function requestDashboardRecovery({
   throw lastError instanceof Error ? lastError : new Error("supervisor control unavailable");
 }
 
-export async function requestAgentUpsert({
+async function requestAgentControl<T>({
   larkinHome,
   agentId,
   operationId = crypto.randomUUID(),
   timeoutMs = 30_000,
+  request = {},
 }: {
   larkinHome: string;
   agentId: string;
   operationId?: string;
   timeoutMs?: number;
-}): Promise<AgentUpsertResponse> {
+  request?: Pick<AgentUpsertRequest, "operation" | "waitReadyMs">;
+}): Promise<T> {
   const { supervisor, daemon } = readProcessState(larkinHome);
   if (supervisor.state !== "owned") throw new Error(`supervisor control ownership=${supervisor.state}（${supervisor.reason}）`);
   if (daemon.state !== "owned") throw new Error(`daemon control ownership=${daemon.state}（${daemon.reason}）`);
@@ -598,23 +739,50 @@ export async function requestAgentUpsert({
   if (!stat.isSocket() || stat.isSymbolicLink()
       || (typeof process.getuid === "function" && stat.uid !== process.getuid())
       || (stat.mode & 0o077) !== 0) throw new Error("daemon control socket 不安全");
-  return await new Promise<AgentUpsertResponse>((resolve, reject) => {
+  return await new Promise<T>((resolve, reject) => {
     const client = net.createConnection(socket);
-    const timer = setTimeout(() => { client.destroy(); reject(new Error("agent upsert control timeout")); }, timeoutMs);
+    const timer = setTimeout(() => { client.destroy(); reject(new Error("agent control timeout")); }, timeoutMs);
     let input = "";
     client.setEncoding("utf8");
     client.once("error", (error) => { clearTimeout(timer); reject(error); });
-    client.once("connect", () => client.write(`${JSON.stringify({ operationId, agentId, authorization: authority.token })}\n`));
+    client.once("connect", () => client.write(`${JSON.stringify({ operationId, agentId, authorization: authority.token, ...request })}\n`));
     client.on("data", (chunk) => {
       input += chunk;
       const newline = input.indexOf("\n");
       if (newline < 0) return;
       clearTimeout(timer);
       client.end();
-      try { resolve(JSON.parse(input.slice(0, newline)) as AgentUpsertResponse); }
+      try { resolve(JSON.parse(input.slice(0, newline)) as T); }
       catch (error) { reject(error); }
     });
   });
+}
+
+export async function requestAgentUpsert(input: {
+  larkinHome: string;
+  agentId: string;
+  operationId?: string;
+  timeoutMs?: number;
+}): Promise<AgentUpsertResponse> {
+  return requestAgentControl<AgentUpsertResponse>(input);
+}
+
+export async function requestSessionReset({
+  larkinHome,
+  agentId,
+  operationId = crypto.randomUUID(),
+  waitReadyMs = 30_000,
+}: {
+  larkinHome: string;
+  agentId: string;
+  operationId?: string;
+  waitReadyMs?: number;
+}): Promise<SessionResetResponse> {
+  const response = await requestAgentControl<SessionResetResponse>({
+    larkinHome, agentId, operationId, timeoutMs: Math.max(1_000, waitReadyMs + 1_000),
+    request: { operation: "session-reset", waitReadyMs },
+  });
+  return response;
 }
 
 export function cleanupStaleAgentControlSocket(larkinHome: string, expectedToken: string): "removed" | "absent" {

--- a/src/app/runtime-process.ts
+++ b/src/app/runtime-process.ts
@@ -91,6 +91,11 @@ export async function main(env: NodeJS.ProcessEnv = process.env, overrides: {
       // are never quarantined or rebuilt during hot attach.
       await hostShell.upsertAgent(agent);
     },
+    async resetSession(request) {
+      const result = await hostShell.resetSession(request.agentId, request.waitReadyMs);
+      return { ok: result.readyForFreshScenario, operationId: request.operationId, agentId: request.agentId,
+        ...result };
+    },
   });
   await controlServer.start();
   await markConfigAppliedAfterRuntimeReady(env, hostShell.agents, hostShell.start());

--- a/src/app/runtime-process.ts
+++ b/src/app/runtime-process.ts
@@ -93,8 +93,7 @@ export async function main(env: NodeJS.ProcessEnv = process.env, overrides: {
     },
     async resetSession(request) {
       const result = await hostShell.resetSession(request.agentId, request.waitReadyMs);
-      return { ok: result.readyForFreshScenario, operationId: request.operationId, agentId: request.agentId,
-        ...result };
+      return { ok: result.readyForFreshScenario, agentId: request.agentId, ...result };
     },
   });
   await controlServer.start();

--- a/src/app/session-cli.ts
+++ b/src/app/session-cli.ts
@@ -1,0 +1,90 @@
+import crypto from "node:crypto";
+import { loadConfig } from "../platform/config.js";
+import { requestSessionReset, type SessionResetResponse } from "./local-control.js";
+
+interface SessionCliIo { stdout(value: string): void; stderr(value: string): void }
+
+interface ResetArguments { agentId: string; waitReadyMs: number; operationId?: string }
+
+function parseResetArguments(args: readonly string[]): ResetArguments {
+  if (args[0] !== "reset") throw new Error("unsupported session subcommand");
+  const values = new Map<string, string>();
+  let json = false;
+  for (let index = 1; index < args.length; index += 1) {
+    const token = args[index];
+    if (token === "--json") {
+      if (json) throw new Error("duplicate flag: --json");
+      json = true;
+      continue;
+    }
+    if (!["--agent", "--wait-ready", "--operation-id"].includes(token)) {
+      throw new Error(token.startsWith("-") ? `unknown flag: ${token}` : `unexpected positional: ${token}`);
+    }
+    if (values.has(token)) throw new Error(`duplicate flag: ${token}`);
+    const value = args[index + 1];
+    if (!value || value.startsWith("-")) throw new Error(`missing value: ${token}`);
+    values.set(token, value);
+    index += 1;
+  }
+  if (!json) throw new Error("--json is required");
+  const agentId = values.get("--agent");
+  if (!agentId || !/^cli_[A-Za-z0-9]+$/.test(agentId)) throw new Error("--agent requires an exact App ID");
+  const waitSeconds = Number(values.get("--wait-ready") ?? "30");
+  if (!Number.isFinite(waitSeconds) || waitSeconds < 0 || waitSeconds > 300) throw new Error("--wait-ready must be 0..300 seconds");
+  const operationId = values.get("--operation-id");
+  if (operationId && !/^[A-Za-z0-9_-]{8,128}$/.test(operationId)) throw new Error("--operation-id has an invalid format");
+  return { agentId, waitReadyMs: Math.round(waitSeconds * 1000), ...(operationId ? { operationId } : {}) };
+}
+
+export async function runSessionCli(
+  args: readonly string[],
+  env: NodeJS.ProcessEnv = process.env,
+  dependencies: {
+    request?: typeof requestSessionReset;
+    io?: SessionCliIo;
+    operationId?: () => string;
+  } = {},
+): Promise<number> {
+  const io = dependencies.io ?? { stdout: (value) => process.stdout.write(value), stderr: (value) => process.stderr.write(value) };
+  const fail = (code: string, message: string, operationId = "invalid", agentId = "invalid"): number => {
+    io.stdout(`${JSON.stringify({ ok: false, operation_id: operationId, agent_id: agentId, code, error: message }, null, 2)}\n`);
+    return 1;
+  };
+  let parsed: ResetArguments;
+  try { parsed = parseResetArguments(args); }
+  catch (error) { return fail("invalid_arguments", error instanceof Error ? error.message : String(error)); }
+  const operationId = parsed.operationId ?? (dependencies.operationId ?? crypto.randomUUID)();
+  const agentId = parsed.agentId;
+  if (typeof env.LARKIN_AGENT_ID === "string" && env.LARKIN_AGENT_ID.trim()) {
+    return fail("user_authority_required", "session reset is available only from a user terminal", operationId, agentId);
+  }
+  try {
+    const loaded = loadConfig(env);
+    const result = await (dependencies.request ?? requestSessionReset)({
+      larkinHome: loaded.config.larkinHome, agentId, operationId, waitReadyMs: parsed.waitReadyMs,
+    });
+    const output = {
+      ok: result.ok, operation_id: result.operationId, agent_id: result.agentId,
+      reset_committed: result.resetCommitted, generation_changed: result.generationChanged,
+      session_changed: result.sessionChanged, turns: result.turns, runtime_ready: result.runtimeReady,
+      channel_connected: result.channelConnected, reconnecting: result.reconnecting,
+      pending_count: result.pendingCount, ready_for_fresh_scenario: result.readyForFreshScenario,
+      inbound_observed: result.inboundObserved, ...(result.code ? { code: result.code } : {}),
+      ...(result.error ? { error: result.error } : {}), ...(result.readiness ? { readiness: result.readiness } : {}),
+    };
+    io.stdout(`${JSON.stringify(output, null, 2)}\n`);
+    return result.ok ? 0 : 1;
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    const output: Pick<SessionResetResponse, "ok"> & { operation_id: string; agent_id: string; code: string; error: string } = {
+      ok: false, operation_id: operationId, agent_id: agentId,
+      code: /timeout/i.test(message) ? "control_timeout" : "control_unavailable", error: message,
+    };
+    io.stdout(`${JSON.stringify(output, null, 2)}\n`);
+    return 1;
+  }
+}
+
+export async function main(args = process.argv.slice(2), env = process.env): Promise<void> {
+  process.exitCode = await runSessionCli(args, env);
+}

--- a/src/app/session-cli.ts
+++ b/src/app/session-cli.ts
@@ -1,10 +1,9 @@
-import crypto from "node:crypto";
 import { loadConfig } from "../platform/config.js";
 import { requestSessionReset, type SessionResetResponse } from "./local-control.js";
 
 interface SessionCliIo { stdout(value: string): void; stderr(value: string): void }
 
-interface ResetArguments { agentId: string; waitReadyMs: number; operationId?: string }
+interface ResetArguments { agentId: string; waitReadyMs: number }
 
 function parseResetArguments(args: readonly string[]): ResetArguments {
   if (args[0] !== "reset") throw new Error("unsupported session subcommand");
@@ -17,7 +16,7 @@ function parseResetArguments(args: readonly string[]): ResetArguments {
       json = true;
       continue;
     }
-    if (!["--agent", "--wait-ready", "--operation-id"].includes(token)) {
+    if (!["--agent", "--wait-ready"].includes(token)) {
       throw new Error(token.startsWith("-") ? `unknown flag: ${token}` : `unexpected positional: ${token}`);
     }
     if (values.has(token)) throw new Error(`duplicate flag: ${token}`);
@@ -31,9 +30,7 @@ function parseResetArguments(args: readonly string[]): ResetArguments {
   if (!agentId || !/^cli_[A-Za-z0-9]+$/.test(agentId)) throw new Error("--agent requires an exact App ID");
   const waitSeconds = Number(values.get("--wait-ready") ?? "30");
   if (!Number.isFinite(waitSeconds) || waitSeconds < 0 || waitSeconds > 300) throw new Error("--wait-ready must be 0..300 seconds");
-  const operationId = values.get("--operation-id");
-  if (operationId && !/^[A-Za-z0-9_-]{8,128}$/.test(operationId)) throw new Error("--operation-id has an invalid format");
-  return { agentId, waitReadyMs: Math.round(waitSeconds * 1000), ...(operationId ? { operationId } : {}) };
+  return { agentId, waitReadyMs: Math.round(waitSeconds * 1000) };
 }
 
 export async function runSessionCli(
@@ -42,29 +39,27 @@ export async function runSessionCli(
   dependencies: {
     request?: typeof requestSessionReset;
     io?: SessionCliIo;
-    operationId?: () => string;
   } = {},
 ): Promise<number> {
   const io = dependencies.io ?? { stdout: (value) => process.stdout.write(value), stderr: (value) => process.stderr.write(value) };
-  const fail = (code: string, message: string, operationId = "invalid", agentId = "invalid"): number => {
-    io.stdout(`${JSON.stringify({ ok: false, operation_id: operationId, agent_id: agentId, code, error: message }, null, 2)}\n`);
+  const fail = (code: string, message: string, agentId = "invalid"): number => {
+    io.stdout(`${JSON.stringify({ ok: false, agent_id: agentId, code, error: message }, null, 2)}\n`);
     return 1;
   };
   let parsed: ResetArguments;
   try { parsed = parseResetArguments(args); }
   catch (error) { return fail("invalid_arguments", error instanceof Error ? error.message : String(error)); }
-  const operationId = parsed.operationId ?? (dependencies.operationId ?? crypto.randomUUID)();
   const agentId = parsed.agentId;
   if (typeof env.LARKIN_AGENT_ID === "string" && env.LARKIN_AGENT_ID.trim()) {
-    return fail("user_authority_required", "session reset is available only from a user terminal", operationId, agentId);
+    return fail("user_authority_required", "session reset is available only from a user terminal", agentId);
   }
   try {
     const loaded = loadConfig(env);
     const result = await (dependencies.request ?? requestSessionReset)({
-      larkinHome: loaded.config.larkinHome, agentId, operationId, waitReadyMs: parsed.waitReadyMs,
+      larkinHome: loaded.config.larkinHome, agentId, waitReadyMs: parsed.waitReadyMs,
     });
     const output = {
-      ok: result.ok, operation_id: result.operationId, agent_id: result.agentId,
+      ok: result.ok, agent_id: result.agentId,
       reset_committed: result.resetCommitted, generation_changed: result.generationChanged,
       session_changed: result.sessionChanged, turns: result.turns, runtime_ready: result.runtimeReady,
       channel_connected: result.channelConnected, reconnecting: result.reconnecting,
@@ -76,8 +71,8 @@ export async function runSessionCli(
     return result.ok ? 0 : 1;
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);
-    const output: Pick<SessionResetResponse, "ok"> & { operation_id: string; agent_id: string; code: string; error: string } = {
-      ok: false, operation_id: operationId, agent_id: agentId,
+    const output: Pick<SessionResetResponse, "ok"> & { agent_id: string; code: string; error: string } = {
+      ok: false, agent_id: agentId,
       code: /timeout/i.test(message) ? "control_timeout" : "control_unavailable", error: message,
     };
     io.stdout(`${JSON.stringify(output, null, 2)}\n`);

--- a/src/feishu/host-processing-eye.ts
+++ b/src/feishu/host-processing-eye.ts
@@ -67,7 +67,8 @@ export class ProcessingEyeOrchestrator {
         const detail = (killed ? "超时(10s)被杀" : `exit=${code ?? "?"}`) + (head ? ` | ${head}` : "");
         const endpoint = apiPath.split("/").slice(-2).join("/");
         this.log(`larkApi ${method} ${endpoint} 失败 agent=${agent.name}: ${detail}`);
-        this.recordError(agent, `larkApi ${method} ${endpoint}: ${detail}`);
+        const processingReaction = /\/reactions(?:\/[^/]+)?$/.test(apiPath);
+        if (!processingReaction) this.recordError(agent, `larkApi ${method} ${endpoint}: ${detail}`);
       }
       callback?.(error, result);
     });

--- a/src/feishu/host-shell.ts
+++ b/src/feishu/host-shell.ts
@@ -77,6 +77,12 @@ export interface HostShell {
   resumeSession(agent: ConfiguredAgent, runtime: string): string | null;
   ingest(agentId: string, event: FeishuInboundEvent, options?: { wake?: boolean }): Promise<void>;
   upsertAgent(agent: ConfiguredAgent): Promise<"added" | "updated" | "unchanged">;
+  resetSession(agentId: string, waitReadyMs?: number): Promise<{
+    resetCommitted: boolean; generationChanged: boolean; sessionChanged: boolean; turns: number;
+    runtimeReady: boolean; channelConnected: boolean; reconnecting: boolean; pendingCount: number;
+    readyForFreshScenario: boolean; inboundObserved: false;
+    code?: string; error?: string;
+  }>;
   start(): Promise<void>;
   shutdown(reason?: string): Promise<void>;
 }
@@ -173,6 +179,7 @@ export function createHostShell({
   execFileImpl = execFile,
   managedCliForAgent = (agent: ConfiguredAgent) => managedOfficialLarkCli(agent, env),
   reconcileAgentWorkspaceImpl = reconcileAgentWorkspace,
+  stateStoreForImpl = createAgentStateStore,
   logImpl = (...parts: unknown[]): void => { process.stderr.write(`[host] ${parts.join(" ")}\n`); },
   onOrderedShutdownComplete,
 }: {
@@ -184,6 +191,7 @@ export function createHostShell({
   execFileImpl?: typeof execFile;
   managedCliForAgent?: (agent: ConfiguredAgent) => ReturnType<typeof managedOfficialLarkCli>;
   reconcileAgentWorkspaceImpl?: typeof reconcileAgentWorkspace;
+  stateStoreForImpl?: typeof createAgentStateStore;
   logImpl?: (...parts: unknown[]) => void;
   onOrderedShutdownComplete?: (exitCode: number) => void;
 }): HostShell {
@@ -209,7 +217,7 @@ export function createHostShell({
     if (!agent) throw new Error(`未知 Agent state store: ${subject.agentId}`);
     let store = stores.get(agent.agentId);
     if (!store) {
-      store = createAgentStateStore(larkinHome, agent.agentId);
+      store = stateStoreForImpl(larkinHome, agent.agentId);
       if (path.resolve(store.paths.root) !== path.resolve(agent.stateDir)) throw new Error(`Agent ${agent.agentId} state store 路径不一致`);
       stores.set(agent.agentId, store);
     }
@@ -935,7 +943,7 @@ export function createHostShell({
     resumeSession(agent, runtime): string | null { return agentStates.get(agent.agentId)?.state.sessions[runtime] || null; },
     async ingest(agentId, event, options): Promise<void> {
       const agent = agents.find((candidate) => candidate.agentId === agentId);
-      if (!agent) throw new Error(`未知 Agent: ${agentId}`);
+      if (!agent) throw Object.assign(new Error(`未知 Agent: ${agentId}`), { code: "unknown_agent" });
       await onFeishuMessage(agent, event, options);
     },
     async upsertAgent(candidate): Promise<"added" | "updated" | "unchanged"> {
@@ -943,6 +951,76 @@ export function createHostShell({
       if (!hotUpsert) throw new Error("Agent control plane 尚未就绪");
       if (runtimeHost.isBusy?.(validated.agentId)) throw new Error(`Agent ${validated.agentId} 正在执行 turn，拒绝中断；请在 idle 后重试`);
       return hotUpsert(validated);
+    },
+    async resetSession(agentId, waitReadyMs = 30_000): Promise<{
+      resetCommitted: boolean; generationChanged: boolean; sessionChanged: boolean; turns: number;
+      runtimeReady: boolean; channelConnected: boolean; reconnecting: boolean; pendingCount: number;
+      readyForFreshScenario: boolean; inboundObserved: false;
+      code?: string; error?: string;
+    }> {
+      const agent = agents.find((candidate) => candidate.agentId === agentId);
+      if (!agent) throw Object.assign(new Error(`未知 Agent: ${agentId}`), { code: "unknown_agent" });
+      if (!runtimeHost.resetSession) throw Object.assign(new Error("Runtime session reset 尚未就绪"), { code: "runtime_unavailable" });
+      const connectionState = (): { channelConnected: boolean; reconnecting: boolean } => {
+        const status = hostState.readStatus(agent);
+        const connectedAt = Date.parse(String(status.connectedAt || ""));
+        const channelConnected = Number.isFinite(connectedAt) && connectedAt >= Date.parse(daemonStartedAt) - 1000;
+        const reconnectingAt = Date.parse(String(status.reconnectingAt || ""));
+        const reconnectedAt = Date.parse(String(status.reconnectedAt || ""));
+        const reconnecting = Number.isFinite(reconnectingAt) && (!Number.isFinite(reconnectedAt) || reconnectingAt > reconnectedAt);
+        return { channelConnected, reconnecting };
+      };
+      const readinessProjection = (): { turns: number; runtimeReady: boolean; channelConnected: boolean; reconnecting: boolean; pendingCount: number } => {
+        const status = hostState.readStatus(agent);
+        const turns = status.session && typeof status.session === "object"
+          ? Math.max(0, Number((status.session as { turns?: unknown }).turns) || 0) : 0;
+        const runtimeReady = Boolean(status.runtimeReadiness && typeof status.runtimeReadiness === "object"
+          && (status.runtimeReadiness as { state?: unknown }).state === "ready");
+        const pendingCount = stateStore(agent).withInboxTransaction(() => stateStore(agent).readNdjson("inbox").length);
+        return { turns, runtimeReady, ...connectionState(), pendingCount };
+      };
+      const initialConnection = connectionState();
+      const { channelConnected, reconnecting } = initialConnection;
+      if (!channelConnected) throw Object.assign(new Error(`Agent ${agentId} channel is not connected`), { code: "channel_unavailable" });
+      if (reconnecting) throw Object.assign(new Error(`Agent ${agentId} channel is reconnecting`), { code: "channel_reconnecting" });
+      const reset = await runtimeHost.resetSession(agentId);
+      const record = agentStates.get(agentId);
+      try {
+        if (record) {
+          if (reset.sessionId) record.state.sessions[agent.runtime] = reset.sessionId;
+          else delete record.state.sessions[agent.runtime];
+          record.store.writeJson("agentState", record.state);
+        }
+        if (!reset.sessionId) hostState.updateStatus(agent, {
+          session: { runtime: agent.runtime, id: null, launchId: null, startedAt: new Date().toISOString(),
+            lastSeenAt: null, lastTurnAt: null, turns: 0 }, runtimeReadiness: { runtime: agent.runtime, state: "ready" },
+        });
+      } catch (error) {
+        const projection = readinessProjection();
+        return { resetCommitted: true, generationChanged: reset.generationChanged, sessionChanged: reset.sessionChanged,
+          ...projection,
+          readyForFreshScenario: false, inboundObserved: false, code: "state_persistence_failed",
+          error: error instanceof Error ? error.message : String(error) };
+      }
+      const deadline = Date.now() + Math.max(0, waitReadyMs);
+      let projection = readinessProjection();
+      do {
+        projection = readinessProjection();
+        if (projection.turns === 0 && projection.runtimeReady && projection.channelConnected && !projection.reconnecting && projection.pendingCount === 0) {
+          return { resetCommitted: true, generationChanged: reset.generationChanged, sessionChanged: reset.sessionChanged,
+            ...projection, readyForFreshScenario: true, inboundObserved: false };
+        }
+        if (Date.now() >= deadline) break;
+        await new Promise<void>((resolve) => setTimeout(resolve, Math.min(25, Math.max(1, deadline - Date.now()))));
+      } while (true);
+      const unavailable = !projection.runtimeReady || !projection.channelConnected;
+      const contaminated = projection.turns > 0 || projection.pendingCount > 0;
+      return { resetCommitted: true, generationChanged: reset.generationChanged, sessionChanged: reset.sessionChanged,
+        ...projection, readyForFreshScenario: false, inboundObserved: false,
+        code: contaminated ? "fresh_scenario_contaminated" : unavailable ? "runtime_unavailable" : "reset_timeout",
+        error: contaminated ? "reset committed but the fresh scenario was contaminated by a turn or Inbox arrival"
+          : unavailable ? "reset committed but Runtime/channel readiness is unavailable"
+            : "reset committed but readiness did not converge before timeout" };
     },
     async start(): Promise<void> {
       try {

--- a/src/runtime/runtime-host.ts
+++ b/src/runtime/runtime-host.ts
@@ -7,6 +7,7 @@ import type {
   NormalizedRuntimeEvent, RuntimeAdapter, RuntimeInput, RuntimeInputResult, RuntimeSession,
 } from "./runtime-contracts.js";
 import {
+  classifyRuntimePrerequisite,
   providerAuthenticationFailureReadiness,
   RuntimePrerequisiteError,
   type RuntimeReadiness,
@@ -70,6 +71,23 @@ export interface RuntimeHost {
   shutdown(reason: string): Promise<void>;
   subscribe(listener: (event: RuntimeHostEvent) => void): () => void;
   isBusy?(agentId: string): boolean;
+  resetSession?(agentId: string): Promise<RuntimeSessionResetResult>;
+}
+
+export interface RuntimeSessionResetResult {
+  generationChanged: boolean;
+  sessionChanged: boolean;
+  turns: 0;
+  runtimeReady: true;
+  pendingCount: 0;
+  sessionId: string | null;
+}
+
+export class RuntimeSessionResetError extends Error {
+  constructor(readonly code: "unknown_agent" | "agent_busy" | "inbox_backlog", message: string, readonly pendingCount = 0) {
+    super(message);
+    this.name = "RuntimeSessionResetError";
+  }
 }
 
 export interface StagedRuntimeCandidate {
@@ -401,7 +419,17 @@ export function createRuntimeHost(options: {
       if (agent.stopped) return;
       void ensureSession(agent).then(() => {
         return retryPending(agent);
-      }).catch((error) => scheduleRecreate(agent, error instanceof Error ? error.message : String(error)));
+      }).catch((error) => {
+        const readiness = error instanceof RuntimePrerequisiteError ? error.readiness
+          : classifyRuntimePrerequisite(agent.adapter.id as RuntimeReadiness["runtime"], error);
+        agent.readiness = readiness;
+        const nextReason = error instanceof Error ? error.message : String(error);
+        if (readiness.state === "unavailable") scheduleRecreate(agent, nextReason);
+        else {
+          agent.disabledReason = nextReason;
+          emit({ type: "agent-status", agentId: agent.config.agentId, status: "error", error: nextReason, readiness });
+        }
+      });
     }, delay);
     agent.retryTimer.unref?.();
   };
@@ -669,8 +697,80 @@ export function createRuntimeHost(options: {
       };
     },
     isBusy(agentId): boolean { const agent = managed.get(agentId); return Boolean(agent?.busy || agent?.submitting || agent?.starting); },
+    async resetSession(agentId): Promise<RuntimeSessionResetResult> {
+      const agent = managed.get(agentId);
+      if (!agent || agent.stopped) throw new RuntimeSessionResetError("unknown_agent", `unknown runtime Agent: ${agentId}`);
+      if (agent.busy || agent.turnInProgress || agent.submitting || agent.starting) {
+        throw new RuntimeSessionResetError("agent_busy", `Agent ${agentId} is not idle`);
+      }
+      const countPending = (): number => agent.stateStore
+        ? agent.stateStore.withInboxTransaction(() => agent.stateStore!.readNdjson?.<Record<string, unknown>>("inbox").length ?? 0)
+        : [...agent.records.values()].filter((record) => isActiveDelivery(record.status)).length;
+      const pendingCount = countPending();
+      if (pendingCount > 0) throw new RuntimeSessionResetError("inbox_backlog", `Agent ${agentId} has unconsumed Inbox backlog`, pendingCount);
+      const oldSession = agent.session;
+      if (!oldSession) throw new RuntimeSessionResetError("agent_busy", `Agent ${agentId} Runtime session is unavailable`);
+      const oldSessionId = oldSession.sessionId;
+      const probeEnv = runtimeEnv(agent.config, `${agent.launchId}:reset`);
+      await assertOfficialCliReady(agent.config, probeEnv);
+      const readiness = agent.adapter.probe ? await agent.adapter.probe({ workspaceDir: agent.config.workspaceDir,
+        env: { LARKIN_PI_COMMAND: process.env.LARKIN_PI_COMMAND, LARKIN_CODEX_COMMAND: process.env.LARKIN_CODEX_COMMAND,
+          LARKIN_CLAUDE_COMMAND: process.env.LARKIN_CLAUDE_COMMAND, ...probeEnv } })
+        : { runtime: agent.adapter.id, state: "ready" as const };
+      if (readiness.state !== "ready") throw new RuntimePrerequisiteError(readiness);
+      const standingPrompt = options.promptBuilder.build({
+        agentId: agent.config.agentId, name: agent.config.displayName || agent.config.name,
+        description: agent.config.description || "", runtime: agent.adapter.id,
+        cli: agentCliPromptCapabilities("larkin"),
+      });
+      const create = agent.adapter.createSession({
+        agentId: agent.config.agentId, model: agent.config.model, reasoningEffort: agent.config.effort || null,
+        workspaceDir: agent.config.workspaceDir, stateDir: agent.config.stateDir,
+        resumeSessionId: null, standingPrompt, env: probeEnv,
+      });
+      agent.starting = create;
+      let fresh: RuntimeSession;
+      try { fresh = await create; }
+      finally { if (agent.starting === create) agent.starting = null; }
+      const commit = (): void => {
+        if (agent.session !== oldSession || agent.busy || agent.turnInProgress || agent.submitting || agent.stopped) {
+          throw new RuntimeSessionResetError("agent_busy", `Agent ${agentId} changed during reset`);
+        }
+        const pendingAfterCreate = agent.stateStore?.readNdjson?.<Record<string, unknown>>("inbox").length
+          ?? [...agent.records.values()].filter((record) => isActiveDelivery(record.status)).length;
+        if (pendingAfterCreate > 0) {
+          throw new RuntimeSessionResetError("inbox_backlog", `Agent ${agentId} received Inbox backlog during reset`, pendingAfterCreate);
+        }
+        agent.generation += 1;
+        agent.launchId = crypto.randomUUID();
+        agent.config.sessionId = null;
+        agent.session = fresh;
+        agent.readiness = readiness;
+        agent.disabledReason = null;
+      };
+      try {
+        if (agent.stateStore) agent.stateStore.withInboxTransaction(commit);
+        else commit();
+      } catch (error) {
+        await fresh.close("fresh session reset precondition changed");
+        throw error;
+      }
+      fresh.subscribe((event) => observe(agent, fresh, event));
+      if (fresh.sessionId) {
+        agent.config.sessionId = fresh.sessionId;
+        emit({ type: "session", agentId, runtime: agent.adapter.id, sessionId: fresh.sessionId, launchId: agent.launchId,
+          ...(fresh.effectiveModel ? { model: fresh.effectiveModel } : {}),
+          ...(fresh.effectiveReasoningEffort ? { reasoningEffort: fresh.effectiveReasoningEffort } : {}) });
+      }
+      emit({ type: "agent-status", agentId, status: "active", readiness });
+      await oldSession.close("fresh session reset committed")
+        .catch((error) => log("previous runtime close after fresh reset failed", String(error)));
+      return { generationChanged: true, sessionChanged: oldSessionId !== fresh.sessionId, turns: 0,
+        runtimeReady: true, pendingCount: 0, sessionId: fresh.sessionId };
+    },
     async start(configs): Promise<void> {
       let activeCount = 0;
+      let recoveringCount = 0;
       const startupFailures: string[] = [];
       for (const config of configs) {
         if (managed.has(config.agentId)) { activeCount += 1; continue; }
@@ -709,14 +809,16 @@ export function createRuntimeHost(options: {
           await retryPending(agent);
         } catch (error) {
           const reason = error instanceof Error ? error.message : String(error);
-          agent.disabledReason = reason;
+          const transient = error instanceof RuntimePrerequisiteError && error.readiness.state === "unavailable";
+          agent.disabledReason = transient ? null : reason;
+          if (transient) { recoveringCount += 1; scheduleRecreate(agent, reason); }
           startupFailures.push(`${config.agentId}: ${reason}`);
           emit({ type: "agent-status", agentId: config.agentId, status: "error", error: reason,
             ...(error instanceof RuntimePrerequisiteError ? { readiness: error.readiness } : {}) });
         }
         agent.poller = setInterval(() => reconcileExternalConsumption(agent), 250); agent.poller.unref?.();
       }
-      if (configs.length > 0 && activeCount === 0) {
+      if (configs.length > 0 && activeCount === 0 && recoveringCount === 0) {
         throw new Error(`No runtime Agent started: ${startupFailures.join("; ")}`);
       }
     },

--- a/src/runtime/runtime-readiness.ts
+++ b/src/runtime/runtime-readiness.ts
@@ -2,7 +2,7 @@ import fs from "node:fs";
 import path from "node:path";
 import { spawnSync } from "node:child_process";
 
-export type RuntimeReadinessState = "missing" | "unauthenticated" | "incompatible" | "ready";
+export type RuntimeReadinessState = "missing" | "unauthenticated" | "unavailable" | "incompatible" | "ready";
 
 export interface RuntimeReadiness {
   runtime: "codex" | "claude" | "pi";
@@ -63,9 +63,17 @@ export function classifyRuntimePrerequisite(runtime: RuntimeReadiness["runtime"]
     runtime, state: "unauthenticated", ...(executable ? { executable } : {}), reason,
     nextAction: runtime === "pi" ? "Run the official `pi` login flow, then retry." : `Authenticate ${runtime}, then retry.`,
   };
-  return {
+  if (/protocol (?:version )?(?:mismatch|unsupported|incompatible)|unsupported (?:rpc|protocol|schema)|schema (?:mismatch|incompatible)|requires (?:a )?newer version/i.test(reason)) return {
     runtime, state: "incompatible", ...(executable ? { executable } : {}), reason,
     nextAction: runtime === "pi" ? "Upgrade local Pi to a version that supports the documented RPC protocol." : `Upgrade ${runtime}, then retry.`,
+  };
+  if (/timeout|timed out|unexpected EOF|\bEOF\b|TLS|ECONNRESET|socket hang up|network|temporar(?:y|ily)|unavailable/i.test(reason)) return {
+    runtime, state: "unavailable", ...(executable ? { executable } : {}), reason,
+    nextAction: `Retry ${runtime}; Larkin will use its bounded Runtime recreate/backoff policy.`,
+  };
+  return {
+    runtime, state: "unavailable", ...(executable ? { executable } : {}), reason,
+    nextAction: `Retry ${runtime}; the failure is not proven to be a protocol incompatibility.`,
   };
 }
 

--- a/test/e2e/runtime-production-mock-e2e.test.mjs
+++ b/test/e2e/runtime-production-mock-e2e.test.mjs
@@ -19,14 +19,143 @@ function callbackValue(card, index = 0) {
 }
 
 class FakeNativeSession {
-  listeners = new Set(); prompts = []; busyInputs = []; sessionId;
+  listeners = new Set(); prompts = []; busyInputs = []; closes = []; sessionId;
   constructor(runtime) { this.sessionId = `${runtime}-session`; }
   subscribe(listener) { this.listeners.add(listener); return () => this.listeners.delete(listener); }
   emit(event) { for (const listener of this.listeners) listener(event); }
   async prompt(input) { this.prompts.push(input); return { status: "accepted", inputId: input.inputId }; }
   async busyInput(input) { this.busyInputs.push(input); return { status: "accepted", inputId: input.inputId }; }
-  async cancel() {} async close() {}
+  async cancel() {} async close(reason) { this.closes.push(reason); }
 }
+
+test("production HostShell fresh reset blocks issue-14 backlog, then preserves durable state and other Agents", async () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "larkin-production-reset-"));
+  const ids = ["cli_resetMockA1", "cli_resetOtherA1"];
+  const stores = new Map(ids.map((id) => [id, createAgentStateStore(root, id)]));
+  const created = new Map(ids.map((id) => [id, []]));
+  let onCreate = () => {};
+  const adapter = { id: "codex", capabilities: {}, async createSession(input) {
+    const list = created.get(input.agentId);
+    const session = new FakeNativeSession("codex");
+    session.sessionId = `${input.agentId}-session-${list.length + 1}`;
+    list.push(session);
+    onCreate(input, session);
+    return session;
+  } };
+  const runtimeHost = createRuntimeHost({ adapterFor: () => adapter, promptBuilder: new ContextPromptBuilder(),
+    stateStoreFor: (id) => stores.get(id), assertOfficialCliReady: () => {} });
+  const agents = ids.map((agentId) => ({ agentId, name: agentId, runtime: "codex", model: "mock",
+    feishuAppId: agentId, feishuProfile: agentId, feishuAppSecret: "fixture-secret",
+    feishuDomain: "https://open.feishu.cn",
+    larkConfigDir: path.join(root, "lark-cli-config"), workspaceDir: path.join(root, "agents", agentId),
+    stateDir: path.join(root, "state", "agents", agentId) }));
+  fs.mkdirSync(root, { recursive: true });
+  fs.writeFileSync(path.join(root, "config.json"), JSON.stringify({ version: 3, serverId: "server-reset",
+    activeAgent: ids[0], agents: Object.fromEntries(ids.map((id) => [id, { runtime: "codex", model: "mock" }])) }), { mode: 0o600 });
+  fs.mkdirSync(path.join(root, "bots"), { recursive: true });
+  fs.writeFileSync(path.join(root, "bots", `${ids[0]}.json`), JSON.stringify({ fixture: "credential-preserved" }), { mode: 0o600 });
+  const host = createHostShell({ env: { LARKIN_HOME: root, LARKIN_CONFIG_DIR: root, LARKIN_SERVER_ID: "server-reset",
+    LARKIN_AGENTS_CONFIG: JSON.stringify(agents), LARKIN_INBOUND_DROUGHT_SEC: "0" }, runtimeHost,
+    stateStoreForImpl: (_root, id) => stores.get(id),
+    managedCliForAgent: testManagedCli, eventSourceStartDelayMs: 60_000,
+    channelPackage: { createLarkChannel() { throw new Error("event source must not start in reset fixture"); } } });
+  try {
+    await host.start();
+    const connectedAt = new Date().toISOString();
+    for (const [id, store] of stores) store.writeJson("status", { ...store.readJson("status", {}), connectedAt, connectedVia: "mock" });
+    const target = stores.get(ids[0]);
+    target.appendNdjson("conversation", { text: "preserve transcript" });
+    target.writeJson("pendingReact", { items: [{ msgId: "om_eye", reactionId: "react_eye" }] });
+    const issue14Bodies = ["consumed-body-must-not-replay", "remaining-body-must-stay-pending"];
+    const issue14Receipts = [];
+    for (const [index, messageId] of ["om_reset_partial_1", "om_reset_partial_2"].entries()) {
+      const envelope = { message_id: messageId, target: "chat:oc_reset", content: issue14Bodies[index] };
+      target.appendNdjson("inbox", envelope);
+      issue14Receipts.push(await runtimeHost.deliver(ids[0], envelope));
+    }
+    assert.deepEqual(issue14Receipts.map((receipt) => receipt.status), ["accepted", "accepted"]);
+    assert.equal(created.get(ids[0])[0].prompts.length + created.get(ids[0])[0].busyInputs.length, 2,
+      "production RuntimeHost prompt/busy-input paths own both issue-14 deliveries before any poll");
+    const transcriptBefore = target.readNdjson("conversation");
+    const otherStateBefore = stores.get(ids[1]).readJson("agentState", {});
+    const configBefore = fs.readFileSync(path.join(root, "config.json"));
+    const credentialBefore = fs.readFileSync(path.join(root, "bots", `${ids[0]}.json`));
+    const nonSessionBefore = target.readJson("pendingReact", {});
+    await assert.rejects(host.resetSession("cli_unknownA1"), (error) => error.code === "unknown_agent");
+    await assert.rejects(host.resetSession(ids[0]), (error) => error.code === "agent_busy");
+    assert.equal(created.get(ids[0]).length, 1, "backlog refusal occurs before fresh Runtime creation");
+    assert.equal(target.readNdjson("inbox").length, 2, "no-poll reset refusal preserves the full canonical backlog");
+    const partial = target.pollInbox({ limit: 1 });
+    assert.deepEqual(partial.envelopes.map((row) => row.message_id), ["om_reset_partial_1"]);
+    assert.deepEqual(partial.consumedDeliveryIds, [issue14Receipts[0].deliveryId]);
+    assert.deepEqual(target.readNdjson("inbox").map((row) => row.content), [issue14Bodies[1]],
+      "partial consumption preserves the unpolled canonical backlog body");
+    await assert.rejects(host.resetSession(ids[0]), (error) => error.code === "agent_busy");
+    assert.equal(target.readNdjson("inbox").length, 1, "partial-poll reset refusal preserves the remaining backlog");
+    const drained = target.pollInbox();
+    assert.deepEqual(drained.envelopes.map((row) => row.message_id), ["om_reset_partial_2"]);
+    assert.deepEqual(drained.consumedDeliveryIds, [issue14Receipts[1].deliveryId]);
+    created.get(ids[0])[0].emit({ type: "turn-end", turnId: "issue-14-drained" });
+    await new Promise((resolve) => setImmediate(resolve));
+    const ledgerBefore = target.readJson("runtimeDeliveries", {});
+    const reset = await host.resetSession(ids[0]);
+    assert.equal(reset.readyForFreshScenario, true);
+    assert.equal(reset.inboundObserved, false);
+    assert.equal(created.get(ids[0]).length, 2);
+    assert.deepEqual(created.get(ids[0])[0].closes, ["fresh session reset committed"]);
+    assert.deepEqual(created.get(ids[1])[0].closes, []);
+    assert.deepEqual(target.readNdjson("conversation"), transcriptBefore);
+    assert.deepEqual(target.readJson("pendingReact", {}), nonSessionBefore);
+    assert.deepEqual(target.readJson("runtimeDeliveries", {}), ledgerBefore);
+    assert.deepEqual(fs.readFileSync(path.join(root, "config.json")), configBefore);
+    assert.deepEqual(fs.readFileSync(path.join(root, "bots", `${ids[0]}.json`)), credentialBefore);
+    assert.deepEqual(stores.get(ids[1]).readJson("agentState", {}), otherStateBefore);
+    assert.equal(target.readNdjson("inbox").length, 0);
+    assert.equal(created.get(ids[0])[1].prompts.length, 0, "consumed issue-14 ledger rows are not replayed into the fresh session");
+    assert.equal(issue14Bodies.some((body) => JSON.stringify(created.get(ids[0])[1].prompts).includes(body)), false,
+      "the fresh session never receives either drained body");
+
+    const originalResetSession = runtimeHost.resetSession.bind(runtimeHost);
+    runtimeHost.resetSession = async (agentId) => {
+      const result = await originalResetSession(agentId);
+      const status = target.readJson("status", {});
+      target.writeJson("status", { ...status, runtimeReadiness: { runtime: "codex", state: "ready" },
+        session: { ...(status.session || {}), turns: 1 } });
+      return result;
+    };
+    const contaminated = await host.resetSession(ids[0], 0);
+    assert.equal(contaminated.resetCommitted, true);
+    assert.equal(contaminated.turns, 1);
+    assert.equal(contaminated.runtimeReady, true);
+    assert.equal(contaminated.readyForFreshScenario, false);
+    assert.equal(contaminated.code, "fresh_scenario_contaminated");
+    runtimeHost.resetSession = originalResetSession;
+
+    onCreate = (input) => {
+      if (input.agentId === ids[0]) target.writeJson("status", { ...target.readJson("status", {}), reconnectingAt: new Date().toISOString() });
+    };
+    const reconnectRace = await host.resetSession(ids[0], 0);
+    assert.equal(reconnectRace.resetCommitted, true);
+    assert.equal(reconnectRace.readyForFreshScenario, false);
+    assert.equal(reconnectRace.code, "reset_timeout");
+    target.writeJson("status", { ...target.readJson("status", {}), reconnectedAt: new Date(Date.now() + 1).toISOString() });
+    onCreate = () => {};
+
+    const originalWriteJson = target.writeJson.bind(target);
+    target.writeJson = (key, value) => {
+      if (key === "agentState") throw new Error("injected agent-state persistence failure");
+      return originalWriteJson(key, value);
+    };
+    const persistenceFailure = await host.resetSession(ids[0], 0);
+    assert.equal(persistenceFailure.resetCommitted, true);
+    assert.equal(persistenceFailure.readyForFreshScenario, false);
+    assert.equal(persistenceFailure.code, "state_persistence_failed");
+    target.writeJson = originalWriteJson;
+  } finally {
+    await host.shutdown("reset Mock E2E complete");
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});
 
 test("member parser accepts the real lark-cli 1.0.79 get/bots shapes", () => {
   assert.deepEqual(memberNamesFromPayloads([

--- a/test/support/local-control-harness.mjs
+++ b/test/support/local-control-harness.mjs
@@ -7,6 +7,7 @@ import { createRuntimeHost } from "../../dist/runtime/runtime-host.mjs";
 import { createHostShell } from "../../dist/feishu/host-shell.mjs";
 import { ContextPromptBuilder } from "../../dist/agent/context-prompt.mjs";
 import { createAgentStateStore } from "../../dist/agent/agent-state-store.mjs";
+import { RuntimePrerequisiteError } from "../../dist/runtime/runtime-readiness.mjs";
 
 const root = process.env.LARKIN_CONFIG_DIR;
 const calls = process.env.LARKIN_CONTROL_CALLS;
@@ -64,29 +65,19 @@ const serverOptions = {
   larkinHome: root,
   authorityToken,
   maxRememberedOperations: 3,
-  maxRememberedResetOperations: 8,
-  operationLedgerWrite(file, value) {
-    const records = value.records || [];
-    if (records.some((record) => record.operationId === "operation_pre_fail_1" && record.state === "intent")) {
-      throw new Error("injected reset intent persistence failure");
-    }
-    if (records.some((record) => record.operationId === "operation_post_fail_1" && record.state === "terminal")) {
-      throw new Error("injected reset terminal persistence failure");
-    }
-    const temporary = `${file}.${process.pid}.harness.tmp`;
-    fs.writeFileSync(temporary, `${JSON.stringify(value, null, 2)}\n`, { mode: 0o600 });
-    fs.renameSync(temporary, file);
-  },
   async upsert(request) {
     fs.appendFileSync(calls, `start:${request.operationId}:${request.agentId}\n`);
     await new Promise((resolve) => setTimeout(resolve, Number(process.env.LARKIN_CONTROL_DELAY_MS || 0)));
+    if (request.operationId === "operation_failed_conflict_1") throw new RuntimePrerequisiteError({
+      runtime: "pi", state: "unavailable", reason: "fixture readiness must not leak",
+    });
     fs.appendFileSync(calls, `end:${request.operationId}:${request.agentId}\n`);
   },
   async resetSession(request) {
-    fs.appendFileSync(calls, `reset:${request.operationId}:${request.agentId}\n`);
-    if (request.operationId === "operation_inflight_1") await new Promise((resolve) => setTimeout(resolve, 80));
+    fs.appendFileSync(calls, `reset:${request.agentId}\n`);
+    await new Promise((resolve) => setTimeout(resolve, 80));
     const result = await resetHost.resetSession(request.agentId, request.waitReadyMs);
-    return { ok: result.readyForFreshScenario, operationId: request.operationId, agentId: request.agentId, ...result };
+    return { ok: result.readyForFreshScenario, agentId: request.agentId, ...result };
   },
 };
 let server = createAgentControlServer(serverOptions);

--- a/test/support/local-control-harness.mjs
+++ b/test/support/local-control-harness.mjs
@@ -3,6 +3,10 @@ import path from "node:path";
 import { spawn } from "node:child_process";
 import { createAgentControlServer, initializeControlAuthority } from "../../dist/app/local-control.mjs";
 import { currentProcessMetadata, inspectProcess } from "../../dist/platform/process-state.mjs";
+import { createRuntimeHost } from "../../dist/runtime/runtime-host.mjs";
+import { createHostShell } from "../../dist/feishu/host-shell.mjs";
+import { ContextPromptBuilder } from "../../dist/agent/context-prompt.mjs";
+import { createAgentStateStore } from "../../dist/agent/agent-state-store.mjs";
 
 const root = process.env.LARKIN_CONFIG_DIR;
 const calls = process.env.LARKIN_CONTROL_CALLS;
@@ -30,17 +34,71 @@ fs.writeFileSync(path.join(root, "daemon-status.json"), JSON.stringify({
   pid: process.pid,
   agents: ["cli_existingA1"],
 }), { mode: 0o600 });
-const server = createAgentControlServer({
+class ResetSession {
+  listeners = new Set(); closes = []; sessionId;
+  constructor(id) { this.sessionId = id; }
+  subscribe(listener) { this.listeners.add(listener); return () => this.listeners.delete(listener); }
+  async prompt(input) { return { status: "accepted", inputId: input.inputId }; }
+  async busyInput(input) { return { status: "accepted", inputId: input.inputId }; }
+  async cancel() {} async close(reason) { this.closes.push(reason); }
+}
+const resetAgentId = "cli_newA1";
+let resetGeneration = 0;
+const resetStore = createAgentStateStore(root, resetAgentId);
+const resetRuntimeHost = createRuntimeHost({
+  adapterFor: () => ({ id: "codex", capabilities: {}, async createSession() { return new ResetSession(`control-session-${++resetGeneration}`); } }),
+  promptBuilder: new ContextPromptBuilder(), stateStoreFor: () => resetStore, assertOfficialCliReady: () => {},
+});
+const resetAgent = { agentId: resetAgentId, name: resetAgentId, runtime: "codex", model: "gpt-5.2",
+  feishuAppId: resetAgentId, feishuProfile: resetAgentId, feishuAppSecret: "fixture-secret", feishuDomain: "https://open.feishu.cn",
+  larkConfigDir: path.join(root, "lark-cli-config"), workspaceDir: path.join(root, "agents", resetAgentId),
+  stateDir: path.join(root, "state", "agents", resetAgentId) };
+const resetHost = createHostShell({ env: { ...process.env, LARKIN_HOME: root, LARKIN_CONFIG_DIR: root,
+  LARKIN_SERVER_ID: "server-control", LARKIN_AGENTS_CONFIG: JSON.stringify([resetAgent]), LARKIN_INBOUND_DROUGHT_SEC: "0" },
+  runtimeHost: resetRuntimeHost, eventSourceStartDelayMs: 60_000,
+  managedCliForAgent: () => ({ command: { command: "/test/lark-cli", argsPrefix: [], version: "1.0.79" }, env: {} }),
+  channelPackage: { createLarkChannel() { throw new Error("not started in control harness"); } }, logImpl: () => {} });
+await resetHost.start();
+resetStore.writeJson("status", { ...resetStore.readJson("status", {}), connectedAt: new Date().toISOString(), connectedVia: "mock" });
+const serverOptions = {
   larkinHome: root,
   authorityToken,
+  maxRememberedOperations: 3,
+  maxRememberedResetOperations: 8,
+  operationLedgerWrite(file, value) {
+    const records = value.records || [];
+    if (records.some((record) => record.operationId === "operation_pre_fail_1" && record.state === "intent")) {
+      throw new Error("injected reset intent persistence failure");
+    }
+    if (records.some((record) => record.operationId === "operation_post_fail_1" && record.state === "terminal")) {
+      throw new Error("injected reset terminal persistence failure");
+    }
+    const temporary = `${file}.${process.pid}.harness.tmp`;
+    fs.writeFileSync(temporary, `${JSON.stringify(value, null, 2)}\n`, { mode: 0o600 });
+    fs.renameSync(temporary, file);
+  },
   async upsert(request) {
     fs.appendFileSync(calls, `start:${request.operationId}:${request.agentId}\n`);
     await new Promise((resolve) => setTimeout(resolve, Number(process.env.LARKIN_CONTROL_DELAY_MS || 0)));
     fs.appendFileSync(calls, `end:${request.operationId}:${request.agentId}\n`);
   },
-});
+  async resetSession(request) {
+    fs.appendFileSync(calls, `reset:${request.operationId}:${request.agentId}\n`);
+    if (request.operationId === "operation_inflight_1") await new Promise((resolve) => setTimeout(resolve, 80));
+    const result = await resetHost.resetSession(request.agentId, request.waitReadyMs);
+    return { ok: result.readyForFreshScenario, operationId: request.operationId, agentId: request.agentId, ...result };
+  },
+};
+let server = createAgentControlServer(serverOptions);
 await server.start();
 console.log("ready");
-const stop = async () => { await server.close(); supervisor.kill("SIGTERM"); process.exit(0); };
+process.on("SIGUSR2", () => { void (async () => {
+  await server.close();
+  fs.mkdirSync(JSON.parse(fs.readFileSync(path.join(root, "daemon-control-auth.json"), "utf8")).socketRoot, { recursive: true, mode: 0o700 });
+  server = createAgentControlServer(serverOptions);
+  await server.start();
+  fs.writeFileSync(path.join(root, "control-restarted"), "ready");
+})().catch((error) => { console.error(error); process.exit(1); }); });
+const stop = async () => { await server.close(); await resetHost.shutdown("control harness stop"); supervisor.kill("SIGTERM"); process.exit(0); };
 process.once("SIGTERM", () => { void stop(); });
 process.once("SIGINT", () => { void stop(); });

--- a/test/unit/agent/transport-business-context.test.mjs
+++ b/test/unit/agent/transport-business-context.test.mjs
@@ -5,6 +5,7 @@ import path from "node:path";
 import { test } from "bun:test";
 import { spawnSync } from "node:child_process";
 import { fileURLToPath } from "node:url";
+import { formatFeishuError } from "../../../dist/agent/transport-business-context.mjs";
 
 const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..", "..", "..");
 const SOURCE = path.join(ROOT, "src/agent/transport-business-context.ts");
@@ -43,6 +44,13 @@ test("business context uses canonical AgentStateStore paths and centralizes loca
   assert.match(source, /path\.join\(paths\.root, ["']attachments\.json["']\)/);
   assert.match(source, /path\.join\(paths\.root, ["']transport\.log["']\)/);
   assert.match(fs.readFileSync(RUNTIME, "utf8"), /transport-business-context\.cjs/);
+});
+
+test("230027 is target membership guidance, not OAuth scope guidance", () => {
+  const formatted = formatFeishuError({ code: 230027, message: "target denied", missing_scopes: ["im:message"] }, "https://grant.invalid");
+  assert.match(formatted, /membership/);
+  assert.match(formatted, /target authorization/);
+  assert.doesNotMatch(formatted, /授权链接|grant\.invalid|补充.*scope/);
 });
 
 test("production context renders a display-name mention and preserves exact lark-cli ordering", () => {

--- a/test/unit/app/local-control.test.mjs
+++ b/test/unit/app/local-control.test.mjs
@@ -10,6 +10,7 @@ import { fileURLToPath } from "node:url";
 import {
   cleanupStaleAgentControlSocket,
   controlSocketPath,
+  createAgentControlServer,
   initializeControlAuthority,
   requestAgentUpsert,
   requestSessionReset,
@@ -39,9 +40,12 @@ async function rawRequest(socket, payload) {
   });
 }
 
-test("local control socket is user-only, agent-id-only, and operation-id idempotent", { timeout: 15_000 }, async () => {
+test("local control keeps upsert ID idempotency and coalesces only concurrent reset requests", { timeout: 15_000 }, async () => {
   const root = fs.mkdtempSync(path.join(os.tmpdir(), "larkin-control-"));
   fs.chmodSync(root, 0o700);
+  const legacyResetLedger = path.join(root, "daemon-control-operations.json");
+  fs.writeFileSync(legacyResetLedger, JSON.stringify({ version: 1, records: [{ operationId: "legacy-reset-id",
+    agentId: "cli_newA1", operation: "session-reset", state: "terminal", response: { ok: true } }] }), { mode: 0o600 });
   const calls = path.join(root, "calls.log");
   const daemonTmp = fs.mkdtempSync("/tmp/lct-");
   fs.chmodSync(daemonTmp, 0o700);
@@ -53,6 +57,7 @@ test("local control socket is user-only, agent-id-only, and operation-id idempot
   child.stderr.on("data", (chunk) => { output += chunk; });
   try {
     await waitForReady(child, () => output);
+    assert.equal(fs.existsSync(legacyResetLedger), false, "startup removes the valid private legacy reset ledger");
     const restartControl = async () => {
       const marker = path.join(root, "control-restarted");
       fs.rmSync(marker, { force: true });
@@ -86,7 +91,24 @@ test("local control socket is user-only, agent-id-only, and operation-id idempot
     assert.deepEqual(fs.readFileSync(calls, "utf8").trim().split("\n"), [
       `start:${operationId}:cli_newA1`, `end:${operationId}:cli_newA1`,
     ]);
+    const conflictProjection = (conflictOperationId) => ({ ok: false, operationId: conflictOperationId,
+      agentId: "cli_otherA1", code: "operation_conflict", error: "operationId 已绑定其他 Agent 或操作" });
+    assert.deepEqual(await requestAgentUpsert({ larkinHome: root, agentId: "cli_otherA1", operationId }),
+      conflictProjection(operationId), "completed successful upsert conflict remains neutral");
 
+    const failedConflictId = "operation_failed_conflict_1";
+    const failedUpsert = await requestAgentUpsert({ larkinHome: root, agentId: "cli_newA1", operationId: failedConflictId });
+    assert.equal(failedUpsert.ok, false);
+    assert.equal(failedUpsert.readiness.reason, "fixture readiness must not leak");
+    assert.deepEqual(await requestAgentUpsert({ larkinHome: root, agentId: "cli_otherA1", operationId: failedConflictId }),
+      conflictProjection(failedConflictId), "completed failed upsert conflict never leaks original readiness");
+
+    const inFlightConflictId = "operation_inflight_conflict_1";
+    const inFlightOriginal = requestAgentUpsert({ larkinHome: root, agentId: "cli_newA1", operationId: inFlightConflictId });
+    await new Promise((resolve) => setTimeout(resolve, 10));
+    assert.deepEqual(await requestAgentUpsert({ larkinHome: root, agentId: "cli_otherA1", operationId: inFlightConflictId }),
+      conflictProjection(inFlightConflictId), "in-flight upsert conflict uses the same exact neutral envelope");
+    assert.equal((await inFlightOriginal).ok, true);
     const [differentOne, differentTwo] = await Promise.all([
       requestAgentUpsert({ larkinHome: root, agentId: "cli_newA1", operationId: "operation_different_1" }),
       requestAgentUpsert({ larkinHome: root, agentId: "cli_newA1", operationId: "operation_different_2" }),
@@ -105,35 +127,30 @@ test("local control socket is user-only, agent-id-only, and operation-id idempot
     assert.match(invalid.error, /未知字段/);
     assert.doesNotMatch(output, /must-not-pass/);
 
-    const resetOperation = "operation_reset_123";
-    const reset = await requestSessionReset({ larkinHome: root, agentId: "cli_newA1", operationId: resetOperation, waitReadyMs: 10 });
-    const resetReplay = await requestSessionReset({ larkinHome: root, agentId: "cli_newA1", operationId: resetOperation, waitReadyMs: 10 });
-    assert.deepEqual(resetReplay, reset);
+    const resetCalls = () => fs.readFileSync(calls, "utf8").trim().split("\n").filter((line) => line.startsWith("reset:")).length;
+    const [reset, concurrentReset] = await Promise.all([
+      requestSessionReset({ larkinHome: root, agentId: "cli_newA1", waitReadyMs: 10 }),
+      requestSessionReset({ larkinHome: root, agentId: "cli_newA1", waitReadyMs: 250 }),
+    ]);
+    assert.deepEqual(concurrentReset, reset, "concurrent reset requests for one Agent share one in-flight result");
     assert.equal(reset.readyForFreshScenario, true);
-    assert.equal(fs.readFileSync(calls, "utf8").trim().split("\n").filter((line) => line.startsWith("reset:")).length, 1);
+    assert.equal("operationId" in reset, false);
+    assert.equal(resetCalls(), 1);
+    const laterReset = await requestSessionReset({ larkinHome: root, agentId: "cli_newA1", waitReadyMs: 10 });
+    assert.equal(laterReset.readyForFreshScenario, true);
+    assert.equal(resetCalls(), 2, "a completed invocation is not replayed and starts a new reset");
     await restartControl();
-    const durableReplay = await requestSessionReset({ larkinHome: root, agentId: "cli_newA1", operationId: resetOperation, waitReadyMs: 10 });
-    assert.deepEqual(durableReplay, reset);
-    assert.equal(fs.readFileSync(calls, "utf8").trim().split("\n").filter((line) => line.startsWith("reset:")).length, 1,
-      "durable replay must not execute a second reset after control-server restart");
-    const conflict = await requestSessionReset({ larkinHome: root, agentId: "cli_otherA1", operationId: resetOperation, waitReadyMs: 10 });
-    const conflictProjection = (operationId) => ({ ok: false, operationId, agentId: "cli_otherA1",
-      code: "operation_conflict", error: "operationId 已绑定其他 Agent 或操作", resetCommitted: false,
-      generationChanged: false, sessionChanged: false, turns: 0, runtimeReady: false, channelConnected: false,
-      reconnecting: false, pendingCount: 0, readyForFreshScenario: false, inboundObserved: false });
-    assert.deepEqual(conflict, conflictProjection(resetOperation), "completed conflict must not leak the original reset projection");
-    const inflightOperation = "operation_inflight_1";
-    const inflightOriginal = requestSessionReset({ larkinHome: root, agentId: "cli_newA1",
-      operationId: inflightOperation, waitReadyMs: 10 });
-    await new Promise((resolve) => setTimeout(resolve, 10));
-    const inflightConflict = await requestSessionReset({ larkinHome: root, agentId: "cli_otherA1",
-      operationId: inflightOperation, waitReadyMs: 10 });
-    assert.deepEqual(inflightConflict, conflictProjection(inflightOperation),
-      "in-flight conflict must expose a complete neutral request-side reset projection");
-    assert.equal((await inflightOriginal).ok, true);
-    assert.equal(fs.lstatSync(path.join(root, "daemon-control-operations.json")).mode & 0o077, 0);
-    const unknown = await requestSessionReset({ larkinHome: root, agentId: "cli_unknownA1",
-      operationId: "operation_unknown_1", waitReadyMs: 10 });
+    const afterRestart = await requestSessionReset({ larkinHome: root, agentId: "cli_newA1", waitReadyMs: 10 });
+    assert.equal(afterRestart.readyForFreshScenario, true);
+    assert.equal(resetCalls(), 3, "reset completion is not persisted or replayed across control-server restart");
+    assert.equal(fs.existsSync(legacyResetLedger), false, "reset execution never recreates the removed legacy ledger");
+    const forbiddenResetId = await rawRequest(socket, { operation: "session-reset", agentId: "cli_newA1",
+      authorization: authority.token, waitReadyMs: 10, operationId: "operation_reset_forbidden" });
+    assert.equal(forbiddenResetId.ok, false);
+    assert.equal("operationId" in forbiddenResetId, false);
+    assert.match(forbiddenResetId.error, /未知字段/);
+    assert.equal(resetCalls(), 3);
+    const unknown = await requestSessionReset({ larkinHome: root, agentId: "cli_unknownA1", waitReadyMs: 10 });
     assert.equal(unknown.ok, false);
     assert.equal(unknown.resetCommitted, false);
     assert.equal(unknown.code, "unknown_agent");
@@ -142,58 +159,26 @@ test("local control socket is user-only, agent-id-only, and operation-id idempot
       const churn = await requestAgentUpsert({ larkinHome: root, agentId: "cli_newA1", operationId: `operation_churn_${index}` });
       assert.equal(churn.ok, true);
     }
-    await restartControl();
-    assert.deepEqual(await requestSessionReset({ larkinHome: root, agentId: "cli_newA1",
-      operationId: resetOperation, waitReadyMs: 10 }), reset, "upsert churn cannot evict durable reset replay");
 
     fs.writeFileSync(path.join(root, "config.json"), JSON.stringify({ version: 3, serverId: "server-control",
       activeAgent: "cli_newA1", agents: { cli_newA1: { runtime: "codex", model: "gpt-5.2" } } }), { mode: 0o600 });
     const deniedRuntimeCli = spawnSync(process.execPath, [path.join(ROOT, "dist/app/cli.mjs"), "session", "reset",
-      "--agent", "cli_newA1", "--json", "--operation-id", "operation_denied_cli_1"], {
+      "--agent", "cli_newA1", "--json"], {
       cwd: ROOT, encoding: "utf8", env: { ...process.env, LARKIN_CONFIG_DIR: root, LARKIN_AGENT_ID: "cli_runtimeA1" },
     });
     assert.equal(deniedRuntimeCli.status, 1);
     assert.equal(JSON.parse(deniedRuntimeCli.stdout).code, "user_authority_required");
     const publicCli = spawnSync(process.execPath, [path.join(ROOT, "dist/app/cli.mjs"), "session", "reset",
-      "--agent", "cli_newA1", "--json", "--wait-ready", "1", "--operation-id", "operation_built_cli_1"], {
+      "--agent", "cli_newA1", "--json", "--wait-ready", "1"], {
       cwd: ROOT, encoding: "utf8", env: { ...process.env, LARKIN_CONFIG_DIR: root },
     });
     assert.equal(publicCli.status, 0, publicCli.stderr || publicCli.stdout);
-    assert.deepEqual(JSON.parse(publicCli.stdout), { ok: true, operation_id: "operation_built_cli_1", agent_id: "cli_newA1",
+    const publicResult = JSON.parse(publicCli.stdout);
+    assert.equal("operation_id" in publicResult, false);
+    assert.deepEqual(publicResult, { ok: true, agent_id: "cli_newA1",
       reset_committed: true, generation_changed: true, session_changed: true, turns: 0,
       runtime_ready: true, channel_connected: true, reconnecting: false, pending_count: 0,
       ready_for_fresh_scenario: true, inbound_observed: false });
-
-    for (let index = 0; index < 4; index += 1) {
-      const fill = await requestSessionReset({ larkinHome: root, agentId: "cli_newA1",
-        operationId: `operation_fill_${index}`, waitReadyMs: 10 });
-      assert.equal(fill.ok, true);
-    }
-    const callsAtFullLedger = fs.readFileSync(calls, "utf8").trim().split("\n").filter((line) => line.startsWith("reset:")).length;
-    const preIntentFailure = await requestSessionReset({ larkinHome: root, agentId: "cli_newA1",
-      operationId: "operation_pre_fail_1", waitReadyMs: 10 });
-    assert.equal(preIntentFailure.resetCommitted, false);
-    assert.equal(preIntentFailure.code, "operation_intent_persist_failed");
-    assert.equal(fs.readFileSync(calls, "utf8").trim().split("\n").filter((line) => line.startsWith("reset:")).length,
-      callsAtFullLedger, "failed intent persistence must prevent mutation");
-    assert.deepEqual(await requestSessionReset({ larkinHome: root, agentId: "cli_newA1",
-      operationId: resetOperation, waitReadyMs: 10 }), reset,
-    "failed full-ledger intent persistence must preserve the would-be-evicted live replay");
-    assert.equal(fs.readFileSync(calls, "utf8").trim().split("\n").filter((line) => line.startsWith("reset:")).length,
-      callsAtFullLedger, "same-process replay of the would-be-evicted ID must not execute a second reset");
-
-    const postCommitFailure = await requestSessionReset({ larkinHome: root, agentId: "cli_newA1",
-      operationId: "operation_post_fail_1", waitReadyMs: 10 });
-    assert.equal(postCommitFailure.resetCommitted, true);
-    assert.equal(postCommitFailure.code, "operation_result_persist_failed");
-    const callsAfterPostCommit = fs.readFileSync(calls, "utf8").trim().split("\n").filter((line) => line.startsWith("reset:")).length;
-    await restartControl();
-    const unknownPostCrash = await requestSessionReset({ larkinHome: root, agentId: "cli_newA1",
-      operationId: "operation_post_fail_1", waitReadyMs: 10 });
-    assert.equal(unknownPostCrash.resetCommitted, null);
-    assert.equal(unknownPostCrash.code, "operation_outcome_unknown");
-    assert.equal(fs.readFileSync(calls, "utf8").trim().split("\n").filter((line) => line.startsWith("reset:")).length,
-      callsAfterPostCommit, "restart replay of unresolved intent must never perform a second reset");
 
     const supervisorStatus = JSON.parse(fs.readFileSync(path.join(root, "supervisor-status.json"), "utf8"));
     const daemonStatus = JSON.parse(fs.readFileSync(path.join(root, "daemon-status.json"), "utf8"));
@@ -219,6 +204,44 @@ test("local control socket is user-only, agent-id-only, and operation-id idempot
     fs.rmSync(root, { recursive: true, force: true });
     fs.rmSync(daemonTmp, { recursive: true, force: true });
   }
+});
+
+test("legacy reset-ledger cleanup refuses unsafe paths without unlinking or following them", async () => {
+  const makeServer = (root) => createAgentControlServer({ larkinHome: root, authorityToken: "A".repeat(43), async upsert() {} });
+
+  const symlinkRoot = fs.mkdtempSync(path.join(os.tmpdir(), "larkin-legacy-ledger-symlink-"));
+  fs.chmodSync(symlinkRoot, 0o700);
+  try {
+    const target = path.join(symlinkRoot, "target.json");
+    const ledger = path.join(symlinkRoot, "daemon-control-operations.json");
+    fs.writeFileSync(target, "target-must-survive", { mode: 0o600 });
+    fs.symlinkSync(target, ledger);
+    await assert.rejects(makeServer(symlinkRoot).start(), /legacy daemon control operation ledger 不安全/);
+    assert.equal(fs.lstatSync(ledger).isSymbolicLink(), true);
+    assert.equal(fs.readFileSync(target, "utf8"), "target-must-survive");
+  } finally { fs.rmSync(symlinkRoot, { recursive: true, force: true }); }
+
+  const directoryRoot = fs.mkdtempSync(path.join(os.tmpdir(), "larkin-legacy-ledger-directory-"));
+  fs.chmodSync(directoryRoot, 0o700);
+  try {
+    const ledger = path.join(directoryRoot, "daemon-control-operations.json");
+    fs.mkdirSync(ledger, { mode: 0o700 });
+    fs.writeFileSync(path.join(ledger, "marker"), "directory-must-survive", { mode: 0o600 });
+    await assert.rejects(makeServer(directoryRoot).start(), /legacy daemon control operation ledger 不安全/);
+    assert.equal(fs.lstatSync(ledger).isDirectory(), true);
+    assert.equal(fs.readFileSync(path.join(ledger, "marker"), "utf8"), "directory-must-survive");
+  } finally { fs.rmSync(directoryRoot, { recursive: true, force: true }); }
+
+  const publicModeRoot = fs.mkdtempSync(path.join(os.tmpdir(), "larkin-legacy-ledger-mode-"));
+  fs.chmodSync(publicModeRoot, 0o700);
+  try {
+    const ledger = path.join(publicModeRoot, "daemon-control-operations.json");
+    fs.writeFileSync(ledger, "public-file-must-survive", { mode: 0o644 });
+    fs.chmodSync(ledger, 0o644);
+    await assert.rejects(makeServer(publicModeRoot).start(), /legacy daemon control operation ledger 不安全/);
+    assert.equal(fs.readFileSync(ledger, "utf8"), "public-file-must-survive");
+    assert.equal(fs.lstatSync(ledger).mode & 0o777, 0o644);
+  } finally { fs.rmSync(publicModeRoot, { recursive: true, force: true }); }
 });
 
 test("stale socket cleanup refuses a different server even when the filesystem reuses its inode", async () => {

--- a/test/unit/app/local-control.test.mjs
+++ b/test/unit/app/local-control.test.mjs
@@ -39,7 +39,7 @@ async function rawRequest(socket, payload) {
   });
 }
 
-test("local control socket is user-only, agent-id-only, and operation-id idempotent", async () => {
+test("local control socket is user-only, agent-id-only, and operation-id idempotent", { timeout: 15_000 }, async () => {
   const root = fs.mkdtempSync(path.join(os.tmpdir(), "larkin-control-"));
   fs.chmodSync(root, 0o700);
   const calls = path.join(root, "calls.log");

--- a/test/unit/app/local-control.test.mjs
+++ b/test/unit/app/local-control.test.mjs
@@ -12,6 +12,7 @@ import {
   controlSocketPath,
   initializeControlAuthority,
   requestAgentUpsert,
+  requestSessionReset,
 } from "../../../dist/app/local-control.mjs";
 import { inspectProcess, readProcessState } from "../../../dist/platform/process-state.mjs";
 
@@ -52,6 +53,13 @@ test("local control socket is user-only, agent-id-only, and operation-id idempot
   child.stderr.on("data", (chunk) => { output += chunk; });
   try {
     await waitForReady(child, () => output);
+    const restartControl = async () => {
+      const marker = path.join(root, "control-restarted");
+      fs.rmSync(marker, { force: true });
+      child.kill("SIGUSR2");
+      for (let index = 0; !fs.existsSync(marker) && index < 200; index += 1) await new Promise((resolve) => setTimeout(resolve, 10));
+      assert.equal(fs.existsSync(marker), true, output);
+    };
     const initialProcessState = readProcessState(root);
     assert.equal(initialProcessState.supervisor.state, "owned", JSON.stringify(initialProcessState.supervisor));
     assert.equal(initialProcessState.daemon.state, "owned", JSON.stringify(initialProcessState.daemon));
@@ -94,8 +102,98 @@ test("local control socket is user-only, agent-id-only, and operation-id idempot
       operationId: "operation_extra_1", agentId: "cli_newA1", authorization: authority.token, secret: "must-not-pass",
     });
     assert.equal(invalid.ok, false);
-    assert.match(invalid.error, /只允许 operationId\/agentId\/authorization/);
+    assert.match(invalid.error, /未知字段/);
     assert.doesNotMatch(output, /must-not-pass/);
+
+    const resetOperation = "operation_reset_123";
+    const reset = await requestSessionReset({ larkinHome: root, agentId: "cli_newA1", operationId: resetOperation, waitReadyMs: 10 });
+    const resetReplay = await requestSessionReset({ larkinHome: root, agentId: "cli_newA1", operationId: resetOperation, waitReadyMs: 10 });
+    assert.deepEqual(resetReplay, reset);
+    assert.equal(reset.readyForFreshScenario, true);
+    assert.equal(fs.readFileSync(calls, "utf8").trim().split("\n").filter((line) => line.startsWith("reset:")).length, 1);
+    await restartControl();
+    const durableReplay = await requestSessionReset({ larkinHome: root, agentId: "cli_newA1", operationId: resetOperation, waitReadyMs: 10 });
+    assert.deepEqual(durableReplay, reset);
+    assert.equal(fs.readFileSync(calls, "utf8").trim().split("\n").filter((line) => line.startsWith("reset:")).length, 1,
+      "durable replay must not execute a second reset after control-server restart");
+    const conflict = await requestSessionReset({ larkinHome: root, agentId: "cli_otherA1", operationId: resetOperation, waitReadyMs: 10 });
+    const conflictProjection = (operationId) => ({ ok: false, operationId, agentId: "cli_otherA1",
+      code: "operation_conflict", error: "operationId 已绑定其他 Agent 或操作", resetCommitted: false,
+      generationChanged: false, sessionChanged: false, turns: 0, runtimeReady: false, channelConnected: false,
+      reconnecting: false, pendingCount: 0, readyForFreshScenario: false, inboundObserved: false });
+    assert.deepEqual(conflict, conflictProjection(resetOperation), "completed conflict must not leak the original reset projection");
+    const inflightOperation = "operation_inflight_1";
+    const inflightOriginal = requestSessionReset({ larkinHome: root, agentId: "cli_newA1",
+      operationId: inflightOperation, waitReadyMs: 10 });
+    await new Promise((resolve) => setTimeout(resolve, 10));
+    const inflightConflict = await requestSessionReset({ larkinHome: root, agentId: "cli_otherA1",
+      operationId: inflightOperation, waitReadyMs: 10 });
+    assert.deepEqual(inflightConflict, conflictProjection(inflightOperation),
+      "in-flight conflict must expose a complete neutral request-side reset projection");
+    assert.equal((await inflightOriginal).ok, true);
+    assert.equal(fs.lstatSync(path.join(root, "daemon-control-operations.json")).mode & 0o077, 0);
+    const unknown = await requestSessionReset({ larkinHome: root, agentId: "cli_unknownA1",
+      operationId: "operation_unknown_1", waitReadyMs: 10 });
+    assert.equal(unknown.ok, false);
+    assert.equal(unknown.resetCommitted, false);
+    assert.equal(unknown.code, "unknown_agent");
+
+    for (let index = 0; index < 6; index += 1) {
+      const churn = await requestAgentUpsert({ larkinHome: root, agentId: "cli_newA1", operationId: `operation_churn_${index}` });
+      assert.equal(churn.ok, true);
+    }
+    await restartControl();
+    assert.deepEqual(await requestSessionReset({ larkinHome: root, agentId: "cli_newA1",
+      operationId: resetOperation, waitReadyMs: 10 }), reset, "upsert churn cannot evict durable reset replay");
+
+    fs.writeFileSync(path.join(root, "config.json"), JSON.stringify({ version: 3, serverId: "server-control",
+      activeAgent: "cli_newA1", agents: { cli_newA1: { runtime: "codex", model: "gpt-5.2" } } }), { mode: 0o600 });
+    const deniedRuntimeCli = spawnSync(process.execPath, [path.join(ROOT, "dist/app/cli.mjs"), "session", "reset",
+      "--agent", "cli_newA1", "--json", "--operation-id", "operation_denied_cli_1"], {
+      cwd: ROOT, encoding: "utf8", env: { ...process.env, LARKIN_CONFIG_DIR: root, LARKIN_AGENT_ID: "cli_runtimeA1" },
+    });
+    assert.equal(deniedRuntimeCli.status, 1);
+    assert.equal(JSON.parse(deniedRuntimeCli.stdout).code, "user_authority_required");
+    const publicCli = spawnSync(process.execPath, [path.join(ROOT, "dist/app/cli.mjs"), "session", "reset",
+      "--agent", "cli_newA1", "--json", "--wait-ready", "1", "--operation-id", "operation_built_cli_1"], {
+      cwd: ROOT, encoding: "utf8", env: { ...process.env, LARKIN_CONFIG_DIR: root },
+    });
+    assert.equal(publicCli.status, 0, publicCli.stderr || publicCli.stdout);
+    assert.deepEqual(JSON.parse(publicCli.stdout), { ok: true, operation_id: "operation_built_cli_1", agent_id: "cli_newA1",
+      reset_committed: true, generation_changed: true, session_changed: true, turns: 0,
+      runtime_ready: true, channel_connected: true, reconnecting: false, pending_count: 0,
+      ready_for_fresh_scenario: true, inbound_observed: false });
+
+    for (let index = 0; index < 4; index += 1) {
+      const fill = await requestSessionReset({ larkinHome: root, agentId: "cli_newA1",
+        operationId: `operation_fill_${index}`, waitReadyMs: 10 });
+      assert.equal(fill.ok, true);
+    }
+    const callsAtFullLedger = fs.readFileSync(calls, "utf8").trim().split("\n").filter((line) => line.startsWith("reset:")).length;
+    const preIntentFailure = await requestSessionReset({ larkinHome: root, agentId: "cli_newA1",
+      operationId: "operation_pre_fail_1", waitReadyMs: 10 });
+    assert.equal(preIntentFailure.resetCommitted, false);
+    assert.equal(preIntentFailure.code, "operation_intent_persist_failed");
+    assert.equal(fs.readFileSync(calls, "utf8").trim().split("\n").filter((line) => line.startsWith("reset:")).length,
+      callsAtFullLedger, "failed intent persistence must prevent mutation");
+    assert.deepEqual(await requestSessionReset({ larkinHome: root, agentId: "cli_newA1",
+      operationId: resetOperation, waitReadyMs: 10 }), reset,
+    "failed full-ledger intent persistence must preserve the would-be-evicted live replay");
+    assert.equal(fs.readFileSync(calls, "utf8").trim().split("\n").filter((line) => line.startsWith("reset:")).length,
+      callsAtFullLedger, "same-process replay of the would-be-evicted ID must not execute a second reset");
+
+    const postCommitFailure = await requestSessionReset({ larkinHome: root, agentId: "cli_newA1",
+      operationId: "operation_post_fail_1", waitReadyMs: 10 });
+    assert.equal(postCommitFailure.resetCommitted, true);
+    assert.equal(postCommitFailure.code, "operation_result_persist_failed");
+    const callsAfterPostCommit = fs.readFileSync(calls, "utf8").trim().split("\n").filter((line) => line.startsWith("reset:")).length;
+    await restartControl();
+    const unknownPostCrash = await requestSessionReset({ larkinHome: root, agentId: "cli_newA1",
+      operationId: "operation_post_fail_1", waitReadyMs: 10 });
+    assert.equal(unknownPostCrash.resetCommitted, null);
+    assert.equal(unknownPostCrash.code, "operation_outcome_unknown");
+    assert.equal(fs.readFileSync(calls, "utf8").trim().split("\n").filter((line) => line.startsWith("reset:")).length,
+      callsAfterPostCommit, "restart replay of unresolved intent must never perform a second reset");
 
     const supervisorStatus = JSON.parse(fs.readFileSync(path.join(root, "supervisor-status.json"), "utf8"));
     const daemonStatus = JSON.parse(fs.readFileSync(path.join(root, "daemon-status.json"), "utf8"));

--- a/test/unit/app/session-cli.test.mjs
+++ b/test/unit/app/session-cli.test.mjs
@@ -1,0 +1,62 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { test } from "bun:test";
+import { runSessionCli } from "../../../dist/app/session-cli.mjs";
+
+test("public session reset emits stable truthful JSON without raw session identifiers", async () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "larkin-session-cli-"));
+  const agentId = "cli_resetPublicA1";
+  fs.writeFileSync(path.join(root, "config.json"), JSON.stringify({ version: 3, serverId: "server-test", activeAgent: agentId,
+    agents: { [agentId]: { runtime: "pi", model: "openai/gpt-5" } } }), { mode: 0o600 });
+  let stdout = "", stderr = "", request;
+  try {
+    const code = await runSessionCli(["reset", "--agent", agentId, "--json", "--wait-ready", "2", "--operation-id", "operation_public_1"],
+      { ...process.env, LARKIN_CONFIG_DIR: root }, {
+        async request(input) { request = input; return { ok: true, operationId: input.operationId, agentId,
+          resetCommitted: true, generationChanged: true, sessionChanged: true, turns: 0,
+          runtimeReady: true, channelConnected: true, reconnecting: false, pendingCount: 0,
+          readyForFreshScenario: true, inboundObserved: false }; },
+        io: { stdout: (value) => { stdout += value; }, stderr: (value) => { stderr += value; } },
+      });
+    assert.equal(code, 0, stderr);
+    assert.equal(request.waitReadyMs, 2_000);
+    const result = JSON.parse(stdout);
+    assert.deepEqual(result, { ok: true, operation_id: "operation_public_1", agent_id: agentId,
+      reset_committed: true, generation_changed: true, session_changed: true, turns: 0,
+      runtime_ready: true, channel_connected: true, reconnecting: false, pending_count: 0,
+      ready_for_fresh_scenario: true, inbound_observed: false });
+    assert.doesNotMatch(stdout, /session-[0-9]|stateDir|credential/i);
+  } finally { fs.rmSync(root, { recursive: true, force: true }); }
+});
+
+test("session reset is user-only and rejects malformed argv before control access", async () => {
+  const cases = [
+    [[], /unsupported session subcommand/],
+    [["show", "--json"], /unsupported session subcommand/],
+    [["reset", "--agent", "cli_parseA1"], /--json is required/],
+    [["reset", "--json", "--agent"], /missing value/],
+    [["reset", "--json", "--agent", "cli_parseA1", "--agent", "cli_parseA1"], /duplicate flag/],
+    [["reset", "--json", "--agent", "cli_parseA1", "--wat"], /unknown flag/],
+    [["reset", "--json", "--agent", "cli_parseA1", "extra"], /unexpected positional/],
+  ];
+  for (const [argv, expected] of cases) {
+    let stdout = "", calls = 0;
+    const code = await runSessionCli(argv, {}, { async request() { calls += 1; throw new Error("must not run"); },
+      io: { stdout: (value) => { stdout += value; }, stderr() {} } });
+    assert.equal(code, 1);
+    assert.equal(calls, 0);
+    const result = JSON.parse(stdout);
+    assert.equal(result.code, "invalid_arguments");
+    assert.match(result.error, expected);
+  }
+
+  let stdout = "", calls = 0;
+  const code = await runSessionCli(["reset", "--json", "--agent", "cli_parseA1", "--operation-id", "operation_user_1"],
+    { LARKIN_AGENT_ID: "cli_runtimeA1" }, { async request() { calls += 1; throw new Error("must not run"); },
+      io: { stdout: (value) => { stdout += value; }, stderr() {} } });
+  assert.equal(code, 1);
+  assert.equal(calls, 0);
+  assert.equal(JSON.parse(stdout).code, "user_authority_required");
+});

--- a/test/unit/app/session-cli.test.mjs
+++ b/test/unit/app/session-cli.test.mjs
@@ -2,8 +2,12 @@ import assert from "node:assert/strict";
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
+import { spawnSync } from "node:child_process";
+import { fileURLToPath } from "node:url";
 import { test } from "bun:test";
 import { runSessionCli } from "../../../dist/app/session-cli.mjs";
+
+const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..", "..", "..");
 
 test("public session reset emits stable truthful JSON without raw session identifiers", async () => {
   const root = fs.mkdtempSync(path.join(os.tmpdir(), "larkin-session-cli-"));
@@ -12,9 +16,9 @@ test("public session reset emits stable truthful JSON without raw session identi
     agents: { [agentId]: { runtime: "pi", model: "openai/gpt-5" } } }), { mode: 0o600 });
   let stdout = "", stderr = "", request;
   try {
-    const code = await runSessionCli(["reset", "--agent", agentId, "--json", "--wait-ready", "2", "--operation-id", "operation_public_1"],
+    const code = await runSessionCli(["reset", "--agent", agentId, "--json", "--wait-ready", "2"],
       { ...process.env, LARKIN_CONFIG_DIR: root }, {
-        async request(input) { request = input; return { ok: true, operationId: input.operationId, agentId,
+        async request(input) { request = input; return { ok: true, agentId,
           resetCommitted: true, generationChanged: true, sessionChanged: true, turns: 0,
           runtimeReady: true, channelConnected: true, reconnecting: false, pendingCount: 0,
           readyForFreshScenario: true, inboundObserved: false }; },
@@ -23,7 +27,8 @@ test("public session reset emits stable truthful JSON without raw session identi
     assert.equal(code, 0, stderr);
     assert.equal(request.waitReadyMs, 2_000);
     const result = JSON.parse(stdout);
-    assert.deepEqual(result, { ok: true, operation_id: "operation_public_1", agent_id: agentId,
+    assert.equal("operationId" in request, false);
+    assert.deepEqual(result, { ok: true, agent_id: agentId,
       reset_committed: true, generation_changed: true, session_changed: true, turns: 0,
       runtime_ready: true, channel_connected: true, reconnecting: false, pending_count: 0,
       ready_for_fresh_scenario: true, inbound_observed: false });
@@ -39,6 +44,7 @@ test("session reset is user-only and rejects malformed argv before control acces
     [["reset", "--json", "--agent"], /missing value/],
     [["reset", "--json", "--agent", "cli_parseA1", "--agent", "cli_parseA1"], /duplicate flag/],
     [["reset", "--json", "--agent", "cli_parseA1", "--wat"], /unknown flag/],
+    [["reset", "--json", "--agent", "cli_parseA1", "--operation-id", "operation_user_1"], /unknown flag: --operation-id/],
     [["reset", "--json", "--agent", "cli_parseA1", "extra"], /unexpected positional/],
   ];
   for (const [argv, expected] of cases) {
@@ -53,10 +59,19 @@ test("session reset is user-only and rejects malformed argv before control acces
   }
 
   let stdout = "", calls = 0;
-  const code = await runSessionCli(["reset", "--json", "--agent", "cli_parseA1", "--operation-id", "operation_user_1"],
+  const code = await runSessionCli(["reset", "--json", "--agent", "cli_parseA1"],
     { LARKIN_AGENT_ID: "cli_runtimeA1" }, { async request() { calls += 1; throw new Error("must not run"); },
       io: { stdout: (value) => { stdout += value; }, stderr() {} } });
   assert.equal(code, 1);
   assert.equal(calls, 0);
   assert.equal(JSON.parse(stdout).code, "user_authority_required");
+});
+
+test("public session help does not expose internal operation IDs", () => {
+  const result = spawnSync(process.execPath, [path.join(ROOT, "dist/app/cli.mjs"), "session", "--help"], {
+    cwd: ROOT, encoding: "utf8",
+  });
+  assert.equal(result.status, 0, result.stderr);
+  assert.match(result.stdout, /larkin session reset --agent <App ID> --json/);
+  assert.doesNotMatch(result.stdout, /operation-id/i);
 });

--- a/test/unit/feishu/host-processing-eye.test.mjs
+++ b/test/unit/feishu/host-processing-eye.test.mjs
@@ -213,7 +213,7 @@ test("failed reaction POST never becomes pending and terminal cleanup remains ha
   assert.match(logs.join("\n"), /点上失败/);
 });
 
-test("larkApi failure records exit code and stderr head instead of echoing the command line", () => {
+test("non-reaction larkApi failure records exit code and stderr head instead of echoing the command line", () => {
   const errors = [];
   const eye = new ProcessingEyeOrchestrator({
     cliForAgent: () => ({ command: "/test/official-lark-cli", argsPrefix: [], env: {} }),
@@ -228,10 +228,27 @@ test("larkApi failure records exit code and stderr head instead of echoing the c
     recordStatusError(_agent, text) { errors.push(text); },
     writePending() {}, setTimer: () => ({ fake: true }), clearTimer() {},
   });
-  eye.add(agent, "om_fail");
+  eye.larkApi(agent, "GET", "/open-apis/im/v1/messages/om_fail", null);
   assert.equal(errors.length, 1);
-  assert.match(errors[0], /^larkApi POST om_fail\/reactions: exit=1 \| FetchError: request to/);
+  assert.match(errors[0], /^larkApi GET messages\/om_fail: exit=1 \| FetchError: request to/);
   assert.doesNotMatch(errors[0], /Command failed/);
+});
+
+test("processing reaction timeout stays in best-effort diagnostics instead of generic status errors", () => {
+  const errors = [], logs = [];
+  const eye = new ProcessingEyeOrchestrator({
+    cliForAgent: () => ({ command: "/test/official-lark-cli", argsPrefix: [], env: {} }),
+    execFile(_command, _args, _options, callback) {
+      callback(Object.assign(new Error("timed out"), { killed: true, code: "ETIMEDOUT" }), "", "");
+      return {};
+    },
+    recordStatusError(_agent, text) { errors.push(text); },
+    log(...parts) { logs.push(parts.join(" ")); },
+    writePending() {}, setTimer: () => ({ fake: true }), clearTimer() {},
+  });
+  eye.add(agent, "om_timeout");
+  assert.deepEqual(errors, []);
+  assert.match(logs.join("\n"), /超时/);
 });
 
 test("larkApi failure without stderr falls back to stdout head", () => {
@@ -245,6 +262,6 @@ test("larkApi failure without stderr falls back to stdout head", () => {
     recordStatusError(_agent, text) { errors.push(text); },
     writePending() {}, setTimer: () => ({ fake: true }), clearTimer() {},
   });
-  eye.add(agent, "om_fail2");
+  eye.larkApi(agent, "GET", "/open-apis/im/v1/messages/om_fail2", null);
   assert.match(errors[0], /exit=ENOENT \| partial garbage output/);
 });

--- a/test/unit/runtime/runtime-host.test.mjs
+++ b/test/unit/runtime/runtime-host.test.mjs
@@ -53,6 +53,90 @@ test("RuntimeHost stages a candidate session without stopping the old healthy Ag
   await host.shutdown("done");
 });
 
+test("RuntimeHost fresh reset replaces only an idle zero-backlog Agent and is generation-isolated", async () => {
+  const sessions = [];
+  const adapter = { id: "pi", capabilities: {}, async createSession(input) {
+    const session = new FakeSession();
+    session.sessionId = `session-${sessions.length + 1}`;
+    sessions.push({ session, input });
+    return session;
+  } };
+  const host = createRuntimeHost({ adapterFor: () => adapter, promptBuilder: new ContextPromptBuilder() });
+  const base = { name: "reset", runtime: "pi", model: "model", workspaceDir: "/tmp" };
+  await host.start([
+    { ...base, agentId: "cli_resetA1", sessionId: "resume-old" },
+    { ...base, agentId: "cli_otherA1", sessionId: "other-old" },
+  ]);
+  const result = await host.resetSession("cli_resetA1");
+  assert.equal(result.generationChanged, true);
+  assert.equal(result.sessionChanged, true);
+  assert.equal(result.turns, 0);
+  assert.equal(result.runtimeReady, true);
+  assert.equal(sessions[2].input.resumeSessionId, null);
+  assert.deepEqual(sessions[0].session.closes, ["fresh session reset committed"]);
+  assert.deepEqual(sessions[1].session.closes, []);
+  await host.shutdown("done");
+});
+
+test("RuntimeHost fresh reset refuses busy and canonical Inbox backlog without mutation", async () => {
+  const session = new FakeSession();
+  const store = {
+    readJson(_key, fallback) { return fallback; },
+    readNdjson() { return [{ message_id: "om_pending" }]; },
+    writeJson() {},
+    withInboxTransaction(operation) { return operation(); },
+  };
+  const host = createRuntimeHost({
+    adapterFor: () => ({ id: "codex", capabilities: {}, async createSession() { return session; } }),
+    promptBuilder: new ContextPromptBuilder(), stateStoreFor: () => store,
+  });
+  await host.start([{ agentId: "cli_resetBlockedA1", name: "blocked", runtime: "codex", model: "model", workspaceDir: "/tmp" }]);
+  await assert.rejects(host.resetSession("cli_resetBlockedA1"), (error) => error.code === "inbox_backlog" && error.pendingCount === 1);
+  assert.deepEqual(session.closes, []);
+  session.emit({ type: "turn-start" });
+  store.readNdjson = () => [];
+  await assert.rejects(host.resetSession("cli_resetBlockedA1"), (error) => error.code === "agent_busy");
+  assert.deepEqual(session.closes, []);
+  await host.shutdown("done");
+});
+
+test("RuntimeHost aborts a staged reset when Inbox arrival or turn start races creation", async () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "larkin-reset-race-"));
+  const agentId = "cli_resetRaceA1";
+  const store = createAgentStateStore(root, agentId);
+  const old = new FakeSession(); old.sessionId = "old-race";
+  let creates = 0, release;
+  const adapter = { id: "codex", capabilities: {}, async createSession() {
+    creates += 1;
+    if (creates === 1) return old;
+    const fresh = new FakeSession(); fresh.sessionId = `fresh-race-${creates}`;
+    await new Promise((resolve) => { release = resolve; });
+    return fresh;
+  } };
+  const host = createRuntimeHost({ adapterFor: () => adapter, promptBuilder: new ContextPromptBuilder(), stateStoreFor: () => store });
+  try {
+    await host.start([{ agentId, name: "race", runtime: "codex", model: "model", workspaceDir: "/tmp" }]);
+    const inboxRace = host.resetSession(agentId);
+    await new Promise((resolve) => setImmediate(resolve));
+    store.appendNdjson("inbox", { message_id: "om_raced", target: "chat:oc_race" });
+    release();
+    await assert.rejects(inboxRace, (error) => error.code === "inbox_backlog");
+    assert.deepEqual(old.closes, []);
+    store.pollInbox();
+
+    const turnRace = host.resetSession(agentId);
+    await new Promise((resolve) => setImmediate(resolve));
+    old.emit({ type: "turn-start" });
+    release();
+    await assert.rejects(turnRace, (error) => error.code === "agent_busy");
+    assert.deepEqual(old.closes, []);
+    old.emit({ type: "turn-end" });
+  } finally {
+    await host.shutdown("done");
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});
+
 test("RuntimeHost isolates a missing runtime and keeps healthy agents active", async () => {
   const healthy = new FakeSession();
   const events = [];
@@ -71,6 +155,41 @@ test("RuntimeHost isolates a missing runtime and keeps healthy agents active", a
   ]);
   assert.ok(events.some((event) => event.type === "agent-status" && event.agentId === "cli_badPiA1" && event.readiness?.state === "missing"));
   assert.ok(events.some((event) => event.type === "agent-status" && event.agentId === "cli_goodCodexA1" && event.status === "active"));
+  await host.shutdown("done");
+});
+
+test("RuntimeHost retries unavailable readiness through bounded recreate instead of disabling the Agent", async () => {
+  const session = new FakeSession();
+  let probes = 0;
+  const adapter = { id: "pi", capabilities: {}, async probe() {
+    probes += 1;
+    return probes === 1 ? { runtime: "pi", state: "unavailable", reason: "get_state timeout", nextAction: "retry" }
+      : { runtime: "pi", state: "ready" };
+  }, async createSession() { return session; } };
+  const host = createRuntimeHost({ adapterFor: () => adapter, promptBuilder: new ContextPromptBuilder(),
+    retryPolicy: { baseDelayMs: 2, maxDelayMs: 2, maxAttempts: 2 } });
+  await host.start([{ agentId: "cli_transientPiA1", name: "transient", runtime: "pi", model: "model", workspaceDir: "/tmp" }]);
+  await new Promise((resolve) => setTimeout(resolve, 10));
+  assert.equal(probes, 2);
+  assert.equal((await host.deliver("cli_transientPiA1", { message_id: "om_after_retry" })).status, "accepted");
+  await host.shutdown("done");
+});
+
+test("RuntimeHost stops recreate when the latest probe changes from unavailable to fatal", async () => {
+  let probes = 0;
+  const events = [];
+  const adapter = { id: "pi", capabilities: {}, async probe() {
+    probes += 1;
+    return probes === 1 ? { runtime: "pi", state: "unavailable", reason: "network timeout", nextAction: "retry" }
+      : { runtime: "pi", state: "unauthenticated", reason: "login required", nextAction: "login" };
+  }, async createSession() { throw new Error("must not create"); } };
+  const host = createRuntimeHost({ adapterFor: () => adapter, promptBuilder: new ContextPromptBuilder(),
+    retryPolicy: { baseDelayMs: 2, maxDelayMs: 2, maxAttempts: 5 } });
+  host.subscribe((event) => events.push(event));
+  await host.start([{ agentId: "cli_transitionPiA1", name: "transition", runtime: "pi", model: "model", workspaceDir: "/tmp" }]);
+  await new Promise((resolve) => setTimeout(resolve, 15));
+  assert.equal(probes, 2);
+  assert.ok(events.some((event) => event.type === "agent-status" && event.readiness?.state === "unauthenticated"));
   await host.shutdown("done");
 });
 

--- a/test/unit/runtime/runtime-readiness.test.mjs
+++ b/test/unit/runtime/runtime-readiness.test.mjs
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict";
 import { test } from "bun:test";
-import { probeNativeRuntimeReadiness } from "../../../dist/runtime/runtime-readiness.mjs";
+import { classifyRuntimePrerequisite, probeNativeRuntimeReadiness } from "../../../dist/runtime/runtime-readiness.mjs";
 
 for (const runtime of ["codex", "claude", "pi"]) {
   test(`${runtime} readiness classifies an unresolved configured command as missing`, async () => {
@@ -13,3 +13,16 @@ for (const runtime of ["codex", "claude", "pi"]) {
     assert.equal(readiness.executable, undefined);
   });
 }
+
+for (const message of ["get_state timeout after 5000ms", "unexpected EOF", "TLS handshake failed", "read ECONNRESET"]) {
+  test(`Pi readiness classifies transient transport failure as unavailable: ${message}`, () => {
+    const readiness = classifyRuntimePrerequisite("pi", new Error(message), "/usr/local/bin/pi");
+    assert.equal(readiness.state, "unavailable");
+    assert.match(readiness.nextAction, /retry/i);
+  });
+}
+
+test("readiness keeps unknown failures unavailable and reserves incompatible for proven protocol failures", () => {
+  assert.equal(classifyRuntimePrerequisite("pi", new Error("opaque probe failure")).state, "unavailable");
+  assert.equal(classifyRuntimePrerequisite("pi", new Error("RPC protocol version mismatch")).state, "incompatible");
+});


### PR DESCRIPTION
## Summary

Adds the reliability foundation required before rerunning the full Agent Experience matrix in #6.

- adds a user-only `larkin session reset --agent <App ID> --json` command through authenticated local control
- refuses busy or non-empty Inbox state before reset and preserves transcripts, delivery state, configuration, credentials, and other Agents
- keeps operation IDs and reset ledgers out of the entire reset argv/JSON/wire/persistence surface; concurrent same-Agent resets share one in-flight result
- returns truthful fresh-scenario readiness, including committed timeout/unavailable and inbound-not-observed states
- classifies transient Runtime/network failures as unavailable instead of incompatible, while preserving fail-closed missing/auth/protocol boundaries
- separates Feishu 230027 membership/target authorization guidance from OAuth scope guidance
- keeps processing-reaction failures observable but non-blocking
- rebases onto main v0.2.37 and increments the source version to 0.2.38

## Root cause

The prior fresh-session regression depended on manually editing Runtime resume pointers and restarting the service. It could not reliably prove idle/zero-backlog preconditions, atomic session replacement, or the distinction between reset commit and external readiness failure. Diagnostics also misclassified transient Runtime failures and Feishu 230027.

## Validation

- post-rebase focused audit: 95 pass
- final reset/control/RuntimeHost/production Mock E2E evaluator matrix: 47 pass
- Agent Experience v6 eval: 3/3
- full suite: frontend 24/24; integration 167 pass with 14 intentional opt-in skips; E2E 6/6
- license notices: 85 package versions
- publication tree/history: 266 files, 95 refs, 7,456 objects, 0 artifacts
- release intent: v0.2.38, create tag and publish
- `git diff --check canonical/main...HEAD`
- independent executor/evaluator loop: no remaining blocking, important, or missing-evidence finding

## Delivery boundary

Owner authorized exact-head merge, automatic v0.2.38 publication, and local release replacement after GitHub checks pass. This PR still does not send real Feishu traffic, run the two-model ten-scenario matrix, change the @ wake policy, or claim duplicate-write/exact-text model behavior is fixed. Issue #6 remains open for that post-install regression.

Relates to #6.
