### PR TITLE
fix(agent): tolerate released Inbox locks

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "larkin",
-  "version": "0.2.47",
+  "version": "0.2.48",
   "private": true,
   "larkinPackageRole": "development-source-checkout",
   "packageManager": "bun@1.3.14",

--- a/src/agent/agent-state-store.ts
+++ b/src/agent/agent-state-store.ts
@@ -280,7 +280,9 @@ export class AgentStateStore {
   private inboxLockState(lockDir: string): InboxLockState {
     const owner = this.readInboxLockOwner(lockDir);
     if (!owner) {
-      const age = Date.now() - fs.lstatSync(lockDir).mtimeMs;
+      const stat = lstatIfExists(lockDir);
+      if (!stat) return "reclaimable";
+      const age = Date.now() - stat.mtimeMs;
       return age >= INBOX_MALFORMED_LOCK_GRACE_MS ? "reclaimable" : "unknown";
     }
     const inspected = this.inspect(owner.pid);
@@ -318,16 +320,43 @@ export class AgentStateStore {
         throw new Error(`invalid inbox lock path: ${lockDir}`);
       }
       if (this.inboxLockState(lockDir) !== "reclaimable") return false;
-      const entries = fs.readdirSync(lockDir);
+      let entries: string[];
+      try { entries = fs.readdirSync(lockDir); }
+      catch (error) {
+        if ((error as NodeJS.ErrnoException).code === "ENOENT") {
+          if (!lstatIfExists(lockDir)) return true;
+          return false;
+        }
+        throw error;
+      }
       if (entries.some((entry) => entry !== INBOX_LOCK_OWNER_FILE)) {
         throw new Error(`Inbox lock 包含未知内容，拒绝回收：${lockDir}`);
       }
       if (entries.includes(INBOX_LOCK_OWNER_FILE)) {
-        const ownerStat = fs.lstatSync(path.join(lockDir, INBOX_LOCK_OWNER_FILE));
+        const ownerFile = path.join(lockDir, INBOX_LOCK_OWNER_FILE);
+        const ownerStat = lstatIfExists(ownerFile);
+        if (!ownerStat) {
+          if (!lstatIfExists(lockDir)) return true;
+          return false;
+        }
         if (!ownerStat.isFile() || ownerStat.isSymbolicLink()) throw new Error(`Inbox lock owner 路径无效：${lockDir}`);
-        fs.unlinkSync(path.join(lockDir, INBOX_LOCK_OWNER_FILE));
+        try { fs.unlinkSync(ownerFile); }
+        catch (error) {
+          if ((error as NodeJS.ErrnoException).code === "ENOENT") {
+            if (!lstatIfExists(lockDir)) return true;
+            return false;
+          }
+          throw error;
+        }
       }
-      fs.rmdirSync(lockDir);
+      try { fs.rmdirSync(lockDir); }
+      catch (error) {
+        if ((error as NodeJS.ErrnoException).code === "ENOENT") {
+          if (!lstatIfExists(lockDir)) return true;
+          return false;
+        }
+        throw error;
+      }
       return true;
     } finally {
       reclaim.release();

--- a/test/unit/agent/agent-state-store.test.mjs
+++ b/test/unit/agent/agent-state-store.test.mjs
@@ -167,6 +167,67 @@ test("Inbox lock reclaims a verifiably dead owner record", async () => {
   } finally { fs.rmSync(root, { recursive: true, force: true }); }
 });
 
+test("Inbox contender retries when the owner releases its lock directory during state inspection", async () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "larkin-state-released-lock-race-"));
+  try {
+    const { createAgentStateStore } = await import(moduleUrl);
+    const store = createAgentStateStore(root, "cli_stateReleasedLockRaceA1");
+    store.writeJson("status", { prepared: true });
+    const lockDir = `${store.paths.inbox}.lock`;
+    fs.mkdirSync(lockDir, { mode: 0o700 });
+    const readOwner = store.readInboxLockOwner.bind(store);
+    let released = false;
+    store.readInboxLockOwner = (candidate) => {
+      const owner = readOwner(candidate);
+      if (!released && candidate === lockDir && owner === null) {
+        released = true;
+        fs.rmdirSync(lockDir);
+      }
+      return owner;
+    };
+
+    store.appendNdjson("inbox", { message_id: "om_after_release_race", chat_id: "oc_lock" });
+
+    assert.equal(released, true, "the lock owner must release between owner read and directory inspection");
+    assert.deepEqual(store.readNdjson("inbox").map((row) => row.message_id), ["om_after_release_race"]);
+    assert.equal(fs.existsSync(lockDir), false);
+  } finally { fs.rmSync(root, { recursive: true, force: true }); }
+});
+
+test("Inbox contender retries when the lock directory disappears after guarded reclaim inspection", async () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "larkin-state-guarded-reclaim-race-"));
+  try {
+    const { createAgentStateStore } = await import(moduleUrl);
+    const store = createAgentStateStore(root, "cli_stateGuardedReclaimRaceA1");
+    store.writeJson("status", { prepared: true });
+    const lockDir = `${store.paths.inbox}.lock`;
+    const ownerFile = path.join(lockDir, "owner.json");
+    fs.mkdirSync(lockDir, { mode: 0o700 });
+    fs.writeFileSync(ownerFile, `${JSON.stringify({
+      version: 1, pid: 2_147_483_647, processStartToken: "dead-process",
+      nonce: "00000000-0000-4000-8000-000000000003",
+    })}\n`, { mode: 0o600 });
+    const inspectState = store.inboxLockState.bind(store);
+    let stateChecks = 0;
+    let released = false;
+    store.inboxLockState = (candidate) => {
+      const state = inspectState(candidate);
+      if (candidate === lockDir && state === "reclaimable" && ++stateChecks === 2) {
+        fs.unlinkSync(ownerFile);
+        fs.rmdirSync(lockDir);
+        released = true;
+      }
+      return state;
+    };
+
+    store.appendNdjson("inbox", { message_id: "om_after_guarded_reclaim_race", chat_id: "oc_lock" });
+
+    assert.equal(released, true, "the owner must release after guarded state inspection and before directory read");
+    assert.deepEqual(store.readNdjson("inbox").map((row) => row.message_id), ["om_after_guarded_reclaim_race"]);
+    assert.equal(fs.existsSync(lockDir), false);
+  } finally { fs.rmSync(root, { recursive: true, force: true }); }
+});
+
 test("EPERM inspection of a live Inbox owner fails closed without reclaim", async () => {
   const root = fs.mkdtempSync(path.join(os.tmpdir(), "larkin-state-eperm-lock-"));
   const child = spawn(process.execPath, ["-e", "setInterval(() => {}, 60_000)"], { stdio: "ignore" });


### PR DESCRIPTION
## Summary

- retry Inbox lock acquisition when a current owner releases the lock directory during contender state inspection
- close the remaining guarded-reclaim ENOENT windows without weakening live-owner, symlink, UID, unknown-entry, or reclaim-guard fail-closed checks
- bump the bugfix version from 0.2.47 to 0.2.48

## Incident

The installed v0.2.47 daemon crashed during the real two-model Issue #6 regression when `inboxLockState()` attempted to `lstat` an Inbox lock directory that its owner had just removed. An independent review found and reproduced the same race after guarded state inspection at `readdirSync`; this patch covers both paths and the owner-stat/unlink/final-rmdir boundaries.

## Validation

- exact deterministic RED for the original `ENOENT lstat` incident
- exact deterministic RED for the nested `ENOENT scandir` race
- focused lock/agent/host tests: 44/44
- independent adversarial lock probes: all pass
- full `bun run test`: frontend 24/24; unit/integration 167 pass, 14 intentional skips; E2E 7/7
- licenses: 85 versions validated
- publication tree/history: 266 files; 115 refs / 7,573 objects
- darwin-arm64 v0.2.48 release smoke: pass
- `bun.lock`: unchanged
- independent evaluator: no Blocking, Important, or Minor findings

Refs #6

Issue #6 remains open until v0.2.48 is automatically released, checksum-installed, and the complete fresh-session two-model 20-run regression passes.