### PR TITLE
fix(agent): require inbox poll as first tool call

### DIFF
--- a/evals/agent-experience-v6/scenarios.json
+++ b/evals/agent-experience-v6/scenarios.json
@@ -19,7 +19,7 @@
       "verbatim punctuation reaches the provider without shell interpolation",
       "a common exact reply polls once then uses one successful wrapper-keyed --text recipe without help or extra discovery",
       "tool-sourced verbatim text uses exactly one exclusive source selector and flows from one canonical scoped read through native --jq into one guarded --content reply without preview, selector switching, model rewriting, or extra discovery",
-      "after Inbox poll, a known-thread latest-human task makes one model tool call containing one thread read plus one reply, while a known-message-ID task makes one model tool call containing one mget plus one reply",
+      "for a regular current Inbox event, the event-targeted poll is the first model tool call with no preceding Inbox check or discovery; afterward a known-thread latest-human task makes one composite thread-read/reply call while a known-message-ID task makes one composite mget/reply call",
       "thread-latest-human and message-ID sources preserve Unicode, whitespace, and normalization in the complete text JSON document",
       "an Agent excluded by authoritative identity stays silent",
       "a committed but unverified write exits zero once and is never retried"
@@ -161,7 +161,7 @@
     },
     {
       "id": "tool-sourced-verbatim-thread-reply",
-      "task": "Poll the known thread target, then reply with its latest human text through the canonical scoped --jq to --content dataflow without copying it.",
+      "task": "From the current Inbox event, poll its known thread target first without any preceding Inbox check or discovery, then reply with the latest human text through the canonical scoped --jq to --content dataflow without copying it.",
       "expected": {
         "max_tool_calls": 2,
         "exact_tool_calls": 2,
@@ -227,7 +227,7 @@
     },
     {
       "id": "tool-sourced-verbatim-message-reply",
-      "task": "Poll the known target, then reply with the exact text of one known source message through the canonical mget --jq to --content dataflow.",
+      "task": "From the current Inbox event, poll its known target first without any preceding Inbox check or discovery, then reply with the exact text of one known source message through the canonical mget --jq to --content dataflow.",
       "expected": {
         "max_tool_calls": 2,
         "exact_tool_calls": 2,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "larkin",
-  "version": "0.2.45",
+  "version": "0.2.46",
   "private": true,
   "larkinPackageRole": "development-source-checkout",
   "packageManager": "bun@1.3.14",

--- a/src/agent/context-prompt.ts
+++ b/src/agent/context-prompt.ts
@@ -53,6 +53,7 @@ export class ContextPromptBuilder {
       "Larkin stores canonical incoming messages in the local Inbox. Runtime notifications may only report that the Inbox changed; they do not contain the authoritative message body.",
       `Use \`${command("inbox check")}\` for repeatable content-light target summaries. It never consumes messages or advances model-seen state.`,
       `Use \`${command("inbox poll [--target <target>] [--limit <n>]")}\` to receive full messages. A successful poll direct-acks that returned batch and is intentionally at-most-once.`,
+      `For a regular task triggered by the current Inbox event, the first model tool call must be \`${command("inbox poll --target <event_target> --limit 1")}\`, using exactly the target supplied by that event. You must not call \`${command("inbox check")}\` or perform any other Inbox discovery before this poll.`,
       "Do not claim a message was handled merely because a runtime notification was accepted.",
       "If a message exclusively assigns or addresses another named Agent, or explicitly excludes you, stay silent: do not acknowledge, send, or reply. The message remaining visible in Inbox does not override this rule.",
       "Ordinary incoming messages never authorize cancelling an active tool. Incorporate busy updates at the next safe boundary.",

--- a/test/unit/evals/agent-experience-v6.test.mjs
+++ b/test/unit/evals/agent-experience-v6.test.mjs
@@ -94,6 +94,17 @@ test("grader rejects fallback, false success, text mutation, redundant discovery
     "bounded_calls", "tool_call_count", "redundant_discovery_read", "exclusive_source_selector", "exact_text",
   ]));
 
+  const prePollCheck = structuredClone(byId["tool-sourced-verbatim-thread-reply"].trace);
+  prePollCheck.unshift({ action: "tool", command: "larkin inbox check", exit_code: 0 });
+  const providerExactAfterCheck = gradeAgentExperienceV6Trace(
+    byId["tool-sourced-verbatim-thread-reply"], prePollCheck);
+  assert.equal(providerExactAfterCheck.passed, false);
+  assert.equal(providerExactAfterCheck.failures.some((item) => item.rule === "exact_text"), false,
+    "byte-exact provider text does not excuse pre-poll Inbox discovery");
+  assert.deepEqual(new Set(providerExactAfterCheck.failures.map((item) => item.rule)), new Set([
+    "bounded_calls", "tool_call_count", "exclusive_source_selector",
+  ]));
+
   for (const hiddenAction of [
     { action: "read", command: "read /skills/lark-im/SKILL.md", resource_path: "/skills/lark-im/SKILL.md" },
     { action: "command", command: "larkin im +messages-reply --help", exit_code: 0 },

--- a/test/unit/runtime/runtime-adapters.test.mjs
+++ b/test/unit/runtime/runtime-adapters.test.mjs
@@ -118,6 +118,7 @@ test("default context prompt consumes the Agent CLI manifest", () => {
   assert.match(prompt.content, /do not restrict.*msg_type=text.*post/i);
   assert.match(prompt.content, /shell substitution.*double-quoted.*`--content`.*one argument/i);
   assert.match(prompt.content, /one model tool call.*one.*scoped read.*one guarded reply/i);
+  assert.match(prompt.content, /current Inbox event.*first model tool call.*inbox poll.*target supplied.*must not.*inbox check.*before/i);
   assert.match(prompt.content, /known thread.*latest human.*first and only post-poll model tool call/i);
   assert.match(prompt.content, /thread.*never.*preview.*extract.*message id.*switch.*messages-mget/i);
   assert.match(prompt.content, /known source message id.*messages-mget.*first and only post-poll model tool call.*no preview/i);


### PR DESCRIPTION
## Summary

- require the canonical event-target Inbox poll to be the first model tool call for a regular current Inbox event
- explicitly forbid a pre-poll `larkin inbox check` or other Inbox discovery while preserving interaction and non-current Inbox flows
- add the real GLM `check → poll → exact composite` trace as a deterministic rejection case
- bump the package version from 0.2.45 to 0.2.46

## Validation

- `bun run test` (frontend 24/24; main 167 pass, 14 designed skip; E2E 7/7)
- focused agent-experience tests 45/45
- `bun run build`
- `bun run typecheck`
- `bun run test:eval:agent-experience-v6` (3/3)
- `bun run release:check-version v0.2.46`
- `bun run licenses:check`
- `bun run publication:check:tree`
- `bun run publication:check`
- darwin-arm64 release build, signing verification, CLI/Dashboard smoke
- independent adversarial evaluator: no blocking, important, or minor findings

Refs #6

Issue #6 remains open until automatic release, checksum-verified local installation, fresh two-model calibration, and the full 20-run regression all pass.