### PR TITLE
Fix startup redelivery after authoritative empty scan

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "larkin",
-  "version": "0.2.39",
+  "version": "0.2.40",
   "private": true,
   "larkinPackageRole": "development-source-checkout",
   "packageManager": "bun@1.3.14",

--- a/src/agent/host-reminder-orchestrator.ts
+++ b/src/agent/host-reminder-orchestrator.ts
@@ -214,17 +214,26 @@ export class HostReminderOrchestrator {
     try {
       lines = String((this.options.readFile ?? fs.readFileSync)(this.options.stateStore(agent).paths.inbox, "utf8"))
         .split("\n").filter(Boolean);
-    } catch { return; }
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code === "ENOENT" && this.options.deliveryTarget) {
+        this.redelivered.add(agent.agentId);
+      }
+      return;
+    }
     const parsed = lines.map((line) => {
       try {
         return { line, value: JSON.parse(line) as Record<string, unknown> };
       } catch { return { line, value: null }; }
     });
+    if (parsed.some(({ value }) => value === null)) return;
     const existing = parsed.find(({ value }) => typeof value?.message_id === "string" && value.message_id.startsWith("redeliver_"))?.value;
     const wakeCount = countWakeEnvelopes(parsed
       .filter(({ value }) => !(typeof value?.message_id === "string" && value.message_id.startsWith("redeliver_")))
       .map(({ line }) => line));
-    if (!wakeCount && !existing) return;
+    if (!wakeCount && !existing) {
+      if (this.options.deliveryTarget) this.redelivered.add(agent.agentId);
+      return;
+    }
     const envelope = existing ?? this.options.envelopeProjector.createRedeliveryEnvelope(agent.agentId, wakeCount);
     if (!existing) {
       try { this.options.stateStore(agent).appendNdjson("inbox", envelope); }

--- a/test/e2e/runtime-production-mock-e2e.test.mjs
+++ b/test/e2e/runtime-production-mock-e2e.test.mjs
@@ -168,6 +168,81 @@ test("production HostShell fresh reset blocks issue-14 backlog, then preserves d
   }
 });
 
+test("production HostShell startup zero-unread one-shot cannot redeliver post-reset inbound work", { timeout: 25_000 }, async () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "larkin-production-redelivery-reset-"));
+  const agentId = "cli_redeliveryResetA1";
+  const store = createAgentStateStore(root, agentId);
+  const sessions = [];
+  const adapter = { id: "codex", capabilities: {}, async createSession() {
+    const session = new FakeNativeSession("codex");
+    session.sessionId = `redelivery-reset-session-${sessions.length + 1}`;
+    sessions.push(session);
+    return session;
+  } };
+  const runtimeHost = createRuntimeHost({ adapterFor: () => adapter, promptBuilder: new ContextPromptBuilder(),
+    stateStoreFor: () => store, assertOfficialCliReady: () => {} });
+  const agent = { agentId, name: agentId, runtime: "codex", model: "mock",
+    feishuAppId: agentId, feishuProfile: agentId, feishuAppSecret: "fixture-secret",
+    feishuDomain: "https://open.feishu.cn", larkConfigDir: path.join(root, "lark-cli-config"),
+    workspaceDir: path.join(root, "agents", agentId), stateDir: store.paths.root };
+  fs.mkdirSync(store.paths.root, { recursive: true });
+  fs.writeFileSync(store.paths.inbox, "", { mode: 0o600 });
+  fs.writeFileSync(path.join(root, "config.json"), JSON.stringify({ version: 3, serverId: "server-redelivery-reset",
+    activeAgent: agentId, agents: { [agentId]: { runtime: "codex", model: "mock" } } }), { mode: 0o600 });
+  const host = createHostShell({ env: { LARKIN_HOME: root, LARKIN_CONFIG_DIR: root,
+    LARKIN_SERVER_ID: "server-redelivery-reset", LARKIN_AGENTS_CONFIG: JSON.stringify([agent]),
+    LARKIN_INBOUND_DROUGHT_SEC: "0" }, runtimeHost, stateStoreForImpl: () => store,
+    managedCliForAgent: testManagedCli, eventSourceStartDelayMs: 60_000,
+    execFileImpl(_command, args, _options, callback) {
+      const data = args.includes("bots")
+        ? { items: [{ bot_id: agentId, bot_name: "Mock Bot" }] }
+        : { items: [{ member_id: "ou_sender", name: "Sender" }] };
+      callback(null, JSON.stringify({ ok: true, data }), "");
+    },
+    channelPackage: { createLarkChannel() { throw new Error("event source must not start in redelivery fixture"); } } });
+  try {
+    await host.start();
+    await new Promise((resolve) => setTimeout(resolve, 5_100));
+    assert.equal(sessions.length, 1);
+    assert.equal(sessions[0].prompts.length + sessions[0].busyInputs.length, 0);
+    assert.deepEqual(store.readNdjson("inbox"), []);
+
+    store.writeJson("status", { ...store.readJson("status", {}), connectedAt: new Date().toISOString(), connectedVia: "mock" });
+    const reset = await host.resetSession(agentId);
+    assert.equal(reset.readyForFreshScenario, true);
+    assert.equal(sessions.length, 2);
+    await host.ingest(agentId, { chat_id: "oc_redelivery_reset", chat_type: "p2p", sender_id: "ou_sender",
+      message_id: "om_after_reset", event_id: "evt_after_reset", content: "fresh formal scenario",
+      create_time: "1785542400000", thread_id: null, _mentioned_bot: false, _mention_all: false, _sender_is_bot: true });
+    assert.equal(sessions[1].prompts.length + sessions[1].busyInputs.length, 1);
+
+    await new Promise((resolve) => setTimeout(resolve, 5_100));
+    assert.equal(sessions[1].prompts.length + sessions[1].busyInputs.length, 1,
+      "the reset active timer must not synthesize a startup redelivery for a new inbound");
+    assert.deepEqual(store.pollInbox().envelopes.map((row) => row.message_id), ["om_after_reset"]);
+    assert.deepEqual(store.readNdjson("inbox"), []);
+
+    sessions[1].emit({ type: "turn-start", turnId: "first-business-turn" });
+    sessions[1].emit({ type: "turn-end", turnId: "first-business-turn" });
+    await new Promise((resolve) => setImmediate(resolve));
+    const secondReset = await host.resetSession(agentId);
+    assert.equal(secondReset.readyForFreshScenario, true);
+    assert.equal(sessions.length, 3);
+    await host.ingest(agentId, { chat_id: "oc_redelivery_reset", chat_type: "p2p", sender_id: "ou_sender",
+      message_id: "om_after_second_reset", event_id: "evt_after_second_reset", content: "fresh polled scenario",
+      create_time: "1785542401000", thread_id: null, _mentioned_bot: false, _mention_all: false, _sender_is_bot: true });
+    assert.equal(sessions[2].prompts.length + sessions[2].busyInputs.length, 1);
+    assert.deepEqual(store.pollInbox().envelopes.map((row) => row.message_id), ["om_after_second_reset"]);
+    await new Promise((resolve) => setTimeout(resolve, 5_100));
+    assert.equal(sessions[2].prompts.length + sessions[2].busyInputs.length, 1,
+      "polling the unique business message before the timer still leaves exactly one business Runtime input");
+    assert.deepEqual(store.readNdjson("inbox"), []);
+  } finally {
+    await host.shutdown("redelivery reset Mock E2E complete");
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});
+
 test("member parser accepts the real lark-cli 1.0.79 get/bots shapes", () => {
   assert.deepEqual(memberNamesFromPayloads([
     { ok: true, data: { items: [{ member_id: "ou_user", name: "User" }] } },

--- a/test/unit/agent/host-reminder-orchestrator.test.mjs
+++ b/test/unit/agent/host-reminder-orchestrator.test.mjs
@@ -61,11 +61,84 @@ test("due fire persists before delivery, updates record, then forces snapshot", 
 
 test("restart redelivery counts only wake=true and delivers once", async () => {
   const f = fixture([]);
-  const orchestrator = new HostReminderOrchestrator({ agents: [agent], stateStore: () => f.state, envelopeProjector: f.projector, deliveryTarget: { deliver(_id, envelope) { f.deliveries.push(envelope); } }, reminderStore: f.api, readFile: () => '{"wake":true}\n{"wake":false}\nbad\n{"wake":true}\n' });
+  const orchestrator = new HostReminderOrchestrator({ agents: [agent], stateStore: () => f.state, envelopeProjector: f.projector, deliveryTarget: { deliver(_id, envelope) { f.deliveries.push(envelope); } }, reminderStore: f.api, readFile: () => '{"wake":true}\n{"wake":false}\n{"wake":true}\n' });
   await orchestrator.redeliverUnread(agent);
   await orchestrator.redeliverUnread(agent);
   assert.deepEqual(f.deliveries, [{ message_id: "redeliver_2", seq: 2 }]);
   assert.deepEqual(f.inbox, [{ message_id: "redeliver_2", seq: 2 }]);
+});
+
+test("authoritative empty startup Inbox consumes redelivery without capturing a later inbound message", async () => {
+  const f = fixture([]);
+  let inbox = "";
+  const orchestrator = new HostReminderOrchestrator({ agents: [agent], stateStore: () => f.state,
+    envelopeProjector: f.projector, deliveryTarget: { deliver(_id, envelope) { f.deliveries.push(envelope); } },
+    reminderStore: f.api, readFile: () => inbox });
+  await orchestrator.redeliverUnread(agent);
+  inbox = `${JSON.stringify({ message_id: "om_after_startup", wake: true })}\n`;
+  await orchestrator.redeliverUnread(agent);
+  assert.deepEqual(f.inbox, []);
+  assert.deepEqual(f.deliveries, []);
+});
+
+test("missing startup Inbox is authoritative empty and consumes redelivery", async () => {
+  const f = fixture([]);
+  let reads = 0;
+  const orchestrator = new HostReminderOrchestrator({ agents: [agent], stateStore: () => f.state,
+    envelopeProjector: f.projector, deliveryTarget: { deliver(_id, envelope) { f.deliveries.push(envelope); } },
+    reminderStore: f.api, readFile() {
+      reads += 1;
+      if (reads === 1) throw Object.assign(new Error("missing Inbox"), { code: "ENOENT" });
+      return `${JSON.stringify({ message_id: "om_after_missing_startup", wake: true })}\n`;
+    } });
+  await orchestrator.redeliverUnread(agent);
+  await orchestrator.redeliverUnread(agent);
+  assert.equal(reads, 1);
+  assert.deepEqual(f.inbox, []);
+  assert.deepEqual(f.deliveries, []);
+});
+
+test("transient startup Inbox read failure does not burn redelivery", async () => {
+  const f = fixture([]);
+  let reads = 0;
+  const orchestrator = new HostReminderOrchestrator({ agents: [agent], stateStore: () => f.state,
+    envelopeProjector: f.projector, deliveryTarget: { deliver(_id, envelope) { f.deliveries.push(envelope); } },
+    reminderStore: f.api, readFile() {
+      reads += 1;
+      if (reads === 1) throw new Error("temporary read failure");
+      return `${JSON.stringify({ message_id: "om_read_retry", wake: true })}\n`;
+    } });
+  await orchestrator.redeliverUnread(agent);
+  await orchestrator.redeliverUnread(agent);
+  await orchestrator.redeliverUnread(agent);
+  assert.equal(reads, 2);
+  assert.deepEqual(f.inbox, [{ message_id: "redeliver_1", seq: 2 }]);
+  assert.deepEqual(f.deliveries, [{ message_id: "redeliver_1", seq: 2 }]);
+});
+
+test("malformed startup Inbox does not burn redelivery after the file is repaired", async () => {
+  const f = fixture([]);
+  let inbox = "not-json\n";
+  const orchestrator = new HostReminderOrchestrator({ agents: [agent], stateStore: () => f.state,
+    envelopeProjector: f.projector, deliveryTarget: { deliver(_id, envelope) { f.deliveries.push(envelope); } },
+    reminderStore: f.api, readFile: () => inbox });
+  await orchestrator.redeliverUnread(agent);
+  inbox = `${JSON.stringify({ message_id: "om_after_repair", wake: true })}\n`;
+  await orchestrator.redeliverUnread(agent);
+  await orchestrator.redeliverUnread(agent);
+  assert.deepEqual(f.inbox, [{ message_id: "redeliver_1", seq: 2 }]);
+  assert.deepEqual(f.deliveries, [{ message_id: "redeliver_1", seq: 2 }]);
+});
+
+test("zero unread without a Runtime delivery target does not burn redelivery", async () => {
+  const f = fixture([]);
+  let inbox = "";
+  const orchestrator = new HostReminderOrchestrator({ agents: [agent], stateStore: () => f.state,
+    envelopeProjector: f.projector, reminderStore: f.api, readFile: () => inbox });
+  await orchestrator.redeliverUnread(agent);
+  inbox = `${JSON.stringify({ message_id: "om_after_targetless_startup", wake: true })}\n`;
+  await orchestrator.redeliverUnread(agent);
+  assert.deepEqual(f.inbox, [{ message_id: "redeliver_1", seq: 2 }]);
 });
 
 test("restart redelivery reuses an existing canonical synthetic envelope instead of appending a duplicate", async () => {


### PR DESCRIPTION
## Summary

- consume the existing per-host startup-redelivery one-shot after an authoritative empty Inbox scan
- treat ENOENT as an empty Inbox while preserving retries for other read errors, malformed NDJSON, missing delivery targets, append failures, and delivery failures
- add unit and production Mock E2E coverage for reset + unique inbound + poll/timer ordering
- bump the package version from 0.2.39 to 0.2.40

## Validation

- focused reminder + production reset regression: 23/23
- full `bun run test`
- `bun run test:eval:agent-experience-v6`: 3/3
- `bun run licenses:check`
- publication tree/history checks
- `bun run release:check-version v0.2.40`
- darwin-arm64 release build + smoke (Dashboard HTTP 200)
- independent evaluator: no blocking or important findings

Refs #6

Issue #6 remains open until exact-head CI, automatic v0.2.40 release, checksum-verified installation, and the real dual-model 20-run regression all pass.