### PR TITLE
Fix stale reconnect state blocking session reset

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "larkin",
-  "version": "0.2.38",
+  "version": "0.2.39",
   "private": true,
   "larkinPackageRole": "development-source-checkout",
   "packageManager": "bun@1.3.14",

--- a/src/app/agent-config.ts
+++ b/src/app/agent-config.ts
@@ -7,7 +7,7 @@ import { discoverClaudeModelCatalog } from "../runtime/claude-model-catalog.js";
 import { discoverCodexModelCatalog } from "../runtime/codex-model-catalog.js";
 import { discoverPiModelCatalog, type PiModelCatalog } from "../runtime/pi-model-catalog.js";
 import { callbackCapability } from "../platform/callback-capability.js";
-import { projectAgentReadiness, type AgentReadinessStatus } from "./agent-readiness.js";
+import { isChannelReconnecting, projectAgentReadiness, type AgentReadinessStatus } from "./agent-readiness.js";
 import { requestAgentUpsert } from "./local-control.js";
 import * as larkinConfig from "../platform/config.js";
 import { managedOfficialLarkCli } from "./agent-lark-cli-workspace.js";
@@ -238,8 +238,7 @@ if (kind === "agents") {
     if (status?.runtimeReadiness) say(`    runtime readiness=${status.runtimeReadiness.state || "incompatible"}${status.runtimeReadiness.reason ? `：${status.runtimeReadiness.reason}` : ""}${status.runtimeReadiness.nextAction ? `；下一步：${status.runtimeReadiness.nextAction}` : ""}`);
     if (status?.runtimeReadiness?.executable) say(`    runtime executable=${status.runtimeReadiness.executable}${status.runtimeReadiness.version ? `  version=${status.runtimeReadiness.version}` : ""}`);
     say(`    bot=${bot ? `${bot.name}(${bot.open_id})` : "（未连接过，无身份缓存）"}`);
-    const reconnecting = connected && !!status?.reconnectingAt
-      && Date.parse(String(status.reconnectingAt)) > Date.parse(String(status?.reconnectedAt || 0));
+    const reconnecting = connected && isChannelReconnecting(status);
     say(`    连接=${connected ? `已建立（${status?.connectedVia || "channel"}，${status?.connectedAt}）${reconnecting ? "（ws 重连中）" : ""}` : "未建立"}`);
     // 三态：已验证 / 未证实（连上但长时间零事件=疑似僵尸，host 会预防性重连）/ 尚未验证（连接还年轻）。
     const silenceMin = connected && status?.connectedAt ? Math.floor((Date.now() - Date.parse(status.connectedAt)) / 60_000) : 0;

--- a/src/app/agent-readiness.ts
+++ b/src/app/agent-readiness.ts
@@ -15,6 +15,14 @@ function timestamp(value: unknown): number | null {
   return Number.isFinite(parsed) ? parsed : null;
 }
 
+export function isChannelReconnecting(status?: AgentReadinessStatus | null): boolean {
+  const reconnectingAt = timestamp(status?.reconnectingAt);
+  const connectedAt = timestamp(status?.connectedAt);
+  const reconnectedAt = timestamp(status?.reconnectedAt);
+  const latestConnectedAt = Math.max(connectedAt ?? Number.NEGATIVE_INFINITY, reconnectedAt ?? Number.NEGATIVE_INFINITY);
+  return reconnectingAt !== null && reconnectingAt > latestConnectedAt;
+}
+
 export function projectAgentReadiness(input: {
   agentId: string;
   daemon: OwnedProcessRecord;
@@ -38,15 +46,11 @@ export function projectAgentReadiness(input: {
     && daemonStartedAt !== null
     && connectedAt !== null
     && connectedAt >= daemonStartedAt;
-  const reconnectingAt = timestamp(status?.reconnectingAt);
-  const reconnectedAt = timestamp(status?.reconnectedAt);
-  const latestConnectedAt = Math.max(connectedAt ?? Number.NEGATIVE_INFINITY, reconnectedAt ?? Number.NEGATIVE_INFINITY);
-  const reconnecting = reconnectingAt !== null && reconnectingAt > latestConnectedAt;
   const readiness = {
     daemon_owned: daemonOwned,
     runtime_ready: status?.runtimeReadiness?.state === "ready",
     channel_connected: channelConnected,
-    channel_not_reconnecting: !reconnecting,
+    channel_not_reconnecting: !isChannelReconnecting(status),
   };
   return {
     ready: Object.values(readiness).every(Boolean),

--- a/src/app/local-control.ts
+++ b/src/app/local-control.ts
@@ -515,11 +515,14 @@ export function createAgentControlServer({
                       ? String((error as { code: string }).code)
                       : error instanceof RuntimePrerequisiteError && error.readiness.state === "unavailable"
                         ? "runtime_unavailable" : "reset_refused";
+                    const projection = error as Partial<Pick<SessionResetResponse,
+                      "turns" | "runtimeReady" | "channelConnected" | "reconnecting" | "pendingCount">>;
                     return { ok: false, agentId: resetRequest.agentId, code,
                       error: error instanceof Error ? error.message : String(error), resetCommitted: false,
-                      generationChanged: false, sessionChanged: false, turns: 0, runtimeReady: false,
-                      channelConnected: false, reconnecting: false,
-                      pendingCount: Number((error as { pendingCount?: unknown }).pendingCount) || 0,
+                      generationChanged: false, sessionChanged: false,
+                      turns: Math.max(0, Number(projection.turns) || 0), runtimeReady: projection.runtimeReady === true,
+                      channelConnected: projection.channelConnected === true, reconnecting: projection.reconnecting === true,
+                      pendingCount: Math.max(0, Number(projection.pendingCount) || 0),
                       readyForFreshScenario: false, inboundObserved: false,
                       ...(error instanceof RuntimePrerequisiteError ? { readiness: error.readiness } : {}) };
                   }

--- a/src/feishu/host-channel-business.ts
+++ b/src/feishu/host-channel-business.ts
@@ -139,7 +139,7 @@ export class HostChannelBusiness {
       });
     } catch (error) { this.log(`bot-identity 写入失败 agent=${agent.name}: ${messageOf(error)}`); }
     this.log(`bot 身份就绪(${via}) agent=${agent.name} bot=${name || "?"}(${openId})`);
-    this.options.state.updateStatus(agent, { connectedAt: this.now().toISOString(), connectedVia: via });
+    this.options.state.updateStatus(agent, { connectedAt: this.now().toISOString(), connectedVia: via, reconnectingAt: null });
   }
 
   async connected(agent: ChannelAgent, channel: ConnectedChannel, onFatal?: (error: Error) => void): Promise<void> {

--- a/src/feishu/host-shell.ts
+++ b/src/feishu/host-shell.ts
@@ -27,6 +27,7 @@ import { verifyCallbackProbe } from "../platform/callback-capability.js";
 import { loadConfig, resolveMentionPolicy } from "../platform/config.js";
 import { processCommandToken } from "../app/internal-command.js";
 import { managedOfficialLarkCli } from "../app/agent-lark-cli-workspace.js";
+import { isChannelReconnecting } from "../app/agent-readiness.js";
 
 interface ConfiguredAgent {
   agentId: string;
@@ -961,14 +962,10 @@ export function createHostShell({
       const agent = agents.find((candidate) => candidate.agentId === agentId);
       if (!agent) throw Object.assign(new Error(`未知 Agent: ${agentId}`), { code: "unknown_agent" });
       if (!runtimeHost.resetSession) throw Object.assign(new Error("Runtime session reset 尚未就绪"), { code: "runtime_unavailable" });
-      const connectionState = (): { channelConnected: boolean; reconnecting: boolean } => {
-        const status = hostState.readStatus(agent);
+      const connectionState = (status = hostState.readStatus(agent)): { channelConnected: boolean; reconnecting: boolean } => {
         const connectedAt = Date.parse(String(status.connectedAt || ""));
         const channelConnected = Number.isFinite(connectedAt) && connectedAt >= Date.parse(daemonStartedAt) - 1000;
-        const reconnectingAt = Date.parse(String(status.reconnectingAt || ""));
-        const reconnectedAt = Date.parse(String(status.reconnectedAt || ""));
-        const reconnecting = Number.isFinite(reconnectingAt) && (!Number.isFinite(reconnectedAt) || reconnectingAt > reconnectedAt);
-        return { channelConnected, reconnecting };
+        return { channelConnected, reconnecting: isChannelReconnecting(status) };
       };
       const readinessProjection = (): { turns: number; runtimeReady: boolean; channelConnected: boolean; reconnecting: boolean; pendingCount: number } => {
         const status = hostState.readStatus(agent);
@@ -977,13 +974,18 @@ export function createHostShell({
         const runtimeReady = Boolean(status.runtimeReadiness && typeof status.runtimeReadiness === "object"
           && (status.runtimeReadiness as { state?: unknown }).state === "ready");
         const pendingCount = stateStore(agent).withInboxTransaction(() => stateStore(agent).readNdjson("inbox").length);
-        return { turns, runtimeReady, ...connectionState(), pendingCount };
+        return { turns, runtimeReady, ...connectionState(status), pendingCount };
       };
-      const initialConnection = connectionState();
-      const { channelConnected, reconnecting } = initialConnection;
-      if (!channelConnected) throw Object.assign(new Error(`Agent ${agentId} channel is not connected`), { code: "channel_unavailable" });
-      if (reconnecting) throw Object.assign(new Error(`Agent ${agentId} channel is reconnecting`), { code: "channel_reconnecting" });
-      const reset = await runtimeHost.resetSession(agentId);
+      const initialProjection = readinessProjection();
+      if (!initialProjection.channelConnected) throw Object.assign(
+        new Error(`Agent ${agentId} channel is not connected`), { code: "channel_unavailable", ...initialProjection });
+      if (initialProjection.reconnecting) throw Object.assign(
+        new Error(`Agent ${agentId} channel is reconnecting`), { code: "channel_reconnecting", ...initialProjection });
+      let reset;
+      try { reset = await runtimeHost.resetSession(agentId); }
+      catch (error) {
+        throw Object.assign(error instanceof Error ? error : new Error(String(error)), readinessProjection());
+      }
       const record = agentStates.get(agentId);
       try {
         if (record) {

--- a/test/e2e/runtime-production-mock-e2e.test.mjs
+++ b/test/e2e/runtime-production-mock-e2e.test.mjs
@@ -98,6 +98,8 @@ test("production HostShell fresh reset blocks issue-14 backlog, then preserves d
     created.get(ids[0])[0].emit({ type: "turn-end", turnId: "issue-14-drained" });
     await new Promise((resolve) => setImmediate(resolve));
     const ledgerBefore = target.readJson("runtimeDeliveries", {});
+    target.writeJson("status", { ...target.readJson("status", {}),
+      reconnectingAt: "2020-01-01T00:00:02.000Z", reconnectedAt: "2020-01-01T00:00:01.000Z" });
     const reset = await host.resetSession(ids[0]);
     assert.equal(reset.readyForFreshScenario, true);
     assert.equal(reset.inboundObserved, false);
@@ -131,14 +133,23 @@ test("production HostShell fresh reset blocks issue-14 backlog, then preserves d
     assert.equal(contaminated.code, "fresh_scenario_contaminated");
     runtimeHost.resetSession = originalResetSession;
 
+    target.writeJson("status", { ...target.readJson("status", {}), reconnectingAt: new Date(Date.now() + 1_000).toISOString() });
+    const createdBeforeReconnectRefusal = created.get(ids[0]).length;
+    await assert.rejects(host.resetSession(ids[0], 0), (error) => error.code === "channel_reconnecting"
+      && error.runtimeReady === true && error.channelConnected === true && error.reconnecting === true
+      && error.pendingCount === 0 && error.turns === 1);
+    assert.equal(created.get(ids[0]).length, createdBeforeReconnectRefusal,
+      "a current reconnect refusal occurs before fresh Runtime creation");
+    target.writeJson("status", { ...target.readJson("status", {}), reconnectingAt: null });
+
     onCreate = (input) => {
-      if (input.agentId === ids[0]) target.writeJson("status", { ...target.readJson("status", {}), reconnectingAt: new Date().toISOString() });
+      if (input.agentId === ids[0]) target.writeJson("status", { ...target.readJson("status", {}), reconnectingAt: new Date(Date.now() + 1).toISOString() });
     };
     const reconnectRace = await host.resetSession(ids[0], 0);
     assert.equal(reconnectRace.resetCommitted, true);
     assert.equal(reconnectRace.readyForFreshScenario, false);
     assert.equal(reconnectRace.code, "reset_timeout");
-    target.writeJson("status", { ...target.readJson("status", {}), reconnectedAt: new Date(Date.now() + 1).toISOString() });
+    target.writeJson("status", { ...target.readJson("status", {}), reconnectedAt: new Date(Date.now() + 2).toISOString() });
     onCreate = () => {};
 
     const originalWriteJson = target.writeJson.bind(target);

--- a/test/support/local-control-harness.mjs
+++ b/test/support/local-control-harness.mjs
@@ -60,7 +60,8 @@ const resetHost = createHostShell({ env: { ...process.env, LARKIN_HOME: root, LA
   managedCliForAgent: () => ({ command: { command: "/test/lark-cli", argsPrefix: [], version: "1.0.79" }, env: {} }),
   channelPackage: { createLarkChannel() { throw new Error("not started in control harness"); } }, logImpl: () => {} });
 await resetHost.start();
-resetStore.writeJson("status", { ...resetStore.readJson("status", {}), connectedAt: new Date().toISOString(), connectedVia: "mock" });
+resetStore.writeJson("status", { ...resetStore.readJson("status", {}), connectedAt: new Date().toISOString(), connectedVia: "mock",
+  reconnectingAt: "2020-01-01T00:00:02.000Z", reconnectedAt: "2020-01-01T00:00:01.000Z" });
 const serverOptions = {
   larkinHome: root,
   authorityToken,

--- a/test/unit/app/agent-config-typescript.test.mjs
+++ b/test/unit/app/agent-config-typescript.test.mjs
@@ -245,10 +245,10 @@ test("compiled agents --json becomes ready only for the current daemon Runtime a
       reconnectingAt: null,
       runtimeReadiness: { state: "ready" },
     });
-    const run = () => spawnSync(process.execPath, [ENTRY, "agents", "--json"], {
+    const run = (...args) => spawnSync(process.execPath, [ENTRY, "agents", ...args], {
       cwd: ROOT, encoding: "utf8", env: { ...process.env, LARKIN_CONFIG_DIR: temp },
     });
-    const ready = run();
+    const ready = run("--json");
     assert.equal(ready.status, 0, ready.stderr);
     const readyPayload = JSON.parse(ready.stdout);
     assert.equal(readyPayload.daemon.owned, true);
@@ -262,14 +262,31 @@ test("compiled agents --json becomes ready only for the current daemon Runtime a
       reconnectedAt: "2026-07-29T01:00:02.000Z",
       runtimeReadiness: { state: "ready" },
     });
-    const reconnecting = JSON.parse(run().stdout).agents[0];
+    const reconnecting = JSON.parse(run("--json").stdout).agents[0];
     assert.equal(reconnecting.ready, false);
     assert.equal(reconnecting.readiness.channel_not_reconnecting, false);
+    const reconnectingHuman = run();
+    assert.equal(reconnectingHuman.status, 0, reconnectingHuman.stderr);
+    assert.match(reconnectingHuman.stdout, /ws 重连中/);
+
+    writeStatus({
+      connectedAt: "2026-07-29T01:00:04.000Z",
+      connectedVia: "channel",
+      reconnectingAt: "2026-07-29T01:00:03.000Z",
+      reconnectedAt: "2026-07-29T01:00:02.000Z",
+      runtimeReadiness: { state: "ready" },
+    });
+    const reconnected = JSON.parse(run("--json").stdout).agents[0];
+    assert.equal(reconnected.ready, true);
+    assert.equal(reconnected.readiness.channel_not_reconnecting, true);
+    const human = run();
+    assert.equal(human.status, 0, human.stderr);
+    assert.doesNotMatch(human.stdout, /ws 重连中/);
 
     fs.writeFileSync(path.join(temp, "config.json"), `${JSON.stringify({
       version: 4, serverId: "server-ready-json", mentionPolicy: "require", activeAgent: null, agents: {},
     })}\n`, { mode: 0o600 });
-    const empty = JSON.parse(run().stdout);
+    const empty = JSON.parse(run("--json").stdout);
     assert.deepEqual(empty.daemon, { owned: true, pid: child.pid, started_at: startedAt });
     assert.deepEqual(empty.agents, []);
   } finally {

--- a/test/unit/app/agent-readiness.test.mjs
+++ b/test/unit/app/agent-readiness.test.mjs
@@ -4,7 +4,7 @@ import { pathToFileURL } from "node:url";
 import { test } from "bun:test";
 
 const ROOT = path.resolve(import.meta.dirname, "../../..");
-const { projectAgentReadiness } = await import(pathToFileURL(path.join(ROOT, "dist/app/agent-readiness.mjs")).href);
+const { isChannelReconnecting, projectAgentReadiness } = await import(pathToFileURL(path.join(ROOT, "dist/app/agent-readiness.mjs")).href);
 
 const daemon = {
   state: "owned",
@@ -70,16 +70,19 @@ test("stale channels, unready Runtimes, foreign daemons, and active reconnects s
 });
 
 test("a newer current connection clears older reconnect markers", () => {
+  const status = {
+    connectedAt: "2026-07-29T01:00:04.000Z",
+    connectedVia: "channel",
+    runtimeReadiness: { state: "ready" },
+    reconnectingAt: "2026-07-29T01:00:03.000Z",
+    reconnectedAt: "2026-07-29T01:00:02.000Z",
+  };
+  assert.equal(isChannelReconnecting(status), false);
+  assert.equal(isChannelReconnecting({ ...status, reconnectingAt: "2026-07-29T01:00:05.000Z" }), true);
   const result = projectAgentReadiness({
     agentId: "cli_ready",
     daemon,
-    status: {
-      connectedAt: "2026-07-29T01:00:04.000Z",
-      connectedVia: "channel",
-      runtimeReadiness: { state: "ready" },
-      reconnectingAt: "2026-07-29T01:00:03.000Z",
-      reconnectedAt: "2026-07-29T01:00:02.000Z",
-    },
+    status,
   });
   assert.equal(result.ready, true);
   assert.equal(result.readiness.channel_not_reconnecting, true);

--- a/test/unit/app/local-control.test.mjs
+++ b/test/unit/app/local-control.test.mjs
@@ -15,6 +15,7 @@ import {
   requestAgentUpsert,
   requestSessionReset,
 } from "../../../dist/app/local-control.mjs";
+import { createAgentStateStore } from "../../../dist/agent/agent-state-store.mjs";
 import { inspectProcess, readProcessState } from "../../../dist/platform/process-state.mjs";
 
 const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..", "..", "..");
@@ -179,6 +180,31 @@ test("local control keeps upsert ID idempotency and coalesces only concurrent re
       reset_committed: true, generation_changed: true, session_changed: true, turns: 0,
       runtime_ready: true, channel_connected: true, reconnecting: false, pending_count: 0,
       ready_for_fresh_scenario: true, inbound_observed: false });
+
+    const publicStore = createAgentStateStore(root, "cli_newA1");
+    const status = publicStore.readJson("status", {});
+    publicStore.writeJson("status", { ...status, reconnectingAt: new Date(Date.now() + 1_000).toISOString() });
+    publicStore.appendNdjson("inbox", { message_id: "om_reconnect_refusal", content: "pending during reconnect" });
+    const refused = await requestSessionReset({ larkinHome: root, agentId: "cli_newA1", waitReadyMs: 0 });
+    assert.deepEqual(refused, {
+      ok: false, agentId: "cli_newA1", code: "channel_reconnecting",
+      error: "Agent cli_newA1 channel is reconnecting", resetCommitted: false,
+      generationChanged: false, sessionChanged: false, turns: 0, runtimeReady: true,
+      channelConnected: true, reconnecting: true, pendingCount: 1,
+      readyForFreshScenario: false, inboundObserved: false,
+    });
+    const refusedCli = spawnSync(process.execPath, [path.join(ROOT, "dist/app/cli.mjs"), "session", "reset",
+      "--agent", "cli_newA1", "--json", "--wait-ready", "0"], {
+      cwd: ROOT, encoding: "utf8", env: { ...process.env, LARKIN_CONFIG_DIR: root },
+    });
+    assert.equal(refusedCli.status, 1, refusedCli.stderr || refusedCli.stdout);
+    assert.deepEqual(JSON.parse(refusedCli.stdout), {
+      ok: false, agent_id: "cli_newA1", reset_committed: false,
+      generation_changed: false, session_changed: false, turns: 0, runtime_ready: true,
+      channel_connected: true, reconnecting: true, pending_count: 1,
+      ready_for_fresh_scenario: false, inbound_observed: false, code: "channel_reconnecting",
+      error: "Agent cli_newA1 channel is reconnecting",
+    });
 
     const supervisorStatus = JSON.parse(fs.readFileSync(path.join(root, "supervisor-status.json"), "utf8"));
     const daemonStatus = JSON.parse(fs.readFileSync(path.join(root, "daemon-status.json"), "utf8"));

--- a/test/unit/app/session-cli.test.mjs
+++ b/test/unit/app/session-cli.test.mjs
@@ -36,6 +36,31 @@ test("public session reset emits stable truthful JSON without raw session identi
   } finally { fs.rmSync(root, { recursive: true, force: true }); }
 });
 
+test("public session reset preserves a truthful reconnect refusal projection", async () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "larkin-session-cli-refusal-"));
+  const agentId = "cli_resetRefusedA1";
+  fs.writeFileSync(path.join(root, "config.json"), JSON.stringify({ version: 3, serverId: "server-test", activeAgent: agentId,
+    agents: { [agentId]: { runtime: "codex", model: "gpt-5.3-codex" } } }), { mode: 0o600 });
+  let stdout = "";
+  try {
+    const code = await runSessionCli(["reset", "--agent", agentId, "--json"],
+      { ...process.env, LARKIN_CONFIG_DIR: root }, {
+        async request() { return { ok: false, agentId, code: "channel_reconnecting", error: "channel is reconnecting",
+          resetCommitted: false, generationChanged: false, sessionChanged: false, turns: 2,
+          runtimeReady: true, channelConnected: true, reconnecting: true, pendingCount: 3,
+          readyForFreshScenario: false, inboundObserved: false }; },
+        io: { stdout: (value) => { stdout += value; }, stderr() {} },
+      });
+    assert.equal(code, 1);
+    assert.deepEqual(JSON.parse(stdout), {
+      ok: false, agent_id: agentId, reset_committed: false, generation_changed: false,
+      session_changed: false, turns: 2, runtime_ready: true, channel_connected: true,
+      reconnecting: true, pending_count: 3, ready_for_fresh_scenario: false,
+      inbound_observed: false, code: "channel_reconnecting", error: "channel is reconnecting",
+    });
+  } finally { fs.rmSync(root, { recursive: true, force: true }); }
+});
+
 test("session reset is user-only and rejects malformed argv before control access", async () => {
   const cases = [
     [[], /unsupported session subcommand/],

--- a/test/unit/feishu/host-channel-business.test.mjs
+++ b/test/unit/feishu/host-channel-business.test.mjs
@@ -94,7 +94,9 @@ test("read receipt and connected identity preserve persistence/status order and 
   });
   assert.equal(agent.botOpenId, "ou_bot");
   assert.deepEqual(f.json.get("bot"), { open_id: "ou_bot", name: "New", avatar_url: "https://avatar", updated_at: "2026-07-16T04:00:00.000Z" });
-  assert.deepEqual(f.statuses.at(-1), { connectedAt: "2026-07-16T04:00:00.000Z", connectedVia: "channel" });
+  assert.deepEqual(f.statuses.at(-1), {
+    connectedAt: "2026-07-16T04:00:00.000Z", connectedVia: "channel", reconnectingAt: null,
+  });
 });
 
 test("ws reconnecting/reconnected transitions are visible in status, not just logs", () => {


### PR DESCRIPTION
## Summary

Normalize confirmed channel connections against stale reconnect markers, make every reset/status readiness path use the same reconnect predicate, and bump the bugfix delivery version from 0.2.38 to 0.2.39 per Owner policy.

This fixes the split-brain state where `larkin agents --json` reported an Agent ready while human status and `larkin session reset` continued to report `channel_reconnecting`.

## Related issue

Refs #20

Issue #20 intentionally remains open after merge. It should be closed only after the 0.2.39 release is produced, installed with checksum verification, and the original live reset workflow is successfully revalidated.

## Root cause and impact

Reconnect state had three independent interpretations:

- JSON readiness compared `reconnectingAt` with the newest of `connectedAt` and `reconnectedAt`.
- Human status and HostShell session reset compared it only with `reconnectedAt`.
- A confirmed channel identity updated `connectedAt` but left a persisted `reconnectingAt` marker in place.

After a transient reconnect or daemon restart, an older reconnect marker could therefore block resets indefinitely even though the current daemon had confirmed its channel connection.

## What changed

- Export and reuse the existing readiness reconnect predicate in JSON readiness, human status, and HostShell reset/readiness projection.
- Clear `reconnectingAt` when channel identity is confirmed.
- Attach the current turns/runtime/channel/reconnect/backlog projection to reset refusals so local-control and public CLI JSON remain truthful.
- Preserve the safety boundary: a genuinely newer reconnect marker is rejected before a fresh Runtime session is created.
- Increment `package.json` from 0.2.38 to 0.2.39; `bun.lock` has no repository-version entry and remains unchanged.

## Scope

- In scope: reconnect-state normalization, reset refusal projection, behavior regressions for readiness, human/JSON status, local control/public session CLI, production HostShell mocks, and the required 0.2.39 patch version.
- Out of scope: creating tags or releases, installation, checksum-install verification, live reset verification, live Larkin state changes, Feishu messaging, and Issue #6 work.
- Compatibility or migration impact: none; existing status fields and public reset JSON shape are preserved.

## Validation

- [x] Regression-first run reproduced four failures on unmodified production code: stale HostShell reset, stale local-control reset, human/JSON status disagreement, and missing confirmed-connection normalization.
- [x] Focused regression suite: 36 passed, 0 failed.
  - `bun test --max-concurrency 1 test/unit/feishu/host-channel-business.test.mjs test/unit/app/agent-config-typescript.test.mjs test/unit/app/agent-readiness.test.mjs test/unit/app/local-control.test.mjs test/unit/app/session-cli.test.mjs test/e2e/runtime-production-mock-e2e.test.mjs`
- [x] `bun run test` passed with exit 0 for the implementation commit, including typecheck, production build, frontend, unit, integration, and E2E suites.
- [x] `bun run build` passed after the 0.2.39 bump.
- [x] `bun run release:check-version v0.2.39` passed.
- [x] `bun test --max-concurrency 1 test/integration/build/release-platform-ci.test.mjs` passed: 2 passed, 0 failed.
- [x] Disposable clean-source release build and `bun run release:smoke -- --release-dir <temporary-directory>` passed on darwin-arm64; artifact version was 0.2.39, source commit was `174681d3411d3997eac806ca91e5a4c19860bb20`, `sourceDirty=false`, and the embedded Dashboard returned HTTP 200. The temporary artifact directory was deleted.
- [x] `bun run licenses:check` passed (85 runtime package versions).
- [x] `bun run publication:check:tree` passed (266 indexed files).
- [x] `bun run publication:check` passed (88 refs, 7,434 objects).
- [x] `git diff --check` passed.
- [x] GitHub `source-checks` passed on current head `174681d3411d3997eac806ca91e5a4c19860bb20` in 3m24s.

## Skipped opt-in/live validation

The full suite reported its existing opt-in skips, including real official channel binding, real CLI/supervisor/browser scenarios, standalone binary/install flows, git-dependency installation, and live provider/Feishu tests. They require external credentials, browsers, platform services, installation, or explicit opt-in and were not enabled for this isolated source fix.

No live Feishu message was sent and no live Larkin state was read or changed.

## Residual risk

This PR validates source, compiled, local-control, production-mock, and disposable 0.2.39 release-artifact behavior. Per task safety constraints it does not publish or install the repaired release. Issue #20 must remain open until the released artifact is checksum-verified, installed, and the original live reset workflow succeeds.

## Safety and publication

- [x] This change contains no credentials, private messages, user data, private filesystem paths, generated `dist/`, dependency directories, or release artifacts.
- [x] No release tag was created, moved, or replaced.
