### PR TITLE
fix(runtime): project Bot display identity

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "larkin",
-  "version": "0.2.48",
+  "version": "0.2.49",
   "private": true,
   "larkinPackageRole": "development-source-checkout",
   "packageManager": "bun@1.3.14",

--- a/src/feishu/host-shell.ts
+++ b/src/feishu/host-shell.ts
@@ -313,14 +313,18 @@ export function createHostShell({
     undefined,
     "larkin",
   );
-  const prepareAgentState = (agent: ConfiguredAgent): void => {
-    fs.mkdirSync(agent.stateDir, { recursive: true });
+  const hydrateBotIdentity = (agent: ConfiguredAgent): void => {
     if (!agent.botOpenId) {
       try {
         const cached = stateStore(agent).readJson<{ open_id?: string; name?: string | null }>("botIdentity", {});
         if (cached.open_id) { agent.botOpenId = cached.open_id; agent.botName = cached.name || null; }
       } catch { /* first run */ }
     }
+    agent.displayName = agent.botName || agent.displayName || null;
+  };
+  const prepareAgentState = (agent: ConfiguredAgent): void => {
+    fs.mkdirSync(agent.stateDir, { recursive: true });
+    hydrateBotIdentity(agent);
     processingEyes.restoreAndClear(agent);
     try {
       const known = new Set(Object.values(hostState.loadMap(agent)).filter((value) => /^oc_/.test(String(value))));
@@ -649,6 +653,7 @@ export function createHostShell({
 
       // Runtime replacement is target-only. The old channel remains connected until the
       // candidate Runtime and channel are both ready, so unrelated Agents are untouched.
+      hydrateBotIdentity(candidate);
       const runtimeCandidate = { ...candidate,
         sessionId: agentStates.get(candidate.agentId)?.state.sessions[candidate.runtime] || null };
       const staged = previous && runtimeHost.stage ? await runtimeHost.stage(runtimeCandidate) : null;

--- a/test/e2e/runtime-production-mock-e2e.test.mjs
+++ b/test/e2e/runtime-production-mock-e2e.test.mjs
@@ -168,6 +168,144 @@ test("production HostShell fresh reset blocks issue-14 backlog, then preserves d
   }
 });
 
+test("production HostShell projects cached Bot display identity into cold, reset, and hot-staged Runtime prompts", async () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "larkin-production-bot-display-identity-"));
+  const agentId = "cli_botDisplayA1";
+  const store = createAgentStateStore(root, agentId);
+  const sessionInputs = [];
+  const sessions = [];
+  const adapter = { id: "codex", capabilities: {}, async createSession(input) {
+    const session = new FakeNativeSession("codex");
+    session.sessionId = `bot-display-session-${sessions.length + 1}`;
+    sessionInputs.push(input);
+    sessions.push(session);
+    return session;
+  } };
+  const runtimeHost = createRuntimeHost({ adapterFor: () => adapter, promptBuilder: new ContextPromptBuilder(),
+    stateStoreFor: () => store, assertOfficialCliReady: () => {} });
+  const agent = { agentId, name: agentId, runtime: "codex", model: "mock-cold",
+    feishuAppId: agentId, feishuProfile: agentId, feishuAppSecret: "fixture-secret",
+    feishuDomain: "https://open.feishu.cn", larkConfigDir: path.join(root, "lark-cli-config"),
+    workspaceDir: path.join(root, "agents", agentId), stateDir: store.paths.root };
+  store.writeJson("botIdentity", { open_id: "ou_bot_display", name: "二蛋", updated_at: "2026-08-01T00:00:00.000Z" });
+  const channels = [];
+  const channelPackage = { createLarkChannel() {
+    const channel = {
+      botIdentity: { openId: "ou_bot_display", name: "二蛋" }, disconnected: 0,
+      on() {}, dispatcher: { register() {} }, async connect() {},
+      async disconnect() { this.disconnected += 1; }, async updateCard() {},
+      rawClient: { async request() { return { bot: { open_id: "ou_bot_display", app_name: "二蛋" } }; } },
+    };
+    channels.push(channel);
+    return channel;
+  } };
+  const host = createHostShell({ env: { LARKIN_HOME: root, LARKIN_CONFIG_DIR: root,
+    LARKIN_SERVER_ID: "server-bot-display", LARKIN_AGENTS_CONFIG: JSON.stringify([agent]),
+    LARKIN_INBOUND_DROUGHT_SEC: "0" }, runtimeHost, stateStoreForImpl: () => store,
+    managedCliForAgent: testManagedCli, eventSourceStartDelayMs: 0, channelPackage });
+  const assertIdentity = (input, phase) => {
+    assert.match(input.standingPrompt.content, /persistent Larkin agent \*\*二蛋\*\*/i, phase);
+    assert.equal(input.standingPrompt.content.toLowerCase().includes(
+      `authoritative self identity is **二蛋** (agent id: \`${agentId}\`)`.toLowerCase()), true, phase);
+    assert.doesNotMatch(input.standingPrompt.content,
+      new RegExp(`authoritative self identity is \\*\\*${agentId}\\*\\*`, "i"), phase);
+  };
+  try {
+    await host.start();
+    const channelDeadline = Date.now() + 2_000;
+    while (!store.readJson("status", {}).connectedAt && Date.now() < channelDeadline) {
+      await new Promise((resolve) => setTimeout(resolve, 10));
+    }
+    assert.equal(sessionInputs.length, 1);
+    assertIdentity(sessionInputs[0], "cold startup");
+
+    const reset = await host.resetSession(agentId);
+    assert.equal(reset.readyForFreshScenario, true);
+    assert.equal(sessionInputs.length, 2);
+    assertIdentity(sessionInputs[1], "fresh reset");
+
+    assert.equal(await host.upsertAgent({ ...agent, model: "mock-hot" }), "updated");
+    assert.equal(sessionInputs.length, 3);
+    assertIdentity(sessionInputs[2], "hot staged candidate");
+    assert.deepEqual(sessionInputs.map((input) => input.model), ["mock-cold", "mock-cold", "mock-hot"]);
+    assert.equal(host.agents[0].displayName, "二蛋");
+  } finally {
+    await host.shutdown("bot display identity Mock E2E complete");
+    assert.equal(channels.every((channel) => channel.disconnected === 1), true);
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("production HostShell safely falls back without Bot cache, then uses persisted identity on the next cold start", { timeout: 10_000 }, async () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "larkin-production-bot-display-next-start-"));
+  const agentId = "cli_botNextStartA1";
+  const store = createAgentStateStore(root, agentId);
+  const baseAgent = { agentId, name: agentId, runtime: "codex", model: "mock",
+    feishuAppId: agentId, feishuProfile: agentId, feishuAppSecret: "fixture-secret",
+    feishuDomain: "https://open.feishu.cn", larkConfigDir: path.join(root, "lark-cli-config"),
+    workspaceDir: path.join(root, "agents", agentId), stateDir: store.paths.root };
+  let run = 0;
+  const startOnce = async (agent = baseAgent) => {
+    run += 1;
+    const inputs = [];
+    const adapter = { id: "codex", capabilities: {}, async createSession(input) {
+      inputs.push(input);
+      const session = new FakeNativeSession("codex");
+      session.sessionId = `bot-next-start-${run}`;
+      return session;
+    } };
+    const runtimeHost = createRuntimeHost({ adapterFor: () => adapter, promptBuilder: new ContextPromptBuilder(),
+      stateStoreFor: () => store, assertOfficialCliReady: () => {} });
+    const channels = [];
+    const channelPackage = { createLarkChannel() {
+      const channel = {
+        connected: false, botIdentity: { openId: "ou_bot_next_start", name: "二蛋" },
+        on() {}, dispatcher: { register() {} }, async connect() { this.connected = true; },
+        async disconnect() {}, async updateCard() {},
+        rawClient: { async request() { return { bot: { open_id: "ou_bot_next_start", app_name: "二蛋" } }; } },
+      };
+      channels.push(channel);
+      return channel;
+    } };
+    const host = createHostShell({ env: { LARKIN_HOME: root, LARKIN_CONFIG_DIR: root,
+      LARKIN_SERVER_ID: `server-bot-next-start-${run}`, LARKIN_AGENTS_CONFIG: JSON.stringify([agent]),
+      LARKIN_INBOUND_DROUGHT_SEC: "0" }, runtimeHost, stateStoreForImpl: () => store,
+      managedCliForAgent: testManagedCli, eventSourceStartDelayMs: 0, channelPackage });
+    try {
+      await host.start();
+      const deadline = Date.now() + 2_000;
+      while (!channels[0]?.connected && Date.now() < deadline) await new Promise((resolve) => setTimeout(resolve, 10));
+      await new Promise((resolve) => setTimeout(resolve, 10));
+      assert.equal(inputs.length, 1);
+      return inputs[0].standingPrompt.content;
+    } finally {
+      await host.shutdown(`bot next-start run ${run}`);
+    }
+  };
+  try {
+    const firstPrompt = await startOnce();
+    assert.match(firstPrompt, new RegExp(`persistent Larkin agent \\*\\*${agentId}\\*\\*`, "i"),
+      "first run without cache must retain the safe App ID fallback");
+    assert.doesNotMatch(firstPrompt, /persistent Larkin agent \*\*二蛋\*\*/i,
+      "the first connection must not silently replace the already-created Runtime session");
+    const persistedIdentity = store.readJson("botIdentity", {});
+    assert.equal(persistedIdentity.open_id, "ou_bot_next_start");
+    assert.equal(persistedIdentity.name, "二蛋");
+    assert.equal(Number.isFinite(Date.parse(persistedIdentity.updated_at)), true);
+
+    const nextPrompt = await startOnce();
+    assert.match(nextPrompt, /persistent Larkin agent \*\*二蛋\*\*/i,
+      "the identity persisted by the first channel connection must reach the next cold Runtime start");
+
+    store.writeJson("botIdentity", { open_id: "ou_bot_next_start", name: "" });
+    const configuredPrompt = await startOnce({ ...baseAgent, displayName: "Configured Alias" });
+    assert.match(configuredPrompt, /persistent Larkin agent \*\*Configured Alias\*\*/i,
+      "an empty cached Bot name must not erase an existing displayName");
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});
+
 test("production HostShell startup zero-unread one-shot cannot redeliver post-reset inbound work", { timeout: 25_000 }, async () => {
   const root = fs.mkdtempSync(path.join(os.tmpdir(), "larkin-production-redelivery-reset-"));
   const agentId = "cli_redeliveryResetA1";

--- a/test/unit/feishu/host-hot-agent-attach.test.mjs
+++ b/test/unit/feishu/host-hot-agent-attach.test.mjs
@@ -46,11 +46,23 @@ test("HostShell hot attach adds only the target Agent and duplicate upsert is id
   fs.chmodSync(root, 0o700);
   const existing = configFor(root, "cli_existingA1");
   const added = configFor(root, "cli_addedB2");
+  createAgentStateStore(root, existing.agentId).writeJson("botIdentity", {
+    open_id: "ou_existing", name: "Existing Bot",
+  });
+  createAgentStateStore(root, added.agentId).writeJson("botIdentity", {
+    open_id: "ou_added", name: "Added Bot",
+  });
   const starts = [];
+  const startInputs = [];
+  const stageInputs = [];
   const stops = [];
   const subscribers = [];
   const runtimeHost = {
-    async start(configs) { starts.push(configs.map(({ agentId }) => agentId)); for (const config of configs) for (const listener of subscribers) listener({ type: "agent-status", agentId: config.agentId, status: "active" }); },
+    async start(configs) { startInputs.push(configs.map((config) => ({ ...config }))); starts.push(configs.map(({ agentId }) => agentId)); for (const config of configs) for (const listener of subscribers) listener({ type: "agent-status", agentId: config.agentId, status: "active" }); },
+    async stage(config) {
+      stageInputs.push({ ...config });
+      return { readiness: { runtime: config.runtime, state: "ready" }, async commit() {}, async rollback() {} };
+    },
     async stop(agentId) { stops.push(agentId); },
     async shutdown() {}, async deliver() { return { status: "accepted", deliveryId: "delivery" }; },
     subscribe(listener) { subscribers.push(listener); return () => {}; },
@@ -59,10 +71,11 @@ test("HostShell hot attach adds only the target Agent and duplicate upsert is id
   const channels = new Map();
   const channelPackage = {
     createLarkChannel(options) {
+      const botName = options.appId === existing.agentId ? "Existing Bot" : "Added Bot";
       const channel = {
         options, handlers: null, disconnected: 0, registrations: {}, cardUpdates: [],
-        botIdentity: { openId: `ou_${options.appId}`, name: options.appId },
-        rawClient: { async request() { return { bot: { open_id: `ou_${options.appId}`, app_name: options.appId } }; } },
+        botIdentity: { openId: `ou_${options.appId}`, name: botName },
+        rawClient: { async request() { return { bot: { open_id: `ou_${options.appId}`, app_name: botName } }; } },
         dispatcher: { register: (map) => Object.assign(channel.registrations, map) }, on(handlers) { this.handlers = handlers; },
         async connect() {}, async disconnect() { this.disconnected += 1; }, async updateCard(messageId, card) { this.cardUpdates.push({ messageId, card }); },
       };
@@ -81,6 +94,9 @@ test("HostShell hot attach adds only the target Agent and duplicate upsert is id
     assert.equal(await shell.upsertAgent(added), "added");
     assert.deepEqual(shell.agents.map(({ agentId }) => agentId), ["cli_existingA1", "cli_addedB2"]);
     assert.deepEqual(starts, [["cli_existingA1"], ["cli_addedB2"]]);
+    assert.equal(startInputs[0][0].displayName, "Existing Bot", "cold Runtime start must receive cached Bot display identity");
+    assert.equal(startInputs[1][0].displayName, "Added Bot", "hot add Runtime start must be hydrated before start");
+    assert.deepEqual(stageInputs, [], "hot add has no previous Runtime and must not stage");
     assert.deepEqual(stops, [], "new attach must not stop the existing Agent Runtime");
     assert.equal(channels.get("cli_existingA1").disconnected, 0, "existing channel must stay connected");
     const addedChannel = channels.get("cli_addedB2");
@@ -89,7 +105,11 @@ test("HostShell hot attach adds only the target Agent and duplicate upsert is id
     assert.match(JSON.stringify(addedResponse), /Agent 正在处理/);
     await new Promise((resolve) => setTimeout(resolve, 20));
     assert.equal(addedChannel.cardUpdates.length, 1, "hot-added Agent must project its card through the new channel");
-    assert.equal(await shell.upsertAgent(added), "unchanged");
+    const updated = { ...added, model: "gpt-5.6-updated" };
+    assert.equal(await shell.upsertAgent(updated), "updated");
+    assert.equal(stageInputs.length, 1, "hot update must stage exactly one replacement Runtime");
+    assert.equal(stageInputs[0].displayName, "Added Bot", "hot update must hydrate Bot identity before stage");
+    assert.equal(await shell.upsertAgent(updated), "unchanged");
     assert.deepEqual(starts, [["cli_existingA1"], ["cli_addedB2"]], "duplicate operation must not create a second Runtime");
   } finally {
     await shell.shutdown("test");


### PR DESCRIPTION
## Summary

- project the existing cached Feishu Bot display name into the existing Runtime `displayName` before cold start and hot add/update
- preserve App ID as the canonical Agent ID and keep the safe App-ID fallback when no Bot identity cache exists
- cover cached cold start, public session reset, hot start/stage ordering, next-start cache adoption, and empty-name fallback
- bump `package.json` from 0.2.48 to 0.2.49

## Regression

The installed v0.2.48 two-model Issue #6 matrix passed scenarios 1–3 (6/20), then the GLM Agent rejected a real self mention because its Inbox identified it as “二蛋” while the standing prompt declared only the App ID as authoritative identity. This change reuses the existing `botIdentity` cache and `displayName` contract; it adds no service, state schema, config, public API, or product entity.

Refs #6. Keep #6 open until the 0.2.49 release is checksum-installed and the fresh two-model 20-run matrix passes.

## Validation

- independent evaluator: Blocking 0, Important 0, Minor 0
- focused Runtime/channel/hot-attach tests
- production Mock E2E
- `bun run test`
- `bun run licenses:check`
- `bun run publication:check:tree`
- `bun run publication:check`
- 0.2.49 Darwin ARM64 clean-source release smoke (version, Dashboard HTTP 200, code signature)
- `git diff --check`

`bun.lock` is unchanged.