### PR TITLE
Publish releases from package version changes

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,23 +2,64 @@ name: Publish release
 
 on:
   push:
+    branches:
+      - main
     tags:
       - "v*.*.*"
+    paths:
+      - package.json
 
 permissions:
   contents: read
 
 concurrency:
-  group: publish-release-${{ github.ref }}
+  group: publish-release-${{ github.sha }}
   cancel-in-progress: false
 
 jobs:
-  validate:
+  resolve-release:
     runs-on: ubuntu-24.04
+    timeout-minutes: 40
+    outputs:
+      mode: ${{ steps.intent.outputs.mode }}
+      release_tag: ${{ steps.intent.outputs.release_tag }}
+      source_sha: ${{ steps.intent.outputs.source_sha }}
+      should_create_tag: ${{ steps.intent.outputs.should_create_tag }}
+      should_publish: ${{ steps.intent.outputs.should_publish }}
     steps:
-      - name: Check out tagged source
+      - name: Check out immutable release source
         uses: actions/checkout@v7
         with:
+          ref: ${{ github.sha }}
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Set up pinned Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: 1.3.14
+
+      - name: Resolve package-version release intent
+        id: intent
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RELEASE_EVENT_NAME: ${{ github.event_name }}
+          RELEASE_REF: ${{ github.ref }}
+          RELEASE_SOURCE_SHA: ${{ github.sha }}
+          RELEASE_BEFORE_SHA: ${{ github.event.before }}
+          RELEASE_PREDECESSOR_ATTEMPTS: "120"
+          RELEASE_PREDECESSOR_DELAY_MS: "15000"
+        run: bun scripts/release/intent.mjs resolve
+
+  validate:
+    needs: resolve-release
+    if: needs.resolve-release.outputs.should_publish == 'true'
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Check out immutable release source
+        uses: actions/checkout@v7
+        with:
+          ref: ${{ needs.resolve-release.outputs.source_sha }}
           fetch-depth: 0
           persist-credentials: false
 
@@ -28,18 +69,26 @@ jobs:
           bun-version: 1.3.14
 
       - name: Verify tagged commit belongs to main
+        env:
+          SOURCE_SHA: ${{ needs.resolve-release.outputs.source_sha }}
         run: |
           git show-ref --verify --quiet refs/remotes/origin/main || {
             echo "Refusing to publish: origin/main is unavailable in the checkout" >&2
             exit 1
           }
-          git merge-base --is-ancestor "$GITHUB_SHA" origin/main || {
-            echo "Refusing to publish: tagged commit $GITHUB_SHA is not contained in origin/main" >&2
+          test "$(git rev-parse HEAD)" = "$SOURCE_SHA" || {
+            echo "Refusing to publish: checkout does not match immutable source $SOURCE_SHA" >&2
+            exit 1
+          }
+          git merge-base --is-ancestor "$SOURCE_SHA" origin/main || {
+            echo "Refusing to publish: source $SOURCE_SHA is not contained in origin/main" >&2
             exit 1
           }
 
       - name: Validate release version
-        run: bun run release:check-version "${GITHUB_REF_NAME}"
+        env:
+          RELEASE_TAG: ${{ needs.resolve-release.outputs.release_tag }}
+        run: bun run release:check-version "$RELEASE_TAG"
 
       - name: Install locked dependencies
         run: bun install --frozen-lockfile
@@ -71,28 +120,41 @@ jobs:
         run: bun run test
 
   prepare-release:
-    needs: validate
+    needs:
+      - resolve-release
+      - validate
+    if: needs.resolve-release.outputs.should_publish == 'true'
     runs-on: ubuntu-24.04
     permissions:
       contents: write
+    outputs:
+      should_publish: ${{ steps.prepare.outputs.should_publish }}
     steps:
-      - name: Create reusable draft release
+      - name: Check out immutable release source
+        uses: actions/checkout@v7
+        with:
+          ref: ${{ needs.resolve-release.outputs.source_sha }}
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Set up pinned Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: 1.3.14
+
+      - name: Materialize immutable tag and reusable draft
+        id: prepare
         env:
           GH_TOKEN: ${{ github.token }}
-          RELEASE_TAG: ${{ github.ref_name }}
-        run: |
-          if gh release view "$RELEASE_TAG" --repo "$GITHUB_REPOSITORY" >/dev/null 2>&1; then
-            test "$(gh release view "$RELEASE_TAG" --repo "$GITHUB_REPOSITORY" --json isDraft --jq .isDraft)" = true || {
-              echo "Refusing to overwrite published release $RELEASE_TAG" >&2
-              exit 1
-            }
-          else
-            gh release create "$RELEASE_TAG" --repo "$GITHUB_REPOSITORY" --draft --verify-tag \
-              --generate-notes --title "Larkin $RELEASE_TAG"
-          fi
+          RELEASE_TAG: ${{ needs.resolve-release.outputs.release_tag }}
+          RELEASE_SOURCE_SHA: ${{ needs.resolve-release.outputs.source_sha }}
+        run: bun scripts/release/intent.mjs prepare
 
   build:
-    needs: prepare-release
+    needs:
+      - resolve-release
+      - prepare-release
+    if: needs.prepare-release.outputs.should_publish == 'true'
     strategy:
       fail-fast: false
       matrix:
@@ -110,9 +172,11 @@ jobs:
     permissions:
       contents: write
     steps:
-      - name: Check out tagged source
+      - name: Check out immutable release source
         uses: actions/checkout@v7
         with:
+          ref: ${{ needs.resolve-release.outputs.source_sha }}
+          fetch-depth: 0
           persist-credentials: false
 
       - name: Set up pinned Bun
@@ -145,9 +209,11 @@ jobs:
       - name: Upload platform artifact to draft release
         env:
           GH_TOKEN: ${{ github.token }}
-          RELEASE_TAG: ${{ github.ref_name }}
+          RELEASE_TAG: ${{ needs.resolve-release.outputs.release_tag }}
           RELEASE_TARGET: ${{ matrix.target }}
+          RELEASE_SOURCE_SHA: ${{ needs.resolve-release.outputs.source_sha }}
         run: |
+          bun scripts/release/intent.mjs assert-draft
           manifest="artifacts/release/release-manifest-${RELEASE_TARGET}.json"
           mv artifacts/release/release-manifest.json "$manifest"
           gh release upload "$RELEASE_TAG" \
@@ -155,14 +221,20 @@ jobs:
             --repo "$GITHUB_REPOSITORY" --clobber
 
   publish:
-    needs: build
+    needs:
+      - resolve-release
+      - prepare-release
+      - build
+    if: needs.prepare-release.outputs.should_publish == 'true'
     runs-on: ubuntu-24.04
     permissions:
       contents: write
     steps:
-      - name: Check out tagged source
+      - name: Check out immutable release source
         uses: actions/checkout@v7
         with:
+          ref: ${{ needs.resolve-release.outputs.source_sha }}
+          fetch-depth: 0
           persist-credentials: false
 
       - name: Set up pinned Bun
@@ -176,7 +248,7 @@ jobs:
       - name: Download platform artifacts from draft release
         env:
           GH_TOKEN: ${{ github.token }}
-          RELEASE_TAG: ${{ github.ref_name }}
+          RELEASE_TAG: ${{ needs.resolve-release.outputs.release_tag }}
         run: |
           mkdir -p artifacts/platform
           gh release download "$RELEASE_TAG" --repo "$GITHUB_REPOSITORY" \
@@ -194,8 +266,10 @@ jobs:
       - name: Finalize GitHub release
         env:
           GH_TOKEN: ${{ github.token }}
-          RELEASE_TAG: ${{ github.ref_name }}
+          RELEASE_TAG: ${{ needs.resolve-release.outputs.release_tag }}
+          RELEASE_SOURCE_SHA: ${{ needs.resolve-release.outputs.source_sha }}
         run: |
+          bun scripts/release/intent.mjs assert-draft
           gh release upload "$RELEASE_TAG" \
             artifacts/release/SHA256SUMS artifacts/release/release-manifest.json \
             artifacts/release/LICENSE artifacts/release/THIRD_PARTY_NOTICES.txt \

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -35,6 +35,8 @@ Never commit credentials, tokens, private keys, local configuration, user data, 
 
 Contributions intentionally submitted for inclusion are licensed under Apache-2.0 as described by the repository `LICENSE` and its contribution terms.
 
-Owner policy: every bugfix or feature delivery must increment the version in `package.json` before merge. Unless the Owner explicitly selects a minor or major increment, default to exactly one patch increment. If the delivery already includes the required increment relative to its base, do not increment it again in a release-only follow-up. This policy does not authorize creating or publishing a tag or GitHub Release.
+Owner policy: every bugfix or feature delivery must increment the version in `package.json` before merge. Unless the Owner explicitly selects a minor or major increment, default to exactly one patch increment. If the delivery already includes the required increment relative to its base, do not increment it again in a release-only follow-up.
 
-Release tags use `vX.Y.Z`, must exactly match the version in `package.json`, and must point to a commit already contained in `main`. Version changes and release tags are explicit maintainer actions; do not create, move, or replace a release tag as part of an ordinary contribution.
+Merging an intentional `package.json` version change to `main` authorizes CI to create the matching immutable tag and GitHub Release. Contributors must not manually create a release tag for an ordinary delivery; the explicit tag-push path is reserved for maintainer recovery. Never move, replace, or overwrite an existing release tag or published GitHub Release.
+
+Release tags use `vX.Y.Z`, must exactly match the version in `package.json`, and must point to a commit already contained in `main`. Outside the authorized workflow, tag operations are explicit maintainer recovery actions; do not create, move, or replace a release tag as part of an ordinary contribution.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "larkin",
-  "version": "0.2.34",
+  "version": "0.2.35",
   "private": true,
   "larkinPackageRole": "development-source-checkout",
   "packageManager": "bun@1.3.14",

--- a/scripts/release/intent.mjs
+++ b/scripts/release/intent.mjs
@@ -1,0 +1,361 @@
+#!/usr/bin/env bun
+
+import fs from "node:fs";
+import path from "node:path";
+import { spawnSync } from "node:child_process";
+import { fileURLToPath } from "node:url";
+
+import {
+  assertReleaseTag,
+  compareStableVersions,
+  parseStableVersion,
+} from "../versioning.mjs";
+
+const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../..");
+const SHA = /^[0-9a-f]{40}$/;
+const REPOSITORY = /^[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+$/;
+const RELEASE_STATES = new Set(["absent", "draft", "published"]);
+
+function checkedSha(value, label) {
+  const normalized = String(value || "").toLowerCase();
+  if (!SHA.test(normalized)) throw new Error(`${label} must be a full commit SHA`);
+  return normalized;
+}
+
+function highestVersion(versions) {
+  let highest = null;
+  for (const value of versions ?? []) {
+    parseStableVersion(value);
+    if (highest === null || compareStableVersions(value, highest) > 0) highest = value;
+  }
+  return highest;
+}
+
+export function resolveReleaseIntent({
+  ref,
+  sourceSha,
+  currentVersion,
+  previousVersion,
+  tagTargetSha,
+  releaseState,
+  publishedVersions = [],
+}) {
+  const source = checkedSha(sourceSha, "source SHA");
+  parseStableVersion(currentVersion);
+  if (!RELEASE_STATES.has(releaseState)) throw new Error(`unsupported release state: ${releaseState}`);
+
+  const releaseTag = `v${currentVersion}`;
+  let mode;
+  if (ref === "refs/heads/main") {
+    mode = "main";
+    parseStableVersion(previousVersion);
+    if (compareStableVersions(currentVersion, previousVersion) <= 0) {
+      throw new Error(`main package version must increase: ${previousVersion} -> ${currentVersion}`);
+    }
+  } else if (String(ref || "").startsWith("refs/tags/")) {
+    mode = "tag";
+    const pushedTag = String(ref).slice("refs/tags/".length);
+    try {
+      assertReleaseTag(currentVersion, pushedTag);
+    } catch {
+      throw new Error(`pushed tag ${pushedTag} does not match package.json v${currentVersion}`);
+    }
+  } else {
+    throw new Error(`unsupported release ref: ${ref || "missing"}`);
+  }
+
+  const tagTarget = tagTargetSha === null || tagTargetSha === undefined || tagTargetSha === ""
+    ? null
+    : checkedSha(tagTargetSha, "tag target SHA");
+  if (tagTarget !== null && tagTarget !== source) {
+    throw new Error(`${releaseTag} already points at another source commit`);
+  }
+  if (mode === "tag" && tagTarget === null) {
+    throw new Error(`pushed tag is unavailable: ${releaseTag}`);
+  }
+  if (releaseState !== "absent" && tagTarget === null) {
+    throw new Error(`${releaseTag} has a ${releaseState} release without its immutable tag`);
+  }
+
+  const publishedSet = new Set(publishedVersions);
+  if (mode === "main" && !publishedSet.has(previousVersion)) {
+    throw new Error(`predecessor release v${previousVersion} is not published`);
+  }
+
+  if (releaseState === "published") {
+    return {
+      mode,
+      releaseTag,
+      sourceSha: source,
+      shouldCreateTag: false,
+      shouldPublish: false,
+    };
+  }
+
+  const published = highestVersion(publishedVersions);
+  if (published !== null && compareStableVersions(currentVersion, published) <= 0) {
+    throw new Error(`release version ${currentVersion} is older than published version ${published}`);
+  }
+
+  return {
+    mode,
+    releaseTag,
+    sourceSha: source,
+    shouldCreateTag: mode === "main" && tagTarget === null,
+    shouldPublish: true,
+  };
+}
+
+function run(command, args, { allowFailure = false } = {}) {
+  const result = spawnSync(command, args, {
+    cwd: ROOT,
+    encoding: "utf8",
+    env: process.env,
+  });
+  if (result.error) throw result.error;
+  if (!allowFailure && result.status !== 0) {
+    const detail = String(result.stderr || result.stdout || "no diagnostic").trim().slice(0, 800);
+    throw new Error(`${command} failed (${result.status}): ${detail}`);
+  }
+  return result;
+}
+
+function git(args, options) {
+  return run("git", args, options);
+}
+
+function gh(args, options) {
+  return run("gh", args, options);
+}
+
+function repository() {
+  const value = String(process.env.GITHUB_REPOSITORY || "");
+  if (!REPOSITORY.test(value)) throw new Error("GITHUB_REPOSITORY is invalid");
+  return value;
+}
+
+function queryJson(endpoint, jq, { allowNotFound = false } = {}) {
+  const result = gh(["api", "--method", "GET", endpoint, "--jq", jq], { allowFailure: true });
+  if (result.status !== 0) {
+    const diagnostic = `${result.stdout || ""}\n${result.stderr || ""}`;
+    if (allowNotFound && /HTTP 404\b/.test(diagnostic)) return null;
+    throw new Error(`GitHub API query failed (${result.status}): ${diagnostic.trim().slice(0, 800)}`);
+  }
+  try {
+    return JSON.parse(result.stdout);
+  } catch {
+    throw new Error(`GitHub API returned invalid JSON for ${endpoint}`);
+  }
+}
+
+function tagTarget(repo, tag) {
+  let object = queryJson(
+    `repos/${repo}/git/ref/tags/${tag}`,
+    "{type: .object.type, sha: .object.sha}",
+    { allowNotFound: true },
+  );
+  if (object === null) return null;
+  for (let depth = 0; depth < 8; depth += 1) {
+    object.sha = checkedSha(object.sha, "tag object SHA");
+    if (object.type === "commit") return object.sha;
+    if (object.type !== "tag") throw new Error(`${tag} resolves to unsupported Git object ${object.type}`);
+    object = queryJson(
+      `repos/${repo}/git/tags/${object.sha}`,
+      "{type: .object.type, sha: .object.sha}",
+    );
+  }
+  throw new Error(`${tag} exceeds the supported annotated-tag depth`);
+}
+
+function releaseState(repo, tag) {
+  const release = queryJson(
+    `repos/${repo}/releases/tags/${tag}`,
+    "{tagName: .tag_name, isDraft: .draft}",
+    { allowNotFound: true },
+  );
+  if (release === null) return "absent";
+  if (release.tagName !== tag) throw new Error(`GitHub Release tag mismatch: ${release.tagName}`);
+  return release.isDraft ? "draft" : "published";
+}
+
+function publishedVersions(repo) {
+  const result = gh([
+    "api",
+    "--method", "GET",
+    "--paginate",
+    `repos/${repo}/releases?per_page=100`,
+    "--jq", ".[] | select(.draft == false) | .tag_name",
+  ]);
+  return String(result.stdout || "")
+    .split(/\r?\n/)
+    .map((tag) => tag.trim())
+    .filter((tag) => /^v(?:0|[1-9]\d*)\.(?:0|[1-9]\d*)\.(?:0|[1-9]\d*)$/.test(tag))
+    .map((tag) => tag.slice(1));
+}
+
+function boundedEnvironmentInteger(name, fallback, minimum, maximum) {
+  const raw = process.env[name];
+  if (raw === undefined || raw === "") return fallback;
+  const value = Number(raw);
+  if (!Number.isSafeInteger(value) || value < minimum || value > maximum) {
+    throw new Error(`${name} must be an integer from ${minimum} through ${maximum}`);
+  }
+  return value;
+}
+
+async function waitForPublishedPredecessor(repo, version) {
+  const attempts = boundedEnvironmentInteger("RELEASE_PREDECESSOR_ATTEMPTS", 120, 1, 240);
+  const delayMs = boundedEnvironmentInteger("RELEASE_PREDECESSOR_DELAY_MS", 15_000, 0, 60_000);
+  for (let attempt = 1; attempt <= attempts; attempt += 1) {
+    const published = publishedVersions(repo);
+    if (published.includes(version)) return published;
+    if (attempt === attempts) break;
+    process.stderr.write(`waiting for predecessor release v${version} (${attempt}/${attempts})\n`);
+    await new Promise((resolve) => setTimeout(resolve, delayMs));
+  }
+  throw new Error(`predecessor release v${version} was not published after ${attempts} attempts`);
+}
+
+function manifestVersionAt(ref) {
+  const manifest = JSON.parse(git(["show", `${ref}:package.json`]).stdout);
+  return String(manifest.version || "");
+}
+
+function assertImmutableMainSource(sourceSha) {
+  const head = checkedSha(git(["rev-parse", "HEAD"]).stdout.trim(), "checked-out HEAD");
+  if (head !== sourceSha) throw new Error(`checked-out HEAD ${head} does not match source ${sourceSha}`);
+  if (git(["show-ref", "--verify", "--quiet", "refs/remotes/origin/main"], { allowFailure: true }).status !== 0) {
+    throw new Error("origin/main is unavailable in the checkout");
+  }
+  if (git(["merge-base", "--is-ancestor", sourceSha, "origin/main"], { allowFailure: true }).status !== 0) {
+    throw new Error(`git merge-base rejected source ${sourceSha}: it is not contained in origin/main`);
+  }
+}
+
+function appendOutputs(values) {
+  const lines = Object.entries(values).map(([key, value]) => `${key}=${String(value)}`).join("\n") + "\n";
+  const output = String(process.env.GITHUB_OUTPUT || "");
+  if (output) fs.appendFileSync(output, lines);
+  else process.stdout.write(lines);
+}
+
+async function resolveCommand() {
+  if (process.env.RELEASE_EVENT_NAME !== "push") throw new Error("release intent requires a push event");
+  const repo = repository();
+  const ref = String(process.env.RELEASE_REF || "");
+  const eventSha = checkedSha(process.env.RELEASE_SOURCE_SHA, "release event SHA");
+  const checkedOutSha = checkedSha(git(["rev-parse", "HEAD"]).stdout.trim(), "checked-out HEAD");
+  const sourceSha = ref.startsWith("refs/tags/") ? checkedOutSha : eventSha;
+  assertImmutableMainSource(sourceSha);
+
+  const currentVersion = manifestVersionAt(sourceSha);
+  const checkoutVersion = String(JSON.parse(fs.readFileSync(path.join(ROOT, "package.json"), "utf8")).version || "");
+  if (checkoutVersion !== currentVersion) {
+    throw new Error(`checked-out package version ${checkoutVersion} does not match immutable source ${currentVersion}`);
+  }
+  let previousVersion;
+  let published;
+  if (ref === "refs/heads/main") {
+    const beforeSha = checkedSha(process.env.RELEASE_BEFORE_SHA, "push before SHA");
+    if (/^0+$/.test(beforeSha)) throw new Error("main release push has no previous source commit");
+    if (git(["merge-base", "--is-ancestor", beforeSha, sourceSha], { allowFailure: true }).status !== 0) {
+      throw new Error(`push before SHA ${beforeSha} is not an ancestor of source ${sourceSha}`);
+    }
+    previousVersion = manifestVersionAt(beforeSha);
+    published = await waitForPublishedPredecessor(repo, previousVersion);
+  } else {
+    published = publishedVersions(repo);
+  }
+
+  const releaseTag = `v${currentVersion}`;
+  const intent = resolveReleaseIntent({
+    ref,
+    sourceSha,
+    currentVersion,
+    previousVersion,
+    tagTargetSha: tagTarget(repo, releaseTag),
+    releaseState: releaseState(repo, releaseTag),
+    publishedVersions: published,
+  });
+  appendOutputs({
+    mode: intent.mode,
+    release_tag: intent.releaseTag,
+    source_sha: intent.sourceSha,
+    should_create_tag: intent.shouldCreateTag,
+    should_publish: intent.shouldPublish,
+  });
+}
+
+function createExactTag(repo, tag, sourceSha) {
+  const existing = tagTarget(repo, tag);
+  if (existing !== null) {
+    if (existing !== sourceSha) throw new Error(`${tag} already points at another source commit`);
+    return false;
+  }
+  if (releaseState(repo, tag) !== "absent") {
+    throw new Error(`${tag} has a release without its immutable tag`);
+  }
+  const created = gh([
+    "api",
+    "--method", "POST",
+    `repos/${repo}/git/refs`,
+    "-f", `ref=refs/tags/${tag}`,
+    "-f", `sha=${sourceSha}`,
+  ], { allowFailure: true });
+  const target = tagTarget(repo, tag);
+  if (target !== sourceSha) {
+    const diagnostic = String(created.stderr || created.stdout || "no diagnostic").trim().slice(0, 800);
+    throw new Error(`failed to create immutable tag ${tag}: ${diagnostic}`);
+  }
+  return created.status === 0;
+}
+
+function prepareCommand() {
+  const repo = repository();
+  const tag = String(process.env.RELEASE_TAG || "");
+  const sourceSha = checkedSha(process.env.RELEASE_SOURCE_SHA, "release source SHA");
+  if (!tag.startsWith("v")) throw new Error(`invalid release tag: ${tag || "missing"}`);
+  assertReleaseTag(manifestVersionAt(sourceSha), tag);
+  assertImmutableMainSource(sourceSha);
+  createExactTag(repo, tag, sourceSha);
+
+  let state = releaseState(repo, tag);
+  if (state === "published") {
+    appendOutputs({ should_publish: false });
+    return;
+  }
+  if (state === "absent") {
+    const created = gh([
+      "release", "create", tag,
+      "--repo", repo,
+      "--draft",
+      "--verify-tag",
+      "--generate-notes",
+      "--title", `Larkin ${tag}`,
+    ], { allowFailure: true });
+    state = releaseState(repo, tag);
+    if (state === "absent") {
+      const diagnostic = String(created.stderr || created.stdout || "no diagnostic").trim().slice(0, 800);
+      throw new Error(`failed to create draft release ${tag}: ${diagnostic}`);
+    }
+  }
+  appendOutputs({ should_publish: state === "draft" });
+}
+
+function assertDraftCommand() {
+  const repo = repository();
+  const tag = String(process.env.RELEASE_TAG || "");
+  const sourceSha = checkedSha(process.env.RELEASE_SOURCE_SHA, "release source SHA");
+  assertReleaseTag(manifestVersionAt(sourceSha), tag);
+  assertImmutableMainSource(sourceSha);
+  if (tagTarget(repo, tag) !== sourceSha) throw new Error(`${tag} no longer points at the immutable release source`);
+  if (releaseState(repo, tag) !== "draft") throw new Error(`refusing to modify non-draft release ${tag}`);
+}
+
+if (import.meta.main) {
+  const command = process.argv[2];
+  if (command === "resolve") await resolveCommand();
+  else if (command === "prepare") prepareCommand();
+  else if (command === "assert-draft") assertDraftCommand();
+  else throw new Error("usage: bun scripts/release/intent.mjs <resolve|prepare|assert-draft>");
+}

--- a/test/integration/build/release-platform-ci.test.mjs
+++ b/test/integration/build/release-platform-ci.test.mjs
@@ -40,15 +40,38 @@ test("PR and main CI validate source without building release artifacts", () => 
   assert.doesNotMatch(workflow, /continue-on-error|actions\/(?:upload|download)-artifact|\b(?:node|npm|pnpm)\b/);
 });
 
-test("tag publication validates an explicit version and publishes one combined release", () => {
+test("package version and explicit tag publication share one immutable combined-release run", () => {
   const workflow = read(".github/workflows/release.yml");
+  const intent = read("scripts/release/intent.mjs");
   assert.equal(fs.existsSync(path.join(ROOT, ".github/workflows/bump-patch-version.yml")), false);
   assert.equal(fs.existsSync(path.join(ROOT, "scripts/bump-patch-version.mjs")), false);
+  assert.match(workflow, /branches:\n\s+- main/);
   assert.match(workflow, /tags:\n\s+- "v\*\.\*\.\*"/);
+  assert.match(workflow, /paths:\n\s+- package\.json/);
+  assert.match(workflow, /group: publish-release-\$\{\{ github\.sha \}\}/);
+  assert.doesNotMatch(workflow, /group: publish-release\n/);
+  assert.match(workflow, /resolve-release:/);
+  assert.match(workflow, /timeout-minutes: 40/);
+  assert.match(workflow, /RELEASE_PREDECESSOR_ATTEMPTS: "120"/);
+  assert.match(workflow, /RELEASE_PREDECESSOR_DELAY_MS: "15000"/);
+  assert.match(workflow, /bun scripts\/release\/intent\.mjs resolve/);
+  assert.match(workflow, /bun scripts\/release\/intent\.mjs prepare/);
+  assert.equal(workflow.match(/bun scripts\/release\/intent\.mjs assert-draft/g)?.length, 2);
+  assert.match(workflow, /source_sha: \$\{\{ steps\.intent\.outputs\.source_sha \}\}/);
+  assert.ok((workflow.match(/ref: \$\{\{ needs\.resolve-release\.outputs\.source_sha \}\}/g) ?? []).length >= 4);
+  assert.match(workflow, /RELEASE_TAG: \$\{\{ needs\.resolve-release\.outputs\.release_tag \}\}/);
+  assert.match(workflow, /should_publish: \$\{\{ steps\.prepare\.outputs\.should_publish \}\}/);
+  assert.match(workflow, /needs\.prepare-release\.outputs\.should_publish == 'true'/);
+  assert.match(intent, /refs\/heads\/main/);
+  assert.match(intent, /refs\/tags\//);
+  assert.match(intent, /git\(\["merge-base", "--is-ancestor"/);
+  assert.match(intent, /repos\/\$\{repo\}\/git\/refs/);
+  assert.match(intent, /"release", "create", tag/);
+  assert.match(intent, /refusing to modify non-draft release/);
+  assert.match(intent, /waitForPublishedPredecessor/);
   assert.match(workflow, /fetch-depth: 0/);
   assert.match(workflow, /git show-ref --verify --quiet refs\/remotes\/origin\/main/);
-  assert.match(workflow, /git merge-base --is-ancestor "\$GITHUB_SHA" origin\/main/);
-  assert.match(workflow, /bun run release:check-version "\$\{GITHUB_REF_NAME\}"/);
+  assert.match(workflow, /bun run release:check-version "\$RELEASE_TAG"/);
   assert.match(workflow, /bun run test/);
   assert.match(workflow, /bun run licenses:check/);
   assert.doesNotMatch(workflow, /actions\/setup-go|go-version:/);
@@ -65,13 +88,12 @@ test("tag publication validates an explicit version and publishes one combined r
   for (const target of ["linux-x64", "linux-arm64", "darwin-arm64", "darwin-x64"]) {
     assert.match(workflow, new RegExp(`target: ${target}`));
   }
-  assert.match(workflow, /gh release create[\s\S]*--draft/);
   assert.match(workflow, /gh release upload/);
   assert.match(workflow, /gh release download/);
   assert.match(workflow, /gh release edit[\s\S]*--draft=false/);
   assert.match(workflow, /bun scripts\/release\/assemble\.ts/);
   assert.match(workflow, /artifacts\/release\/LICENSE artifacts\/release\/THIRD_PARTY_NOTICES\.txt/);
-  assert.match(workflow, /gh release create/);
   assert.match(workflow, /publish:\n[\s\S]*permissions:\n\s+contents: write/);
   assert.doesNotMatch(workflow, /git (?:commit|push)|continue-on-error|\b(?:node|npm|pnpm)\b/);
+  assert.doesNotMatch(intent, /git push|--force/);
 });

--- a/test/unit/platform/release-intent-command.test.mjs
+++ b/test/unit/platform/release-intent-command.test.mjs
@@ -1,0 +1,281 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { spawnSync } from "node:child_process";
+import { describe, test } from "bun:test";
+
+const ROOT = path.resolve(import.meta.dirname, "../../..");
+const HELPER = path.join(ROOT, "scripts/release/intent.mjs");
+const SOURCE_SHA = "a".repeat(40);
+const BEFORE_SHA = "b".repeat(40);
+const OTHER_SHA = "c".repeat(40);
+const TAG_OBJECT_SHA = "d".repeat(40);
+
+const FAKE_GIT = `#!/usr/bin/env bun
+const args = process.argv.slice(2);
+const source = process.env.FAKE_SOURCE_SHA;
+const before = process.env.FAKE_BEFORE_SHA;
+if (args[0] === "rev-parse" && args[1] === "HEAD") console.log(source);
+else if (args[0] === "show-ref") process.exit(process.env.FAKE_SHOW_REF_FAIL === "1" ? 1 : 0);
+else if (args[0] === "merge-base") process.exit(process.env.FAKE_MERGE_BASE_FAIL === "1" ? 1 : 0);
+else if (args[0] === "show" && args[1] === source + ":package.json") console.log(JSON.stringify({ version: process.env.FAKE_CURRENT_VERSION }));
+else if (args[0] === "show" && args[1] === before + ":package.json") console.log(JSON.stringify({ version: process.env.FAKE_PREVIOUS_VERSION }));
+else { console.error("unexpected fake git command: " + JSON.stringify(args)); process.exit(70); }
+`;
+
+const FAKE_GH = `#!/usr/bin/env bun
+import fs from "node:fs";
+const file = process.env.FAKE_GH_STATE;
+const state = JSON.parse(fs.readFileSync(file, "utf8"));
+const args = process.argv.slice(2);
+state.commands ??= [];
+state.commands.push(args);
+const save = () => fs.writeFileSync(file, JSON.stringify(state));
+const missing = () => { save(); console.error("gh: Not Found (HTTP 404)"); process.exit(1); };
+if (args[0] === "api" && args.includes("GET")) {
+  const endpoint = args.find((value) => value.startsWith("repos/"));
+  const ref = endpoint.match(/\\/git\\/ref\\/tags\\/(.+)$/);
+  const object = endpoint.match(/\\/git\\/tags\\/([0-9a-f]{40})$/);
+  const release = endpoint.match(/\\/releases\\/tags\\/(.+)$/);
+  if (ref) {
+    const value = state.tags?.[ref[1]];
+    if (!value) missing();
+    save(); console.log(JSON.stringify(value));
+  } else if (object) {
+    const value = state.tagObjects?.[object[1]];
+    if (!value) missing();
+    save(); console.log(JSON.stringify(value));
+  } else if (release) {
+    const value = state.releases?.[release[1]];
+    if (!value) missing();
+    save(); console.log(JSON.stringify({ tagName: release[1], isDraft: value === "draft" }));
+  } else if (endpoint.includes("/releases?per_page=100")) {
+    const sequences = state.publishedSequences;
+    let published = state.published ?? [];
+    if (Array.isArray(sequences)) {
+      const index = Math.min(state.publishedQueries ?? 0, sequences.length - 1);
+      published = sequences[index];
+      state.publishedQueries = (state.publishedQueries ?? 0) + 1;
+    }
+    save();
+    if (published.length) console.log(published.join("\\n"));
+  } else { save(); console.error("unexpected fake gh GET: " + endpoint); process.exit(71); }
+} else if (args[0] === "api" && args.includes("POST")) {
+  const refArg = args.find((value) => value.startsWith("ref=refs/tags/"));
+  const shaArg = args.find((value) => value.startsWith("sha="));
+  const tag = refArg.slice("ref=refs/tags/".length);
+  const sha = shaArg.slice("sha=".length);
+  const mode = state.createTagMode ?? "success";
+  if (mode === "success" || mode === "race-same") state.tags[tag] = { type: "commit", sha };
+  else if (mode === "race-conflict") state.tags[tag] = { type: "commit", sha: state.conflictingSha };
+  save();
+  if (mode === "success") console.log("{}");
+  else { console.error("gh: reference update conflict (HTTP 422)"); process.exit(1); }
+} else if (args[0] === "release" && args[1] === "create") {
+  const tag = args[2];
+  if (state.createReleaseMode === "failure") { save(); console.error("release create failed"); process.exit(1); }
+  state.releases[tag] = "draft";
+  save();
+  console.log("created");
+} else { save(); console.error("unexpected fake gh command: " + JSON.stringify(args)); process.exit(72); }
+`;
+
+function fixture(initial = {}) {
+  const directory = fs.mkdtempSync(path.join(os.tmpdir(), "larkin-release-intent-command-"));
+  const bin = path.join(directory, "bin");
+  const stateFile = path.join(directory, "gh-state.json");
+  const outputFile = path.join(directory, "github-output.txt");
+  fs.mkdirSync(bin);
+  fs.writeFileSync(path.join(bin, "git"), FAKE_GIT, { mode: 0o755 });
+  fs.writeFileSync(path.join(bin, "gh"), FAKE_GH, { mode: 0o755 });
+  fs.writeFileSync(stateFile, JSON.stringify({
+    tags: {},
+    tagObjects: {},
+    releases: {},
+    published: ["v0.2.34"],
+    ...initial,
+  }));
+  const environment = {
+    ...process.env,
+    PATH: `${bin}:${process.env.PATH}`,
+    GH_TOKEN: "fake-token",
+    GITHUB_REPOSITORY: "owner/repository",
+    GITHUB_OUTPUT: outputFile,
+    RELEASE_EVENT_NAME: "push",
+    RELEASE_REF: "refs/heads/main",
+    RELEASE_SOURCE_SHA: SOURCE_SHA,
+    RELEASE_BEFORE_SHA: BEFORE_SHA,
+    RELEASE_TAG: "v0.2.35",
+    RELEASE_PREDECESSOR_ATTEMPTS: "2",
+    RELEASE_PREDECESSOR_DELAY_MS: "0",
+    FAKE_SOURCE_SHA: SOURCE_SHA,
+    FAKE_BEFORE_SHA: BEFORE_SHA,
+    FAKE_CURRENT_VERSION: "0.2.35",
+    FAKE_PREVIOUS_VERSION: "0.2.34",
+    FAKE_GH_STATE: stateFile,
+  };
+  const execute = (command, overrides = {}) => {
+    fs.writeFileSync(outputFile, "");
+    const result = spawnSync(process.execPath, [HELPER, command], {
+      cwd: ROOT,
+      encoding: "utf8",
+      env: { ...environment, ...overrides },
+    });
+    const outputs = Object.fromEntries(fs.readFileSync(outputFile, "utf8").trim().split("\n").filter(Boolean).map((line) => {
+      const separator = line.indexOf("=");
+      return [line.slice(0, separator), line.slice(separator + 1)];
+    }));
+    return { result, outputs, state: JSON.parse(fs.readFileSync(stateFile, "utf8")) };
+  };
+  return { directory, execute };
+}
+
+function commandCount(state, prefix) {
+  return state.commands.filter((args) => args.slice(0, prefix.length).join(" ") === prefix.join(" ")).length;
+}
+
+describe("release intent executable command boundary", () => {
+  test("resolve peels lightweight and annotated tags to one immutable commit", () => {
+    for (const annotated of [false, true]) {
+      const tag = annotated
+        ? { type: "tag", sha: TAG_OBJECT_SHA }
+        : { type: "commit", sha: SOURCE_SHA };
+      const f = fixture({
+        tags: { "v0.2.35": tag },
+        tagObjects: annotated ? { [TAG_OBJECT_SHA]: { type: "commit", sha: SOURCE_SHA } } : {},
+      });
+      try {
+        const run = f.execute("resolve", { RELEASE_REF: "refs/tags/v0.2.35" });
+        assert.equal(run.result.status, 0, run.result.stderr);
+        assert.deepEqual(run.outputs, {
+          mode: "tag",
+          release_tag: "v0.2.35",
+          source_sha: SOURCE_SHA,
+          should_create_tag: "false",
+          should_publish: "true",
+        });
+        assert.equal(commandCount(run.state, ["api", "--method", "GET"]), annotated ? 4 : 3);
+      } finally {
+        fs.rmSync(f.directory, { recursive: true, force: true });
+      }
+    }
+  });
+
+  test("main resolve waits for its published predecessor and fails when the bound is exhausted", () => {
+    const eventual = fixture({ publishedSequences: [[], ["v0.2.34"]] });
+    try {
+      const run = eventual.execute("resolve");
+      assert.equal(run.result.status, 0, run.result.stderr);
+      assert.equal(run.outputs.should_publish, "true");
+      assert.equal(run.state.publishedQueries, 2);
+    } finally {
+      fs.rmSync(eventual.directory, { recursive: true, force: true });
+    }
+
+    const missing = fixture({ publishedSequences: [[], []] });
+    try {
+      const run = missing.execute("resolve");
+      assert.notEqual(run.result.status, 0);
+      assert.match(run.result.stderr, /predecessor release v0\.2\.34 was not published after 2 attempts/);
+      assert.equal(run.state.publishedQueries, 2);
+    } finally {
+      fs.rmSync(missing.directory, { recursive: true, force: true });
+    }
+  });
+
+  test("a main package diff without a version increment fails closed", () => {
+    const f = fixture({ published: ["v0.2.35"] });
+    try {
+      const run = f.execute("resolve", { FAKE_PREVIOUS_VERSION: "0.2.35" });
+      assert.notEqual(run.result.status, 0);
+      assert.match(run.result.stderr, /main package version must increase: 0\.2\.35 -> 0\.2\.35/);
+      assert.deepEqual(run.outputs, {});
+    } finally {
+      fs.rmSync(f.directory, { recursive: true, force: true });
+    }
+  });
+
+  test("prepare creates an exact tag and draft and reports publishable output", () => {
+    const f = fixture();
+    try {
+      const run = f.execute("prepare");
+      assert.equal(run.result.status, 0, run.result.stderr);
+      assert.equal(run.outputs.should_publish, "true");
+      assert.deepEqual(run.state.tags["v0.2.35"], { type: "commit", sha: SOURCE_SHA });
+      assert.equal(run.state.releases["v0.2.35"], "draft");
+      assert.equal(commandCount(run.state, ["api", "--method", "POST"]), 1);
+      assert.equal(commandCount(run.state, ["release", "create"]), 1);
+    } finally {
+      fs.rmSync(f.directory, { recursive: true, force: true });
+    }
+  });
+
+  test("prepare accepts a same-SHA create race but rejects a conflicting race and a failed create", () => {
+    const same = fixture({ createTagMode: "race-same" });
+    try {
+      const run = same.execute("prepare");
+      assert.equal(run.result.status, 0, run.result.stderr);
+      assert.equal(run.outputs.should_publish, "true");
+      assert.equal(run.state.tags["v0.2.35"].sha, SOURCE_SHA);
+    } finally {
+      fs.rmSync(same.directory, { recursive: true, force: true });
+    }
+
+    for (const [mode, pattern] of [["race-conflict", /failed to create immutable tag/], ["failure", /failed to create immutable tag/]]) {
+      const f = fixture({ createTagMode: mode, conflictingSha: OTHER_SHA });
+      try {
+        const run = f.execute("prepare");
+        assert.notEqual(run.result.status, 0);
+        assert.match(run.result.stderr, pattern);
+        assert.equal(run.state.releases["v0.2.35"], undefined);
+      } finally {
+        fs.rmSync(f.directory, { recursive: true, force: true });
+      }
+    }
+  });
+
+  test("prepare resumes a draft and treats a published exact release as a no-op", () => {
+    for (const [release, expected] of [["draft", "true"], ["published", "false"]]) {
+      const f = fixture({
+        tags: { "v0.2.35": { type: "commit", sha: SOURCE_SHA } },
+        releases: { "v0.2.35": release },
+      });
+      try {
+        const run = f.execute("prepare");
+        assert.equal(run.result.status, 0, run.result.stderr);
+        assert.equal(run.outputs.should_publish, expected);
+        assert.equal(commandCount(run.state, ["api", "--method", "POST"]), 0);
+        assert.equal(commandCount(run.state, ["release", "create"]), 0);
+      } finally {
+        fs.rmSync(f.directory, { recursive: true, force: true });
+      }
+    }
+  });
+
+  test("assert-draft rejects published releases and conflicting immutable tags", () => {
+    const published = fixture({
+      tags: { "v0.2.35": { type: "commit", sha: SOURCE_SHA } },
+      releases: { "v0.2.35": "published" },
+    });
+    try {
+      const run = published.execute("assert-draft");
+      assert.notEqual(run.result.status, 0);
+      assert.match(run.result.stderr, /refusing to modify non-draft release/);
+    } finally {
+      fs.rmSync(published.directory, { recursive: true, force: true });
+    }
+
+    const conflict = fixture({
+      tags: { "v0.2.35": { type: "commit", sha: OTHER_SHA } },
+      releases: { "v0.2.35": "draft" },
+    });
+    try {
+      const run = conflict.execute("assert-draft");
+      assert.notEqual(run.result.status, 0);
+      assert.match(run.result.stderr, /no longer points at the immutable release source/);
+    } finally {
+      fs.rmSync(conflict.directory, { recursive: true, force: true });
+    }
+  });
+});

--- a/test/unit/platform/release-intent.test.mjs
+++ b/test/unit/platform/release-intent.test.mjs
@@ -1,0 +1,92 @@
+import assert from "node:assert/strict";
+import { describe, test } from "bun:test";
+
+import { resolveReleaseIntent } from "../../../scripts/release/intent.mjs";
+
+const SOURCE_SHA = "a".repeat(40);
+const OTHER_SHA = "b".repeat(40);
+
+describe("package-version release intent", () => {
+  test("main version increments derive one same-run tag publication", () => {
+    assert.deepEqual(resolveReleaseIntent({
+      ref: "refs/heads/main",
+      sourceSha: SOURCE_SHA,
+      currentVersion: "0.2.35",
+      previousVersion: "0.2.34",
+      tagTargetSha: null,
+      releaseState: "absent",
+      publishedVersions: ["0.2.34"],
+    }), {
+      mode: "main",
+      releaseTag: "v0.2.35",
+      sourceSha: SOURCE_SHA,
+      shouldCreateTag: true,
+      shouldPublish: true,
+    });
+  });
+
+  test("matching draft resumes and matching published release is an idempotent no-op", () => {
+    const input = {
+      ref: "refs/heads/main",
+      sourceSha: SOURCE_SHA,
+      currentVersion: "0.2.35",
+      previousVersion: "0.2.34",
+      tagTargetSha: SOURCE_SHA,
+      publishedVersions: ["0.2.34"],
+    };
+    assert.deepEqual(resolveReleaseIntent({ ...input, releaseState: "draft" }), {
+      mode: "main",
+      releaseTag: "v0.2.35",
+      sourceSha: SOURCE_SHA,
+      shouldCreateTag: false,
+      shouldPublish: true,
+    });
+    assert.equal(resolveReleaseIntent({ ...input, releaseState: "published" }).shouldPublish, false);
+  });
+
+  test("an explicit matching tag retains the same immutable pipeline", () => {
+    assert.deepEqual(resolveReleaseIntent({
+      ref: "refs/tags/v0.2.35",
+      sourceSha: SOURCE_SHA,
+      currentVersion: "0.2.35",
+      tagTargetSha: SOURCE_SHA,
+      releaseState: "absent",
+      publishedVersions: ["0.2.34"],
+    }), {
+      mode: "tag",
+      releaseTag: "v0.2.35",
+      sourceSha: SOURCE_SHA,
+      shouldCreateTag: false,
+      shouldPublish: true,
+    });
+  });
+
+  test("conflicts, non-increments, downgrades, and unsupported refs fail closed", () => {
+    const main = {
+      ref: "refs/heads/main",
+      sourceSha: SOURCE_SHA,
+      currentVersion: "0.2.35",
+      previousVersion: "0.2.34",
+      tagTargetSha: null,
+      releaseState: "absent",
+      publishedVersions: ["0.2.34"],
+    };
+    assert.throws(() => resolveReleaseIntent({ ...main, previousVersion: "0.2.35" }), /increase/);
+    assert.throws(() => resolveReleaseIntent({ ...main, previousVersion: "0.3.0" }), /increase/);
+    assert.throws(() => resolveReleaseIntent({ ...main, tagTargetSha: OTHER_SHA }), /another source commit/);
+    assert.throws(() => resolveReleaseIntent({ ...main, releaseState: "draft" }), /without its immutable tag/);
+    assert.throws(() => resolveReleaseIntent({ ...main, publishedVersions: [] }), /predecessor release/);
+    assert.throws(() => resolveReleaseIntent({ ...main, publishedVersions: ["0.2.34", "0.2.36"] }), /older than published/);
+    assert.throws(() => resolveReleaseIntent({ ...main, ref: "refs/heads/feature" }), /unsupported release ref/);
+    assert.throws(() => resolveReleaseIntent({
+      ...main,
+      ref: "refs/tags/v0.2.34",
+      tagTargetSha: SOURCE_SHA,
+    }), /does not match/);
+    assert.throws(() => resolveReleaseIntent({
+      ...main,
+      ref: "refs/tags/v0.2.35",
+      tagTargetSha: null,
+    }), /pushed tag is unavailable/);
+  });
+});


### PR DESCRIPTION
## Summary

- treat `package.json.version` as the single human-edited release intent
- on a version change merged to `main`, derive and create the immutable `vX.Y.Z` tag and continue the existing four-platform release in the same workflow run
- keep explicit tag pushes as a maintainer recovery path
- fail closed on version/tag/source conflicts, downgrades, missing predecessors, and non-draft mutation attempts
- make reruns idempotent for an exact published release
- update Owner policy and bump this delivery from 0.2.34 to 0.2.35

## Safety and ordering

GitHub events created with `GITHUB_TOKEN` do not start a second workflow, so tag creation and publication stay in one run. Each source SHA gets its own concurrency group; later package versions wait for the immediately preceding version to be published, preventing GitHub's single-pending concurrency behavior from dropping an intermediate release.

All build jobs check out the resolved immutable source SHA. Tag and draft state is rechecked before release uploads/finalization.

## Validation

- focused RED on the old contract
- focused GREEN: 17/17 release intent, command-boundary, versioning, and workflow tests
- full `bun run test`: PASS (integration 167 pass / 14 opt-in skip / 0 fail; E2E 5/5)
- license check: 85 package versions
- candidate tree/full-history publication: PASS (263 files; 86 refs; 7,396 objects)
- release version `v0.2.35`, YAML parse, and diff checks: PASS
- independent evaluator repair loop: no blocking, important, or missing-evidence finding remains

The already merged 0.2.34 source was separately recovered through the existing workflow: [v0.2.34](https://github.com/eddiearc/larkin/releases/tag/v0.2.34), run 30620127675, exact source c22d4e96.

## Post-merge acceptance

The merge's package version change must automatically create and publish `v0.2.35` from the exact merge SHA. This PR is not complete until exact-head source checks, merge-result checks, tag SHA, workflow jobs, Release manifest/checksums, and eight-asset inventory are verified.