### PR TITLE
Baseline synthetic secrets for release recovery

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -138,11 +138,52 @@ jobs:
       - name: Verify public source, refs, and history
         run: bun run scripts/check-publication.mjs --trusted --denylist "$RUNNER_TEMP/larkin-publication-denylist.txt"
 
+      - name: Check out recovery secret baseline
+        if: github.event_name == 'workflow_dispatch'
+        uses: actions/checkout@v7
+        with:
+          ref: ${{ github.workflow_sha }}
+          path: release-tooling
+          sparse-checkout: .gitleaksignore
+          sparse-checkout-cone-mode: false
+          fetch-depth: 1
+          persist-credentials: false
+
+      - name: Apply exact recovery secret baseline
+        id: recovery-secret-baseline
+        if: github.event_name == 'workflow_dispatch'
+        run: |
+          if git ls-files --error-unmatch .gitleaksignore >/dev/null 2>&1; then
+            cp -- .gitleaksignore "$RUNNER_TEMP/larkin-source-gitleaksignore"
+            echo "source_baseline=present" >> "$GITHUB_OUTPUT"
+          else
+            echo "source_baseline=absent" >> "$GITHUB_OUTPUT"
+          fi
+          cp -- "$GITHUB_WORKSPACE/release-tooling/.gitleaksignore" "$GITHUB_WORKSPACE/.gitleaksignore"
+
       - name: Scan tagged history for secrets
         uses: gitleaks/gitleaks-action@e0c47f4f8be36e29cdc102c57e68cb5cbf0e8d1e # v3
         env:
           GITHUB_TOKEN: ${{ github.token }}
           GITLEAKS_ENABLE_UPLOAD_ARTIFACT: false
+
+      - name: Restore immutable source secret baseline
+        if: always() && github.event_name == 'workflow_dispatch'
+        env:
+          SOURCE_BASELINE: ${{ steps.recovery-secret-baseline.outputs.source_baseline }}
+        run: |
+          case "$SOURCE_BASELINE" in
+            present)
+              cp -- "$RUNNER_TEMP/larkin-source-gitleaksignore" .gitleaksignore
+              ;;
+            absent)
+              rm -f -- .gitleaksignore
+              ;;
+            *)
+              echo "Refusing to continue: immutable source baseline state was not recorded" >&2
+              exit 1
+              ;;
+          esac
 
       - name: Remove Gitleaks SARIF output
         run: rm -f -- results.sarif

--- a/.gitleaksignore
+++ b/.gitleaksignore
@@ -1,0 +1,2 @@
+26a9006be595b4bc86b851d797bbc58bb815a772:test/unit/app/runtime-agent-interface-v2-live-safety.test.mjs:generic-api-key:202
+1e12236e5462a361cf45e1b1b218aae035ed7451:test/unit/app/runtime-agent-interface-v2-live-safety.test.mjs:generic-api-key:138

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "larkin",
-  "version": "0.2.36",
+  "version": "0.2.37",
   "private": true,
   "larkinPackageRole": "development-source-checkout",
   "packageManager": "bun@1.3.14",

--- a/test/integration/build/release-platform-ci.test.mjs
+++ b/test/integration/build/release-platform-ci.test.mjs
@@ -5,10 +5,14 @@ import { test } from "bun:test";
 
 const ROOT = path.resolve(import.meta.dirname, "../../..");
 const read = (file) => fs.readFileSync(path.join(ROOT, file), "utf8");
+const GITLEAKS_BASELINE = [
+  "26a9006be595b4bc86b851d797bbc58bb815a772:test/unit/app/runtime-agent-interface-v2-live-safety.test.mjs:generic-api-key:202",
+  "1e12236e5462a361cf45e1b1b218aae035ed7451:test/unit/app/runtime-agent-interface-v2-live-safety.test.mjs:generic-api-key:138",
+];
 
 test("PR and main CI validate source without building release artifacts", () => {
   const workflow = read(".github/workflows/release-platform-smoke.yml");
-  assert.equal(fs.existsSync(path.join(ROOT, ".gitleaksignore")), false, "synthetic secrets must be constructed at runtime without fingerprint exceptions");
+  assert.equal(read(".gitleaksignore"), `${GITLEAKS_BASELINE.join("\n")}\n`, "only the two verified synthetic history fingerprints may be ignored");
   assert.equal(fs.existsSync(path.join(ROOT, "THIRD_PARTY_NOTICES.md")), false, "complete lock-graph notices must not be tracked at the repository root");
   assert.match(workflow, /pull_request:/);
   assert.match(workflow, /push:\n\s+branches:\n\s+- main/);
@@ -91,10 +95,17 @@ test("package version and explicit tag publication share one immutable combined-
   assert.match(workflow, /secrets\.LARKIN_PUBLICATION_DENYLIST/);
   assert.match(workflow, /--trusted --denylist "\$RUNNER_TEMP\/larkin-publication-denylist\.txt"/);
   assert.match(workflow, /gitleaks\/gitleaks-action@e0c47f4f8be36e29cdc102c57e68cb5cbf0e8d1e # v3/);
+  assert.match(workflow, /name: Check out recovery secret baseline\n\s+if: github\.event_name == 'workflow_dispatch'[\s\S]*ref: \$\{\{ github\.workflow_sha \}\}[\s\S]*path: release-tooling[\s\S]*sparse-checkout: \.gitleaksignore[\s\S]*sparse-checkout-cone-mode: false/);
+  assert.match(workflow, /name: Apply exact recovery secret baseline\n\s+id: recovery-secret-baseline\n\s+if: github\.event_name == 'workflow_dispatch'[\s\S]*git ls-files --error-unmatch \.gitleaksignore[\s\S]*cp -- \.gitleaksignore "\$RUNNER_TEMP\/larkin-source-gitleaksignore"[\s\S]*source_baseline=present[\s\S]*source_baseline=absent[\s\S]*cp -- "\$GITHUB_WORKSPACE\/release-tooling\/\.gitleaksignore" "\$GITHUB_WORKSPACE\/\.gitleaksignore"/);
+  assert.match(workflow, /name: Restore immutable source secret baseline\n\s+if: always\(\) && github\.event_name == 'workflow_dispatch'[\s\S]*SOURCE_BASELINE: \$\{\{ steps\.recovery-secret-baseline\.outputs\.source_baseline \}\}[\s\S]*present\)[\s\S]*cp -- "\$RUNNER_TEMP\/larkin-source-gitleaksignore" \.gitleaksignore[\s\S]*absent\)[\s\S]*rm -f -- \.gitleaksignore/);
   assert.match(workflow, /GITHUB_TOKEN: \$\{\{ github\.token \}\}\n\s+GITLEAKS_ENABLE_UPLOAD_ARTIFACT: false/);
-  assert.match(workflow, /GITLEAKS_ENABLE_UPLOAD_ARTIFACT: false\n\n\s+- name: Remove Gitleaks SARIF output\n\s+run: rm -f -- results\.sarif/);
+  assert.match(workflow, /GITLEAKS_ENABLE_UPLOAD_ARTIFACT: false[\s\S]*- name: Remove Gitleaks SARIF output\n\s+run: rm -f -- results\.sarif/);
   assert.equal(workflow.match(/rm -f -- results\.sarif/g)?.length, 1, "only the generated Gitleaks SARIF path may be removed");
   assert.ok(workflow.indexOf("gitleaks/gitleaks-action@") < workflow.indexOf("run: rm -f -- results.sarif"));
+  assert.ok(workflow.indexOf("- name: Verify public source, refs, and history") < workflow.indexOf("- name: Check out recovery secret baseline"));
+  assert.ok(workflow.indexOf("- name: Apply exact recovery secret baseline") < workflow.indexOf("gitleaks/gitleaks-action@"));
+  assert.ok(workflow.indexOf("gitleaks/gitleaks-action@") < workflow.indexOf("- name: Restore immutable source secret baseline"));
+  assert.ok(workflow.indexOf("- name: Restore immutable source secret baseline") < workflow.indexOf("- name: Run full test suite"));
   assert.ok(workflow.indexOf("run: rm -f -- results.sarif") < workflow.indexOf("- name: Build current platform release"));
   assert.match(workflow, /bun run scripts\/check-publication\.mjs --trusted --denylist "\$RUNNER_TEMP\/larkin-publication-denylist\.txt" artifacts\/release\/larkin-v\*/);
   assert.match(workflow, /artifacts\/release\/larkin-v\* artifacts\/release\/THIRD_PARTY_NOTICES\.txt/);


### PR DESCRIPTION
## Summary

- preserve the workflow_dispatch full-history Gitleaks scan while ignoring only two verified synthetic test-secret fingerprints
- source that baseline from current default-branch workflow tooling for recovery of older immutable commits
- restore the recovered source baseline exactly after scanning, including when the scan fails
- bump package.json from 0.2.36 to 0.2.37

## Why

Recovery run 30625346801 correctly checked out v0.2.35 at 29ce76f, but gitleaks-action v3 scans all history for workflow_dispatch and stopped on two historical synthetic fixtures. The original push validation had scanned only the pushed range. This change retains the stronger full-history scan and baselines only those exact fingerprints.

## Validation

- focused workflow contract tests: 18 passed in independent evaluation
- full build/test/license/publication checks passed
- exact-commit Gitleaks scans pass with the two fingerprints
- independent evaluator: no blocking or important findings

## Post-merge acceptance

1. Dispatch v0.2.35 recovery at exact source 29ce76fe389d44626a95421858323237440c68b0.
2. Verify retained draft 362991614 publishes without moving the tag.
3. Verify already-running v0.2.36 and new v0.2.37 package-driven releases publish at their exact merge commits.