### PR TITLE
Bundle official Pi runtime and auth into setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,9 @@ Run `larkin --help` or `larkin config --help` for the available commands and con
 During setup, a new Agent is offered Pi first, followed by Codex and Claude Code. Pi can use an existing
 official `pi` installation or the official Pi runtime bundled in Larkin. The bundled option supports
 DeepSeek, Kimi/Moonshot, MiniMax, Zhipu/BigModel, and a custom OpenAI-compatible Base URL. Provider keys
-are stored only in the selected Agent's private provider directory, not in the ordinary Agent config.
+are stored only in the selected Agent's private provider directory, not in the ordinary Agent config. Setup
+also discovers every API-key and OAuth/subscription login exposed by the pinned official Pi registry and
+delegates those flows to Pi. Use `larkin pi-auth status` or `larkin pi-auth logout <provider>` to manage them.
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -19,6 +19,11 @@ larkin status
 
 Run `larkin --help` or `larkin config --help` for the available commands and configuration options. Local configuration is stored under `~/.larkin` by default; set `LARKIN_CONFIG_DIR` to use another directory.
 
+During setup, a new Agent is offered Pi first, followed by Codex and Claude Code. Pi can use an existing
+official `pi` installation or the official Pi runtime bundled in Larkin. The bundled option supports
+DeepSeek, Kimi/Moonshot, MiniMax, Zhipu/BigModel, and a custom OpenAI-compatible Base URL. Provider keys
+are stored only in the selected Agent's private provider directory, not in the ordinary Agent config.
+
 ## Development
 
 ```bash

--- a/bun.lock
+++ b/bun.lock
@@ -9,6 +9,7 @@
         "@larksuite/channel": "^0.4.0",
         "@radix-ui/react-dialog": "^1.1.21",
         "lucide-react": "^1.26.0",
+        "proper-lockfile": "4.1.2",
         "qrcode-terminal": "^0.12.0",
         "react": "^19.2.8",
         "react-dom": "^19.2.8",

--- a/bun.lock
+++ b/bun.lock
@@ -5,6 +5,7 @@
     "": {
       "name": "larkin",
       "dependencies": {
+        "@earendil-works/pi-coding-agent": "0.83.0",
         "@larksuite/channel": "^0.4.0",
         "@radix-ui/react-dialog": "^1.1.21",
         "lucide-react": "^1.26.0",
@@ -34,6 +35,8 @@
   "packages": {
     "@adobe/css-tools": ["@adobe/css-tools@4.5.0", "https://registry.npmmirror.com/@adobe/css-tools/-/css-tools-4.5.0.tgz", {}, "sha512-6OzddxPio9UiWTCemp4N8cYLV2ZN1ncRnV1cVGtve7dhPOtRkleRyx32GQCYSwDYgaHU3USMm84tNsvKzRCa1Q=="],
 
+    "@anthropic-ai/sdk": ["@anthropic-ai/sdk@0.91.1", "https://registry.npmmirror.com/@anthropic-ai/sdk/-/sdk-0.91.1.tgz", { "dependencies": { "json-schema-to-ts": "^3.1.1" }, "peerDependencies": { "zod": "^3.25.0 || ^4.0.0" }, "optionalPeers": ["zod"], "bin": { "anthropic-ai-sdk": "bin/cli" } }, "sha512-LAmu761tSN9r66ixvmciswUj/ZC+1Q4iAfpedTfSVLeswRwnY3n2Nb6Tsk+cLPP28aLOPWeMgIuTuCcMC6W/iw=="],
+
     "@asamuzakjp/css-color": ["@asamuzakjp/css-color@5.1.11", "https://registry.npmmirror.com/@asamuzakjp/css-color/-/css-color-5.1.11.tgz", { "dependencies": { "@asamuzakjp/generational-cache": "^1.0.1", "@csstools/css-calc": "^3.2.0", "@csstools/css-color-parser": "^4.1.0", "@csstools/css-parser-algorithms": "^4.0.0", "@csstools/css-tokenizer": "^4.0.0" } }, "sha512-KVw6qIiCTUQhByfTd78h2yD1/00waTmm9uy/R7Ck/ctUyAPj+AEDLkQIdJW0T8+qGgj3j5bpNKK7Q3G+LedJWg=="],
 
     "@asamuzakjp/dom-selector": ["@asamuzakjp/dom-selector@7.1.1", "https://registry.npmmirror.com/@asamuzakjp/dom-selector/-/dom-selector-7.1.1.tgz", { "dependencies": { "@asamuzakjp/generational-cache": "^1.0.1", "@asamuzakjp/nwsapi": "^2.3.9", "bidi-js": "^1.0.3", "css-tree": "^3.2.1", "is-potential-custom-element-name": "^1.0.1" } }, "sha512-67RZDnYRc8H/8MLDgQCDE//zoqVFwajkepHZgmXrbwybzXOEwOWGPYGmALYl9J2DOLfFPPs6kKCqmbzV895hTQ=="],
@@ -41,6 +44,54 @@
     "@asamuzakjp/generational-cache": ["@asamuzakjp/generational-cache@1.0.1", "https://registry.npmmirror.com/@asamuzakjp/generational-cache/-/generational-cache-1.0.1.tgz", {}, "sha512-wajfB8KqzMCN2KGNFdLkReeHncd0AslUSrvHVvvYWuU8ghncRJoA50kT3zP9MVL0+9g4/67H+cdvBskj9THPzg=="],
 
     "@asamuzakjp/nwsapi": ["@asamuzakjp/nwsapi@2.3.9", "https://registry.npmmirror.com/@asamuzakjp/nwsapi/-/nwsapi-2.3.9.tgz", {}, "sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q=="],
+
+    "@aws-crypto/sha256-browser": ["@aws-crypto/sha256-browser@5.2.0", "https://registry.npmmirror.com/@aws-crypto/sha256-browser/-/sha256-browser-5.2.0.tgz", { "dependencies": { "@aws-crypto/sha256-js": "^5.2.0", "@aws-crypto/supports-web-crypto": "^5.2.0", "@aws-crypto/util": "^5.2.0", "@aws-sdk/types": "^3.222.0", "@aws-sdk/util-locate-window": "^3.0.0", "@smithy/util-utf8": "^2.0.0", "tslib": "^2.6.2" } }, "sha512-AXfN/lGotSQwu6HNcEsIASo7kWXZ5HYWvfOmSNKDsEqC4OashTp8alTmaz+F7TC2L083SFv5RdB+qU3Vs1kZqw=="],
+
+    "@aws-crypto/sha256-js": ["@aws-crypto/sha256-js@5.2.0", "https://registry.npmmirror.com/@aws-crypto/sha256-js/-/sha256-js-5.2.0.tgz", { "dependencies": { "@aws-crypto/util": "^5.2.0", "@aws-sdk/types": "^3.222.0", "tslib": "^2.6.2" } }, "sha512-FFQQyu7edu4ufvIZ+OadFpHHOt+eSTBaYaki44c+akjg7qZg9oOQeLlk77F6tSYqjDAFClrHJk9tMf0HdVyOvA=="],
+
+    "@aws-crypto/supports-web-crypto": ["@aws-crypto/supports-web-crypto@5.2.0", "https://registry.npmmirror.com/@aws-crypto/supports-web-crypto/-/supports-web-crypto-5.2.0.tgz", { "dependencies": { "tslib": "^2.6.2" } }, "sha512-iAvUotm021kM33eCdNfwIN//F77/IADDSs58i+MDaOqFrVjZo9bAal0NK7HurRuWLLpF1iLX7gbWrjHjeo+YFg=="],
+
+    "@aws-crypto/util": ["@aws-crypto/util@5.2.0", "https://registry.npmmirror.com/@aws-crypto/util/-/util-5.2.0.tgz", { "dependencies": { "@aws-sdk/types": "^3.222.0", "@smithy/util-utf8": "^2.0.0", "tslib": "^2.6.2" } }, "sha512-4RkU9EsI6ZpBve5fseQlGNUWKMa1RLPQ1dnjnQoe07ldfIzcsGb5hC5W0Dm7u423KWzawlrpbjXBrXCEv9zazQ=="],
+
+    "@aws-sdk/client-bedrock-runtime": ["@aws-sdk/client-bedrock-runtime@3.1048.0", "https://registry.npmmirror.com/@aws-sdk/client-bedrock-runtime/-/client-bedrock-runtime-3.1048.0.tgz", { "dependencies": { "@aws-crypto/sha256-browser": "5.2.0", "@aws-crypto/sha256-js": "5.2.0", "@aws-sdk/core": "^3.974.11", "@aws-sdk/credential-provider-node": "^3.972.42", "@aws-sdk/eventstream-handler-node": "^3.972.16", "@aws-sdk/middleware-eventstream": "^3.972.12", "@aws-sdk/middleware-websocket": "^3.972.19", "@aws-sdk/token-providers": "3.1048.0", "@aws-sdk/types": "^3.973.8", "@smithy/core": "^3.24.2", "@smithy/fetch-http-handler": "^5.4.2", "@smithy/node-http-handler": "^4.7.2", "@smithy/types": "^4.14.1", "tslib": "^2.6.2" } }, "sha512-u+NT61JZEkRFtpL0CAw1N1dwxnaLgwVXQl/zjJxTGgLyS/jTIdg2SdoEoCTHxgDyCnqa1HEi9QOoE9/pYRNpOQ=="],
+
+    "@aws-sdk/core": ["@aws-sdk/core@3.977.6", "https://registry.npmmirror.com/@aws-sdk/core/-/core-3.977.6.tgz", { "dependencies": { "@aws-sdk/types": "^3.974.2", "@aws-sdk/xml-builder": "^3.972.37", "@aws/lambda-invoke-store": "^0.3.0", "@smithy/core": "^3.31.1", "@smithy/signature-v4": "^5.6.12", "@smithy/types": "^4.16.1", "bowser": "^2.11.0", "tslib": "^2.6.2" } }, "sha512-QiaJV4/zDrB4ZY2mfeSXSzSTc36W16sZXcGz+SPFk0CJ26gziO0cS+4LjJUMAbdeeBOvS0k0Aq1cZpfGdUXxSw=="],
+
+    "@aws-sdk/credential-provider-env": ["@aws-sdk/credential-provider-env@3.972.67", "https://registry.npmmirror.com/@aws-sdk/credential-provider-env/-/credential-provider-env-3.972.67.tgz", { "dependencies": { "@aws-sdk/core": "^3.977.6", "@aws-sdk/types": "^3.974.2", "@smithy/core": "^3.31.1", "@smithy/types": "^4.16.1", "tslib": "^2.6.2" } }, "sha512-rcIpk5kxUqDaaNa6Xk23pQ6ViY7jlqzmfFWCahQcBT97ddXaXYYwzCen9Tz1Jvo6aJft6wDl5bN44/Jw5B4oLA=="],
+
+    "@aws-sdk/credential-provider-http": ["@aws-sdk/credential-provider-http@3.972.69", "https://registry.npmmirror.com/@aws-sdk/credential-provider-http/-/credential-provider-http-3.972.69.tgz", { "dependencies": { "@aws-sdk/core": "^3.977.6", "@aws-sdk/types": "^3.974.2", "@smithy/core": "^3.31.1", "@smithy/fetch-http-handler": "^5.6.13", "@smithy/node-http-handler": "^4.9.13", "@smithy/types": "^4.16.1", "tslib": "^2.6.2" } }, "sha512-nggwJtZ4eeNsUw5IeWBMXsi1ryct5idi0K+/SCRF3kybLubOMaNTb3XCihXpWMiVpyzyPeIrl0zTkzhBH9porA=="],
+
+    "@aws-sdk/credential-provider-ini": ["@aws-sdk/credential-provider-ini@3.973.12", "https://registry.npmmirror.com/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.973.12.tgz", { "dependencies": { "@aws-sdk/core": "^3.977.6", "@aws-sdk/credential-provider-env": "^3.972.67", "@aws-sdk/credential-provider-http": "^3.972.69", "@aws-sdk/credential-provider-login": "^3.972.74", "@aws-sdk/credential-provider-process": "^3.972.67", "@aws-sdk/credential-provider-sso": "^3.973.11", "@aws-sdk/credential-provider-web-identity": "^3.972.73", "@aws-sdk/nested-clients": "^3.997.41", "@aws-sdk/types": "^3.974.2", "@smithy/core": "^3.31.1", "@smithy/credential-provider-imds": "^4.4.16", "@smithy/types": "^4.16.1", "tslib": "^2.6.2" } }, "sha512-pNEf/OeyN5X3VmLKlgSO6TqaWmW10CvI3TfwL1XhsuhYjSLT2VDaxFnCPHnOeQXSaFisMX4jNhpETriqN8DOmg=="],
+
+    "@aws-sdk/credential-provider-login": ["@aws-sdk/credential-provider-login@3.972.74", "https://registry.npmmirror.com/@aws-sdk/credential-provider-login/-/credential-provider-login-3.972.74.tgz", { "dependencies": { "@aws-sdk/core": "^3.977.6", "@aws-sdk/nested-clients": "^3.997.41", "@aws-sdk/types": "^3.974.2", "@smithy/core": "^3.31.1", "@smithy/types": "^4.16.1", "tslib": "^2.6.2" } }, "sha512-0AQfDcf99TNmqVKv0owHrw/TQs6i4ZE5t9qmz6NvO53bE/sA/tpXhXL9AAcEP1qHc6Zzjd1UMb69+/9zdhvY3g=="],
+
+    "@aws-sdk/credential-provider-node": ["@aws-sdk/credential-provider-node@3.972.78", "https://registry.npmmirror.com/@aws-sdk/credential-provider-node/-/credential-provider-node-3.972.78.tgz", { "dependencies": { "@aws-sdk/credential-provider-env": "^3.972.67", "@aws-sdk/credential-provider-http": "^3.972.69", "@aws-sdk/credential-provider-ini": "^3.973.12", "@aws-sdk/credential-provider-process": "^3.972.67", "@aws-sdk/credential-provider-sso": "^3.973.11", "@aws-sdk/credential-provider-web-identity": "^3.972.73", "@aws-sdk/types": "^3.974.2", "@smithy/core": "^3.31.1", "@smithy/credential-provider-imds": "^4.4.16", "@smithy/types": "^4.16.1", "tslib": "^2.6.2" } }, "sha512-OgPAnfvbGAMWac6yvxJ1ihslrvDpPVwR68D2csospdNCCyPvHk9JLzYKwz48SNiS1T2znDwHauywRKRFfpyYng=="],
+
+    "@aws-sdk/credential-provider-process": ["@aws-sdk/credential-provider-process@3.972.67", "https://registry.npmmirror.com/@aws-sdk/credential-provider-process/-/credential-provider-process-3.972.67.tgz", { "dependencies": { "@aws-sdk/core": "^3.977.6", "@aws-sdk/types": "^3.974.2", "@smithy/core": "^3.31.1", "@smithy/types": "^4.16.1", "tslib": "^2.6.2" } }, "sha512-IlUEejorGTWKb4/Dm7K5Yw4QxUmXLThLhrvBmzVBqZFTbW72cv9LTcITmo1dsnYriALE4h68mOq4LB99x6sQ7Q=="],
+
+    "@aws-sdk/credential-provider-sso": ["@aws-sdk/credential-provider-sso@3.973.11", "https://registry.npmmirror.com/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.973.11.tgz", { "dependencies": { "@aws-sdk/core": "^3.977.6", "@aws-sdk/nested-clients": "^3.997.41", "@aws-sdk/token-providers": "3.1103.0", "@aws-sdk/types": "^3.974.2", "@smithy/core": "^3.31.1", "@smithy/types": "^4.16.1", "tslib": "^2.6.2" } }, "sha512-gAQBkBZxUB84d71+pPcI9L+jh2ujhuAVxc/4FgGiWFDjkPBlMKxzd5XDtkSXTFX8Ro7ansnT88+XadasxMeCRw=="],
+
+    "@aws-sdk/credential-provider-web-identity": ["@aws-sdk/credential-provider-web-identity@3.972.73", "https://registry.npmmirror.com/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.972.73.tgz", { "dependencies": { "@aws-sdk/core": "^3.977.6", "@aws-sdk/nested-clients": "^3.997.41", "@aws-sdk/types": "^3.974.2", "@smithy/core": "^3.31.1", "@smithy/types": "^4.16.1", "tslib": "^2.6.2" } }, "sha512-SnlEmQa6SjOgs6iOPLUQl1Eyq4AKiAdPQlkOhFhqNfDtDCwibMGvL6QlkSmf3o6vAUSImzdPCxowT5dfQUZP1A=="],
+
+    "@aws-sdk/eventstream-handler-node": ["@aws-sdk/eventstream-handler-node@3.972.31", "https://registry.npmmirror.com/@aws-sdk/eventstream-handler-node/-/eventstream-handler-node-3.972.31.tgz", { "dependencies": { "@aws-sdk/types": "^3.974.2", "@smithy/core": "^3.31.1", "@smithy/types": "^4.16.1", "tslib": "^2.6.2" } }, "sha512-/BRzvkp46mF6eXBL/l9WKPQQfifLlUPaWli6n9/T/WDLUg8he7TCyuNFnk6RvHP5j5W/kMj5Gxw7W778LJaXDA=="],
+
+    "@aws-sdk/middleware-eventstream": ["@aws-sdk/middleware-eventstream@3.972.26", "https://registry.npmmirror.com/@aws-sdk/middleware-eventstream/-/middleware-eventstream-3.972.26.tgz", { "dependencies": { "@aws-sdk/types": "^3.974.2", "@smithy/core": "^3.31.1", "@smithy/types": "^4.16.1", "tslib": "^2.6.2" } }, "sha512-2eIvouTZoxPu5ClHY6ij13De1yhY8Rmllt0dlGeBNXX3wmR7fU1pvMCGb50fKm1GxcuntWK0t1T0cMjTyDoUQA=="],
+
+    "@aws-sdk/middleware-websocket": ["@aws-sdk/middleware-websocket@3.972.49", "https://registry.npmmirror.com/@aws-sdk/middleware-websocket/-/middleware-websocket-3.972.49.tgz", { "dependencies": { "@aws-sdk/core": "^3.977.6", "@aws-sdk/types": "^3.974.2", "@smithy/core": "^3.31.1", "@smithy/fetch-http-handler": "^5.6.13", "@smithy/signature-v4": "^5.6.12", "@smithy/types": "^4.16.1", "tslib": "^2.6.2" } }, "sha512-wGYJvu1/stdWuzGcNyh44u8aY7ArU8XFrMesBlzIYn70HWVCRBNEngQexDuPIMu0NEgsKGKmTc0uvnS/bF7KWw=="],
+
+    "@aws-sdk/nested-clients": ["@aws-sdk/nested-clients@3.997.41", "https://registry.npmmirror.com/@aws-sdk/nested-clients/-/nested-clients-3.997.41.tgz", { "dependencies": { "@aws-sdk/core": "^3.977.6", "@aws-sdk/signature-v4-multi-region": "^3.996.43", "@aws-sdk/types": "^3.974.2", "@smithy/core": "^3.31.1", "@smithy/fetch-http-handler": "^5.6.13", "@smithy/node-http-handler": "^4.9.13", "@smithy/types": "^4.16.1", "tslib": "^2.6.2" } }, "sha512-RDHqPGQWlF6tatA/Tp3rg6oIwtgN9IVderxE+9av2Y93Dfyu+mO1hZ5Bu2jpfZg2rwdNbsssnwM+sLafIczMlQ=="],
+
+    "@aws-sdk/signature-v4-multi-region": ["@aws-sdk/signature-v4-multi-region@3.996.43", "https://registry.npmmirror.com/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.996.43.tgz", { "dependencies": { "@aws-sdk/types": "^3.974.2", "@smithy/signature-v4": "^5.6.12", "@smithy/types": "^4.16.1", "tslib": "^2.6.2" } }, "sha512-lKekx8bLBXSv4O+cslk9Zfnw2XKSkWBs3uWL5QGhH2ZAQfNS7FE0vcSSN2vD/AhxX54ZTywWxR4STThoeOXlBA=="],
+
+    "@aws-sdk/token-providers": ["@aws-sdk/token-providers@3.1048.0", "https://registry.npmmirror.com/@aws-sdk/token-providers/-/token-providers-3.1048.0.tgz", { "dependencies": { "@aws-sdk/core": "^3.974.11", "@aws-sdk/nested-clients": "^3.997.9", "@aws-sdk/types": "^3.973.8", "@smithy/core": "^3.24.2", "@smithy/types": "^4.14.1", "tslib": "^2.6.2" } }, "sha512-k0y/GcuesuSfWyUM0WamrGyeZmltRYaPbHO82UDA6mZ/doB+FOHKutikPAtSXMn/hDz970cF+iRuuiYO9VEbAA=="],
+
+    "@aws-sdk/types": ["@aws-sdk/types@3.974.2", "https://registry.npmmirror.com/@aws-sdk/types/-/types-3.974.2.tgz", { "dependencies": { "@smithy/types": "^4.16.1", "tslib": "^2.6.2" } }, "sha512-3W6IUtSxFbH6X7Wb7DzGCV5QiFQsd0g8bOfntpmDxQlzBoKWUMBu/JPQR0DwkE+Hpnxd6db1tXbOwdeHddG6cA=="],
+
+    "@aws-sdk/util-locate-window": ["@aws-sdk/util-locate-window@3.965.8", "https://registry.npmmirror.com/@aws-sdk/util-locate-window/-/util-locate-window-3.965.8.tgz", { "dependencies": { "tslib": "^2.6.2" } }, "sha512-uUbMs1cBZPafD0ohUj6EwNf0fPZ534NvBxHox4hjX+0Rxq5paSYUem7+hi833pYrzrcnBATKIYpR02MDXT5M9g=="],
+
+    "@aws-sdk/xml-builder": ["@aws-sdk/xml-builder@3.972.37", "https://registry.npmmirror.com/@aws-sdk/xml-builder/-/xml-builder-3.972.37.tgz", { "dependencies": { "@smithy/types": "^4.16.1", "tslib": "^2.6.2" } }, "sha512-zKq4HQum8JwDyEuyfuI4bbiAcU0KxP6qy+9PR/IsR92IyE/DaBAikzAS50tjxip4bqIIANpCcG+Yyj6CVhXupg=="],
+
+    "@aws/lambda-invoke-store": ["@aws/lambda-invoke-store@0.3.0", "https://registry.npmmirror.com/@aws/lambda-invoke-store/-/lambda-invoke-store-0.3.0.tgz", {}, "sha512-sl4Bm6yiMNYrZKkqqDFWN0UfnWhlS8ivKxrYl+6t0gCLrqr8y3B2IqZZbFRkfaVVp7C/baApyh71P+LeE1A2sQ=="],
 
     "@babel/code-frame": ["@babel/code-frame@7.29.7", "https://registry.npmmirror.com/@babel/code-frame/-/code-frame-7.29.7.tgz", { "dependencies": { "@babel/helper-validator-identifier": "^7.29.7", "js-tokens": "^4.0.0", "picocolors": "^1.1.1" } }, "sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw=="],
 
@@ -62,6 +113,14 @@
 
     "@csstools/css-tokenizer": ["@csstools/css-tokenizer@4.0.0", "https://registry.npmmirror.com/@csstools/css-tokenizer/-/css-tokenizer-4.0.0.tgz", {}, "sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA=="],
 
+    "@earendil-works/pi-agent-core": ["@earendil-works/pi-agent-core@0.83.0", "https://registry.npmmirror.com/@earendil-works/pi-agent-core/-/pi-agent-core-0.83.0.tgz", { "dependencies": { "@earendil-works/pi-ai": "^0.83.0", "diff": "8.0.4", "ignore": "7.0.5", "typebox": "1.3.7", "yaml": "2.9.0" } }, "sha512-RorGp9OH5l3ElpuC5a5ZQ2eWcchZGXflXRzVGkV99y3y6tT+LLNyxoYIdVKvTKWEObwhExeQbTH0fI2tE4iX4g=="],
+
+    "@earendil-works/pi-ai": ["@earendil-works/pi-ai@0.83.0", "https://registry.npmmirror.com/@earendil-works/pi-ai/-/pi-ai-0.83.0.tgz", { "dependencies": { "@anthropic-ai/sdk": "0.91.1", "@aws-sdk/client-bedrock-runtime": "3.1048.0", "@google/genai": "1.52.0", "@mistralai/mistralai": "2.2.6", "@opentelemetry/api": "1.9.0", "@smithy/node-http-handler": "4.7.3", "http-proxy-agent": "7.0.2", "https-proxy-agent": "7.0.6", "openai": "6.26.0", "partial-json": "0.1.7", "typebox": "1.3.7" }, "bin": { "pi-ai": "dist/cli.js" } }, "sha512-m3IZD4g3er0V8TC9+Vpgw/sjTKqcJlkcIBy/JvsgRubuuik3tAVzyugUg4rVrShIkkOT69mEd34NEqKUIsl6JQ=="],
+
+    "@earendil-works/pi-coding-agent": ["@earendil-works/pi-coding-agent@0.83.0", "https://registry.npmmirror.com/@earendil-works/pi-coding-agent/-/pi-coding-agent-0.83.0.tgz", { "dependencies": { "@earendil-works/pi-agent-core": "^0.83.0", "@earendil-works/pi-ai": "^0.83.0", "@earendil-works/pi-tui": "^0.83.0", "@silvia-odwyer/photon-node": "0.3.4", "chalk": "5.6.2", "cross-spawn": "7.0.6", "diff": "8.0.4", "glob": "13.0.6", "highlight.js": "10.7.3", "hosted-git-info": "9.0.3", "ignore": "7.0.5", "jiti": "2.7.0", "minimatch": "10.2.5", "proper-lockfile": "4.1.2", "semver": "7.8.0", "typebox": "1.3.7", "undici": "8.5.0", "yaml": "2.9.0" }, "optionalDependencies": { "@mariozechner/clipboard": "0.3.9" }, "bin": { "pi": "dist/cli.js" } }, "sha512-uYhF+FsZxogoSX/AxBcUdiY+ZklubwaXyAoEGA2eQwsHcyEAhUYIKh/WLXe/a8+k8eTCmxb+ZN2Zo9mzQtzbWw=="],
+
+    "@earendil-works/pi-tui": ["@earendil-works/pi-tui@0.83.0", "https://registry.npmmirror.com/@earendil-works/pi-tui/-/pi-tui-0.83.0.tgz", { "dependencies": { "get-east-asian-width": "1.6.0", "marked": "18.0.5" } }, "sha512-IoYrb0rORjELmEpNtoCA/U8je3KopMkRAVJRdSzvXRvgb+Huo1gNh8Q5CSZvNOiYtDxJdj2tYZZHZ4B3+IN3hA=="],
+
     "@emnapi/core": ["@emnapi/core@1.11.1", "https://registry.npmmirror.com/@emnapi/core/-/core-1.11.1.tgz", { "dependencies": { "@emnapi/wasi-threads": "1.2.2", "tslib": "^2.4.0" } }, "sha512-RSvbQmHzdKzNsLYa/wHrbc3KN4sYLKAdPZxqiM2HATqv/SBk2/ENSHpvXGaLOMcsAyz0poEGqkmmKYG3OWiJEQ=="],
 
     "@emnapi/runtime": ["@emnapi/runtime@1.11.1", "https://registry.npmmirror.com/@emnapi/runtime/-/runtime-1.11.1.tgz", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-vgj7R3y3Wgx24IQaGPA/R6YFXLHVMOZ0uVEyIQPaWs+rd1AzfEMXlAC22FYwO1XkKR6NPsq7mUandH8oIRdZFw=="],
@@ -69,6 +128,8 @@
     "@emnapi/wasi-threads": ["@emnapi/wasi-threads@1.2.2", "https://registry.npmmirror.com/@emnapi/wasi-threads/-/wasi-threads-1.2.2.tgz", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-c95qOXkHdydNKhscBTebqEC1CVAZpyqOfVfBzQ1qgzyl3gfeldUjIggDbIZgDKsHLgnsM+igH7TJ/eAasaVuMA=="],
 
     "@exodus/bytes": ["@exodus/bytes@1.15.1", "https://registry.npmmirror.com/@exodus/bytes/-/bytes-1.15.1.tgz", { "peerDependencies": { "@noble/hashes": "^1.8.0 || ^2.0.0" }, "optionalPeers": ["@noble/hashes"] }, "sha512-S6mL0yNB/Abt9Ei4tq8gDhcczc4S3+vQ4ra7vxnAf+YHC02srtqxKKZghx2Dq6p0e66THKwR6r8N6P95wEty7Q=="],
+
+    "@google/genai": ["@google/genai@1.52.0", "https://registry.npmmirror.com/@google/genai/-/genai-1.52.0.tgz", { "dependencies": { "google-auth-library": "^10.3.0", "p-retry": "^4.6.2", "protobufjs": "^7.5.4", "ws": "^8.18.0" }, "peerDependencies": { "@modelcontextprotocol/sdk": "^1.25.2" }, "optionalPeers": ["@modelcontextprotocol/sdk"] }, "sha512-gwSvbpiN/17O9TbsqSsE/OzZcpv5Fo4RQjdngGgogtuB9RsyJ8ZHhX5KjHj1bp5N9snN2eK8LDGXSaWW2hof8Q=="],
 
     "@jridgewell/gen-mapping": ["@jridgewell/gen-mapping@0.3.13", "https://registry.npmmirror.com/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz", { "dependencies": { "@jridgewell/sourcemap-codec": "^1.5.0", "@jridgewell/trace-mapping": "^0.3.24" } }, "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA=="],
 
@@ -84,9 +145,35 @@
 
     "@larksuiteoapi/node-sdk": ["@larksuiteoapi/node-sdk@1.71.1", "https://registry.npmmirror.com/@larksuiteoapi/node-sdk/-/node-sdk-1.71.1.tgz", { "dependencies": { "axios": "^1.16.0", "lodash.identity": "^3.0.0", "lodash.merge": "^4.6.2", "lodash.pickby": "^4.6.0", "protobufjs": "^7.2.6", "qs": "^6.14.2", "ws": "^8.19.0" } }, "sha512-Z4cZmgWvwiE7tCHqGm+t7DKvbpNRRTH2HqVwcYiOMAwbjIytXSoQqWytsOVu3p+d0fIvrtyIPZok5HOV/VNxxw=="],
 
+    "@mariozechner/clipboard": ["@mariozechner/clipboard@0.3.9", "https://registry.npmmirror.com/@mariozechner/clipboard/-/clipboard-0.3.9.tgz", { "optionalDependencies": { "@mariozechner/clipboard-darwin-arm64": "0.3.9", "@mariozechner/clipboard-darwin-universal": "0.3.9", "@mariozechner/clipboard-darwin-x64": "0.3.9", "@mariozechner/clipboard-linux-arm64-gnu": "0.3.9", "@mariozechner/clipboard-linux-arm64-musl": "0.3.9", "@mariozechner/clipboard-linux-riscv64-gnu": "0.3.9", "@mariozechner/clipboard-linux-x64-gnu": "0.3.9", "@mariozechner/clipboard-linux-x64-musl": "0.3.9", "@mariozechner/clipboard-win32-arm64-msvc": "0.3.9", "@mariozechner/clipboard-win32-x64-msvc": "0.3.9" } }, "sha512-ABnA53mdfkGZwOFUdZNv2S0CWGO/EIuPj8Vv9xmBFmSYg/qFc7ihO6q5FcQjvoE67kZpWkEc4AhD6B/os04yuA=="],
+
+    "@mariozechner/clipboard-darwin-arm64": ["@mariozechner/clipboard-darwin-arm64@0.3.9", "https://registry.npmmirror.com/@mariozechner/clipboard-darwin-arm64/-/clipboard-darwin-arm64-0.3.9.tgz", { "os": "darwin", "cpu": "arm64" }, "sha512-BfgV7vCEWZwJwZJw03r6bP5+tf0iI/ANuQYCxi9RNn7FrWB3yzGuMKCrNLRl6V761vXRdL8+OqZ0wd4TqlsNOQ=="],
+
+    "@mariozechner/clipboard-darwin-universal": ["@mariozechner/clipboard-darwin-universal@0.3.9", "https://registry.npmmirror.com/@mariozechner/clipboard-darwin-universal/-/clipboard-darwin-universal-0.3.9.tgz", { "os": "darwin" }, "sha512-BGGR4iA9Z2shAjI65eI5xtyb3LYNlDW9X3gxKxDbqtbnREohsrqznov6zpKoIrsRWpzlYVEdKphS7ksJ0/ndSQ=="],
+
+    "@mariozechner/clipboard-darwin-x64": ["@mariozechner/clipboard-darwin-x64@0.3.9", "https://registry.npmmirror.com/@mariozechner/clipboard-darwin-x64/-/clipboard-darwin-x64-0.3.9.tgz", { "os": "darwin", "cpu": "x64" }, "sha512-4kURmCbS6nt8uYhtmWpUcJWyPHfmAr5dTpXD1nO3pIfa+TSQ9DbrGOYCKH+aEFW47XhQ4Vp8ZTszie+wfFvDKg=="],
+
+    "@mariozechner/clipboard-linux-arm64-gnu": ["@mariozechner/clipboard-linux-arm64-gnu@0.3.9", "https://registry.npmmirror.com/@mariozechner/clipboard-linux-arm64-gnu/-/clipboard-linux-arm64-gnu-0.3.9.tgz", { "os": "linux", "cpu": "arm64" }, "sha512-g59OkUGP2DDfCOIKypHeYgv2M55u/cKvXa5dSxFbEJ34XvIQMdcVmpKCkGUro3ZgefXiGVdwguvTMQGpHWzIXw=="],
+
+    "@mariozechner/clipboard-linux-arm64-musl": ["@mariozechner/clipboard-linux-arm64-musl@0.3.9", "https://registry.npmmirror.com/@mariozechner/clipboard-linux-arm64-musl/-/clipboard-linux-arm64-musl-0.3.9.tgz", { "os": "linux", "cpu": "arm64" }, "sha512-AGuJdgKsmJdm4Pych7kv3sqe591ERRaAHW3xjLooiFzn8J+PxUyof++7YZrB5Y5tpnTO+K18Og3taj2NpluCRQ=="],
+
+    "@mariozechner/clipboard-linux-riscv64-gnu": ["@mariozechner/clipboard-linux-riscv64-gnu@0.3.9", "https://registry.npmmirror.com/@mariozechner/clipboard-linux-riscv64-gnu/-/clipboard-linux-riscv64-gnu-0.3.9.tgz", { "os": "linux", "cpu": "none" }, "sha512-DXBEAiuMpk7dhS1a9NzNxVAFi1vaKoPu7rQNgY8LIDLGrK3lnIp3nT10DUum+PKVJoJppIP+NAA8IZe4DMNDPw=="],
+
+    "@mariozechner/clipboard-linux-x64-gnu": ["@mariozechner/clipboard-linux-x64-gnu@0.3.9", "https://registry.npmmirror.com/@mariozechner/clipboard-linux-x64-gnu/-/clipboard-linux-x64-gnu-0.3.9.tgz", { "os": "linux", "cpu": "x64" }, "sha512-WORrMLd6EpElEME7JRKfSaY34nW1P5LbdgK5YNCS1ncG2LqmITsSMEJ8nh2mpvxb3TxqbOOKgY7k9eMJYlW9Mw=="],
+
+    "@mariozechner/clipboard-linux-x64-musl": ["@mariozechner/clipboard-linux-x64-musl@0.3.9", "https://registry.npmmirror.com/@mariozechner/clipboard-linux-x64-musl/-/clipboard-linux-x64-musl-0.3.9.tgz", { "os": "linux", "cpu": "x64" }, "sha512-/DHn+1DrfL6oRaPPWXaOKvonFFrni666fxd+zFqiQEfvBH0tsHVWjq9iqBk0oDp0qaPA72lIMy5BptxISBEhZQ=="],
+
+    "@mariozechner/clipboard-win32-arm64-msvc": ["@mariozechner/clipboard-win32-arm64-msvc@0.3.9", "https://registry.npmmirror.com/@mariozechner/clipboard-win32-arm64-msvc/-/clipboard-win32-arm64-msvc-0.3.9.tgz", { "os": "win32", "cpu": "arm64" }, "sha512-O5FHD3ErkMwMhNzAfu3ggy0ug4z7btZuoQgwwxlzPrwV2bxlD6WDpqBY4NCgICAgZdDKdp+loUEKVAVt8aYnhQ=="],
+
+    "@mariozechner/clipboard-win32-x64-msvc": ["@mariozechner/clipboard-win32-x64-msvc@0.3.9", "https://registry.npmmirror.com/@mariozechner/clipboard-win32-x64-msvc/-/clipboard-win32-x64-msvc-0.3.9.tgz", { "os": "win32", "cpu": "x64" }, "sha512-ihQC3EufqEY81vhXBgVBtK4prL+wc62zJsSvxrgz7K1hsdt6OObz6v9p3Rn1OG3GJksTTKMJF0u/guMISHPhSA=="],
+
+    "@mistralai/mistralai": ["@mistralai/mistralai@2.2.6", "https://registry.npmmirror.com/@mistralai/mistralai/-/mistralai-2.2.6.tgz", { "dependencies": { "@opentelemetry/semantic-conventions": "^1.40.0", "ws": "^8.18.0", "zod": "^3.25.0 || ^4.0.0", "zod-to-json-schema": "^3.25.0" }, "peerDependencies": { "@opentelemetry/api": "^1.9.0" }, "optionalPeers": ["@opentelemetry/api"] }, "sha512-W8pX7zHxjJvMIpw8JMxeJEleapXX0Q9NPszdNzqkM3MIEoIGPObdodujj+WHteXEvGfaP/AMwlNyRfEzSY6dQQ=="],
+
     "@napi-rs/wasm-runtime": ["@napi-rs/wasm-runtime@1.1.6", "https://registry.npmmirror.com/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.6.tgz", { "dependencies": { "@tybys/wasm-util": "^0.10.3" }, "peerDependencies": { "@emnapi/core": "^1.7.1", "@emnapi/runtime": "^1.7.1" } }, "sha512-ZLv/JdUfkvOy9eCnnBaGfiO+XimbjebAeO+MRQqD/B+FR1tnRN0tpKSJHRbE8sFfS6aqsXZ67TQjfwfsxULVbg=="],
 
     "@opentelemetry/api": ["@opentelemetry/api@1.9.0", "https://registry.npmmirror.com/@opentelemetry/api/-/api-1.9.0.tgz", {}, "sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg=="],
+
+    "@opentelemetry/semantic-conventions": ["@opentelemetry/semantic-conventions@1.43.0", "https://registry.npmmirror.com/@opentelemetry/semantic-conventions/-/semantic-conventions-1.43.0.tgz", {}, "sha512-eSYWTm620tTk45EKSedaUL8MFYI8hW164hIXsgIHyxu3VobUB3fFCu5t0hQby6OoWRPsG1KkKUG2M5UadiLiVg=="],
 
     "@oxc-project/types": ["@oxc-project/types@0.139.0", "https://registry.npmmirror.com/@oxc-project/types/-/types-0.139.0.tgz", {}, "sha512-r9gHphtCs+1M7J0pw6Sn/hh/Wpa/iQrOOkrNAlVLF/gHq+/CJmHIWKKUUhdWjcD6CIa8idarspCsASiXCXvFUw=="],
 
@@ -172,6 +259,26 @@
 
     "@rolldown/pluginutils": ["@rolldown/pluginutils@1.0.1", "https://registry.npmmirror.com/@rolldown/pluginutils/-/pluginutils-1.0.1.tgz", {}, "sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw=="],
 
+    "@silvia-odwyer/photon-node": ["@silvia-odwyer/photon-node@0.3.4", "https://registry.npmmirror.com/@silvia-odwyer/photon-node/-/photon-node-0.3.4.tgz", {}, "sha512-bnly4BKB3KDTFxrUIcgCLbaeVVS8lrAkri1pEzskpmxu9MdfGQTy8b8EgcD83ywD3RPMsIulY8xJH5Awa+t9fA=="],
+
+    "@smithy/core": ["@smithy/core@3.31.1", "https://registry.npmmirror.com/@smithy/core/-/core-3.31.1.tgz", { "dependencies": { "@smithy/types": "^4.16.1", "tslib": "^2.6.2" } }, "sha512-CyogUINxvi7C7LDsh8Syo6hVJOT9ckz4rG8dRZfTJ8r91HkMY59PnNooaj7WcHyxEkxPfBAmbgztZU+xTo76lg=="],
+
+    "@smithy/credential-provider-imds": ["@smithy/credential-provider-imds@4.4.16", "https://registry.npmmirror.com/@smithy/credential-provider-imds/-/credential-provider-imds-4.4.16.tgz", { "dependencies": { "@smithy/core": "^3.31.1", "@smithy/types": "^4.16.1", "tslib": "^2.6.2" } }, "sha512-QfuLWAkLzptffFW980AFeHZFdqds2B64rpEd3uJ6lgs3xVn9QegGMUgUcj+4d7dRrAsya3r58ZKpku97WcFb4w=="],
+
+    "@smithy/fetch-http-handler": ["@smithy/fetch-http-handler@5.6.13", "https://registry.npmmirror.com/@smithy/fetch-http-handler/-/fetch-http-handler-5.6.13.tgz", { "dependencies": { "@smithy/core": "^3.31.1", "@smithy/types": "^4.16.1", "tslib": "^2.6.2" } }, "sha512-4fW86pEUOMbrD5nkbyl/tTvPHHWJFbuB2odl6ps9lWfHoXf9HWh3Q/Smh59qH1g7+c/BSZghX6bbUk4gsiMs8A=="],
+
+    "@smithy/is-array-buffer": ["@smithy/is-array-buffer@2.2.0", "https://registry.npmmirror.com/@smithy/is-array-buffer/-/is-array-buffer-2.2.0.tgz", { "dependencies": { "tslib": "^2.6.2" } }, "sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA=="],
+
+    "@smithy/node-http-handler": ["@smithy/node-http-handler@4.7.3", "https://registry.npmmirror.com/@smithy/node-http-handler/-/node-http-handler-4.7.3.tgz", { "dependencies": { "@smithy/core": "^3.24.3", "@smithy/types": "^4.14.2", "tslib": "^2.6.2" } }, "sha512-/jPhevcTFPMVl6KNjbaI47iOg1zxC7IsnX4PQDGVZKMFceOXtB8IEYaB7a9VvkP/3oC60WzTeKocvSI7vLT0vA=="],
+
+    "@smithy/signature-v4": ["@smithy/signature-v4@5.6.12", "https://registry.npmmirror.com/@smithy/signature-v4/-/signature-v4-5.6.12.tgz", { "dependencies": { "@smithy/core": "^3.31.1", "@smithy/types": "^4.16.1", "tslib": "^2.6.2" } }, "sha512-I6KLtq3H0qqSuV9vLglfi8puHqzygzWHOnI4z/Rdoo+q50vvo18vBRdPAvvEtcaKROz7Zn6qnPa14kRfPH6PcQ=="],
+
+    "@smithy/types": ["@smithy/types@4.16.1", "https://registry.npmmirror.com/@smithy/types/-/types-4.16.1.tgz", { "dependencies": { "tslib": "^2.6.2" } }, "sha512-0JFs3V2y2M9tKW5na/qxe69Zv+uxLMO7QBbhxF/FHu/Gp2NFZAAL9tWl9PU02xxo07pb3G9FTyjNc6D5uZrJIg=="],
+
+    "@smithy/util-buffer-from": ["@smithy/util-buffer-from@2.2.0", "https://registry.npmmirror.com/@smithy/util-buffer-from/-/util-buffer-from-2.2.0.tgz", { "dependencies": { "@smithy/is-array-buffer": "^2.2.0", "tslib": "^2.6.2" } }, "sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA=="],
+
+    "@smithy/util-utf8": ["@smithy/util-utf8@2.3.0", "https://registry.npmmirror.com/@smithy/util-utf8/-/util-utf8-2.3.0.tgz", { "dependencies": { "@smithy/util-buffer-from": "^2.2.0", "tslib": "^2.6.2" } }, "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A=="],
+
     "@standard-schema/spec": ["@standard-schema/spec@1.1.0", "https://registry.npmmirror.com/@standard-schema/spec/-/spec-1.1.0.tgz", {}, "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w=="],
 
     "@tailwindcss/node": ["@tailwindcss/node@4.3.3", "https://registry.npmmirror.com/@tailwindcss/node/-/node-4.3.3.tgz", { "dependencies": { "@jridgewell/remapping": "^2.3.5", "enhanced-resolve": "^5.24.1", "jiti": "^2.7.0", "lightningcss": "1.32.0", "magic-string": "^0.30.21", "source-map-js": "^1.2.1", "tailwindcss": "4.3.3" } }, "sha512-/T8IKEsf9VTU6tLjgC7+sv2mOPtQxzE2jMw7u4Tt40Tx+QSZxpzh95/H6cMKoja9XuW7iMdLJYBB0o9G1CaAgg=="],
@@ -227,6 +334,8 @@
     "@types/react": ["@types/react@19.2.14", "https://registry.npmmirror.com/@types/react/-/react-19.2.14.tgz", { "dependencies": { "csstype": "^3.2.2" } }, "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w=="],
 
     "@types/react-dom": ["@types/react-dom@19.2.3", "https://registry.npmmirror.com/@types/react-dom/-/react-dom-19.2.3.tgz", { "peerDependencies": { "@types/react": "^19.2.0" } }, "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ=="],
+
+    "@types/retry": ["@types/retry@0.12.0", "https://registry.npmmirror.com/@types/retry/-/retry-0.12.0.tgz", {}, "sha512-wWKOClTTiizcZhXnPY4wikVAwmdYHp8q6DmC+EJUzAMsycb7HB32Kh9RN4+0gExjmPmZSAQjgURXIGATPegAvA=="],
 
     "@typescript/typescript-aix-ppc64": ["@typescript/typescript-aix-ppc64@7.0.2", "https://registry.npmmirror.com/@typescript/typescript-aix-ppc64/-/typescript-aix-ppc64-7.0.2.tgz", { "os": "aix", "cpu": "ppc64" }, "sha512-MTKKkWB7p/0E9xi1d1tHtZ5PiLkGEMIq88pK2CubZjOsLtYTLqhgIgi6zepFa+9GHZ6h05NMCkQxGKiPXMxXtQ=="],
 
@@ -300,7 +409,19 @@
 
     "axios": ["axios@1.18.1", "https://registry.npmmirror.com/axios/-/axios-1.18.1.tgz", { "dependencies": { "follow-redirects": "^1.16.0", "form-data": "^4.0.5", "https-proxy-agent": "^5.0.1", "proxy-from-env": "^2.1.0" } }, "sha512-3nTvFlvpn9Zu/RkHUqtc7/+al4UpRW5az71ap5zccp6e8RAYEzhMTecX8Dz1wWDYrPpUoB1HAQEGEAEvUr7S9g=="],
 
+    "balanced-match": ["balanced-match@4.0.4", "https://registry.npmmirror.com/balanced-match/-/balanced-match-4.0.4.tgz", {}, "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA=="],
+
+    "base64-js": ["base64-js@1.5.1", "https://registry.npmmirror.com/base64-js/-/base64-js-1.5.1.tgz", {}, "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA=="],
+
     "bidi-js": ["bidi-js@1.0.3", "https://registry.npmmirror.com/bidi-js/-/bidi-js-1.0.3.tgz", { "dependencies": { "require-from-string": "^2.0.2" } }, "sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw=="],
+
+    "bignumber.js": ["bignumber.js@9.3.1", "https://registry.npmmirror.com/bignumber.js/-/bignumber.js-9.3.1.tgz", {}, "sha512-Ko0uX15oIUS7wJ3Rb30Fs6SkVbLmPBAKdlm7q9+ak9bbIeFf0MwuBsQV6z7+X768/cHsfg+WlysDWJcmthjsjQ=="],
+
+    "bowser": ["bowser@2.14.1", "https://registry.npmmirror.com/bowser/-/bowser-2.14.1.tgz", {}, "sha512-tzPjzCxygAKWFOJP011oxFHs57HzIhOEracIgAePE4pqB3LikALKnSzUyU4MGs9/iCEUuHlAJTjTc5M+u7YEGg=="],
+
+    "brace-expansion": ["brace-expansion@5.0.9", "https://registry.npmmirror.com/brace-expansion/-/brace-expansion-5.0.9.tgz", { "dependencies": { "balanced-match": "^4.0.2" } }, "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg=="],
+
+    "buffer-equal-constant-time": ["buffer-equal-constant-time@1.0.1", "https://registry.npmmirror.com/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz", {}, "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA=="],
 
     "call-bind-apply-helpers": ["call-bind-apply-helpers@1.0.2", "https://registry.npmmirror.com/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz", { "dependencies": { "es-errors": "^1.3.0", "function-bind": "^1.1.2" } }, "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ=="],
 
@@ -308,15 +429,21 @@
 
     "chai": ["chai@6.2.2", "https://registry.npmmirror.com/chai/-/chai-6.2.2.tgz", {}, "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg=="],
 
+    "chalk": ["chalk@5.6.2", "https://registry.npmmirror.com/chalk/-/chalk-5.6.2.tgz", {}, "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA=="],
+
     "combined-stream": ["combined-stream@1.0.8", "https://registry.npmmirror.com/combined-stream/-/combined-stream-1.0.8.tgz", { "dependencies": { "delayed-stream": "~1.0.0" } }, "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg=="],
 
     "convert-source-map": ["convert-source-map@2.0.0", "https://registry.npmmirror.com/convert-source-map/-/convert-source-map-2.0.0.tgz", {}, "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg=="],
+
+    "cross-spawn": ["cross-spawn@7.0.6", "https://registry.npmmirror.com/cross-spawn/-/cross-spawn-7.0.6.tgz", { "dependencies": { "path-key": "^3.1.0", "shebang-command": "^2.0.0", "which": "^2.0.1" } }, "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA=="],
 
     "css-tree": ["css-tree@3.2.1", "https://registry.npmmirror.com/css-tree/-/css-tree-3.2.1.tgz", { "dependencies": { "mdn-data": "2.27.1", "source-map-js": "^1.2.1" } }, "sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA=="],
 
     "css.escape": ["css.escape@1.5.1", "https://registry.npmmirror.com/css.escape/-/css.escape-1.5.1.tgz", {}, "sha512-YUifsXXuknHlUsmlgyY0PKzgPOr7/FjCePfHNt0jxm83wHZi44VDMQ7/fGNkjY3/jV1MC+1CmZbaHzugyeRtpg=="],
 
     "csstype": ["csstype@3.2.3", "https://registry.npmmirror.com/csstype/-/csstype-3.2.3.tgz", {}, "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ=="],
+
+    "data-uri-to-buffer": ["data-uri-to-buffer@4.0.1", "https://registry.npmmirror.com/data-uri-to-buffer/-/data-uri-to-buffer-4.0.1.tgz", {}, "sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A=="],
 
     "data-urls": ["data-urls@7.0.0", "https://registry.npmmirror.com/data-urls/-/data-urls-7.0.0.tgz", { "dependencies": { "whatwg-mimetype": "^5.0.0", "whatwg-url": "^16.0.0" } }, "sha512-23XHcCF+coGYevirZceTVD7NdJOqVn+49IHyxgszm+JIiHLoB2TkmPtsYkNWT1pvRSGkc35L6NHs0yHkN2SumA=="],
 
@@ -332,9 +459,13 @@
 
     "detect-node-es": ["detect-node-es@1.1.0", "https://registry.npmmirror.com/detect-node-es/-/detect-node-es-1.1.0.tgz", {}, "sha512-ypdmJU/TbBby2Dxibuv7ZLW3Bs1QEmM7nHjEANfohJLvE0XVujisn1qPJcZxg+qDucsr+bP6fLD1rPS3AhJ7EQ=="],
 
+    "diff": ["diff@8.0.4", "https://registry.npmmirror.com/diff/-/diff-8.0.4.tgz", {}, "sha512-DPi0FmjiSU5EvQV0++GFDOJ9ASQUVFh5kD+OzOnYdi7n3Wpm9hWWGfB/O2blfHcMVTL5WkQXSnRiK9makhrcnw=="],
+
     "dom-accessibility-api": ["dom-accessibility-api@0.6.3", "https://registry.npmmirror.com/dom-accessibility-api/-/dom-accessibility-api-0.6.3.tgz", {}, "sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w=="],
 
     "dunder-proto": ["dunder-proto@1.0.1", "https://registry.npmmirror.com/dunder-proto/-/dunder-proto-1.0.1.tgz", { "dependencies": { "call-bind-apply-helpers": "^1.0.1", "es-errors": "^1.3.0", "gopd": "^1.2.0" } }, "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A=="],
+
+    "ecdsa-sig-formatter": ["ecdsa-sig-formatter@1.0.11", "https://registry.npmmirror.com/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz", { "dependencies": { "safe-buffer": "^5.0.1" } }, "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ=="],
 
     "enhanced-resolve": ["enhanced-resolve@5.24.3", "https://registry.npmmirror.com/enhanced-resolve/-/enhanced-resolve-5.24.3.tgz", { "dependencies": { "graceful-fs": "^4.2.4", "tapable": "^2.3.3" } }, "sha512-PwKooW9JUzh5chmYfHM3IQl5OkK2u2Nm011MgeZrss3JmFraUx/fqrf78kk8GUMYoibx/14MdwTl/1WKkG7TpQ=="],
 
@@ -354,21 +485,39 @@
 
     "expect-type": ["expect-type@1.4.0", "https://registry.npmmirror.com/expect-type/-/expect-type-1.4.0.tgz", {}, "sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA=="],
 
+    "extend": ["extend@3.0.2", "https://registry.npmmirror.com/extend/-/extend-3.0.2.tgz", {}, "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g=="],
+
     "fdir": ["fdir@6.5.0", "https://registry.npmmirror.com/fdir/-/fdir-6.5.0.tgz", { "peerDependencies": { "picomatch": "^3 || ^4" }, "optionalPeers": ["picomatch"] }, "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg=="],
+
+    "fetch-blob": ["fetch-blob@3.2.0", "https://registry.npmmirror.com/fetch-blob/-/fetch-blob-3.2.0.tgz", { "dependencies": { "node-domexception": "^1.0.0", "web-streams-polyfill": "^3.0.3" } }, "sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ=="],
 
     "follow-redirects": ["follow-redirects@1.16.0", "https://registry.npmmirror.com/follow-redirects/-/follow-redirects-1.16.0.tgz", { "peerDependencies": { "debug": "*" }, "optionalPeers": ["debug"] }, "sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw=="],
 
     "form-data": ["form-data@4.0.6", "https://registry.npmmirror.com/form-data/-/form-data-4.0.6.tgz", { "dependencies": { "asynckit": "^0.4.0", "combined-stream": "^1.0.8", "es-set-tostringtag": "^2.1.0", "hasown": "^2.0.4", "mime-types": "^2.1.35" } }, "sha512-vKatAh4SlVfgbv+YtmhiRjhEMJsYpsG1Y2rMQtR+SVSbytsSD1YGzDIcrAJmdFec88u/+VoGmxnl+80gL1tRCQ=="],
 
+    "formdata-polyfill": ["formdata-polyfill@4.0.10", "https://registry.npmmirror.com/formdata-polyfill/-/formdata-polyfill-4.0.10.tgz", { "dependencies": { "fetch-blob": "^3.1.2" } }, "sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g=="],
+
     "fsevents": ["fsevents@2.3.3", "https://registry.npmmirror.com/fsevents/-/fsevents-2.3.3.tgz", { "os": "darwin" }, "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw=="],
 
     "function-bind": ["function-bind@1.1.2", "https://registry.npmmirror.com/function-bind/-/function-bind-1.1.2.tgz", {}, "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA=="],
+
+    "gaxios": ["gaxios@7.3.0", "https://registry.npmmirror.com/gaxios/-/gaxios-7.3.0.tgz", { "dependencies": { "extend": "^3.0.2", "https-proxy-agent": "^7.0.1", "node-fetch": "^3.3.2" } }, "sha512-RB5vLV+vvQeoFPCX4QMK6/hjVkbIamPp1QSUD0CiZcnj12qbpiL+pLbYtgD+oZkWl0tl9z+o2Utp+MpM3QRhBA=="],
+
+    "gcp-metadata": ["gcp-metadata@8.1.2", "https://registry.npmmirror.com/gcp-metadata/-/gcp-metadata-8.1.2.tgz", { "dependencies": { "gaxios": "^7.0.0", "google-logging-utils": "^1.0.0", "json-bigint": "^1.0.0" } }, "sha512-zV/5HKTfCeKWnxG0Dmrw51hEWFGfcF2xiXqcA3+J90WDuP0SvoiSO5ORvcBsifmx/FoIjgQN3oNOGaQ5PhLFkg=="],
+
+    "get-east-asian-width": ["get-east-asian-width@1.6.0", "https://registry.npmmirror.com/get-east-asian-width/-/get-east-asian-width-1.6.0.tgz", {}, "sha512-QRbvDIbx6YklUe6RxeTeleMR0yv3cYH6PsPZHcnVn7xv7zO1BHN8r0XETu8n6Ye3Q+ahtSarc3WgtNWmehIBfA=="],
 
     "get-intrinsic": ["get-intrinsic@1.3.0", "https://registry.npmmirror.com/get-intrinsic/-/get-intrinsic-1.3.0.tgz", { "dependencies": { "call-bind-apply-helpers": "^1.0.2", "es-define-property": "^1.0.1", "es-errors": "^1.3.0", "es-object-atoms": "^1.1.1", "function-bind": "^1.1.2", "get-proto": "^1.0.1", "gopd": "^1.2.0", "has-symbols": "^1.1.0", "hasown": "^2.0.2", "math-intrinsics": "^1.1.0" } }, "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ=="],
 
     "get-nonce": ["get-nonce@1.0.1", "https://registry.npmmirror.com/get-nonce/-/get-nonce-1.0.1.tgz", {}, "sha512-FJhYRoDaiatfEkUK8HKlicmu/3SGFD51q3itKDGoSTysQJBnfOcxU5GxnhE1E6soB76MbT0MBtnKJuXyAx+96Q=="],
 
     "get-proto": ["get-proto@1.0.1", "https://registry.npmmirror.com/get-proto/-/get-proto-1.0.1.tgz", { "dependencies": { "dunder-proto": "^1.0.1", "es-object-atoms": "^1.0.0" } }, "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g=="],
+
+    "glob": ["glob@13.0.6", "https://registry.npmmirror.com/glob/-/glob-13.0.6.tgz", { "dependencies": { "minimatch": "^10.2.2", "minipass": "^7.1.3", "path-scurry": "^2.0.2" } }, "sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw=="],
+
+    "google-auth-library": ["google-auth-library@10.9.1", "https://registry.npmmirror.com/google-auth-library/-/google-auth-library-10.9.1.tgz", { "dependencies": { "base64-js": "^1.3.0", "ecdsa-sig-formatter": "^1.0.11", "gaxios": "^7.1.4", "gcp-metadata": "8.1.2", "google-logging-utils": "1.1.3", "jws": "^4.0.0" } }, "sha512-i1ydyHrqcIxXkWh/uBmVkzCvIuq5yiK2ATndIe5XxKholrG/MTYP9xGYka4sQhrbIAgGjL2B6NOE7rFaiF3fXw=="],
+
+    "google-logging-utils": ["google-logging-utils@1.1.3", "https://registry.npmmirror.com/google-logging-utils/-/google-logging-utils-1.1.3.tgz", {}, "sha512-eAmLkjDjAFCVXg7A1unxHsLf961m6y17QFqXqAXGj/gVkKFrEICfStRfwUlGNfeCEjNRa32JEWOUTlYXPyyKvA=="],
 
     "gopd": ["gopd@1.2.0", "https://registry.npmmirror.com/gopd/-/gopd-1.2.0.tgz", {}, "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg=="],
 
@@ -380,19 +529,37 @@
 
     "hasown": ["hasown@2.0.4", "https://registry.npmmirror.com/hasown/-/hasown-2.0.4.tgz", { "dependencies": { "function-bind": "^1.1.2" } }, "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A=="],
 
+    "highlight.js": ["highlight.js@10.7.3", "https://registry.npmmirror.com/highlight.js/-/highlight.js-10.7.3.tgz", {}, "sha512-tzcUFauisWKNHaRkN4Wjl/ZA07gENAjFl3J/c480dprkGTg5EQstgaNFqBfUqCq54kZRIEcreTsAgF/m2quD7A=="],
+
+    "hosted-git-info": ["hosted-git-info@9.0.3", "https://registry.npmmirror.com/hosted-git-info/-/hosted-git-info-9.0.3.tgz", { "dependencies": { "lru-cache": "^11.1.0" } }, "sha512-Hc+ghLoSt6QaYZUv0WBiIvmMDZuZZ7oaDvdH8MbfOO4lOsxdXLEvuC6ePoGs9H1X9oCLyq6+NVN0MKqD+ydxyg=="],
+
     "html-encoding-sniffer": ["html-encoding-sniffer@6.0.0", "https://registry.npmmirror.com/html-encoding-sniffer/-/html-encoding-sniffer-6.0.0.tgz", { "dependencies": { "@exodus/bytes": "^1.6.0" } }, "sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg=="],
 
+    "http-proxy-agent": ["http-proxy-agent@7.0.2", "https://registry.npmmirror.com/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz", { "dependencies": { "agent-base": "^7.1.0", "debug": "^4.3.4" } }, "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig=="],
+
     "https-proxy-agent": ["https-proxy-agent@9.1.0", "https://registry.npmmirror.com/https-proxy-agent/-/https-proxy-agent-9.1.0.tgz", { "dependencies": { "agent-base": "9.0.0", "debug": "^4.3.4", "proxy-agent-negotiate": "1.1.0" } }, "sha512-ag87y7cJJ9/3+GxFr8Oy4O5faDsGRGnBGsJj/YjOSsSx/5eadKLYTMPlzuR6obgoCDDm0abAAZitXXQkMOPSpA=="],
+
+    "ignore": ["ignore@7.0.5", "https://registry.npmmirror.com/ignore/-/ignore-7.0.5.tgz", {}, "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg=="],
 
     "indent-string": ["indent-string@4.0.0", "https://registry.npmmirror.com/indent-string/-/indent-string-4.0.0.tgz", {}, "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg=="],
 
     "is-potential-custom-element-name": ["is-potential-custom-element-name@1.0.1", "https://registry.npmmirror.com/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz", {}, "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ=="],
+
+    "isexe": ["isexe@2.0.0", "https://registry.npmmirror.com/isexe/-/isexe-2.0.0.tgz", {}, "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw=="],
 
     "jiti": ["jiti@2.7.0", "https://registry.npmmirror.com/jiti/-/jiti-2.7.0.tgz", { "bin": { "jiti": "lib/jiti-cli.mjs" } }, "sha512-AC/7JofJvZGrrneWNaEnJeOLUx+JlGt7tNa0wZiRPT4MY1wmfKjt2+6O2p2uz2+skll8OZZmJMNqeke7kKbNgQ=="],
 
     "js-tokens": ["js-tokens@4.0.0", "https://registry.npmmirror.com/js-tokens/-/js-tokens-4.0.0.tgz", {}, "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="],
 
     "jsdom": ["jsdom@29.1.1", "https://registry.npmmirror.com/jsdom/-/jsdom-29.1.1.tgz", { "dependencies": { "@asamuzakjp/css-color": "^5.1.11", "@asamuzakjp/dom-selector": "^7.1.1", "@bramus/specificity": "^2.4.2", "@csstools/css-syntax-patches-for-csstree": "^1.1.3", "@exodus/bytes": "^1.15.0", "css-tree": "^3.2.1", "data-urls": "^7.0.0", "decimal.js": "^10.6.0", "html-encoding-sniffer": "^6.0.0", "is-potential-custom-element-name": "^1.0.1", "lru-cache": "^11.3.5", "parse5": "^8.0.1", "saxes": "^6.0.0", "symbol-tree": "^3.2.4", "tough-cookie": "^6.0.1", "undici": "^7.25.0", "w3c-xmlserializer": "^5.0.0", "webidl-conversions": "^8.0.1", "whatwg-mimetype": "^5.0.0", "whatwg-url": "^16.0.1", "xml-name-validator": "^5.0.0" }, "peerDependencies": { "canvas": "^3.0.0" }, "optionalPeers": ["canvas"] }, "sha512-ECi4Fi2f7BdJtUKTflYRTiaMxIB0O6zfR1fX0GXpUrf6flp8QIYn1UT20YQqdSOfk2dfkCwS8LAFoJDEppNK5Q=="],
+
+    "json-bigint": ["json-bigint@1.0.0", "https://registry.npmmirror.com/json-bigint/-/json-bigint-1.0.0.tgz", { "dependencies": { "bignumber.js": "^9.0.0" } }, "sha512-SiPv/8VpZuWbvLSMtTDU8hEfrZWg/mH/nV/b4o0CYbSxu1UIQPLdwKOCIyLQX+VIPO5vrLX3i8qtqFyhdPSUSQ=="],
+
+    "json-schema-to-ts": ["json-schema-to-ts@3.1.1", "https://registry.npmmirror.com/json-schema-to-ts/-/json-schema-to-ts-3.1.1.tgz", { "dependencies": { "@babel/runtime": "^7.18.3", "ts-algebra": "^2.0.0" } }, "sha512-+DWg8jCJG2TEnpy7kOm/7/AxaYoaRbjVB4LFZLySZlWn8exGs3A4OLJR966cVvU26N7X9TWxl+Jsw7dzAqKT6g=="],
+
+    "jwa": ["jwa@2.0.1", "https://registry.npmmirror.com/jwa/-/jwa-2.0.1.tgz", { "dependencies": { "buffer-equal-constant-time": "^1.0.1", "ecdsa-sig-formatter": "1.0.11", "safe-buffer": "^5.0.1" } }, "sha512-hRF04fqJIP8Abbkq5NKGN0Bbr3JxlQ+qhZufXVr0DvujKy93ZCbXZMHDL4EOtodSbCWxOqR8MS1tXA5hwqCXDg=="],
+
+    "jws": ["jws@4.0.1", "https://registry.npmmirror.com/jws/-/jws-4.0.1.tgz", { "dependencies": { "jwa": "^2.0.1", "safe-buffer": "^5.0.1" } }, "sha512-EKI/M/yqPncGUUh44xz0PxSidXFr/+r0pA70+gIYhjv+et7yxM+s29Y+VGDkovRofQem0fs7Uvf4+YmAdyRduA=="],
 
     "lightningcss": ["lightningcss@1.33.0", "https://registry.npmmirror.com/lightningcss/-/lightningcss-1.33.0.tgz", { "dependencies": { "detect-libc": "^2.0.3" }, "optionalDependencies": { "lightningcss-android-arm64": "1.33.0", "lightningcss-darwin-arm64": "1.33.0", "lightningcss-darwin-x64": "1.33.0", "lightningcss-freebsd-x64": "1.33.0", "lightningcss-linux-arm-gnueabihf": "1.33.0", "lightningcss-linux-arm64-gnu": "1.33.0", "lightningcss-linux-arm64-musl": "1.33.0", "lightningcss-linux-x64-gnu": "1.33.0", "lightningcss-linux-x64-musl": "1.33.0", "lightningcss-win32-arm64-msvc": "1.33.0", "lightningcss-win32-x64-msvc": "1.33.0" } }, "sha512-WkUDrojuJs0xkgGf2udWxa3yGBRxPtxUkB79i6aCZLRgc7PM8fZe9TosfPDcvEpQZbuFASnHYmRLBLUbmLOIIA=="],
 
@@ -434,6 +601,8 @@
 
     "magic-string": ["magic-string@0.30.21", "https://registry.npmmirror.com/magic-string/-/magic-string-0.30.21.tgz", { "dependencies": { "@jridgewell/sourcemap-codec": "^1.5.5" } }, "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ=="],
 
+    "marked": ["marked@18.0.5", "https://registry.npmmirror.com/marked/-/marked-18.0.5.tgz", { "bin": { "marked": "bin/marked.js" } }, "sha512-S6GcvALHg6K4ohtu4E7x0a1AqhAjp6cV8KhLSyN9qVapnzJkusVBxZRcIU9AeYsbe6P1hKDusSbEOzGyyuce6w=="],
+
     "math-intrinsics": ["math-intrinsics@1.1.0", "https://registry.npmmirror.com/math-intrinsics/-/math-intrinsics-1.1.0.tgz", {}, "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g=="],
 
     "mdn-data": ["mdn-data@2.27.1", "https://registry.npmmirror.com/mdn-data/-/mdn-data-2.27.1.tgz", {}, "sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ=="],
@@ -444,15 +613,33 @@
 
     "min-indent": ["min-indent@1.0.1", "https://registry.npmmirror.com/min-indent/-/min-indent-1.0.1.tgz", {}, "sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg=="],
 
+    "minimatch": ["minimatch@10.2.5", "https://registry.npmmirror.com/minimatch/-/minimatch-10.2.5.tgz", { "dependencies": { "brace-expansion": "^5.0.5" } }, "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg=="],
+
+    "minipass": ["minipass@7.1.3", "https://registry.npmmirror.com/minipass/-/minipass-7.1.3.tgz", {}, "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A=="],
+
     "ms": ["ms@2.1.3", "https://registry.npmmirror.com/ms/-/ms-2.1.3.tgz", {}, "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="],
 
     "nanoid": ["nanoid@3.3.16", "https://registry.npmmirror.com/nanoid/-/nanoid-3.3.16.tgz", { "bin": { "nanoid": "bin/nanoid.cjs" } }, "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q=="],
+
+    "node-domexception": ["node-domexception@1.0.0", "https://registry.npmmirror.com/node-domexception/-/node-domexception-1.0.0.tgz", {}, "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ=="],
+
+    "node-fetch": ["node-fetch@3.3.2", "https://registry.npmmirror.com/node-fetch/-/node-fetch-3.3.2.tgz", { "dependencies": { "data-uri-to-buffer": "^4.0.0", "fetch-blob": "^3.1.4", "formdata-polyfill": "^4.0.10" } }, "sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA=="],
 
     "object-inspect": ["object-inspect@1.13.4", "https://registry.npmmirror.com/object-inspect/-/object-inspect-1.13.4.tgz", {}, "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew=="],
 
     "obug": ["obug@2.1.4", "https://registry.npmmirror.com/obug/-/obug-2.1.4.tgz", {}, "sha512-4a+OsYv9UktOJKE+l1A4OufDgdRF9PifWj+tJnHURo/P+WOxpG4GzUFL9qCalmWauao6ogiG+QvnCovwPoyAWA=="],
 
+    "openai": ["openai@6.26.0", "https://registry.npmmirror.com/openai/-/openai-6.26.0.tgz", { "peerDependencies": { "ws": "^8.18.0", "zod": "^3.25 || ^4.0" }, "optionalPeers": ["ws", "zod"], "bin": { "openai": "bin/cli" } }, "sha512-zd23dbWTjiJ6sSAX6s0HrCZi41JwTA1bQVs0wLQPZ2/5o2gxOJA5wh7yOAUgwYybfhDXyhwlpeQf7Mlgx8EOCA=="],
+
+    "p-retry": ["p-retry@4.6.2", "https://registry.npmmirror.com/p-retry/-/p-retry-4.6.2.tgz", { "dependencies": { "@types/retry": "0.12.0", "retry": "^0.13.1" } }, "sha512-312Id396EbJdvRONlngUx0NydfrIQ5lsYu0znKVUzVvArzEIt08V1qhtyESbGVd1FGX7UKtiFp5uwKZdM8wIuQ=="],
+
     "parse5": ["parse5@8.0.1", "https://registry.npmmirror.com/parse5/-/parse5-8.0.1.tgz", { "dependencies": { "entities": "^8.0.0" } }, "sha512-z1e/HMG90obSGeidlli3hj7cbocou0/wa5HacvI3ASx34PecNjNQeaHNo5WIZpWofN9kgkqV1q5YvXe3F0FoPw=="],
+
+    "partial-json": ["partial-json@0.1.7", "https://registry.npmmirror.com/partial-json/-/partial-json-0.1.7.tgz", {}, "sha512-Njv/59hHaokb/hRUjce3Hdv12wd60MtM9Z5Olmn+nehe0QDAsRtRbJPvJ0Z91TusF0SuZRIvnM+S4l6EIP8leA=="],
+
+    "path-key": ["path-key@3.1.1", "https://registry.npmmirror.com/path-key/-/path-key-3.1.1.tgz", {}, "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q=="],
+
+    "path-scurry": ["path-scurry@2.0.2", "https://registry.npmmirror.com/path-scurry/-/path-scurry-2.0.2.tgz", { "dependencies": { "lru-cache": "^11.0.0", "minipass": "^7.1.2" } }, "sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg=="],
 
     "pathe": ["pathe@2.0.3", "https://registry.npmmirror.com/pathe/-/pathe-2.0.3.tgz", {}, "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w=="],
 
@@ -465,6 +652,8 @@
     "postcss": ["postcss@8.5.23", "https://registry.npmmirror.com/postcss/-/postcss-8.5.23.tgz", { "dependencies": { "nanoid": "^3.3.16", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-g50586zr4bZmwFiTlflMu8E0bDTb5I5gertgwAKmsdUlTQIhZtunzUlD1WSzwcVWPoAVpsrA6vlfCD7oXvRwgg=="],
 
     "pretty-format": ["pretty-format@27.5.1", "https://registry.npmmirror.com/pretty-format/-/pretty-format-27.5.1.tgz", { "dependencies": { "ansi-regex": "^5.0.1", "ansi-styles": "^5.0.0", "react-is": "^17.0.1" } }, "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ=="],
+
+    "proper-lockfile": ["proper-lockfile@4.1.2", "https://registry.npmmirror.com/proper-lockfile/-/proper-lockfile-4.1.2.tgz", { "dependencies": { "graceful-fs": "^4.2.4", "retry": "^0.12.0", "signal-exit": "^3.0.2" } }, "sha512-TjNPblN4BwAWMXU8s9AEz4JmQxnD1NNL7bNOY/AKUzyamc379FWASUhc/K1pL2noVb+XmZKLL68cjzLsiOAMaA=="],
 
     "protobufjs": ["protobufjs@7.6.5", "https://registry.npmmirror.com/protobufjs/-/protobufjs-7.6.5.tgz", { "dependencies": { "@protobufjs/aspromise": "^1.1.2", "@protobufjs/base64": "^1.1.2", "@protobufjs/codegen": "^2.0.5", "@protobufjs/eventemitter": "^1.1.1", "@protobufjs/fetch": "^1.1.1", "@protobufjs/float": "^1.0.2", "@protobufjs/path": "^1.1.2", "@protobufjs/pool": "^1.1.0", "@protobufjs/utf8": "^1.1.1", "@types/node": ">=13.7.0", "long": "^5.3.2" } }, "sha512-/FPD0nUc9jH6rfFjji9IBqOz4pcSE3CsT1m7Ep6Mdb0LxSUMj8hgl6GomOvZzpNpAqqGaXA0P3VSrZLFzIhQrw=="],
 
@@ -494,11 +683,21 @@
 
     "require-from-string": ["require-from-string@2.0.2", "https://registry.npmmirror.com/require-from-string/-/require-from-string-2.0.2.tgz", {}, "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw=="],
 
+    "retry": ["retry@0.12.0", "https://registry.npmmirror.com/retry/-/retry-0.12.0.tgz", {}, "sha512-9LkiTwjUh6rT555DtE9rTX+BKByPfrMzEAtnlEtdEwr3Nkffwiihqe2bWADg+OQRjt9gl6ICdmB/ZFDCGAtSow=="],
+
     "rolldown": ["rolldown@1.1.5", "https://registry.npmmirror.com/rolldown/-/rolldown-1.1.5.tgz", { "dependencies": { "@oxc-project/types": "=0.139.0", "@rolldown/pluginutils": "^1.0.0" }, "optionalDependencies": { "@rolldown/binding-android-arm64": "1.1.5", "@rolldown/binding-darwin-arm64": "1.1.5", "@rolldown/binding-darwin-x64": "1.1.5", "@rolldown/binding-freebsd-x64": "1.1.5", "@rolldown/binding-linux-arm-gnueabihf": "1.1.5", "@rolldown/binding-linux-arm64-gnu": "1.1.5", "@rolldown/binding-linux-arm64-musl": "1.1.5", "@rolldown/binding-linux-ppc64-gnu": "1.1.5", "@rolldown/binding-linux-s390x-gnu": "1.1.5", "@rolldown/binding-linux-x64-gnu": "1.1.5", "@rolldown/binding-linux-x64-musl": "1.1.5", "@rolldown/binding-openharmony-arm64": "1.1.5", "@rolldown/binding-wasm32-wasi": "1.1.5", "@rolldown/binding-win32-arm64-msvc": "1.1.5", "@rolldown/binding-win32-x64-msvc": "1.1.5" }, "bin": { "rolldown": "./bin/cli.mjs" } }, "sha512-t9z29cJjXf/vxQ8dyhCSpt6H6aSwHTk8cT5I3iy6SMXuFpk5mB6PL6XfC8PCwrPTx93udwKUm9HRteAlTGBLiA=="],
+
+    "safe-buffer": ["safe-buffer@5.2.1", "https://registry.npmmirror.com/safe-buffer/-/safe-buffer-5.2.1.tgz", {}, "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="],
 
     "saxes": ["saxes@6.0.0", "https://registry.npmmirror.com/saxes/-/saxes-6.0.0.tgz", { "dependencies": { "xmlchars": "^2.2.0" } }, "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA=="],
 
     "scheduler": ["scheduler@0.27.0", "https://registry.npmmirror.com/scheduler/-/scheduler-0.27.0.tgz", {}, "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q=="],
+
+    "semver": ["semver@7.8.0", "https://registry.npmmirror.com/semver/-/semver-7.8.0.tgz", { "bin": { "semver": "bin/semver.js" } }, "sha512-AcM7dV/5ul4EekoQ29Agm5vri8JNqRyj39o0qpX6vDF2GZrtutZl5RwgD1XnZjiTAfncsJhMI48QQH3sN87YNA=="],
+
+    "shebang-command": ["shebang-command@2.0.0", "https://registry.npmmirror.com/shebang-command/-/shebang-command-2.0.0.tgz", { "dependencies": { "shebang-regex": "^3.0.0" } }, "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA=="],
+
+    "shebang-regex": ["shebang-regex@3.0.0", "https://registry.npmmirror.com/shebang-regex/-/shebang-regex-3.0.0.tgz", {}, "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A=="],
 
     "side-channel": ["side-channel@1.1.1", "https://registry.npmmirror.com/side-channel/-/side-channel-1.1.1.tgz", { "dependencies": { "es-errors": "^1.3.0", "object-inspect": "^1.13.4", "side-channel-list": "^1.0.1", "side-channel-map": "^1.0.1", "side-channel-weakmap": "^1.0.2" } }, "sha512-6x6dK6zJdpTzF4sQeNYxwtvBzf6Eg4GtlesS94HOvTudUeyK2WXAaIfmDgsyslYrRBeFIlsi54AYsFGUuhmvrQ=="],
 
@@ -509,6 +708,8 @@
     "side-channel-weakmap": ["side-channel-weakmap@1.0.2", "https://registry.npmmirror.com/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz", { "dependencies": { "call-bound": "^1.0.2", "es-errors": "^1.3.0", "get-intrinsic": "^1.2.5", "object-inspect": "^1.13.3", "side-channel-map": "^1.0.1" } }, "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A=="],
 
     "siginfo": ["siginfo@2.0.0", "https://registry.npmmirror.com/siginfo/-/siginfo-2.0.0.tgz", {}, "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g=="],
+
+    "signal-exit": ["signal-exit@3.0.7", "https://registry.npmmirror.com/signal-exit/-/signal-exit-3.0.7.tgz", {}, "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ=="],
 
     "source-map-js": ["source-map-js@1.2.1", "https://registry.npmmirror.com/source-map-js/-/source-map-js-1.2.1.tgz", {}, "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA=="],
 
@@ -540,7 +741,11 @@
 
     "tr46": ["tr46@6.0.0", "https://registry.npmmirror.com/tr46/-/tr46-6.0.0.tgz", { "dependencies": { "punycode": "^2.3.1" } }, "sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw=="],
 
+    "ts-algebra": ["ts-algebra@2.0.0", "https://registry.npmmirror.com/ts-algebra/-/ts-algebra-2.0.0.tgz", {}, "sha512-FPAhNPFMrkwz76P7cdjdmiShwMynZYN6SgOujD1urY4oNm80Ou9oMdmbR45LotcKOXoy7wSmHkRFE6Mxbrhefw=="],
+
     "tslib": ["tslib@2.8.1", "https://registry.npmmirror.com/tslib/-/tslib-2.8.1.tgz", {}, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
+
+    "typebox": ["typebox@1.3.7", "https://registry.npmmirror.com/typebox/-/typebox-1.3.7.tgz", {}, "sha512-meKuifc33Pccx0O6PdIzYMq3Og8zvP4TIi/a+Bw3AEMZMxOD0+RHGQvpglEe6Zdy3wZ8nqn/j95h8LUZLk/6Hg=="],
 
     "typescript": ["typescript@7.0.2", "https://registry.npmmirror.com/typescript/-/typescript-7.0.2.tgz", { "optionalDependencies": { "@typescript/typescript-aix-ppc64": "7.0.2", "@typescript/typescript-darwin-arm64": "7.0.2", "@typescript/typescript-darwin-x64": "7.0.2", "@typescript/typescript-freebsd-arm64": "7.0.2", "@typescript/typescript-freebsd-x64": "7.0.2", "@typescript/typescript-linux-arm": "7.0.2", "@typescript/typescript-linux-arm64": "7.0.2", "@typescript/typescript-linux-loong64": "7.0.2", "@typescript/typescript-linux-mips64el": "7.0.2", "@typescript/typescript-linux-ppc64": "7.0.2", "@typescript/typescript-linux-riscv64": "7.0.2", "@typescript/typescript-linux-s390x": "7.0.2", "@typescript/typescript-linux-x64": "7.0.2", "@typescript/typescript-netbsd-arm64": "7.0.2", "@typescript/typescript-netbsd-x64": "7.0.2", "@typescript/typescript-openbsd-arm64": "7.0.2", "@typescript/typescript-openbsd-x64": "7.0.2", "@typescript/typescript-sunos-x64": "7.0.2", "@typescript/typescript-win32-arm64": "7.0.2", "@typescript/typescript-win32-x64": "7.0.2" }, "bin": { "tsc": "bin/tsc" } }, "sha512-8FYau96o3NKOhbjKi/qNvG/W5jhzxkbdm5sj9AbZ/5T5sWqn3hJgLfGx27sRKZWTvyzCP8dLRBTf5tBTSRVUNA=="],
 
@@ -558,11 +763,15 @@
 
     "w3c-xmlserializer": ["w3c-xmlserializer@5.0.0", "https://registry.npmmirror.com/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz", { "dependencies": { "xml-name-validator": "^5.0.0" } }, "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA=="],
 
+    "web-streams-polyfill": ["web-streams-polyfill@3.3.3", "https://registry.npmmirror.com/web-streams-polyfill/-/web-streams-polyfill-3.3.3.tgz", {}, "sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw=="],
+
     "webidl-conversions": ["webidl-conversions@8.0.1", "https://registry.npmmirror.com/webidl-conversions/-/webidl-conversions-8.0.1.tgz", {}, "sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ=="],
 
     "whatwg-mimetype": ["whatwg-mimetype@5.0.0", "https://registry.npmmirror.com/whatwg-mimetype/-/whatwg-mimetype-5.0.0.tgz", {}, "sha512-sXcNcHOC51uPGF0P/D4NVtrkjSU2fNsm9iog4ZvZJsL3rjoDAzXZhkm2MWt1y+PUdggKAYVoMAIYcs78wJ51Cw=="],
 
     "whatwg-url": ["whatwg-url@16.0.1", "https://registry.npmmirror.com/whatwg-url/-/whatwg-url-16.0.1.tgz", { "dependencies": { "@exodus/bytes": "^1.11.0", "tr46": "^6.0.0", "webidl-conversions": "^8.0.1" } }, "sha512-1to4zXBxmXHV3IiSSEInrreIlu02vUOvrhxJJH5vcxYTBDAx51cqZiKdyTxlecdKNSjj8EcxGBxNf6Vg+945gw=="],
+
+    "which": ["which@2.0.2", "https://registry.npmmirror.com/which/-/which-2.0.2.tgz", { "dependencies": { "isexe": "^2.0.0" }, "bin": { "node-which": "./bin/node-which" } }, "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA=="],
 
     "why-is-node-running": ["why-is-node-running@2.3.0", "https://registry.npmmirror.com/why-is-node-running/-/why-is-node-running-2.3.0.tgz", { "dependencies": { "siginfo": "^2.0.0", "stackback": "0.0.2" }, "bin": { "why-is-node-running": "cli.js" } }, "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w=="],
 
@@ -573,6 +782,18 @@
     "xmlchars": ["xmlchars@2.2.0", "https://registry.npmmirror.com/xmlchars/-/xmlchars-2.2.0.tgz", {}, "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw=="],
 
     "yaml": ["yaml@2.9.0", "https://registry.npmmirror.com/yaml/-/yaml-2.9.0.tgz", { "bin": { "yaml": "bin.mjs" } }, "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA=="],
+
+    "zod": ["zod@4.4.3", "https://registry.npmmirror.com/zod/-/zod-4.4.3.tgz", {}, "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ=="],
+
+    "zod-to-json-schema": ["zod-to-json-schema@3.25.2", "https://registry.npmmirror.com/zod-to-json-schema/-/zod-to-json-schema-3.25.2.tgz", { "peerDependencies": { "zod": "^3.25.28 || ^4" } }, "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA=="],
+
+    "@aws-sdk/credential-provider-http/@smithy/node-http-handler": ["@smithy/node-http-handler@4.9.13", "https://registry.npmmirror.com/@smithy/node-http-handler/-/node-http-handler-4.9.13.tgz", { "dependencies": { "@smithy/core": "^3.31.1", "@smithy/types": "^4.16.1", "tslib": "^2.6.2" } }, "sha512-Nmd/Nl35zfYrd+a6OO2cDJb3GPh9bgTjIUhcM+JFfjpp8/osCgboDV5nCT1I01Pv6R13eSKDKLSoVa5ZB6Zsfw=="],
+
+    "@aws-sdk/credential-provider-sso/@aws-sdk/token-providers": ["@aws-sdk/token-providers@3.1103.0", "https://registry.npmmirror.com/@aws-sdk/token-providers/-/token-providers-3.1103.0.tgz", { "dependencies": { "@aws-sdk/core": "^3.977.6", "@aws-sdk/nested-clients": "^3.997.41", "@aws-sdk/types": "^3.974.2", "@smithy/core": "^3.31.1", "@smithy/types": "^4.16.1", "tslib": "^2.6.2" } }, "sha512-N4wy26MNn31ItGVHYHPrEuCIFY4MBBjC+C5v1lJKqIUSA7OZBdhleCY53zCCrXn27hsk7YNOaTuhQu807S4AfQ=="],
+
+    "@aws-sdk/nested-clients/@smithy/node-http-handler": ["@smithy/node-http-handler@4.9.13", "https://registry.npmmirror.com/@smithy/node-http-handler/-/node-http-handler-4.9.13.tgz", { "dependencies": { "@smithy/core": "^3.31.1", "@smithy/types": "^4.16.1", "tslib": "^2.6.2" } }, "sha512-Nmd/Nl35zfYrd+a6OO2cDJb3GPh9bgTjIUhcM+JFfjpp8/osCgboDV5nCT1I01Pv6R13eSKDKLSoVa5ZB6Zsfw=="],
+
+    "@earendil-works/pi-ai/https-proxy-agent": ["https-proxy-agent@7.0.6", "https://registry.npmmirror.com/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz", { "dependencies": { "agent-base": "^7.1.2", "debug": "4" } }, "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw=="],
 
     "@tailwindcss/node/lightningcss": ["lightningcss@1.32.0", "https://registry.npmmirror.com/lightningcss/-/lightningcss-1.32.0.tgz", { "dependencies": { "detect-libc": "^2.0.3" }, "optionalDependencies": { "lightningcss-android-arm64": "1.32.0", "lightningcss-darwin-arm64": "1.32.0", "lightningcss-darwin-x64": "1.32.0", "lightningcss-freebsd-x64": "1.32.0", "lightningcss-linux-arm-gnueabihf": "1.32.0", "lightningcss-linux-arm64-gnu": "1.32.0", "lightningcss-linux-arm64-musl": "1.32.0", "lightningcss-linux-x64-gnu": "1.32.0", "lightningcss-linux-x64-musl": "1.32.0", "lightningcss-win32-arm64-msvc": "1.32.0", "lightningcss-win32-x64-msvc": "1.32.0" } }, "sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ=="],
 
@@ -594,7 +815,15 @@
 
     "axios/https-proxy-agent": ["https-proxy-agent@5.0.1", "https://registry.npmmirror.com/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz", { "dependencies": { "agent-base": "6", "debug": "4" } }, "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA=="],
 
+    "gaxios/https-proxy-agent": ["https-proxy-agent@7.0.6", "https://registry.npmmirror.com/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz", { "dependencies": { "agent-base": "^7.1.2", "debug": "4" } }, "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw=="],
+
+    "http-proxy-agent/agent-base": ["agent-base@7.1.4", "https://registry.npmmirror.com/agent-base/-/agent-base-7.1.4.tgz", {}, "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ=="],
+
     "jsdom/undici": ["undici@7.29.0", "https://registry.npmmirror.com/undici/-/undici-7.29.0.tgz", {}, "sha512-IDxfleLmmbSskfWSUATiN1nfn2rDuvnMOqb5CWR92iIfojA0Ud+ulOAAEQ57LPr9rWmsreUyf5lwyao+7GNNVw=="],
+
+    "p-retry/retry": ["retry@0.13.1", "https://registry.npmmirror.com/retry/-/retry-0.13.1.tgz", {}, "sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg=="],
+
+    "@earendil-works/pi-ai/https-proxy-agent/agent-base": ["agent-base@7.1.4", "https://registry.npmmirror.com/agent-base/-/agent-base-7.1.4.tgz", {}, "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ=="],
 
     "@tailwindcss/node/lightningcss/lightningcss-android-arm64": ["lightningcss-android-arm64@1.32.0", "https://registry.npmmirror.com/lightningcss-android-arm64/-/lightningcss-android-arm64-1.32.0.tgz", { "os": "android", "cpu": "arm64" }, "sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg=="],
 
@@ -619,5 +848,7 @@
     "@tailwindcss/node/lightningcss/lightningcss-win32-x64-msvc": ["lightningcss-win32-x64-msvc@1.32.0", "https://registry.npmmirror.com/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.32.0.tgz", { "os": "win32", "cpu": "x64" }, "sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q=="],
 
     "axios/https-proxy-agent/agent-base": ["agent-base@6.0.2", "https://registry.npmmirror.com/agent-base/-/agent-base-6.0.2.tgz", { "dependencies": { "debug": "4" } }, "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ=="],
+
+    "gaxios/https-proxy-agent/agent-base": ["agent-base@7.1.4", "https://registry.npmmirror.com/agent-base/-/agent-base-7.1.4.tgz", {}, "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ=="],
   }
 }

--- a/package.json
+++ b/package.json
@@ -69,6 +69,7 @@
     "@larksuite/channel": "^0.4.0",
     "@radix-ui/react-dialog": "^1.1.21",
     "lucide-react": "^1.26.0",
+    "proper-lockfile": "4.1.2",
     "qrcode-terminal": "^0.12.0",
     "react": "^19.2.8",
     "react-dom": "^19.2.8",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "larkin",
-  "version": "0.2.57",
+  "version": "0.2.58",
   "private": true,
   "larkinPackageRole": "development-source-checkout",
   "packageManager": "bun@1.3.14",
@@ -65,6 +65,7 @@
     "test:live:agent-cli-routing-codex": "bun run build && LARKIN_RUN_AGENT_CLI_ROUTING_CODEX_LIVE=1 bun test --max-concurrency 1 test/live/agent-cli-routing-codex-live.test.mjs"
   },
   "dependencies": {
+    "@earendil-works/pi-coding-agent": "0.83.0",
     "@larksuite/channel": "^0.4.0",
     "@radix-ui/react-dialog": "^1.1.21",
     "lucide-react": "^1.26.0",

--- a/scripts/generate-third-party-notices.mjs
+++ b/scripts/generate-third-party-notices.mjs
@@ -7,13 +7,40 @@ const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
 const outputIndex = process.argv.indexOf("--output");
 const OUTPUT = outputIndex >= 0 ? path.resolve(process.argv[outputIndex + 1] ?? "") : "";
 const sha256 = (bytes) => crypto.createHash("sha256").update(bytes).digest("hex");
+const compareText = (left, right) => left < right ? -1 : left > right ? 1 : 0;
 const licenseName = /^(?:licen[cs]e|notice|copying|copyright)(?:[._-].*)?$/i;
 const AUDITED_LICENSE_FALLBACKS = Object.freeze({
+  "@aws-sdk/credential-provider-http@3.972.69": { source: "@aws-sdk/core", version: "3.977.6", file: "LICENSE", sha256: "edea91454b811f127fbdea3d86f378f6719bd372ed440abf82b232f6fca06c3d" },
+  "@aws-sdk/credential-provider-login@3.972.74": { source: "@aws-sdk/core", version: "3.977.6", file: "LICENSE", sha256: "edea91454b811f127fbdea3d86f378f6719bd372ed440abf82b232f6fca06c3d" },
+  "@aws-sdk/nested-clients@3.997.41": { source: "@aws-sdk/core", version: "3.977.6", file: "LICENSE", sha256: "edea91454b811f127fbdea3d86f378f6719bd372ed440abf82b232f6fca06c3d" },
   "agent-base@6.0.2": { source: "agent-base", version: "9.0.0", file: "LICENSE", sha256: "8d8c55319c7729d57be811c747452636688d54f19701ee0752b6b15ad3771d9a" },
   "https-proxy-agent@5.0.1": { source: "https-proxy-agent", version: "9.1.0", file: "LICENSE", sha256: "8d8c55319c7729d57be811c747452636688d54f19701ee0752b6b15ad3771d9a" },
   "proxy-agent-negotiate@1.1.0": { source: "agent-base", version: "9.0.0", file: "LICENSE", sha256: "8d8c55319c7729d57be811c747452636688d54f19701ee0752b6b15ad3771d9a" },
   "react-remove-scroll-bar@2.3.8": { source: "react-remove-scroll", version: "2.7.2", file: "LICENSE", sha256: "30f0cfddf483d1128e3610205020f2041a6c5e837aa999e0aa82e5576187d4a9" },
 });
+const MIT_TERMS = `MIT License
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+`;
+const PI_MIT_LICENSE = `Copyright (c) 2025 Mario Zechner
+
+${MIT_TERMS}`;
 
 function packageRoot(name, fromRoot = ROOT) {
   const local = path.join(fromRoot, "node_modules", ...name.split("/"));
@@ -27,18 +54,29 @@ function bundledLicenseFiles(root) {
   return fs.readdirSync(root, { withFileTypes: true })
     .filter((entry) => entry.isFile() && licenseName.test(entry.name))
     .map((entry) => ({ name: entry.name, bytes: fs.readFileSync(path.join(root, entry.name)) }))
-    .sort((left, right) => left.name.localeCompare(right.name));
+    .sort((left, right) => compareText(left.name, right.name));
 }
 
-function auditedLicenseFallback(key) {
+function auditedLicenseFallback(key, declaredLicense) {
   const fallback = AUDITED_LICENSE_FALLBACKS[key];
-  if (!fallback) throw new Error(`${key} has no bundled license text or audited exact fallback`);
+  if (!fallback) {
+    if (key.startsWith("@earendil-works/pi-") && declaredLicense === "MIT") {
+      return [{ name: "AUDITED-pi-MIT-LICENSE", bytes: Buffer.from(PI_MIT_LICENSE) }];
+    }
+    if ((key.startsWith("@mariozechner/clipboard@") || key.startsWith("@mariozechner/clipboard-")) && declaredLicense === "MIT") {
+      return [{ name: "AUDITED-clipboard-package-declared-MIT", bytes: Buffer.from(MIT_TERMS) }];
+    }
+    if (key === "data-uri-to-buffer@4.0.1" && declaredLicense === "MIT") {
+      return [{ name: "AUDITED-package-declared-MIT", bytes: Buffer.from(MIT_TERMS) }];
+    }
+    throw new Error(`${key} has no bundled license text or audited exact fallback`);
+  }
   const sourceRoot = packageRoot(fallback.source);
   const sourceManifest = JSON.parse(fs.readFileSync(path.join(sourceRoot, "package.json"), "utf8"));
   if (sourceManifest.version !== fallback.version) throw new Error(`${key} audited license source version changed`);
   if (!lockedIntegrities().has(`${fallback.source}@${fallback.version}`)) throw new Error(`${key} audited license source is not lock-integrity pinned`);
   const bytes = fs.readFileSync(path.join(sourceRoot, fallback.file));
-  if (sha256(bytes) !== fallback.sha256 || !/Copyright \(c\) \d{4}/.test(bytes.toString("utf8"))) {
+  if (sha256(bytes) !== fallback.sha256 || !/(?:Copyright \(c\) \d{4}|Apache License\s+Version 2\.0)/.test(bytes.toString("utf8"))) {
     throw new Error(`${key} audited license text provenance mismatch`);
   }
   return [{ name: `AUDITED-${fallback.source}@${fallback.version}-${fallback.file}`, bytes }];
@@ -55,14 +93,15 @@ function lockedIntegrities() {
   return entries;
 }
 
-function runtimePackages() {
+function runtimePackages(options = {}) {
   const rootManifest = JSON.parse(fs.readFileSync(path.join(ROOT, "package.json"), "utf8"));
-  const queue = Object.keys(rootManifest.dependencies ?? {}).map((name) => ({ name, fromRoot: ROOT, direct: true }));
+  const queue = Object.keys(rootManifest.dependencies ?? {}).map((name) => ({ name, fromRoot: ROOT, direct: true, optional: false }));
   const seen = new Set();
   const integrities = lockedIntegrities();
   const packages = [];
   while (queue.length > 0) {
     const candidate = queue.shift();
+    if (candidate.optional && options.installedOptionalPackageNames && !options.installedOptionalPackageNames.has(candidate.name)) continue;
     const root = packageRoot(candidate.name, candidate.fromRoot);
     const manifest = JSON.parse(fs.readFileSync(path.join(root, "package.json"), "utf8"));
     const key = `${manifest.name}@${manifest.version}`;
@@ -73,8 +112,7 @@ function runtimePackages() {
     let files = bundledLicenseFiles(root);
     const license = manifest.license ?? manifest.licenses ?? null;
     if (files.length === 0) {
-      if (license !== "MIT") throw new Error(`${key} has no bundled license text and is not eligible for an MIT fallback`);
-      files = auditedLicenseFallback(key);
+      files = auditedLicenseFallback(key, license);
     }
     packages.push({ name: manifest.name, version: manifest.version, license, files, direct: candidate.direct, integrity });
 
@@ -85,16 +123,27 @@ function runtimePackages() {
     };
     for (const name of Object.keys(children).sort()) {
       if (name.startsWith("@types/")) continue;
+      const optional = Object.hasOwn(manifest.optionalDependencies ?? {}, name) || manifest.peerDependenciesMeta?.[name]?.optional === true;
       try {
         packageRoot(name, root);
-        queue.push({ name, fromRoot: root, direct: false });
+        queue.push({ name, fromRoot: root, direct: false, optional });
       } catch {
-        const optional = Object.hasOwn(manifest.optionalDependencies ?? {}, name) || manifest.peerDependenciesMeta?.[name]?.optional === true;
         if (!optional) throw new Error(`runtime dependency is not installed: ${key} -> ${name}`);
       }
     }
   }
-  return packages.sort((left, right) => left.name.localeCompare(right.name) || left.version.localeCompare(right.version));
+  // Bun installs only the current target's native clipboard packages. Append
+  // every integrity-pinned variant so all release targets generate one notice.
+  for (const [key, integrity] of integrities) {
+    if (key !== "@mariozechner/clipboard@0.3.9" && !key.startsWith("@mariozechner/clipboard-")) continue;
+    if (seen.has(key)) continue;
+    const separator = key.lastIndexOf("@");
+    const name = key.slice(0, separator);
+    const version = key.slice(separator + 1);
+    packages.push({ name, version, license: "MIT", files: auditedLicenseFallback(key, "MIT"), direct: false, integrity });
+    seen.add(key);
+  }
+  return packages.sort((left, right) => compareText(left.name, right.name) || compareText(left.version, right.version));
 }
 
 function expression(value) {
@@ -105,8 +154,8 @@ function expression(value) {
 
 const escapeCell = (value) => String(value).replaceAll("|", "\\|").replaceAll("\n", " ");
 
-export function generateRuntimeNotices() {
-  const packages = runtimePackages();
+export function generateRuntimeNotices(options = {}) {
+  const packages = runtimePackages(options);
   const texts = new Map();
   const lines = [
     "Third-party notices", "", "Generated at release time from Larkin's installed runtime dependency closure.",
@@ -131,7 +180,7 @@ export function generateRuntimeNotices() {
     throw new Error("qrcode-terminal bundled MIT attribution is missing from the runtime closure");
   }
   lines.push("", "Bundled license and notice texts", "");
-  for (const [hash, text] of [...texts.entries()].sort(([left], [right]) => left.localeCompare(right))) {
+  for (const [hash, text] of [...texts.entries()].sort(([left], [right]) => compareText(left, right))) {
     lines.push(`--- SHA-256 ${hash} ---`, text.replace(/\n$/, ""), "");
   }
   return `${lines.join("\n").replace(/\n+$/, "")}\n`;

--- a/scripts/release/standalone-entry.ts
+++ b/scripts/release/standalone-entry.ts
@@ -2,6 +2,9 @@
 import mark from "../../assets/larkin-mark.svg" with { type: "text" };
 import css from "../../dist/dashboard/web/assets/dashboard.css" with { type: "text" };
 import javascript from "../../dist/dashboard/web/assets/dashboard.js" with { type: "text" };
+import piPackageJson from "../../node_modules/@earendil-works/pi-coding-agent/package.json" with { type: "text" };
+import piDarkTheme from "../../node_modules/@earendil-works/pi-coding-agent/dist/modes/interactive/theme/dark.json" with { type: "text" };
+import piLightTheme from "../../node_modules/@earendil-works/pi-coding-agent/dist/modes/interactive/theme/light.json" with { type: "text" };
 import { main } from "../../dist/app/binary-entry.mjs";
 
 const encoder = new TextEncoder();
@@ -10,6 +13,11 @@ globalThis.__LARKIN_EMBEDDED_DASHBOARD_ASSETS__ = Object.freeze({
   "larkin-mark.svg": encoder.encode(mark),
   "dashboard.css": encoder.encode(css),
   "dashboard.js": encoder.encode(javascript),
+});
+globalThis.__LARKIN_EMBEDDED_BUILTIN_PI_ASSETS__ = Object.freeze({
+  packageJson: piPackageJson,
+  darkTheme: piDarkTheme,
+  lightTheme: piLightTheme,
 });
 process.env.LARKIN_STANDALONE = "1";
 // Bun preserves the wrapper entry at argv[1]; the public binary contract is argv[1] = first user argument.

--- a/src/app/binary-entry.ts
+++ b/src/app/binary-entry.ts
@@ -32,6 +32,7 @@ async function dispatchInternal(mode: InternalMode, rest: string[]): Promise<voi
       await import("@earendil-works/pi-coding-agent/rpc-entry");
       return;
     }
+    case "pi-auth": await (await import("./pi-auth-cli.js")).main(rest, process.env); return;
   }
 }
 

--- a/src/app/binary-entry.ts
+++ b/src/app/binary-entry.ts
@@ -26,6 +26,12 @@ async function dispatchInternal(mode: InternalMode, rest: string[]): Promise<voi
     case "setup-bind": await (await import("../setup/setup-bind.js")).main(); return;
     case "grant-scopes": await (await import("../setup/grant-scopes.js")).main(); return;
     case "lark-channel-secret": await (await import("./lark-channel-secret.js")).main(process.env); return;
+    case "pi-rpc": {
+      const { prepareBuiltinPiPackageAssets } = await import("../runtime/builtin-pi-assets.js");
+      prepareBuiltinPiPackageAssets();
+      await import("@earendil-works/pi-coding-agent/rpc-entry");
+      return;
+    }
   }
 }
 

--- a/src/app/cli.ts
+++ b/src/app/cli.ts
@@ -38,6 +38,7 @@ const routes: Record<string, Route> = {
   chats: ["agent-config", "chats"],
   config: ["agent-config", "config"],
   session: ["session-cli"],
+  "pi-auth": ["pi-auth"],
 };
 const runtimeAgentAuthority = typeof process.env.LARKIN_AGENT_ID === "string"
   && process.env.LARKIN_AGENT_ID.trim().length > 0;
@@ -80,6 +81,9 @@ Examples:
 Credentials, internal paths, serverId, activeAgent, and raw config are never exposed here.`,
   session: `Usage: larkin session reset --agent <App ID> --json [--wait-ready <seconds>]
 Atomically replace one idle, zero-backlog Agent Runtime session through authenticated local control.`,
+  "pi-auth": `Usage: larkin pi-auth status [--agent <App ID>] [--json]
+       larkin pi-auth logout <provider> [--agent <App ID>]
+Show non-sensitive official Pi credential metadata or remove one target provider credential.`,
 };
 
 if (command === "--version" || command === "-V") {
@@ -125,6 +129,7 @@ Usage: larkin <command>
   chats            List known chats; use free/strict <oc_id> to configure mention requirements
   config           Inspect effective config/source, edit mention inheritance, or explicitly apply runtime changes
   session reset    Replace one idle, zero-backlog Agent Runtime session for a fresh scenario
+  pi-auth          Show non-sensitive built-in Pi auth status or logout one provider
   <lark-cli 命令组>  im/docs/wiki/drive 等 lark-cli 命令原样转发，机器人身份已锁定（如 larkin im +chat-list）
 Getting started:
   First-time setup: larkin setup

--- a/src/app/internal-command.ts
+++ b/src/app/internal-command.ts
@@ -17,6 +17,7 @@ export const INTERNAL_MODES = [
   "setup-bind",
   "grant-scopes",
   "lark-channel-secret",
+  "pi-rpc",
 ] as const;
 
 export type InternalMode = typeof INTERNAL_MODES[number];

--- a/src/app/internal-command.ts
+++ b/src/app/internal-command.ts
@@ -18,6 +18,7 @@ export const INTERNAL_MODES = [
   "grant-scopes",
   "lark-channel-secret",
   "pi-rpc",
+  "pi-auth",
 ] as const;
 
 export type InternalMode = typeof INTERNAL_MODES[number];

--- a/src/app/pi-auth-cli.ts
+++ b/src/app/pi-auth-cli.ts
@@ -1,0 +1,60 @@
+import * as larkinConfig from "../platform/config.js";
+import {
+  beginBuiltinPiCredentialTransaction,
+  createOfficialPiCredentialRuntime,
+  createOfficialPiLogoutRuntime,
+  logoutOfficialPiProvider,
+  officialPiAuthStatus,
+} from "../runtime/pi-official-auth.js";
+
+const APP_ID = /^cli_[A-Za-z0-9]+$/;
+
+function flag(args: readonly string[], name: string): string | undefined {
+  const index = args.indexOf(name);
+  return index >= 0 ? args[index + 1] : undefined;
+}
+
+export async function main(args: readonly string[] = process.argv.slice(2), env: NodeJS.ProcessEnv = process.env): Promise<void> {
+  const action = args[0] || "status";
+  const json = args.includes("--json");
+  const requestedAgent = flag(args, "--agent");
+  let index = action === "logout" ? 2 : 1;
+  let valid = action === "status" || action === "logout";
+  while (valid && index < args.length) {
+    const argument = args[index];
+    if (argument === "--json" && action === "status") { index += 1; continue; }
+    if (argument === "--agent" && args[index + 1]) { index += 2; continue; }
+    valid = false;
+  }
+  if (!valid) {
+    throw new Error("Usage: larkin pi-auth status [--agent <App ID>] [--json] | larkin pi-auth logout <provider> [--agent <App ID>]");
+  }
+  const loaded = larkinConfig.loadConfig(env);
+  const agentId = requestedAgent || loaded.config.activeAgent || undefined;
+  if (!agentId || !APP_ID.test(agentId)) throw new Error("请用 --agent <App ID> 选择 Agent");
+  const agent = loaded.config.agents[agentId];
+  if (!agent) throw new Error(`Agent ${agentId} 不存在`);
+  if (agent.runtime !== "pi" || agent.piDistribution !== "builtin") throw new Error(`Agent ${agentId} 不是内置 Pi`);
+  if (action === "status") {
+    const runtime = await createOfficialPiCredentialRuntime(loaded.configDir, agentId);
+    const statuses = await officialPiAuthStatus(runtime);
+    if (json) console.log(JSON.stringify({ agentId, credentials: statuses }));
+    else if (statuses.length === 0) console.log(`Agent ${agentId} 尚无已配置的官方 Pi credential`);
+    else {
+      console.log(`Agent ${agentId} 官方 Pi credential：`);
+      for (const entry of statuses) console.log(`  ${entry.providerName} (${entry.providerId}): ${entry.credentialType}/${entry.source}${entry.stored ? " [stored]" : " [ambient]"}`);
+    }
+    return;
+  }
+  const providerId = args[1];
+  if (!providerId || providerId.startsWith("--") || !/^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$/.test(providerId)) {
+    throw new Error("logout 需要安全的 provider ID");
+  }
+  const transaction = beginBuiltinPiCredentialTransaction(loaded.configDir, agentId);
+  try {
+    const runtime = await createOfficialPiLogoutRuntime(loaded.configDir, agentId);
+    await logoutOfficialPiProvider(runtime, providerId);
+    transaction.commit();
+  } catch (error) { transaction.rollback(); throw error; }
+  console.log(`Agent ${agentId} 已退出 ${providerId}；其他 provider 未修改`);
+}

--- a/src/app/runtime-agent-config.ts
+++ b/src/app/runtime-agent-config.ts
@@ -1,4 +1,4 @@
-import { spawnSync } from "node:child_process";
+import { spawn, spawnSync, type ChildProcess } from "node:child_process";
 import crypto from "node:crypto";
 import fs from "node:fs";
 import path from "node:path";
@@ -34,6 +34,13 @@ export interface RuntimeAgentConfigDependencies {
   resolveOfficialCli?(env: NodeJS.ProcessEnv): OfficialLarkCliCommand;
   runOfficialCli?(command: OfficialLarkCliCommand, args: readonly string[], options: Parameters<typeof spawnSync>[2]): ReturnType<typeof spawnSync>;
   forceRebind?: boolean;
+}
+
+export interface AsyncRuntimeAgentConfigDependencies extends RuntimeAgentConfigDependencies {
+  signal?: AbortSignal;
+  timeoutMs?: number;
+  maxOutputBytes?: number;
+  onChild?(child: ChildProcess | null): void;
 }
 
 function assertSecureProfileDirectory(directory: string): void {
@@ -185,6 +192,62 @@ function officialFailure(label: string, result: ReturnType<typeof spawnSync>, se
   return new Error(`${label} failed (exit=${result.status ?? "none"})${detail ? `: ${detail}` : ""}`);
 }
 
+interface BoundedOfficialResult { status: number | null; stdout: string; stderr: string }
+
+function runOfficialLarkCliAsync(command: OfficialLarkCliCommand, args: readonly string[], env: NodeJS.ProcessEnv,
+  dependencies: AsyncRuntimeAgentConfigDependencies): Promise<BoundedOfficialResult> {
+  const timeoutMs = dependencies.timeoutMs ?? 60_000;
+  const maxOutputBytes = dependencies.maxOutputBytes ?? 64 * 1024;
+  return new Promise((resolve, reject) => {
+    const child = spawn(command.command, [...command.argsPrefix, ...args], { env, stdio: ["ignore", "pipe", "pipe"] });
+    dependencies.onChild?.(child);
+    const stdout: Buffer[] = [];
+    const stderr: Buffer[] = [];
+    let outputBytes = 0;
+    let failure: Error | null = null;
+    let settled = false;
+    let killTimer: NodeJS.Timeout | null = null;
+    const terminate = (error: Error): void => {
+      if (failure) return;
+      failure = error;
+      child.kill("SIGTERM");
+      killTimer = setTimeout(() => { if (child.exitCode === null && child.signalCode === null) child.kill("SIGKILL"); }, 1_000);
+      killTimer.unref?.();
+    };
+    const collect = (target: Buffer[], chunk: Buffer): void => {
+      outputBytes += chunk.length;
+      if (outputBytes > maxOutputBytes) { terminate(new Error("official lark-cli output exceeded the bounded limit")); return; }
+      target.push(Buffer.from(chunk));
+    };
+    child.stdout?.on("data", (chunk: Buffer) => collect(stdout, chunk));
+    child.stderr?.on("data", (chunk: Buffer) => collect(stderr, chunk));
+    const timeout = setTimeout(() => terminate(new Error("official lark-cli config bind timed out")), timeoutMs);
+    timeout.unref?.();
+    const abort = (): void => terminate(new Error("official lark-cli config bind cancelled"));
+    if (dependencies.signal?.aborted) abort();
+    else dependencies.signal?.addEventListener("abort", abort, { once: true });
+    child.once("error", (error) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timeout);
+      if (killTimer) clearTimeout(killTimer);
+      dependencies.signal?.removeEventListener("abort", abort);
+      dependencies.onChild?.(null);
+      reject(error);
+    });
+    child.once("exit", (status) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timeout);
+      if (killTimer) clearTimeout(killTimer);
+      dependencies.signal?.removeEventListener("abort", abort);
+      dependencies.onChild?.(null);
+      if (failure) { reject(failure); return; }
+      resolve({ status, stdout: Buffer.concat(stdout).toString("utf8"), stderr: Buffer.concat(stderr).toString("utf8") });
+    });
+  });
+}
+
 export function installRuntimeCommandShims(agent: Pick<RuntimeAgentConfig, "stateDir">): string {
   const stateDir = path.resolve(agent.stateDir);
   const commandDir = path.join(stateDir, "runtime-bin");
@@ -290,6 +353,63 @@ export function syncAgentProfile(
         encoding: "utf8", env: profileEnv,
       }, dependencies);
       if (sync.status !== 0 || sync.error) throw officialFailure(`Agent ${agent.agentId} lark-channel bind`, sync, agent.feishuAppSecret);
+      const workspace = captureProfileSnapshot(workspaceFile);
+      if (!workspace) throw new Error(`Agent ${agent.agentId} lark-channel workspace config missing`);
+      validateExclusiveBotProfile(workspace, agent);
+      atomicPublishProfile(sourceFile, fs.readFileSync(stagedSource), 0o600);
+      assertAgentWorkspaceBound(agent);
+    } catch (error) {
+      const message = error instanceof Error ? error.message : `Agent ${agent.agentId} lark-channel bind failed`;
+      throw new Error(`${message}；官方 bind/keychain 结果未被证明可回滚，当前 Agent 保持 fail-closed，请重跑 larkin setup`);
+    }
+  } finally {
+    try { fs.unlinkSync(stagedSource); } catch { /* renamed/absent */ }
+    lock.release();
+  }
+}
+
+/** Async setup-only profile sync. Existing runtime callers retain the synchronous contract above. */
+export async function syncAgentProfileAsync(
+  agent: RuntimeAgentConfig,
+  env: NodeJS.ProcessEnv,
+  dependencies: AsyncRuntimeAgentConfigDependencies = {},
+): Promise<void> {
+  const expected = path.join(path.resolve(env.LARKIN_CONFIG_DIR || ""), "state", "agents", agent.agentId, "lark-cli-config");
+  if (path.resolve(agent.larkConfigDir) !== expected) throw new Error("lark-cli profile 路径不是 canonical contained 路径");
+  fs.mkdirSync(expected, { recursive: true, mode: 0o700 });
+  assertSecureProfileDirectory(expected);
+  const sourceFile = larkChannelSourceConfigPath(agent);
+  const sourceDir = path.dirname(sourceFile);
+  fs.mkdirSync(sourceDir, { recursive: true, mode: 0o700 });
+  assertSecureProfileDirectory(sourceDir);
+  const lock = acquireProcessLock(path.join(expected, ".larkin-profile-sync.lock.json"), path.basename(process.argv[1] || "node"));
+  const workspaceFile = larkChannelWorkspaceConfigPath(agent);
+  const stagedSource = path.join(sourceDir, `.config.${process.pid}.${crypto.randomUUID()}.bind-source`);
+  try {
+    captureProfileSnapshot(sourceFile);
+    captureProfileSnapshot(workspaceFile);
+    fs.writeFileSync(stagedSource, `${JSON.stringify(sourceProjection(agent, env), null, 2)}\n`, { mode: 0o600, flag: "wx" });
+    validateSourceProjection(stagedSource, agent);
+    installRuntimeCommandShims(agent);
+    if (!dependencies.forceRebind) {
+      try {
+        validateSourceProjection(sourceFile, agent);
+        const existingWorkspace = captureProfileSnapshot(workspaceFile);
+        if (!existingWorkspace) throw new Error("workspace missing");
+        validateExclusiveBotProfile(existingWorkspace, agent);
+        assertAgentWorkspaceBound(agent);
+        return;
+      } catch { /* stale, absent, or mismatched state requires exactly one bind */ }
+    }
+    const profileEnv = { ...managedLarkCliEnv(agent, env), LARK_CHANNEL_CONFIG: stagedSource };
+    try {
+      const official = dependencies.resolveOfficialCli?.(profileEnv) ?? resolveOfficialLarkCli({ env: profileEnv });
+      const result = await runOfficialLarkCliAsync(official,
+        ["config", "bind", "--source", "lark-channel", "--identity", "bot-only"], profileEnv, dependencies);
+      if (result.status !== 0) {
+        const stderr = result.stderr.replaceAll(agent.feishuAppSecret, "<redacted>").trim().slice(0, 400);
+        throw new Error(`Agent ${agent.agentId} lark-channel bind failed (exit=${result.status ?? "none"})${stderr ? `: ${stderr}` : ""}`);
+      }
       const workspace = captureProfileSnapshot(workspaceFile);
       if (!workspace) throw new Error(`Agent ${agent.agentId} lark-channel workspace config missing`);
       validateExclusiveBotProfile(workspace, agent);

--- a/src/app/runtime-process.ts
+++ b/src/app/runtime-process.ts
@@ -23,7 +23,7 @@ export function loadAndSyncRuntimeAgent(env: NodeJS.ProcessEnv, agentId: string,
 
 export async function markConfigAppliedAfterRuntimeReady(
   env: NodeJS.ProcessEnv,
-  runningAgents: ReadonlyArray<{ agentId: string; runtime: string; model: string; effort?: string | null }>,
+  runningAgents: ReadonlyArray<{ agentId: string; runtime: string; model: string; piDistribution?: "external" | "builtin"; effort?: string | null }>,
   runtimeReady: Promise<void>,
 ): Promise<void> {
   await runtimeReady;
@@ -31,7 +31,9 @@ export async function markConfigAppliedAfterRuntimeReady(
     const loaded = loadConfig(env);
     for (const running of runningAgents) {
       const current = loaded.config.agents[running.agentId];
-      if (!current || current.runtime !== running.runtime || current.model !== running.model || (current.effort || null) !== (running.effort || null)) continue;
+      if (!current || current.runtime !== running.runtime || current.model !== running.model
+          || (current.piDistribution || "external") !== (running.piDistribution || "external")
+          || (current.effort || null) !== (running.effort || null)) continue;
       markConfigApplied(env, running.agentId, runtimeConfigSignature(loaded.config, running.agentId));
     }
   } catch { /* Runtime is ready; apply projection stays pending on a concurrent config change. */ }

--- a/src/app/setup.ts
+++ b/src/app/setup.ts
@@ -112,7 +112,9 @@ export async function main(): Promise<void> {
   if (!configuredAgent) die(`setup 完成但 Agent ${selectedAgentId} 配置不可读`);
   if (!(["codex", "claude", "pi"] as const).includes(configuredAgent.runtime as "codex" | "claude" | "pi")) die(`Runtime ${configuredAgent.runtime} 不受支持`);
   const runtimeReadiness = await probeNativeRuntimeReadiness({ runtime: configuredAgent.runtime as "codex" | "claude" | "pi",
-    cwd: configuredAgent.workspaceDir, env: process.env });
+    agentId: selectedAgentId, cwd: configuredAgent.workspaceDir,
+    env: { ...process.env, LARKIN_CONFIG_DIR: CFG_DIR,
+      ...(configuredAgent.piDistribution ? { LARKIN_PI_DISTRIBUTION: configuredAgent.piDistribution } : {}) } });
   if (runtimeReadiness.state !== "ready") {
     die(`Runtime ${configuredAgent.runtime} ${runtimeReadiness.state}：${runtimeReadiness.reason || "prerequisite unavailable"}；${runtimeReadiness.nextAction || "修复后重试"}`);
   }

--- a/src/feishu/host-shell.ts
+++ b/src/feishu/host-shell.ts
@@ -34,6 +34,7 @@ interface ConfiguredAgent {
   name: string;
   runtime: string;
   model: string;
+  piDistribution?: "external" | "builtin";
   effort?: string | null;
   displayName?: string | null;
   description?: string | null;
@@ -124,7 +125,7 @@ export function memberNamesFromPayloads(payloads: readonly unknown[]): Record<st
 function errorMessage(error: unknown): string { return error instanceof Error ? error.message : String(error); }
 function agentConfigSignature(agent: ConfiguredAgent): string {
   return JSON.stringify({
-    agentId: agent.agentId, runtime: agent.runtime, model: agent.model, effort: agent.effort ?? null,
+    agentId: agent.agentId, runtime: agent.runtime, model: agent.model, piDistribution: agent.piDistribution ?? null, effort: agent.effort ?? null,
     feishuAppId: agent.feishuAppId, feishuProfile: agent.feishuProfile,
     larkConfigDir: agent.larkConfigDir, feishuDomain: agent.feishuDomain,
     feishuAppSecret: agent.feishuAppSecret, workspaceDir: agent.workspaceDir, stateDir: agent.stateDir,

--- a/src/platform/config.ts
+++ b/src/platform/config.ts
@@ -15,6 +15,7 @@ export type MentionPolicyOverride = MentionPolicy | "inherit";
 export interface StoredAgent {
   runtime: string;
   model: string;
+  piDistribution?: "external" | "builtin";
   effort?: string;
   mentionPolicy?: MentionPolicy;
   chatMentionPolicies?: Record<string, MentionPolicy>;
@@ -71,7 +72,7 @@ interface ConfigApplyFile { version: 1; persistedRevision: string; agents: Recor
 const TOP_FIELDS_V3 = new Set(["version", "serverId", "activeAgent", "agents"]);
 const TOP_FIELDS_V4 = new Set(["version", "serverId", "mentionPolicy", "activeAgent", "agents"]);
 const AGENT_FIELDS_V3 = new Set(["runtime", "model", "effort", "noMentionChats", "createdAt"]);
-const AGENT_FIELDS_V4 = new Set(["runtime", "model", "effort", "mentionPolicy", "chatMentionPolicies", "createdAt"]);
+const AGENT_FIELDS_V4 = new Set(["runtime", "model", "piDistribution", "effort", "mentionPolicy", "chatMentionPolicies", "createdAt"]);
 const APP_ID = /^cli_[A-Za-z0-9]+$/;
 const CHAT_ID = /^oc_[A-Za-z0-9_-]+$/;
 const PI_EFFORTS = new Set(["off", "minimal", "low", "medium", "high", "xhigh", "max"]);
@@ -158,6 +159,11 @@ function validateStoredAgent(key: string, agent: unknown, version: 3 | 4): asser
   if (!loadRuntimeModels()[agent.runtime]) throw new Error(`Agent ${key}.runtime 未知：${agent.runtime}`);
   if (typeof agent.model !== "string" || !agent.model) throw new Error(`Agent ${key}.model 必须是非空字符串`);
   assertModel(agent.runtime, agent.model);
+  if (Object.hasOwn(agent, "piDistribution")) {
+    if (agent.runtime !== "pi" || (agent.piDistribution !== "external" && agent.piDistribution !== "builtin")) {
+      throw new Error(`Agent ${key}.piDistribution 只允许 Pi runtime 使用 external/builtin`);
+    }
+  }
   if (Object.hasOwn(agent, "effort") && (typeof agent.effort !== "string" || !agent.effort)) throw new Error(`Agent ${key}.effort 必须是非空字符串`);
   if (agent.model === "default" && Object.hasOwn(agent, "effort")) throw new Error(`Agent ${key}.model=default 时不能保存 effort`);
   if (typeof agent.effort === "string") {
@@ -191,6 +197,7 @@ function hydratedStoredAgent(key: string, agent: Obj, version: 3 | 4): StoredAge
   return {
     runtime: agent.runtime as string,
     model: agent.model as string,
+    ...(agent.piDistribution === "external" || agent.piDistribution === "builtin" ? { piDistribution: agent.piDistribution } : {}),
     ...(typeof agent.effort === "string" ? { effort: agent.effort } : {}),
     ...(version === 4 && (agent.mentionPolicy === "require" || agent.mentionPolicy === "free") ? { mentionPolicy: agent.mentionPolicy } : {}),
     ...(Object.keys(chatMentionPolicies).length ? { chatMentionPolicies, noMentionChats: Object.entries(chatMentionPolicies).filter(([, policy]) => policy === "free").map(([chatId]) => chatId) } : {}),
@@ -203,6 +210,7 @@ export function hydrateAgent(key: string, agent: StoredAgent & { noMentionChats?
   return {
     name: key, agentId: key, feishuAppId: key, feishuProfile: key,
     runtime: agent.runtime, model: agent.model,
+    ...(agent.piDistribution ? { piDistribution: agent.piDistribution } : {}),
     workspaceDir: layout.workspaceDir(key), stateDir: layout.agentStateDir(key),
     larkConfigDir: path.join(layout.agentStateDir(key), "lark-cli-config"),
     ...(agent.effort ? { effort: agent.effort } : {}),
@@ -298,6 +306,7 @@ export function toStored(config: HydratedConfig): { version: 4; serverId: string
   const out = { version: 4 as const, serverId: config.serverId, mentionPolicy: config.mentionPolicy, activeAgent: config.activeAgent, agents: {} as Record<string, StoredAgent> };
   for (const [key, agent] of Object.entries(config.agents || {})) {
     const stored: StoredAgent = { runtime: agent.runtime, model: agent.model };
+    if (agent.piDistribution) stored.piDistribution = agent.piDistribution;
     if (typeof agent.effort === "string" && agent.effort) stored.effort = agent.effort;
     if (agent.mentionPolicy) stored.mentionPolicy = agent.mentionPolicy;
     if (agent.chatMentionPolicies && Object.keys(agent.chatMentionPolicies).length) stored.chatMentionPolicies = { ...agent.chatMentionPolicies };
@@ -325,7 +334,7 @@ function agentSignature(config: HydratedConfig, agentId: string): string {
   if (!agent) throw new Error(`Agent 不存在：${agentId}`);
   const chats = Object.fromEntries(Object.entries(agent.chatMentionPolicies || {}).sort(([left], [right]) => left.localeCompare(right)));
   return revision(JSON.stringify({
-    runtime: agent.runtime, model: agent.model, effort: agent.effort ?? null,
+    runtime: agent.runtime, model: agent.model, piDistribution: agent.piDistribution ?? null, effort: agent.effort ?? null,
     globalMentionPolicy: config.mentionPolicy, agentMentionPolicy: agent.mentionPolicy ?? null, chatMentionPolicies: chats,
   }));
 }

--- a/src/runtime/builtin-pi-assets.ts
+++ b/src/runtime/builtin-pi-assets.ts
@@ -1,0 +1,45 @@
+import fs from "node:fs";
+import path from "node:path";
+
+type BuiltinPiAssets = Readonly<{
+  packageJson: string;
+  darkTheme: string;
+  lightTheme: string;
+}>;
+
+declare global {
+  // Filled by the standalone wrapper. Source-tree execution keeps using the
+  // official package's own files in node_modules.
+  var __LARKIN_EMBEDDED_BUILTIN_PI_ASSETS__: BuiltinPiAssets | undefined;
+}
+
+function privateDirectory(directory: string): void {
+  fs.mkdirSync(directory, { recursive: true, mode: 0o700 });
+  const stat = fs.lstatSync(directory);
+  if (!stat.isDirectory() || stat.isSymbolicLink()) throw new Error(`unsafe bundled Pi asset directory: ${directory}`);
+  fs.chmodSync(directory, 0o700);
+}
+
+function writeEmbeddedFile(file: string, contents: string): void {
+  const temporary = `${file}.${process.pid}.${Math.random().toString(16).slice(2)}.tmp`;
+  fs.writeFileSync(temporary, contents, { mode: 0o600, flag: "wx" });
+  fs.renameSync(temporary, file);
+  fs.chmodSync(file, 0o600);
+}
+
+/** Materialize upstream runtime assets that Bun cannot serve through ordinary fs paths. */
+export function prepareBuiltinPiPackageAssets(): void {
+  const assets = globalThis.__LARKIN_EMBEDDED_BUILTIN_PI_ASSETS__;
+  if (!assets) return;
+  const agentDir = process.env.PI_CODING_AGENT_DIR;
+  if (!agentDir) throw new Error("bundled Pi requires PI_CODING_AGENT_DIR");
+  privateDirectory(agentDir);
+  const packageDir = path.join(agentDir, ".larkin-official-pi-package");
+  const themeDir = path.join(packageDir, "theme");
+  privateDirectory(packageDir);
+  privateDirectory(themeDir);
+  writeEmbeddedFile(path.join(packageDir, "package.json"), assets.packageJson);
+  writeEmbeddedFile(path.join(themeDir, "dark.json"), assets.darkTheme);
+  writeEmbeddedFile(path.join(themeDir, "light.json"), assets.lightTheme);
+  process.env.PI_PACKAGE_DIR = packageDir;
+}

--- a/src/runtime/pi-official-auth.ts
+++ b/src/runtime/pi-official-auth.ts
@@ -1,0 +1,467 @@
+import fs from "node:fs";
+import path from "node:path";
+import crypto from "node:crypto";
+import { pathToFileURL } from "node:url";
+// proper-lockfile does not publish TypeScript declarations.
+// @ts-expect-error bundled CommonJS dependency
+import properLockfile from "proper-lockfile";
+import { ModelRuntime, readStoredCredential } from "@earendil-works/pi-coding-agent";
+import type {
+  AuthEvent,
+  AuthInteraction,
+  AuthPrompt,
+  AuthType,
+  Credential,
+  CredentialStore,
+  Provider,
+} from "@earendil-works/pi-ai";
+import { InMemoryCredentialStore } from "@earendil-works/pi-ai";
+import { piAgentDirectory } from "./pi-provider-config.js";
+
+export interface OfficialPiAuthMethod {
+  type: AuthType;
+  name: string;
+}
+
+export interface OfficialPiAuthProvider {
+  id: string;
+  name: string;
+  methods: OfficialPiAuthMethod[];
+  models: string[];
+  ambientOnly: boolean;
+}
+
+export interface OfficialPiAuthRuntime {
+  getProviders(): readonly Provider[];
+  login(providerId: string, type: AuthType, interaction: AuthInteraction): Promise<Credential>;
+  logout(providerId: string): Promise<void>;
+  listCredentials(): Promise<readonly { providerId: string; type: "api_key" | "oauth" }[]>;
+  checkAuth(providerId: string): Promise<{ source?: string; type: "api_key" | "oauth" } | undefined>;
+}
+
+export interface PiAuthQuestioner {
+  ask(prompt: string, signal?: AbortSignal): Promise<string>;
+  secret(prompt: string, signal?: AbortSignal): Promise<string>;
+}
+
+export interface OfficialPiAuthStatus {
+  providerId: string;
+  providerName: string;
+  credentialType: "api_key" | "oauth";
+  source: string;
+  stored: boolean;
+}
+
+const SNAPSHOT_FILES = ["auth.json", "models.json", "models-store.json"] as const;
+const LOCK_WAIT_MS = 15_000;
+const LOCK_RETRY_MS = 25;
+interface LockOwner { pid: number; token: string; createdAt: number }
+interface HeldCredentialLock { owner: LockOwner; depth: number; release(): void }
+const heldCredentialLocks = new Map<string, HeldCredentialLock>();
+const credentialQueues = new Map<string, Promise<unknown>>();
+
+function credentialLockPath(configDir: string, agentId: string): string {
+  if (!/^cli_[A-Za-z0-9]+$/.test(agentId)) throw new Error("invalid Agent ID for Pi credential lock");
+  return path.join(piAgentDirectory(configDir, agentId), "auth.json");
+}
+
+function ensureLockDirectory(lockPath: string): void {
+  const directory = path.dirname(lockPath);
+  fs.mkdirSync(directory, { recursive: true, mode: 0o700 });
+  fs.chmodSync(directory, 0o700);
+  const stat = fs.lstatSync(directory);
+  if (!stat.isDirectory() || stat.isSymbolicLink()
+      || (typeof process.getuid === "function" && stat.uid !== process.getuid())
+      || (stat.mode & 0o777) !== 0o700) throw new Error("Pi credential lock directory must be an owned 0700 directory");
+}
+
+function acquireCredentialLockSync(lockPath: string): LockOwner {
+  const existing = heldCredentialLocks.get(lockPath);
+  if (existing) { existing.depth += 1; return existing.owner; }
+  ensureLockDirectory(lockPath);
+  const owner = { pid: process.pid, token: crypto.randomUUID(), createdAt: Date.now() };
+  const deadline = Date.now() + LOCK_WAIT_MS;
+  while (true) {
+    try {
+      const release = properLockfile.lockSync(lockPath, { realpath: false, stale: 30_000, update: 10_000 });
+      heldCredentialLocks.set(lockPath, { owner, depth: 1, release });
+      return owner;
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code !== "ELOCKED") throw error;
+      if (Date.now() >= deadline) throw new Error("Pi credential store is locked by another live process");
+      Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, LOCK_RETRY_MS);
+    }
+  }
+}
+
+function releaseCredentialLock(lockPath: string, owner: LockOwner): void {
+  const held = heldCredentialLocks.get(lockPath);
+  if (!held || held.owner.token !== owner.token) throw new Error("Pi credential lock ownership mismatch");
+  held.depth -= 1;
+  if (held.depth > 0) return;
+  try { held.release(); }
+  finally { heldCredentialLocks.delete(lockPath); }
+}
+
+function withCredentialLock<T>(lockPath: string, operation: () => Promise<T>): Promise<T> {
+  const previous = credentialQueues.get(lockPath) ?? Promise.resolve();
+  const result = previous.catch(() => undefined).then(async () => {
+    const owner = acquireCredentialLockSync(lockPath);
+    try { return await operation(); }
+    finally { releaseCredentialLock(lockPath, owner); }
+  });
+  credentialQueues.set(lockPath, result.catch(() => undefined));
+  return result;
+}
+
+function ensurePrivateDirectory(directory: string): void {
+  fs.mkdirSync(path.dirname(directory), { recursive: true, mode: 0o700 });
+  fs.chmodSync(path.dirname(directory), 0o700);
+  fs.mkdirSync(directory, { recursive: true, mode: 0o700 });
+  fs.chmodSync(directory, 0o700);
+  const stat = fs.lstatSync(directory);
+  if (!stat.isDirectory() || stat.isSymbolicLink()
+      || (typeof process.getuid === "function" && stat.uid !== process.getuid())
+      || (stat.mode & 0o777) !== 0o700) {
+    throw new Error("Pi official credential directory must be an owned 0700 directory");
+  }
+}
+
+function safeRead(file: string): Buffer | null {
+  try {
+    const stat = fs.lstatSync(file);
+    if (!stat.isFile() || stat.isSymbolicLink()
+        || (typeof process.getuid === "function" && stat.uid !== process.getuid())
+        || (stat.mode & 0o777) !== 0o600) throw new Error(`unsafe Pi auth file: ${path.basename(file)}`);
+    return fs.readFileSync(file);
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") return null;
+    throw error;
+  }
+}
+
+function restoreFile(file: string, bytes: Buffer | null): void {
+  if (bytes === null) {
+    try { fs.unlinkSync(file); } catch (error) { if ((error as NodeJS.ErrnoException).code !== "ENOENT") throw error; }
+    return;
+  }
+  const temporary = `${file}.${process.pid}.${crypto.randomUUID()}.tmp`;
+  try {
+    fs.writeFileSync(temporary, bytes, { mode: 0o600, flag: "wx" });
+    fs.renameSync(temporary, file);
+    fs.chmodSync(file, 0o600);
+  } finally { try { fs.unlinkSync(temporary); } catch { /* renamed or absent */ } }
+}
+
+function readCredentialData(authPath: string): Record<string, Credential> {
+  const bytes = safeRead(authPath);
+  if (bytes === null) return {};
+  const parsed = JSON.parse(bytes.toString("utf8")) as unknown;
+  if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) throw new Error("Pi auth.json must contain an object");
+  return parsed as Record<string, Credential>;
+}
+
+function writeCredentialData(authPath: string, data: Record<string, Credential>): void {
+  ensurePrivateDirectory(path.dirname(authPath));
+  const temporary = `${authPath}.${process.pid}.${crypto.randomUUID()}.tmp`;
+  try {
+    fs.writeFileSync(temporary, `${JSON.stringify(data, null, 2)}\n`, { mode: 0o600, flag: "wx" });
+    fs.renameSync(temporary, authPath);
+    fs.chmodSync(authPath, 0o600);
+  } finally { try { fs.unlinkSync(temporary); } catch { /* renamed or absent */ } }
+}
+
+/** Official CredentialStore contract backed by raw auth.json bytes.
+ * Reads never resolve `!command` API-key values and absent stores stay absent.
+ */
+class RawFileCredentialStore implements CredentialStore {
+  constructor(private readonly authPath: string, private readonly lockPath: string) {}
+  read(providerId: string): Promise<Credential | undefined> {
+    if (!fs.existsSync(this.authPath)) return Promise.resolve(undefined);
+    return withCredentialLock(this.lockPath, async () => {
+      safeRead(this.authPath); // enforce owner/type/mode before the official raw reader
+      return readStoredCredential(providerId, this.authPath);
+    });
+  }
+  list(): Promise<readonly { providerId: string; type: Credential["type"] }[]> {
+    if (!fs.existsSync(this.authPath)) return Promise.resolve([]);
+    return withCredentialLock(this.lockPath, async () => Object.entries(readCredentialData(this.authPath)).flatMap(([providerId, credential]) =>
+      credential?.type === "api_key" || credential?.type === "oauth" ? [{ providerId, type: credential.type }] : []));
+  }
+  modify(providerId: string, fn: (current: Credential | undefined) => Promise<Credential | undefined>): Promise<Credential | undefined> {
+    ensurePrivateDirectory(path.dirname(this.authPath));
+    return withCredentialLock(this.lockPath, async () => {
+      const data = readCredentialData(this.authPath);
+      const current = data[providerId];
+      const next = await fn(current);
+      if (next === undefined) return current;
+      data[providerId] = next;
+      writeCredentialData(this.authPath, data);
+      return next;
+    });
+  }
+  delete(providerId: string): Promise<void> {
+    if (!fs.existsSync(this.authPath)) return Promise.resolve();
+    return withCredentialLock(this.lockPath, async () => {
+      const data = readCredentialData(this.authPath);
+      if (!(providerId in data)) return;
+      delete data[providerId];
+      writeCredentialData(this.authPath, data);
+    });
+  }
+}
+
+/** Logout only sees an empty credential view; the official logout mutation is
+ * delegated to the raw store for its one requested provider. This prevents
+ * ModelRuntime's create/post-logout refresh from resolving unrelated entries.
+ */
+class DeleteOnlyCredentialStore implements CredentialStore {
+  constructor(private readonly target: RawFileCredentialStore) {}
+  async read(): Promise<undefined> { return undefined; }
+  async list(): Promise<readonly []> { return []; }
+  async modify(): Promise<undefined> { return undefined; }
+  delete(providerId: string): Promise<void> { return this.target.delete(providerId); }
+}
+
+export interface BuiltinPiCredentialTransaction {
+  directory: string;
+  commit(): void;
+  rollback(): void;
+}
+
+export function beginBuiltinPiCredentialTransaction(configDir: string, agentId: string): BuiltinPiCredentialTransaction {
+  const directory = piAgentDirectory(configDir, agentId);
+  const lockPath = credentialLockPath(configDir, agentId);
+  const existed = fs.existsSync(directory);
+  ensurePrivateDirectory(directory);
+  const lockOwner = acquireCredentialLockSync(lockPath);
+  let snapshots: Map<typeof SNAPSHOT_FILES[number], Buffer | null>;
+  try { snapshots = new Map(SNAPSHOT_FILES.map((name) => [name, safeRead(path.join(directory, name))])); }
+  catch (error) { releaseCredentialLock(lockPath, lockOwner); throw error; }
+  let active = true;
+  return {
+    directory,
+    commit() {
+      if (!active) return;
+      active = false;
+      releaseCredentialLock(lockPath, lockOwner);
+      if (!existed) { try { fs.rmdirSync(directory); } catch { /* keep non-empty provider state */ } }
+    },
+    rollback() {
+      if (!active) return;
+      try {
+        for (const name of [...SNAPSHOT_FILES].reverse()) restoreFile(path.join(directory, name), snapshots.get(name) ?? null);
+      } finally { active = false; releaseCredentialLock(lockPath, lockOwner); }
+      if (!existed) { try { fs.rmdirSync(directory); } catch { /* keep a non-empty safe directory */ } }
+    },
+  };
+}
+
+async function createOfficialRuntime(options: Parameters<typeof ModelRuntime.create>[0]): Promise<ModelRuntime> {
+  const previousOffline = process.env.PI_OFFLINE;
+  process.env.PI_OFFLINE = "1";
+  try {
+    const runtime = await ModelRuntime.create({ ...options, allowModelNetwork: false });
+    if (process.env.LARKIN_TEST_BOT_REGISTER_MODULE && process.env.LARKIN_TEST_PI_AUTH_PROVIDER_MODULE) {
+      const fixture = await import(pathToFileURL(path.resolve(process.env.LARKIN_TEST_PI_AUTH_PROVIDER_MODULE)).href) as {
+        configure?(runtime: ModelRuntime): void | Promise<void>;
+      };
+      await fixture.configure?.(runtime);
+    }
+    return runtime;
+  } finally {
+    if (previousOffline === undefined) delete process.env.PI_OFFLINE;
+    else process.env.PI_OFFLINE = previousOffline;
+  }
+}
+
+/** Provider catalog only: no Agent credential/model path is opened or created. */
+export function createOfficialPiRegistryRuntime(): Promise<ModelRuntime> {
+  return createOfficialRuntime({ credentials: new InMemoryCredentialStore(), modelsPath: null });
+}
+
+/** Status/logout runtime: raw credentials are injected without resolving API-key commands. */
+export function createOfficialPiCredentialRuntime(configDir: string, agentId: string): Promise<ModelRuntime> {
+  const directory = piAgentDirectory(configDir, agentId);
+  return createOfficialRuntime({
+    credentials: new RawFileCredentialStore(path.join(directory, "auth.json"), credentialLockPath(configDir, agentId)),
+    modelsPath: null,
+  });
+}
+
+/** Logout runtime deletes through the official ModelRuntime API while keeping
+ * unrelated stored credentials invisible to its automatic refreshes. */
+export function createOfficialPiLogoutRuntime(configDir: string, agentId: string): Promise<ModelRuntime> {
+  const directory = piAgentDirectory(configDir, agentId);
+  const store = new RawFileCredentialStore(path.join(directory, "auth.json"), credentialLockPath(configDir, agentId));
+  return createOfficialRuntime({ credentials: new DeleteOnlyCredentialStore(store), modelsPath: null });
+}
+
+/** Login/request runtime: official auth orchestration with a command-free persistent CredentialStore. */
+export function createOfficialPiModelRuntime(configDir: string, agentId: string): Promise<ModelRuntime> {
+  const directory = piAgentDirectory(configDir, agentId);
+  return createOfficialRuntime({
+    credentials: new RawFileCredentialStore(path.join(directory, "auth.json"), credentialLockPath(configDir, agentId)),
+    modelsPath: fs.existsSync(path.join(directory, "models.json")) ? path.join(directory, "models.json") : null,
+    modelsStorePath: path.join(directory, "models-store.json"),
+  });
+}
+
+export function listOfficialPiAuthProviders(runtime: Pick<OfficialPiAuthRuntime, "getProviders">): OfficialPiAuthProvider[] {
+  return runtime.getProviders().map((provider) => {
+    const methods: OfficialPiAuthMethod[] = [];
+    if (provider.auth.apiKey?.login) methods.push({ type: "api_key", name: provider.auth.apiKey.name });
+    if (provider.auth.oauth?.login) methods.push({ type: "oauth", name: provider.auth.oauth.loginLabel || provider.auth.oauth.name });
+    return {
+      id: provider.id,
+      name: provider.name,
+      methods,
+      models: provider.getModels().map((model) => `${model.provider}/${model.id}`),
+      ambientOnly: methods.length === 0 && Boolean(provider.auth.apiKey),
+    };
+  });
+}
+
+function abortError(): Error {
+  const error = new Error("Pi auth login cancelled");
+  error.name = "AbortError";
+  return error;
+}
+
+async function abortable<T>(promise: Promise<T>, signals: readonly (AbortSignal | undefined)[]): Promise<T> {
+  const active = signals.filter((signal): signal is AbortSignal => Boolean(signal));
+  if (active.some((signal) => signal.aborted)) throw abortError();
+  let cleanup = (): void => {};
+  const aborted = new Promise<never>((_resolve, reject) => {
+    const listener = (): void => reject(abortError());
+    for (const signal of active) signal.addEventListener("abort", listener, { once: true });
+    cleanup = () => { for (const signal of active) signal.removeEventListener("abort", listener); };
+  });
+  try { return await Promise.race([promise, aborted]); }
+  finally { cleanup(); }
+}
+
+function safeUrl(raw: string): string {
+  try {
+    const url = new URL(raw);
+    url.username = "";
+    url.password = "";
+    url.search = "";
+    url.hash = "";
+    return url.toString();
+  } catch { return "(invalid URL)"; }
+}
+
+function copyableAuthUrl(raw: string): string | null {
+  try {
+    const url = new URL(raw);
+    if (url.protocol !== "https:" && url.protocol !== "http:") return null;
+    if (url.username || url.password || /[\0\r\n]/.test(raw)) return null;
+    return url.toString();
+  } catch { return null; }
+}
+
+function promptLabel(prompt: AuthPrompt): string {
+  return `${prompt.message}${"placeholder" in prompt && prompt.placeholder ? `（${prompt.placeholder}）` : ""}`;
+}
+
+export function createOfficialPiAuthInteraction(input: {
+  questioner: PiAuthQuestioner;
+  report(message: string): void;
+  openUrl?: (url: string) => boolean;
+  signal?: AbortSignal;
+}): AuthInteraction {
+  const prompt = async (request: AuthPrompt): Promise<string> => {
+    if (request.type === "select") {
+      const lines = request.options.map((option, index) => `  ${index + 1}. ${option.label}${option.description ? ` — ${option.description}` : ""}`).join("\n");
+      const answer = await abortable(input.questioner.ask(`${request.message}\n${lines}\n> `, request.signal), [input.signal, request.signal]);
+      const index = Number(answer.trim()) - 1;
+      if (!Number.isInteger(index) || index < 0 || index >= request.options.length) throw new Error(`请选择 1-${request.options.length}`);
+      return request.options[index]!.id;
+    }
+    const question = `${promptLabel(request)}\n> `;
+    const operation = request.type === "secret" || request.type === "manual_code"
+      ? input.questioner.secret(question, request.signal)
+      : input.questioner.ask(question, request.signal);
+    return abortable(operation, [input.signal, request.signal]);
+  };
+  const notify = (event: AuthEvent): void => {
+    if (event.type === "info") {
+      input.report(event.message);
+      for (const link of event.links ?? []) input.report(`${link.label || "More information"}: ${safeUrl(link.url)}`);
+      return;
+    }
+    if (event.type === "auth_url") {
+      const fullUrl = copyableAuthUrl(event.url);
+      const opened = Boolean(fullUrl) && input.openUrl?.(fullUrl!) === true;
+      input.report(`${opened ? "登录地址已在浏览器打开" : "请复制完整登录地址"}: ${opened ? safeUrl(fullUrl!) : fullUrl || "(invalid URL)"}`);
+      if (event.instructions) input.report(event.instructions);
+      return;
+    }
+    if (event.type === "device_code") {
+      input.report(`设备登录码：${event.userCode}`);
+      input.report(`验证地址：${safeUrl(event.verificationUri)}`);
+      if (event.expiresInSeconds) input.report(`有效期：${event.expiresInSeconds} 秒`);
+      return;
+    }
+    input.report(event.message);
+  };
+  return { signal: input.signal, prompt, notify };
+}
+
+export function runOfficialPiLogin(runtime: Pick<OfficialPiAuthRuntime, "login">, providerId: string,
+  authType: AuthType, interaction: AuthInteraction): Promise<Credential> {
+  return runtime.login(providerId, authType, interaction);
+}
+
+export async function verifyOfficialPiProviderTurn(runtime: ModelRuntime, modelId: string,
+  signal?: AbortSignal): Promise<void> {
+  const separator = modelId.indexOf("/");
+  const providerId = separator > 0 ? modelId.slice(0, separator) : "";
+  const providerModelId = separator > 0 ? modelId.slice(separator + 1) : "";
+  const model = runtime.getModel(providerId, providerModelId);
+  if (!model) throw new Error("selected Pi provider model is not registered");
+  const timeout = new AbortController();
+  const timer = setTimeout(() => timeout.abort(), 60_000);
+  const combined = signal ? AbortSignal.any([signal, timeout.signal]) : timeout.signal;
+  try {
+    const response = await runtime.completeSimple(model, {
+      systemPrompt: "This is a setup readiness check. Do not use tools.",
+      messages: [{ role: "user", content: "Reply exactly: LARKIN_READY", timestamp: Date.now() }],
+    }, { maxTokens: 32, signal: combined });
+    const text = response.content.flatMap((entry) => entry.type === "text" ? [entry.text] : []).join("").trim();
+    if (response.stopReason === "error" || response.stopReason === "aborted" || !text) {
+      throw new Error(response.errorMessage || "provider readiness turn returned no authenticated text");
+    }
+  } finally { clearTimeout(timer); }
+}
+
+function safeSource(value: string | undefined): string {
+  if (!value || value.length > 120 || /[\0\r\n]/.test(value) || /[?&#=]/.test(value)) return "configured";
+  return value;
+}
+
+export async function officialPiAuthStatus(runtime: Pick<OfficialPiAuthRuntime,
+  "getProviders" | "listCredentials" | "checkAuth">): Promise<OfficialPiAuthStatus[]> {
+  const providers = new Map(runtime.getProviders().map((provider) => [provider.id, provider.name]));
+  const stored = new Map((await runtime.listCredentials()).map((entry) => [entry.providerId, entry.type]));
+  const providerIds = [...new Set([...providers.keys(), ...stored.keys()])];
+  const statuses: OfficialPiAuthStatus[] = [];
+  for (const providerId of providerIds) {
+    const check = await runtime.checkAuth(providerId);
+    const credentialType = stored.get(providerId) || check?.type;
+    if (!credentialType) continue;
+    statuses.push({
+      providerId,
+      providerName: providers.get(providerId) || providerId,
+      credentialType,
+      source: safeSource(check?.source),
+      stored: stored.has(providerId),
+    });
+  }
+  return statuses;
+}
+
+export function logoutOfficialPiProvider(runtime: Pick<OfficialPiAuthRuntime, "logout">, providerId: string): Promise<void> {
+  return runtime.logout(providerId);
+}

--- a/src/runtime/pi-provider-config.ts
+++ b/src/runtime/pi-provider-config.ts
@@ -1,0 +1,207 @@
+import crypto from "node:crypto";
+import fs from "node:fs";
+import path from "node:path";
+
+export type PiDistribution = "external" | "builtin";
+export const BUNDLED_PI_VERSION = "0.83.0";
+export type PiProviderPresetId = "deepseek" | "kimi" | "minimax" | "zhipu" | "custom";
+
+export interface PiProviderPreset {
+  id: Exclude<PiProviderPresetId, "custom">;
+  name: string;
+  provider: string;
+  baseUrl: string;
+  defaultModel: string;
+  api: "openai-completions" | "anthropic-messages";
+}
+
+// These values mirror the catalog shipped by the pinned official Pi distribution.
+// Keeping the user-facing defaults here makes endpoint changes reviewable in Larkin.
+export const PI_PROVIDER_PRESETS: readonly PiProviderPreset[] = Object.freeze([
+  { id: "deepseek", name: "DeepSeek（推荐）", provider: "deepseek", baseUrl: "https://api.deepseek.com", defaultModel: "deepseek-v4-pro", api: "openai-completions" },
+  { id: "kimi", name: "Kimi / Moonshot（中国）", provider: "moonshotai-cn", baseUrl: "https://api.moonshot.cn/v1", defaultModel: "kimi-k2.7-code", api: "openai-completions" },
+  { id: "minimax", name: "MiniMax（中国）", provider: "minimax-cn", baseUrl: "https://api.minimaxi.com/anthropic", defaultModel: "MiniMax-M2.7", api: "anthropic-messages" },
+  { id: "zhipu", name: "智谱 / BigModel", provider: "zai-coding-cn", baseUrl: "https://open.bigmodel.cn/api/coding/paas/v4", defaultModel: "glm-5.2", api: "openai-completions" },
+]);
+
+export interface BuiltinPiProviderSelection {
+  distribution: "builtin";
+  preset: PiProviderPresetId;
+  apiKey: string;
+  model: string;
+  baseUrl?: string;
+}
+
+export interface ValidatedBuiltinPiProviderSelection extends BuiltinPiProviderSelection {
+  provider: string;
+  baseUrl: string;
+  api: "openai-completions" | "anthropic-messages";
+}
+
+const APP_ID = /^cli_[A-Za-z0-9]+$/;
+const MODEL_ID = /^[A-Za-z0-9][A-Za-z0-9._:@+\/-]{0,255}$/;
+
+export function validatePiBaseUrl(raw: string): string {
+  const input = raw.trim();
+  if (!input || /[\0\r\n\t]/.test(input)) throw new Error("Base URL 不能为空或包含控制字符");
+  let url: URL;
+  try { url = new URL(input); }
+  catch { throw new Error("Base URL 不是合法 URL"); }
+  if (url.username || url.password) throw new Error("Base URL 不允许包含用户名或凭证");
+  if (url.search || url.hash) throw new Error("Base URL 不允许 query 或 fragment");
+  const local = ["localhost", "127.0.0.1", "::1"].includes(url.hostname);
+  if (url.protocol !== "https:" && !(url.protocol === "http:" && local)) {
+    throw new Error("Base URL 必须使用 https；仅 localhost/loopback 开发端点允许 http");
+  }
+  if (/\/(?:chat\/completions|responses|models)\/?$/i.test(url.pathname)) {
+    throw new Error("Base URL 应填写 API 根路径，不要包含 chat/completions、responses 或 models");
+  }
+  return url.toString().replace(/\/$/, "");
+}
+
+export function validateBuiltinPiProviderSelection(input: BuiltinPiProviderSelection): ValidatedBuiltinPiProviderSelection {
+  if (input.distribution !== "builtin") throw new Error("provider 凭证只能用于内置 Pi");
+  const key = input.apiKey.trim();
+  if (!key || key.length > 16_384 || /[\0\r\n]/.test(key)) throw new Error("API Key 不能为空或包含控制字符");
+  const model = input.model.trim();
+  if (!MODEL_ID.test(model)) throw new Error("模型 ID 格式不安全");
+  if (input.preset === "custom") {
+    const provider = "larkin-custom";
+    return {
+      ...input,
+      apiKey: key,
+      model: model.startsWith(`${provider}/`) ? model : `${provider}/${model}`,
+      provider,
+      baseUrl: validatePiBaseUrl(input.baseUrl || ""),
+      api: "openai-completions",
+    };
+  }
+  const preset = PI_PROVIDER_PRESETS.find((candidate) => candidate.id === input.preset);
+  if (!preset) throw new Error(`未知 Pi provider preset: ${String(input.preset)}`);
+  return { ...input, apiKey: key, model: model.startsWith(`${preset.provider}/`) ? model : `${preset.provider}/${model}`,
+    provider: preset.provider, baseUrl: preset.baseUrl, api: preset.api };
+}
+
+export function piAgentDirectory(configDir: string, agentId: string): string {
+  if (!APP_ID.test(agentId)) throw new Error("Pi Agent ID 格式无效");
+  return path.join(path.resolve(configDir), "providers", "pi", agentId);
+}
+
+function assertPrivateDirectory(directory: string): void {
+  const stat = fs.lstatSync(directory);
+  if (!stat.isDirectory() || stat.isSymbolicLink()
+      || (typeof process.getuid === "function" && stat.uid !== process.getuid())
+      || (stat.mode & 0o777) !== 0o700) {
+    throw new Error("Pi provider 凭证目录必须是当前用户拥有、非 symlink、权限精确 0700 的目录");
+  }
+}
+
+export function assertBuiltinPiAgentDirectory(directory: string): void {
+  assertPrivateDirectory(directory);
+  const authFile = path.join(directory, "auth.json");
+  const auth = readSnapshot(authFile);
+  if (!auth) throw new Error("内置 Pi 尚未配置 API Key");
+  try {
+    const value = JSON.parse(auth.toString("utf8"));
+    if (!value || typeof value !== "object" || Array.isArray(value) || Object.keys(value).length === 0) throw new Error("empty");
+  } catch { throw new Error("内置 Pi auth.json 格式无效"); }
+}
+
+function ensurePrivateDirectory(directory: string): void {
+  fs.mkdirSync(path.dirname(directory), { recursive: true, mode: 0o700 });
+  fs.chmodSync(path.dirname(directory), 0o700);
+  fs.mkdirSync(directory, { recursive: true, mode: 0o700 });
+  fs.chmodSync(directory, 0o700);
+  assertPrivateDirectory(directory);
+}
+
+function readSnapshot(file: string): Buffer | null {
+  try {
+    const stat = fs.lstatSync(file);
+    if (!stat.isFile() || stat.isSymbolicLink()
+        || (typeof process.getuid === "function" && stat.uid !== process.getuid())
+        || (stat.mode & 0o777) !== 0o600) throw new Error(`Pi provider 文件不安全: ${path.basename(file)}`);
+    return fs.readFileSync(file);
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") return null;
+    throw error;
+  }
+}
+
+function atomicPrivateWrite(file: string, content: string): void {
+  const directory = path.dirname(file);
+  assertPrivateDirectory(directory);
+  const temporary = path.join(directory, `.${path.basename(file)}.${process.pid}.${crypto.randomUUID()}.tmp`);
+  try {
+    fs.writeFileSync(temporary, content, { mode: 0o600, flag: "wx" });
+    fs.renameSync(temporary, file);
+    fs.chmodSync(file, 0o600);
+  } finally { try { fs.unlinkSync(temporary); } catch { /* renamed or absent */ } }
+}
+
+function restore(file: string, snapshot: Buffer | null): void {
+  if (snapshot === null) {
+    try { fs.unlinkSync(file); } catch (error) { if ((error as NodeJS.ErrnoException).code !== "ENOENT") throw error; }
+  } else atomicPrivateWrite(file, snapshot.toString("utf8"));
+}
+
+export interface PiProviderTransaction {
+  directory: string;
+  commit(): void;
+  rollback(): void;
+}
+
+export function stageBuiltinPiProvider(configDir: string, agentId: string,
+  raw: BuiltinPiProviderSelection): PiProviderTransaction {
+  const selection = validateBuiltinPiProviderSelection(raw);
+  const directory = piAgentDirectory(configDir, agentId);
+  ensurePrivateDirectory(directory);
+  const authFile = path.join(directory, "auth.json");
+  const modelsFile = path.join(directory, "models.json");
+  const beforeAuth = readSnapshot(authFile);
+  const beforeModels = readSnapshot(modelsFile);
+  const currentAuth = beforeAuth ? JSON.parse(beforeAuth.toString("utf8")) as Record<string, unknown> : {};
+  if (!currentAuth || typeof currentAuth !== "object" || Array.isArray(currentAuth)) throw new Error("现有 Pi auth.json 格式无效");
+  const auth = { ...currentAuth, [selection.provider]: { type: "api_key", key: selection.apiKey } };
+  const currentModels = beforeModels ? JSON.parse(beforeModels.toString("utf8")) as Record<string, unknown> : {};
+  if (!currentModels || typeof currentModels !== "object" || Array.isArray(currentModels)) throw new Error("现有 Pi models.json 格式无效");
+  const currentProviders = currentModels.providers === undefined ? {} : currentModels.providers;
+  if (!currentProviders || typeof currentProviders !== "object" || Array.isArray(currentProviders)) throw new Error("现有 Pi models.json providers 格式无效");
+  const customModels = selection.preset === "custom" ? {
+    ...currentModels,
+    providers: {
+      ...currentProviders as Record<string, unknown>,
+      [selection.provider]: {
+        baseUrl: selection.baseUrl,
+        api: selection.api,
+        models: [{
+          id: selection.model.slice(`${selection.provider}/`.length),
+          name: selection.model.slice(`${selection.provider}/`.length),
+          reasoning: false,
+          input: ["text"],
+          contextWindow: 131_072,
+          maxTokens: 16_384,
+          cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+        }],
+      },
+    },
+  } : null;
+  let active = true;
+  try {
+    atomicPrivateWrite(authFile, `${JSON.stringify(auth, null, 2)}\n`);
+    if (customModels) atomicPrivateWrite(modelsFile, `${JSON.stringify(customModels, null, 2)}\n`);
+  } catch (error) {
+    try { restore(authFile, beforeAuth); restore(modelsFile, beforeModels); } catch { /* original error remains primary */ }
+    throw error;
+  }
+  return {
+    directory,
+    commit() { active = false; },
+    rollback() {
+      if (!active) return;
+      restore(authFile, beforeAuth);
+      restore(modelsFile, beforeModels);
+      active = false;
+    },
+  };
+}

--- a/src/runtime/pi-provider-config.ts
+++ b/src/runtime/pi-provider-config.ts
@@ -24,15 +24,24 @@ export const PI_PROVIDER_PRESETS: readonly PiProviderPreset[] = Object.freeze([
   { id: "zhipu", name: "智谱 / BigModel", provider: "zai-coding-cn", baseUrl: "https://open.bigmodel.cn/api/coding/paas/v4", defaultModel: "glm-5.2", api: "openai-completions" },
 ]);
 
-export interface BuiltinPiProviderSelection {
+export interface BuiltinPiProviderSetupSelection {
   distribution: "builtin";
   preset: PiProviderPresetId;
-  apiKey: string;
   model: string;
   baseUrl?: string;
 }
 
+export interface BuiltinPiProviderSelection extends BuiltinPiProviderSetupSelection {
+  apiKey: string;
+}
+
 export interface ValidatedBuiltinPiProviderSelection extends BuiltinPiProviderSelection {
+  provider: string;
+  baseUrl: string;
+  api: "openai-completions" | "anthropic-messages";
+}
+
+export interface ResolvedBuiltinPiProviderSetupSelection extends BuiltinPiProviderSetupSelection {
   provider: string;
   baseUrl: string;
   api: "openai-completions" | "anthropic-messages";
@@ -59,17 +68,14 @@ export function validatePiBaseUrl(raw: string): string {
   return url.toString().replace(/\/$/, "");
 }
 
-export function validateBuiltinPiProviderSelection(input: BuiltinPiProviderSelection): ValidatedBuiltinPiProviderSelection {
+export function resolveBuiltinPiProviderSetupSelection(input: BuiltinPiProviderSetupSelection): ResolvedBuiltinPiProviderSetupSelection {
   if (input.distribution !== "builtin") throw new Error("provider 凭证只能用于内置 Pi");
-  const key = input.apiKey.trim();
-  if (!key || key.length > 16_384 || /[\0\r\n]/.test(key)) throw new Error("API Key 不能为空或包含控制字符");
   const model = input.model.trim();
   if (!MODEL_ID.test(model)) throw new Error("模型 ID 格式不安全");
   if (input.preset === "custom") {
     const provider = "larkin-custom";
     return {
       ...input,
-      apiKey: key,
       model: model.startsWith(`${provider}/`) ? model : `${provider}/${model}`,
       provider,
       baseUrl: validatePiBaseUrl(input.baseUrl || ""),
@@ -78,8 +84,14 @@ export function validateBuiltinPiProviderSelection(input: BuiltinPiProviderSelec
   }
   const preset = PI_PROVIDER_PRESETS.find((candidate) => candidate.id === input.preset);
   if (!preset) throw new Error(`未知 Pi provider preset: ${String(input.preset)}`);
-  return { ...input, apiKey: key, model: model.startsWith(`${preset.provider}/`) ? model : `${preset.provider}/${model}`,
+  return { ...input, model: model.startsWith(`${preset.provider}/`) ? model : `${preset.provider}/${model}`,
     provider: preset.provider, baseUrl: preset.baseUrl, api: preset.api };
+}
+
+export function validateBuiltinPiProviderSelection(input: BuiltinPiProviderSelection): ValidatedBuiltinPiProviderSelection {
+  const key = input.apiKey.trim();
+  if (!key || key.length > 16_384 || /[\0\r\n]/.test(key)) throw new Error("API Key 不能为空或包含控制字符");
+  return { ...resolveBuiltinPiProviderSetupSelection(input), apiKey: key };
 }
 
 export function piAgentDirectory(configDir: string, agentId: string): string {
@@ -149,6 +161,36 @@ export interface PiProviderTransaction {
   directory: string;
   commit(): void;
   rollback(): void;
+}
+
+export function configureBuiltinPiProviderModel(configDir: string, agentId: string,
+  raw: BuiltinPiProviderSetupSelection): ResolvedBuiltinPiProviderSetupSelection {
+  const selection = resolveBuiltinPiProviderSetupSelection(raw);
+  const directory = piAgentDirectory(configDir, agentId);
+  ensurePrivateDirectory(directory);
+  if (selection.preset !== "custom") return selection;
+  const modelsFile = path.join(directory, "models.json");
+  const beforeModels = readSnapshot(modelsFile);
+  const currentModels = beforeModels ? JSON.parse(beforeModels.toString("utf8")) as Record<string, unknown> : {};
+  if (!currentModels || typeof currentModels !== "object" || Array.isArray(currentModels)) throw new Error("现有 Pi models.json 格式无效");
+  const currentProviders = currentModels.providers === undefined ? {} : currentModels.providers;
+  if (!currentProviders || typeof currentProviders !== "object" || Array.isArray(currentProviders)) throw new Error("现有 Pi models.json providers 格式无效");
+  const modelId = selection.model.slice(`${selection.provider}/`.length);
+  atomicPrivateWrite(modelsFile, `${JSON.stringify({
+    ...currentModels,
+    providers: {
+      ...currentProviders as Record<string, unknown>,
+      [selection.provider]: {
+        baseUrl: selection.baseUrl,
+        api: selection.api,
+        models: [{
+          id: modelId, name: modelId, reasoning: false, input: ["text"], contextWindow: 131_072, maxTokens: 16_384,
+          cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+        }],
+      },
+    },
+  }, null, 2)}\n`);
+  return selection;
 }
 
 export function stageBuiltinPiProvider(configDir: string, agentId: string,

--- a/src/runtime/runtime-adapters.ts
+++ b/src/runtime/runtime-adapters.ts
@@ -17,6 +17,8 @@ import type {
 } from "./runtime-contracts.js";
 import { isPiThinkingLevel } from "./pi-model-catalog.js";
 import { PiRpcClient } from "./pi-rpc-client.js";
+import { internalCommandSpec } from "../app/internal-command.js";
+import { piAgentDirectory } from "./pi-provider-config.js";
 import {
   classifyRuntimePrerequisite,
   probeNativeRuntimeReadiness,
@@ -764,10 +766,19 @@ async function createPiRpcBackend(input: RuntimeSessionCreate, dependencies: Nat
     ...(session.sessionFile ? ["--session", session.sessionFile] : []),
     ...(requestedModel ? ["--model", requestedModel] : []),
     ...(requestedEffort ? ["--thinking", requestedEffort] : [])];
-  const command = dependencies.piCommand ?? dependencies.env?.LARKIN_PI_COMMAND ?? process.env.LARKIN_PI_COMMAND ?? "pi";
-  const child = spawn(command, args, {
+  const mergedEnv: NodeJS.ProcessEnv = { ...globalThis.process.env, ...dependencies.env, ...input.env, NO_COLOR: "1" };
+  const builtin = mergedEnv.LARKIN_PI_DISTRIBUTION === "builtin";
+  const builtinSpec = builtin ? internalCommandSpec("pi-rpc", [], mergedEnv) : null;
+  const command = builtinSpec?.command ?? dependencies.piCommand ?? dependencies.env?.LARKIN_PI_COMMAND ?? process.env.LARKIN_PI_COMMAND ?? "pi";
+  const commandArgs = [...(builtinSpec?.args ?? []), ...args];
+  if (builtin) {
+    if (!mergedEnv.LARKIN_CONFIG_DIR) throw new Error("内置 Pi 缺少 LARKIN_CONFIG_DIR");
+    mergedEnv.PI_CODING_AGENT_DIR = piAgentDirectory(mergedEnv.LARKIN_CONFIG_DIR, input.agentId);
+    mergedEnv.PI_TELEMETRY = "0";
+  }
+  const child = spawn(command, commandArgs, {
     cwd: input.workspaceDir,
-    env: { ...globalThis.process.env, ...dependencies.env, ...input.env, NO_COLOR: "1" },
+    env: mergedEnv,
     stdio: ["pipe", "pipe", "pipe"],
   });
   const client = new PiRpcClient(child);
@@ -874,7 +885,7 @@ export function createNativeRuntimeAdapter(id: RuntimeId | string, dependencies:
     id,
     capabilities: CAPABILITIES[id],
     async probe(input) {
-      const readiness = await probeNativeRuntimeReadiness({ runtime: id, cwd: input.workspaceDir,
+      const readiness = await probeNativeRuntimeReadiness({ runtime: id, agentId: input.agentId, cwd: input.workspaceDir,
         env: { ...dependencies.env, ...input.env }, command: configuredCommand });
       resolvedExecutable = readiness.state === "ready" ? readiness.executable ?? null : null;
       return readiness;

--- a/src/runtime/runtime-contracts.ts
+++ b/src/runtime/runtime-contracts.ts
@@ -79,7 +79,7 @@ export interface RuntimeSession {
 export interface RuntimeAdapter {
   readonly id: RuntimeId;
   readonly capabilities: RuntimeCapabilities;
-  probe?(input: Pick<RuntimeSessionCreate, "workspaceDir" | "env">): Promise<import("./runtime-readiness.js").RuntimeReadiness>;
+  probe?(input: Pick<RuntimeSessionCreate, "agentId" | "workspaceDir" | "stateDir" | "env">): Promise<import("./runtime-readiness.js").RuntimeReadiness>;
   createSession(input: RuntimeSessionCreate): Promise<RuntimeSession>;
   recoverConfigurationError?(message: string): Promise<{ recovered: boolean; reason: string }>;
 }

--- a/src/runtime/runtime-host.ts
+++ b/src/runtime/runtime-host.ts
@@ -18,6 +18,7 @@ import { assertAgentWorkspaceBound, managedLarkCliEnv } from "../app/agent-lark-
 export interface AgentRuntimeConfig {
   agentId: string; name: string; displayName?: string | null; description?: string | null;
   runtime: string; model: string; effort?: string | null; workspaceDir: string;
+  piDistribution?: "external" | "builtin";
   stateDir?: string; sessionId?: string | null;
   larkConfigDir?: string;
   feishuAppId?: string;
@@ -182,6 +183,7 @@ export function createRuntimeHost(options: {
     ...(generation ? { LARKIN_RUNTIME_OBSERVATION_GENERATION: generation } : {}),
     LARKIN_CONFIG_DIR: process.env.LARKIN_CONFIG_DIR,
     LARKIN_HOME: process.env.LARKIN_HOME,
+    ...(config.piDistribution ? { LARKIN_PI_DISTRIBUTION: config.piDistribution } : {}),
     ...(process.env.HOME ? { HOME: process.env.HOME } : {}),
     ...(process.env.SHELL ? { SHELL: process.env.SHELL } : {}),
     ...(process.env.ZDOTDIR ? { ZDOTDIR: process.env.ZDOTDIR } : {}),
@@ -569,7 +571,8 @@ export function createRuntimeHost(options: {
     if (agent.starting) return agent.starting;
     const probeEnv = runtimeEnv(agent.config);
     await assertOfficialCliReady(agent.config, probeEnv);
-    const readiness = agent.adapter.probe ? await agent.adapter.probe({ workspaceDir: agent.config.workspaceDir,
+    const readiness = agent.adapter.probe ? await agent.adapter.probe({ agentId: agent.config.agentId,
+      workspaceDir: agent.config.workspaceDir, stateDir: agent.config.stateDir,
       env: { LARKIN_PI_COMMAND: process.env.LARKIN_PI_COMMAND, LARKIN_CODEX_COMMAND: process.env.LARKIN_CODEX_COMMAND,
         LARKIN_CLAUDE_COMMAND: process.env.LARKIN_CLAUDE_COMMAND, ...probeEnv } })
       : { runtime: agent.adapter.id, state: "ready" as const };
@@ -619,7 +622,7 @@ export function createRuntimeHost(options: {
       const adapter = options.adapterFor(config.runtime);
       const env = runtimeEnv(config);
       await assertOfficialCliReady(config, env);
-      return adapter.probe ? adapter.probe({ workspaceDir: config.workspaceDir,
+      return adapter.probe ? adapter.probe({ agentId: config.agentId, workspaceDir: config.workspaceDir, stateDir: config.stateDir,
         env: { LARKIN_PI_COMMAND: process.env.LARKIN_PI_COMMAND, LARKIN_CODEX_COMMAND: process.env.LARKIN_CODEX_COMMAND,
           LARKIN_CLAUDE_COMMAND: process.env.LARKIN_CLAUDE_COMMAND, ...env } })
         : { runtime: adapter.id, state: "ready" };
@@ -633,7 +636,7 @@ export function createRuntimeHost(options: {
       const adapter = options.adapterFor(config.runtime);
       const stageEnv = runtimeEnv(config, `${crypto.randomUUID()}:staged`);
       await assertOfficialCliReady(config, stageEnv);
-      const readiness = adapter.probe ? await adapter.probe({ workspaceDir: config.workspaceDir,
+      const readiness = adapter.probe ? await adapter.probe({ agentId: config.agentId, workspaceDir: config.workspaceDir, stateDir: config.stateDir,
         env: { LARKIN_PI_COMMAND: process.env.LARKIN_PI_COMMAND, LARKIN_CODEX_COMMAND: process.env.LARKIN_CODEX_COMMAND,
           LARKIN_CLAUDE_COMMAND: process.env.LARKIN_CLAUDE_COMMAND, ...stageEnv } })
         : { runtime: adapter.id, state: "ready" as const };
@@ -713,7 +716,8 @@ export function createRuntimeHost(options: {
       const oldSessionId = oldSession.sessionId;
       const probeEnv = runtimeEnv(agent.config, `${agent.launchId}:reset`);
       await assertOfficialCliReady(agent.config, probeEnv);
-      const readiness = agent.adapter.probe ? await agent.adapter.probe({ workspaceDir: agent.config.workspaceDir,
+      const readiness = agent.adapter.probe ? await agent.adapter.probe({ agentId: agent.config.agentId,
+        workspaceDir: agent.config.workspaceDir, stateDir: agent.config.stateDir,
         env: { LARKIN_PI_COMMAND: process.env.LARKIN_PI_COMMAND, LARKIN_CODEX_COMMAND: process.env.LARKIN_CODEX_COMMAND,
           LARKIN_CLAUDE_COMMAND: process.env.LARKIN_CLAUDE_COMMAND, ...probeEnv } })
         : { runtime: agent.adapter.id, state: "ready" as const };

--- a/src/runtime/runtime-readiness.ts
+++ b/src/runtime/runtime-readiness.ts
@@ -1,6 +1,7 @@
 import fs from "node:fs";
 import path from "node:path";
 import { spawnSync } from "node:child_process";
+import { assertBuiltinPiAgentDirectory, BUNDLED_PI_VERSION, piAgentDirectory } from "./pi-provider-config.js";
 
 export type RuntimeReadinessState = "missing" | "unauthenticated" | "unavailable" | "incompatible" | "ready";
 
@@ -82,6 +83,7 @@ export interface ProbeNativeRuntimeReadinessOptions {
   cwd: string;
   env?: NodeJS.ProcessEnv;
   command?: string;
+  agentId?: string;
 }
 
 function selectedCommand(options: ProbeNativeRuntimeReadinessOptions): string {
@@ -100,6 +102,16 @@ function executableVersion(executable: string, env: NodeJS.ProcessEnv): string |
 /** Resolve and handshake through each runtime's structured native control protocol. */
 export async function probeNativeRuntimeReadiness(options: ProbeNativeRuntimeReadinessOptions): Promise<RuntimeReadiness> {
   const env = { ...process.env, ...options.env };
+  if (options.runtime === "pi" && env.LARKIN_PI_DISTRIBUTION === "builtin") {
+    try {
+      if (!options.agentId || !env.LARKIN_CONFIG_DIR) throw new Error("内置 Pi readiness 缺少 Agent/config identity");
+      assertBuiltinPiAgentDirectory(piAgentDirectory(env.LARKIN_CONFIG_DIR, options.agentId));
+      return { runtime: "pi", state: "ready", executable: process.execPath, version: `official-pi ${BUNDLED_PI_VERSION} (bundled)` };
+    } catch (error) {
+      return { runtime: "pi", state: "unauthenticated", reason: error instanceof Error ? error.message : String(error),
+        nextAction: "重新运行 larkin setup，选择内置 Pi 并配置有效 API Key。" };
+    }
+  }
   const command = selectedCommand(options);
   const executable = resolveRuntimeExecutable(command, env);
   if (!executable) return {

--- a/src/setup/bot-register.ts
+++ b/src/setup/bot-register.ts
@@ -1,18 +1,33 @@
 #!/usr/bin/env bun
 // Internal setup stage: browser-select a bot, verify credentials, publish them, then bind its App-ID Agent.
 
-import { spawnSync as systemSpawnSync } from "node:child_process";
+import { spawn as systemSpawn, spawnSync as systemSpawnSync, type ChildProcess } from "node:child_process";
 import fs from "node:fs";
 import path from "node:path";
 import { fileURLToPath, pathToFileURL } from "node:url";
 import { registerApp as channelRegisterApp } from "@larksuite/channel";
 import { internalCommandSpec } from "../app/internal-command.js";
 import * as larkinConfig from "../platform/config.js";
-import { hydrateRuntimeAgent, syncAgentProfile } from "../app/runtime-agent-config.js";
+import { hydrateRuntimeAgent, syncAgentProfile, syncAgentProfileAsync } from "../app/runtime-agent-config.js";
 import { managedLarkCliEnv } from "../app/agent-lark-cli-workspace.js";
-import { resolveOfficialLarkCli } from "../app/official-lark-cli.js";
+import { resolveOfficialLarkCli, type OfficialLarkCliCommand } from "../app/official-lark-cli.js";
 import { collectSetupAgentChoice, recoverUnavailableExternalPi, terminalSetupQuestioner } from "./setup-agent-choice.js";
 import { probeNativeRuntimeReadiness } from "../runtime/runtime-readiness.js";
+import { configureBuiltinPiProviderModel, type BuiltinPiProviderSetupSelection } from "../runtime/pi-provider-config.js";
+import {
+  beginBuiltinPiCredentialTransaction,
+  createOfficialPiCredentialRuntime,
+  createOfficialPiAuthInteraction,
+  createOfficialPiModelRuntime,
+  createOfficialPiLogoutRuntime,
+  createOfficialPiRegistryRuntime,
+  listOfficialPiAuthProviders,
+  logoutOfficialPiProvider,
+  officialPiAuthStatus,
+  runOfficialPiLogin,
+  verifyOfficialPiProviderTurn,
+} from "../runtime/pi-official-auth.js";
+import type { OfficialPiAuthSelection, SetupAgentChoice } from "./setup-agent-choice.js";
 // qrcode-terminal does not publish TypeScript declarations.
 // @ts-expect-error bundled CommonJS dependency
 import qrcodePackage from "qrcode-terminal";
@@ -54,10 +69,44 @@ const resolveOfficialCli = testFixture?.resolveOfficialLarkCli ?? resolveOfficia
 const wait = testFixture?.wait ?? ((milliseconds: number) => new Promise<void>((resolve) => setTimeout(resolve, milliseconds)));
 const CFG_DIR = larkinConfig.resolveConfigDir(process.env);
 let temporaryAgentChoiceFile: string | null = null;
+let pendingPiAuthTransaction: ReturnType<typeof beginBuiltinPiCredentialTransaction> | null = null;
+let pendingBindChild: ChildProcess | null = null;
+let pendingChildSettled: Promise<void> | null = null;
+let settlePendingChild: (() => void) | null = null;
+let requestedShutdown: "SIGINT" | "SIGTERM" | null = null;
+const shutdownController = new AbortController();
+let resolvedSetupOfficialCli: OfficialLarkCliCommand | null = null;
+
+function trackPendingChild(child: ChildProcess | null): void {
+  if (child) {
+    pendingBindChild = child;
+    pendingChildSettled = new Promise<void>((resolve) => { settlePendingChild = resolve; });
+    return;
+  }
+  pendingBindChild = null;
+  settlePendingChild?.();
+  settlePendingChild = null;
+  pendingChildSettled = null;
+}
+
 process.on("exit", () => {
+  pendingPiAuthTransaction?.rollback();
   if (!temporaryAgentChoiceFile) return;
   try { fs.unlinkSync(temporaryAgentChoiceFile); } catch { /* consumed or best effort */ }
 });
+for (const signal of ["SIGINT", "SIGTERM"] as const) {
+  process.once(signal, () => {
+    if (requestedShutdown) return;
+    requestedShutdown = signal;
+    const settling = pendingChildSettled;
+    shutdownController.abort(new Error(`setup interrupted by ${signal}`));
+    void (settling ?? Promise.resolve()).finally(() => {
+      pendingPiAuthTransaction?.rollback();
+      pendingPiAuthTransaction = null;
+      process.exit(signal === "SIGINT" ? 130 : 143);
+    });
+  });
+}
 const argv = process.argv.slice(2);
 const flag = (name: string): string | undefined => {
   const index = argv.indexOf(name);
@@ -66,12 +115,24 @@ const flag = (name: string): string | undefined => {
 const has = (name: string): boolean => argv.includes(name);
 const say = (...args: unknown[]): void => console.error(...args);
 const die = (message: string): never => {
+  if (requestedShutdown) throw new Error(`setup shutdown pending (${requestedShutdown})`);
   console.error(`✗ ${message}`);
   process.exit(1);
 };
 const errorMessage = (error: unknown): string => error instanceof Error ? error.message : String(error);
 const APP_ID = /^cli_[A-Za-z0-9]+$/;
 const BOT_VERIFY_BACKOFF_MS = [500, 1_000, 2_000, 4_000, 8_000, 15_000] as const;
+const testChildTimeout = process.env.LARKIN_TEST_BOT_REGISTER_MODULE ? Number(process.env.LARKIN_TEST_CHILD_TIMEOUT_MS) : NaN;
+const testChildMaxOutput = process.env.LARKIN_TEST_BOT_REGISTER_MODULE ? Number(process.env.LARKIN_TEST_CHILD_MAX_OUTPUT_BYTES) : NaN;
+const CHILD_TIMEOUT_MS = Number.isFinite(testChildTimeout) && testChildTimeout >= 50 ? testChildTimeout : 60_000;
+const CHILD_MAX_OUTPUT_BYTES = Number.isFinite(testChildMaxOutput) && testChildMaxOutput >= 256 ? testChildMaxOutput : 64 * 1024;
+
+function officialCliForProfile(env: NodeJS.ProcessEnv): OfficialLarkCliCommand {
+  if (resolvedSetupOfficialCli) return resolvedSetupOfficialCli;
+  if (pendingPiAuthTransaction) throw new Error("official lark-cli must be resolved before the Pi credential transaction starts");
+  resolvedSetupOfficialCli = resolveOfficialCli({ env });
+  return resolvedSetupOfficialCli;
+}
 
 function botVerificationRetryable(result: { status: number | null; stdout?: unknown; stderr?: unknown }): boolean {
   const text = `${typeof result.stdout === "string" ? result.stdout : ""}\n${typeof result.stderr === "string" ? result.stderr : ""}`;
@@ -93,9 +154,101 @@ function ensureSecureBotsDir(): string {
 }
 
 function openBrowser(url: string): boolean {
-  const command = process.platform === "darwin" ? "open" : process.platform === "win32" ? "cmd" : "xdg-open";
-  const args = process.platform === "win32" ? ["/c", "start", "", url] : [url];
-  return spawnSync(command, args, { stdio: "ignore" }).status === 0;
+  const command = process.platform === "darwin" ? "open" : process.platform === "win32" ? "rundll32.exe" : "xdg-open";
+  const args = process.platform === "win32" ? ["url.dll,FileProtocolHandler", url] : [url];
+  try {
+    const child = systemSpawn(command, args, { stdio: "ignore", shell: false });
+    child.once("error", () => say(`[setup] 浏览器启动失败，请手动打开完整地址：${url}`));
+    child.unref?.();
+    return true;
+  } catch {
+    say(`[setup] 浏览器启动失败，请手动打开完整地址：${url}`);
+    return false;
+  }
+}
+
+async function runBindProcess(command: string, args: readonly string[]): Promise<number | null> {
+  if (testFixture?.spawnSync && !pendingPiAuthTransaction) {
+    return spawnSync(command, [...args], { env: process.env, stdio: "inherit" }).status;
+  }
+  return await new Promise<number | null>((resolve, reject) => {
+    const child = systemSpawn(command, [...args], { env: process.env, stdio: "inherit" });
+    trackPendingChild(child);
+    let killTimer: NodeJS.Timeout | null = null;
+    const abort = (): void => {
+      child.kill("SIGTERM");
+      killTimer = setTimeout(() => { if (child.exitCode === null && child.signalCode === null) child.kill("SIGKILL"); }, 1_000);
+      killTimer.unref?.();
+    };
+    if (shutdownController.signal.aborted) abort();
+    else shutdownController.signal.addEventListener("abort", abort, { once: true });
+    child.once("error", (error) => {
+      if (killTimer) clearTimeout(killTimer);
+      shutdownController.signal.removeEventListener("abort", abort);
+      reject(error);
+    });
+    child.once("exit", (code) => {
+      if (killTimer) clearTimeout(killTimer);
+      shutdownController.signal.removeEventListener("abort", abort);
+      resolve(code);
+    });
+  }).finally(() => { trackPendingChild(null); });
+}
+
+async function runIdentityProcess(command: string, args: readonly string[], env: NodeJS.ProcessEnv): Promise<{
+  status: number | null; stdout: string; stderr: string;
+}> {
+  if (testFixture?.spawnSync && !pendingPiAuthTransaction && process.env.LARKIN_TEST_ASYNC_IDENTITY !== "1") {
+    const result = spawnSync(command, [...args], { encoding: "utf8", env });
+    return { status: result.status, stdout: result.stdout || "", stderr: result.stderr || "" };
+  }
+  return await new Promise<{ status: number | null; stdout: string; stderr: string }>((resolve, reject) => {
+    const child = systemSpawn(command, [...args], { env, stdio: ["ignore", "pipe", "pipe"] });
+    trackPendingChild(child);
+    let stdout = "";
+    let stderr = "";
+    let outputBytes = 0;
+    let failure: Error | null = null;
+    let settled = false;
+    let killTimer: NodeJS.Timeout | null = null;
+    const terminate = (error: Error): void => {
+      if (failure) return;
+      failure = error;
+      child.kill("SIGTERM");
+      killTimer = setTimeout(() => { if (child.exitCode === null && child.signalCode === null) child.kill("SIGKILL"); }, 1_000);
+      killTimer.unref?.();
+    };
+    const collect = (target: "stdout" | "stderr", chunk: Buffer): void => {
+      outputBytes += chunk.length;
+      if (outputBytes > CHILD_MAX_OUTPUT_BYTES) { terminate(new Error("Bot identity output exceeded the bounded limit")); return; }
+      if (target === "stdout") stdout += chunk.toString("utf8"); else stderr += chunk.toString("utf8");
+    };
+    child.stdout?.on("data", (chunk: Buffer) => collect("stdout", chunk));
+    child.stderr?.on("data", (chunk: Buffer) => collect("stderr", chunk));
+    const timeout = setTimeout(() => terminate(new Error("Bot identity verification timed out")), CHILD_TIMEOUT_MS);
+    timeout.unref?.();
+    const abort = (): void => terminate(new Error("Bot identity verification cancelled"));
+    if (shutdownController.signal.aborted) abort();
+    else shutdownController.signal.addEventListener("abort", abort, { once: true });
+    const cleanup = (): void => {
+      clearTimeout(timeout);
+      if (killTimer) clearTimeout(killTimer);
+      shutdownController.signal.removeEventListener("abort", abort);
+    };
+    child.once("error", (error) => {
+      if (settled) return;
+      settled = true;
+      cleanup();
+      reject(error);
+    });
+    child.once("exit", (status) => {
+      if (settled) return;
+      settled = true;
+      cleanup();
+      if (failure) { reject(failure); return; }
+      resolve({ status, stdout, stderr });
+    });
+  }).finally(() => { trackPendingChild(null); });
 }
 
 export async function main(): Promise<void> {
@@ -175,15 +328,55 @@ const prior: StoredCredential = (() => {
 
 if (!flag("--runtime") && (!testFixture || process.env.LARKIN_TEST_ENABLE_AGENT_CHOICE === "1")) {
   const existing = larkinConfig.loadConfig(process.env).config.agents[id];
+  // The official resolver performs a synchronous login-shell probe. Resolve it
+  // exactly once before the credential heartbeat lock becomes active.
+  resolvedSetupOfficialCli = resolveOfficialCli({ env: process.env });
   const questioner = terminalSetupQuestioner();
+  // One setup-owned transaction starts before status/logout and remains active
+  // through selection, login, bind, readiness, and the final setup commit.
+  pendingPiAuthTransaction = beginBuiltinPiCredentialTransaction(CFG_DIR, id);
+  const authServices = {
+    providers: async () => listOfficialPiAuthProviders(await createOfficialPiRegistryRuntime()),
+    status: async () => officialPiAuthStatus(await createOfficialPiCredentialRuntime(CFG_DIR, id)),
+    logout: async (providerId: string) => logoutOfficialPiProvider(await createOfficialPiLogoutRuntime(CFG_DIR, id), providerId),
+    report: (message: string) => say(message),
+  };
   try {
-    const requested = await collectSetupAgentChoice(questioner, existing);
+    const requested = await collectSetupAgentChoice(questioner, existing, authServices);
     const choice = await recoverUnavailableExternalPi(requested, questioner, () => probeNativeRuntimeReadiness({
       runtime: "pi", agentId: id, cwd: path.join(CFG_DIR, "agents", id), env: process.env,
-    }), (message) => say(`! ${message}`));
+    }), (message) => say(`! ${message}`), authServices);
     if (choice) {
+      let serializedChoice: SetupAgentChoice & { authCompleted?: true; readinessCompleted?: true } = choice;
+      if (choice.runtime === "pi" && choice.distribution === "builtin") {
+        const official = choice.preset === "official" ? choice as OfficialPiAuthSelection : null;
+        const configured = official ? null : configureBuiltinPiProviderModel(CFG_DIR, id, choice as BuiltinPiProviderSetupSelection);
+        const providerId = official?.providerId || configured!.provider;
+        const authType = official?.authType || "api_key";
+        let piRuntime: Awaited<ReturnType<typeof createOfficialPiModelRuntime>>;
+        try {
+          say(`正在通过捆绑官方 Pi 登录 ${providerId}（${authType}）…`);
+          piRuntime = await createOfficialPiModelRuntime(CFG_DIR, id);
+          await runOfficialPiLogin(piRuntime, providerId, authType,
+            createOfficialPiAuthInteraction({ questioner, report: (message) => say(message), openUrl: openBrowser }));
+        } catch {
+          pendingPiAuthTransaction.rollback();
+          pendingPiAuthTransaction = null;
+          throw new Error(`官方 Pi ${providerId} 登录失败或已取消；credential/config 未修改`);
+        }
+        if (process.env.LARKIN_TEST_SKIP_BUILTIN_PI_PROVIDER_TURN !== "1") {
+          say("正在验证内置 Pi provider（受控单轮，不发送飞书消息）…");
+          try { await verifyOfficialPiProviderTurn(piRuntime, choice.model); }
+          catch {
+            pendingPiAuthTransaction.rollback();
+            pendingPiAuthTransaction = null;
+            throw new Error(`官方 Pi ${providerId} readiness 失败；credential/config 未修改`);
+          }
+        }
+        serializedChoice = { ...choice, authCompleted: true, readinessCompleted: true };
+      }
       temporaryAgentChoiceFile = path.join(CFG_DIR, `.setup-agent-choice-${process.pid}-${Date.now()}.json`);
-      fs.writeFileSync(temporaryAgentChoiceFile, `${JSON.stringify(choice)}\n`, { mode: 0o600, flag: "wx" });
+      fs.writeFileSync(temporaryAgentChoiceFile, `${JSON.stringify(serializedChoice)}\n`, { mode: 0o600, flag: "wx" });
     }
   } finally { questioner.close?.(); }
 }
@@ -213,8 +406,10 @@ const runtime = flag("--runtime");
 if (runtime) bindArgs.push("--runtime", runtime);
 if (temporaryAgentChoiceFile) bindArgs.push("--selection-file", temporaryAgentChoiceFile);
 const bindSpec = internalCommandSpec("setup-bind", bindArgs, process.env);
-const bind = spawnSync(bindSpec.command, bindSpec.args, { env: process.env, stdio: "inherit" });
-if (bind.status !== 0) {
+const bindStatus = await runBindProcess(bindSpec.command, bindSpec.args);
+if (bindStatus !== 0) {
+  pendingPiAuthTransaction?.rollback();
+  pendingPiAuthTransaction = null;
   die("新 bot 凭证已发布但 Agent 绑定失败；权威凭证状态已保留，请重跑 larkin setup 并在网页中重新选择机器人");
 }
 try {
@@ -222,12 +417,21 @@ try {
   const stored = loaded.config.agents[targetAgent];
   if (!stored) throw new Error(`Agent ${targetAgent} 不存在于 canonical config`);
   const agent = hydrateRuntimeAgent(loaded.configDir, stored);
-  synchronizeAgentProfile(agent, { ...process.env, LARKIN_CONFIG_DIR: loaded.configDir }, { forceRebind: true });
+  const profileEnv = { ...process.env, LARKIN_CONFIG_DIR: loaded.configDir };
+  const official = officialCliForProfile(profileEnv);
+  if (testFixture?.syncAgentProfile) synchronizeAgentProfile(agent, profileEnv, { forceRebind: true });
+  else await syncAgentProfileAsync(agent, profileEnv, {
+    forceRebind: true,
+    timeoutMs: CHILD_TIMEOUT_MS,
+    maxOutputBytes: CHILD_MAX_OUTPUT_BYTES,
+    signal: shutdownController.signal,
+    resolveOfficialCli: () => official,
+    onChild(child) { trackPendingChild(child); },
+  });
   const cliEnv = managedLarkCliEnv(agent, process.env);
-  const official = resolveOfficialCli({ env: cliEnv });
   let verified = false;
   for (let index = 0; index <= BOT_VERIFY_BACKOFF_MS.length; index += 1) {
-    const result = spawnSync(official.command, [...official.argsPrefix, "im", "+chat-list", "--as", "bot"], { encoding: "utf8", env: cliEnv });
+    const result = await runIdentityProcess(official.command, [...official.argsPrefix, "im", "+chat-list", "--as", "bot"], cliEnv);
     let envelope: { ok?: unknown; identity?: unknown } | undefined;
     try { envelope = JSON.parse(result.stdout || "") as { ok?: unknown; identity?: unknown }; } catch { /* fail closed below */ }
     if (result.status === 0 && envelope?.ok === true && envelope.identity === "bot") { verified = true; break; }
@@ -247,8 +451,10 @@ if (resultFile) {
   try { fs.writeFileSync(resultFile, `${JSON.stringify({ agentId: id })}\n`, { mode: 0o600, flag: "wx" }); }
   catch { die("Agent 绑定与新 bot 凭证已保留，但 setup 结果写入失败；请重跑 larkin setup 并在网页中重新选择机器人"); }
 }
+pendingPiAuthTransaction?.commit();
+pendingPiAuthTransaction = null;
 }
 
 if (path.resolve(process.argv[1] || "") === path.resolve(fileURLToPath(import.meta.url))) {
-  main().catch((error: unknown) => die(errorMessage(error)));
+  main().catch((error: unknown) => { if (!requestedShutdown) die(errorMessage(error)); });
 }

--- a/src/setup/bot-register.ts
+++ b/src/setup/bot-register.ts
@@ -11,6 +11,8 @@ import * as larkinConfig from "../platform/config.js";
 import { hydrateRuntimeAgent, syncAgentProfile } from "../app/runtime-agent-config.js";
 import { managedLarkCliEnv } from "../app/agent-lark-cli-workspace.js";
 import { resolveOfficialLarkCli } from "../app/official-lark-cli.js";
+import { collectSetupAgentChoice, recoverUnavailableExternalPi, terminalSetupQuestioner } from "./setup-agent-choice.js";
+import { probeNativeRuntimeReadiness } from "../runtime/runtime-readiness.js";
 // qrcode-terminal does not publish TypeScript declarations.
 // @ts-expect-error bundled CommonJS dependency
 import qrcodePackage from "qrcode-terminal";
@@ -51,6 +53,11 @@ const synchronizeAgentProfile = testFixture?.syncAgentProfile ?? syncAgentProfil
 const resolveOfficialCli = testFixture?.resolveOfficialLarkCli ?? resolveOfficialLarkCli;
 const wait = testFixture?.wait ?? ((milliseconds: number) => new Promise<void>((resolve) => setTimeout(resolve, milliseconds)));
 const CFG_DIR = larkinConfig.resolveConfigDir(process.env);
+let temporaryAgentChoiceFile: string | null = null;
+process.on("exit", () => {
+  if (!temporaryAgentChoiceFile) return;
+  try { fs.unlinkSync(temporaryAgentChoiceFile); } catch { /* consumed or best effort */ }
+});
 const argv = process.argv.slice(2);
 const flag = (name: string): string | undefined => {
   const index = argv.indexOf(name);
@@ -166,6 +173,21 @@ const prior: StoredCredential = (() => {
   catch { return {}; }
 })();
 
+if (!flag("--runtime") && (!testFixture || process.env.LARKIN_TEST_ENABLE_AGENT_CHOICE === "1")) {
+  const existing = larkinConfig.loadConfig(process.env).config.agents[id];
+  const questioner = terminalSetupQuestioner();
+  try {
+    const requested = await collectSetupAgentChoice(questioner, existing);
+    const choice = await recoverUnavailableExternalPi(requested, questioner, () => probeNativeRuntimeReadiness({
+      runtime: "pi", agentId: id, cwd: path.join(CFG_DIR, "agents", id), env: process.env,
+    }), (message) => say(`! ${message}`));
+    if (choice) {
+      temporaryAgentChoiceFile = path.join(CFG_DIR, `.setup-agent-choice-${process.pid}-${Date.now()}.json`);
+      fs.writeFileSync(temporaryAgentChoiceFile, `${JSON.stringify(choice)}\n`, { mode: 0o600, flag: "wx" });
+    }
+  } finally { questioner.close?.(); }
+}
+
 const stagedBotFile = path.join(botsDir, `.${id}.${process.pid}.tmp`);
 try {
   fs.writeFileSync(stagedBotFile, `${JSON.stringify({
@@ -189,6 +211,7 @@ const targetAgent = flag("--agent") || id;
 const bindArgs = ["--profile", id, "--yes", "--agent", targetAgent];
 const runtime = flag("--runtime");
 if (runtime) bindArgs.push("--runtime", runtime);
+if (temporaryAgentChoiceFile) bindArgs.push("--selection-file", temporaryAgentChoiceFile);
 const bindSpec = internalCommandSpec("setup-bind", bindArgs, process.env);
 const bind = spawnSync(bindSpec.command, bindSpec.args, { env: process.env, stdio: "inherit" });
 if (bind.status !== 0) {

--- a/src/setup/setup-agent-choice.ts
+++ b/src/setup/setup-agent-choice.ts
@@ -1,0 +1,125 @@
+import { createInterface } from "node:readline/promises";
+import { stdin, stdout } from "node:process";
+import type { StoredAgent } from "./setup-binding.js";
+import {
+  PI_PROVIDER_PRESETS,
+  validateBuiltinPiProviderSelection,
+  type BuiltinPiProviderSelection,
+  type PiDistribution,
+} from "../runtime/pi-provider-config.js";
+
+export type SetupAgentChoice =
+  | { runtime: "codex" | "claude" }
+  | { runtime: "pi"; distribution: "external" }
+  | ({ runtime: "pi" } & BuiltinPiProviderSelection);
+
+export interface SetupQuestioner {
+  ask(prompt: string): Promise<string>;
+  secret(prompt: string): Promise<string>;
+  close?(): void;
+}
+
+export interface ExternalPiProbeResult {
+  state: "missing" | "unauthenticated" | "unavailable" | "incompatible" | "ready";
+  reason?: string;
+  nextAction?: string;
+}
+
+function number(value: string, fallback: number, max: number): number {
+  const parsed = value.trim() ? Number(value.trim()) : fallback;
+  if (!Number.isInteger(parsed) || parsed < 1 || parsed > max) throw new Error(`请选择 1-${max}`);
+  return parsed;
+}
+
+export async function collectBuiltinPiChoice(questioner: SetupQuestioner): Promise<SetupAgentChoice> {
+  const lines = PI_PROVIDER_PRESETS.map((preset, index) => `  ${index + 1}. ${preset.name} — ${preset.baseUrl}`).join("\n");
+  const providerChoice = number(await questioner.ask(`选择模型服务：\n${lines}\n  5. Custom OpenAI-compatible\n> `), 1, 5);
+  const preset = providerChoice === 5 ? "custom" : PI_PROVIDER_PRESETS[providerChoice - 1].id;
+  const selected = preset === "custom" ? null : PI_PROVIDER_PRESETS.find((candidate) => candidate.id === preset)!;
+  const baseUrl = preset === "custom" ? await questioner.ask("Base URL（https；localhost 可用 http）：") : selected!.baseUrl;
+  const model = (await questioner.ask(`模型 ID${selected ? `（默认 ${selected.defaultModel}）` : ""}：`)).trim() || selected?.defaultModel || "";
+  const apiKey = await questioner.secret("API Key（不会回显）：");
+  const validated = validateBuiltinPiProviderSelection({ distribution: "builtin", preset, apiKey, model, ...(baseUrl ? { baseUrl } : {}) });
+  return { runtime: "pi", distribution: "builtin", preset, apiKey: validated.apiKey, model: validated.model, ...(preset === "custom" ? { baseUrl: validated.baseUrl } : {}) };
+}
+
+export async function collectSetupAgentChoice(questioner: SetupQuestioner, prior?: StoredAgent): Promise<SetupAgentChoice | null> {
+  if (prior) {
+    const keep = (await questioner.ask(`已有 Agent：${prior.runtime}/${prior.model}。直接回车保留；输入 c 才修改：`)).trim().toLowerCase();
+    if (!keep) return null;
+    if (keep !== "c") throw new Error("请输入 c 修改，或直接回车保留现有配置");
+  }
+  const runtimeChoice = number(await questioner.ask("选择 Agent：\n  1. Pi（推荐）\n  2. Codex\n  3. Claude Code\n> "), 1, 3);
+  if (runtimeChoice === 2) return { runtime: "codex" };
+  if (runtimeChoice === 3) return { runtime: "claude" };
+  const sourceChoice = number(await questioner.ask("选择 Pi：\n  1. 外置 Pi（使用本机官方 pi）\n  2. 内置 Pi（无需安装 Agent CLI，推荐）\n> "), 2, 2);
+  const distribution: PiDistribution = sourceChoice === 1 ? "external" : "builtin";
+  return distribution === "external" ? { runtime: "pi", distribution } : collectBuiltinPiChoice(questioner);
+}
+
+export async function recoverUnavailableExternalPi(
+  initial: SetupAgentChoice | null,
+  questioner: SetupQuestioner,
+  probe: () => Promise<ExternalPiProbeResult>,
+  report: (message: string) => void = () => {},
+): Promise<SetupAgentChoice | null> {
+  let choice = initial;
+  for (let attempt = 1; attempt <= 3; attempt += 1) {
+    if (choice?.runtime !== "pi" || choice.distribution !== "external") return choice;
+    const readiness = await probe();
+    if (readiness.state === "ready") return choice;
+    report(`外置 Pi ${readiness.state}：${readiness.reason || "prerequisite unavailable"}；${readiness.nextAction || "可切换到内置 Pi"}`);
+    const action = number(await questioner.ask("外置 Pi 当前不可用：\n  1. 切换到内置 Pi（推荐）\n  2. 重新选择 Agent\n  3. 取消 setup（保留原配置）\n> "), 1, 3);
+    if (action === 1) return collectBuiltinPiChoice(questioner);
+    if (action === 3) throw new Error("setup 已取消；未修改 Agent/config");
+    choice = await collectSetupAgentChoice(questioner);
+  }
+  throw new Error("外置 Pi 恢复选择已达到 3 次；未修改 Agent/config，请修复后重试");
+}
+
+export function terminalSetupQuestioner(): SetupQuestioner {
+  let rl: ReturnType<typeof createInterface> | null = createInterface({ input: stdin, output: stdout, terminal: Boolean(stdin.isTTY) });
+  const lines = rl[Symbol.asyncIterator]();
+  const close = (): void => { rl?.close(); rl = null; };
+  const nextLine = async (prompt: string): Promise<string> => {
+    if (!rl) throw new Error("setup input 已关闭");
+    stdout.write(prompt);
+    const next = await lines.next();
+    if (next.done) throw new Error("setup 输入已结束；未保存配置");
+    return next.value;
+  };
+  return {
+    ask: nextLine,
+    secret: async (prompt) => {
+      if (!stdin.isTTY || typeof stdin.setRawMode !== "function") {
+        try { return await nextLine(prompt); }
+        finally { close(); }
+      }
+      close();
+      stdout.write(prompt);
+      const wasRaw = stdin.isRaw;
+      stdin.setRawMode(true);
+      stdin.resume();
+      return await new Promise<string>((resolve, reject) => {
+        let value = "";
+        const finish = (error?: Error): void => {
+          stdin.off("data", onData);
+          stdin.setRawMode(Boolean(wasRaw));
+          stdin.pause();
+          stdout.write("\n");
+          if (error) reject(error); else resolve(value);
+        };
+        const onData = (chunk: Buffer): void => {
+          for (const byte of chunk) {
+            if (byte === 3) return finish(new Error("setup 已取消；未保存 API Key"));
+            if (byte === 10 || byte === 13) return finish();
+            if (byte === 8 || byte === 127) { value = value.slice(0, -1); continue; }
+            if (byte >= 32 && byte <= 126) value += String.fromCharCode(byte);
+          }
+        };
+        stdin.on("data", onData);
+      });
+    },
+    close,
+  };
+}

--- a/src/setup/setup-agent-choice.ts
+++ b/src/setup/setup-agent-choice.ts
@@ -3,20 +3,36 @@ import { stdin, stdout } from "node:process";
 import type { StoredAgent } from "./setup-binding.js";
 import {
   PI_PROVIDER_PRESETS,
-  validateBuiltinPiProviderSelection,
-  type BuiltinPiProviderSelection,
+  resolveBuiltinPiProviderSetupSelection,
+  type BuiltinPiProviderSetupSelection,
   type PiDistribution,
 } from "../runtime/pi-provider-config.js";
+import type { OfficialPiAuthProvider, OfficialPiAuthStatus } from "../runtime/pi-official-auth.js";
+
+export interface OfficialPiAuthSelection {
+  distribution: "builtin";
+  preset: "official";
+  providerId: string;
+  authType: "api_key" | "oauth";
+  model: string;
+}
 
 export type SetupAgentChoice =
   | { runtime: "codex" | "claude" }
   | { runtime: "pi"; distribution: "external" }
-  | ({ runtime: "pi" } & BuiltinPiProviderSelection);
+  | ({ runtime: "pi" } & (BuiltinPiProviderSetupSelection | OfficialPiAuthSelection));
 
 export interface SetupQuestioner {
-  ask(prompt: string): Promise<string>;
-  secret(prompt: string): Promise<string>;
+  ask(prompt: string, signal?: AbortSignal): Promise<string>;
+  secret(prompt: string, signal?: AbortSignal): Promise<string>;
   close?(): void;
+}
+
+export interface BuiltinPiChoiceServices {
+  providers(): Promise<OfficialPiAuthProvider[]>;
+  status(): Promise<OfficialPiAuthStatus[]>;
+  logout(providerId: string): Promise<void>;
+  report(message: string): void;
 }
 
 export interface ExternalPiProbeResult {
@@ -31,19 +47,48 @@ function number(value: string, fallback: number, max: number): number {
   return parsed;
 }
 
-export async function collectBuiltinPiChoice(questioner: SetupQuestioner): Promise<SetupAgentChoice> {
+export async function collectBuiltinPiChoice(questioner: SetupQuestioner,
+  services?: BuiltinPiChoiceServices): Promise<SetupAgentChoice> {
   const lines = PI_PROVIDER_PRESETS.map((preset, index) => `  ${index + 1}. ${preset.name} — ${preset.baseUrl}`).join("\n");
-  const providerChoice = number(await questioner.ask(`选择模型服务：\n${lines}\n  5. Custom OpenAI-compatible\n> `), 1, 5);
+  const providerChoice = number(await questioner.ask(`选择模型服务 / 认证：\n${lines}\n  5. Custom OpenAI-compatible\n  6. 官方 Pi provider 登录（API Key / OAuth / subscription）\n  7. 查看或退出已有官方 Pi 认证\n> `), 1, 7);
+  if (providerChoice === 7) {
+    if (!services) throw new Error("当前 setup 上下文无法管理官方 Pi 认证");
+    const status = await services.status();
+    if (status.length === 0) services.report("尚无已配置的官方 Pi credential");
+    else status.forEach((entry, index) => services.report(`  ${index + 1}. ${entry.providerName} (${entry.providerId}) — ${entry.credentialType}/${entry.source}${entry.stored ? "，已存储" : "，ambient"}`));
+    const answer = (await questioner.ask("输入要 logout 的序号；直接回车返回：")).trim();
+    if (answer) {
+      const selected = number(answer, 0, status.length);
+      await services.logout(status[selected - 1]!.providerId);
+      services.report(`已退出 ${status[selected - 1]!.providerName}；未修改其他 provider`);
+    }
+    return collectBuiltinPiChoice(questioner, services);
+  }
+  if (providerChoice === 6) {
+    if (!services) throw new Error("当前 setup 上下文无法读取官方 Pi auth registry");
+    const providers = await services.providers();
+    const methods = providers.flatMap((provider) => provider.methods.map((method) => ({ provider, method })));
+    if (methods.length === 0) throw new Error("捆绑官方 Pi auth registry 没有可交互登录方式");
+    const methodLines = methods.map(({ provider, method }, index) => `  ${index + 1}. ${provider.name} — ${method.name} [${method.type}]`).join("\n");
+    const methodChoice = number(await questioner.ask(`选择官方 Pi 登录方式：\n${methodLines}\n> `), 1, methods.length);
+    const selected = methods[methodChoice - 1]!;
+    const defaultModel = selected.provider.models[0] || "";
+    const model = (await questioner.ask(`模型 ID${defaultModel ? `（默认 ${defaultModel}）` : "（provider/model）"}：`)).trim() || defaultModel;
+    if (!/^[A-Za-z0-9][A-Za-z0-9._-]{0,127}\/[A-Za-z0-9][A-Za-z0-9._:@+\/-]{0,255}$/.test(model)) throw new Error("模型 ID 必须是安全的 provider/model");
+    if (!model.startsWith(`${selected.provider.id}/`)) throw new Error(`模型 ID 必须属于 ${selected.provider.id}`);
+    return { runtime: "pi", distribution: "builtin", preset: "official", providerId: selected.provider.id,
+      authType: selected.method.type, model };
+  }
   const preset = providerChoice === 5 ? "custom" : PI_PROVIDER_PRESETS[providerChoice - 1].id;
   const selected = preset === "custom" ? null : PI_PROVIDER_PRESETS.find((candidate) => candidate.id === preset)!;
   const baseUrl = preset === "custom" ? await questioner.ask("Base URL（https；localhost 可用 http）：") : selected!.baseUrl;
   const model = (await questioner.ask(`模型 ID${selected ? `（默认 ${selected.defaultModel}）` : ""}：`)).trim() || selected?.defaultModel || "";
-  const apiKey = await questioner.secret("API Key（不会回显）：");
-  const validated = validateBuiltinPiProviderSelection({ distribution: "builtin", preset, apiKey, model, ...(baseUrl ? { baseUrl } : {}) });
-  return { runtime: "pi", distribution: "builtin", preset, apiKey: validated.apiKey, model: validated.model, ...(preset === "custom" ? { baseUrl: validated.baseUrl } : {}) };
+  const validated = resolveBuiltinPiProviderSetupSelection({ distribution: "builtin", preset, model, ...(baseUrl ? { baseUrl } : {}) });
+  return { runtime: "pi", distribution: "builtin", preset, model: validated.model, ...(preset === "custom" ? { baseUrl: validated.baseUrl } : {}) };
 }
 
-export async function collectSetupAgentChoice(questioner: SetupQuestioner, prior?: StoredAgent): Promise<SetupAgentChoice | null> {
+export async function collectSetupAgentChoice(questioner: SetupQuestioner, prior?: StoredAgent,
+  services?: BuiltinPiChoiceServices): Promise<SetupAgentChoice | null> {
   if (prior) {
     const keep = (await questioner.ask(`已有 Agent：${prior.runtime}/${prior.model}。直接回车保留；输入 c 才修改：`)).trim().toLowerCase();
     if (!keep) return null;
@@ -54,7 +99,7 @@ export async function collectSetupAgentChoice(questioner: SetupQuestioner, prior
   if (runtimeChoice === 3) return { runtime: "claude" };
   const sourceChoice = number(await questioner.ask("选择 Pi：\n  1. 外置 Pi（使用本机官方 pi）\n  2. 内置 Pi（无需安装 Agent CLI，推荐）\n> "), 2, 2);
   const distribution: PiDistribution = sourceChoice === 1 ? "external" : "builtin";
-  return distribution === "external" ? { runtime: "pi", distribution } : collectBuiltinPiChoice(questioner);
+  return distribution === "external" ? { runtime: "pi", distribution } : collectBuiltinPiChoice(questioner, services);
 }
 
 export async function recoverUnavailableExternalPi(
@@ -62,6 +107,7 @@ export async function recoverUnavailableExternalPi(
   questioner: SetupQuestioner,
   probe: () => Promise<ExternalPiProbeResult>,
   report: (message: string) => void = () => {},
+  services?: BuiltinPiChoiceServices,
 ): Promise<SetupAgentChoice | null> {
   let choice = initial;
   for (let attempt = 1; attempt <= 3; attempt += 1) {
@@ -70,30 +116,45 @@ export async function recoverUnavailableExternalPi(
     if (readiness.state === "ready") return choice;
     report(`外置 Pi ${readiness.state}：${readiness.reason || "prerequisite unavailable"}；${readiness.nextAction || "可切换到内置 Pi"}`);
     const action = number(await questioner.ask("外置 Pi 当前不可用：\n  1. 切换到内置 Pi（推荐）\n  2. 重新选择 Agent\n  3. 取消 setup（保留原配置）\n> "), 1, 3);
-    if (action === 1) return collectBuiltinPiChoice(questioner);
+    if (action === 1) return collectBuiltinPiChoice(questioner, services);
     if (action === 3) throw new Error("setup 已取消；未修改 Agent/config");
-    choice = await collectSetupAgentChoice(questioner);
+    choice = await collectSetupAgentChoice(questioner, undefined, services);
   }
   throw new Error("外置 Pi 恢复选择已达到 3 次；未修改 Agent/config，请修复后重试");
 }
 
 export function terminalSetupQuestioner(): SetupQuestioner {
-  let rl: ReturnType<typeof createInterface> | null = createInterface({ input: stdin, output: stdout, terminal: Boolean(stdin.isTTY) });
-  const lines = rl[Symbol.asyncIterator]();
-  const close = (): void => { rl?.close(); rl = null; };
-  const nextLine = async (prompt: string): Promise<string> => {
-    if (!rl) throw new Error("setup input 已关闭");
+  let rl: ReturnType<typeof createInterface> | null = null;
+  let lines: AsyncIterator<string> | null = null;
+  const ensureInput = (): AsyncIterator<string> => {
+    if (!rl) {
+      rl = createInterface({ input: stdin, output: stdout, terminal: Boolean(stdin.isTTY) });
+      lines = rl[Symbol.asyncIterator]();
+    }
+    return lines!;
+  };
+  const close = (): void => { rl?.close(); rl = null; lines = null; };
+  const nextLine = async (prompt: string, signal?: AbortSignal): Promise<string> => {
+    if (signal?.aborted) throw new Error("setup auth prompt 已取消");
+    const inputLines = ensureInput();
     stdout.write(prompt);
-    const next = await lines.next();
+    let onAbort: (() => void) | undefined;
+    const aborted = new Promise<never>((_resolve, reject) => {
+      if (!signal) return;
+      onAbort = () => { close(); reject(new Error("setup auth prompt 已取消")); };
+      signal.addEventListener("abort", onAbort, { once: true });
+    });
+    let next: IteratorResult<string>;
+    try { next = await Promise.race([inputLines.next(), aborted]); }
+    finally { if (signal && onAbort) signal.removeEventListener("abort", onAbort); }
     if (next.done) throw new Error("setup 输入已结束；未保存配置");
     return next.value;
   };
   return {
     ask: nextLine,
-    secret: async (prompt) => {
+    secret: async (prompt, signal) => {
       if (!stdin.isTTY || typeof stdin.setRawMode !== "function") {
-        try { return await nextLine(prompt); }
-        finally { close(); }
+        return nextLine(prompt, signal);
       }
       close();
       stdout.write(prompt);
@@ -104,6 +165,7 @@ export function terminalSetupQuestioner(): SetupQuestioner {
         let value = "";
         const finish = (error?: Error): void => {
           stdin.off("data", onData);
+          signal?.removeEventListener("abort", onAbort);
           stdin.setRawMode(Boolean(wasRaw));
           stdin.pause();
           stdout.write("\n");
@@ -117,6 +179,9 @@ export function terminalSetupQuestioner(): SetupQuestioner {
             if (byte >= 32 && byte <= 126) value += String.fromCharCode(byte);
           }
         };
+        const onAbort = (): void => finish(new Error("setup auth prompt 已取消"));
+        if (signal?.aborted) return onAbort();
+        signal?.addEventListener("abort", onAbort, { once: true });
         stdin.on("data", onData);
       });
     },

--- a/src/setup/setup-bind.ts
+++ b/src/setup/setup-bind.ts
@@ -10,9 +10,15 @@ import { fileURLToPath } from "node:url";
 import { TargetRootLayout } from "../platform/root-layout.js";
 import { planSingleRootBinding, type StoredConfig } from "./setup-binding.js";
 import { discoverPiModelCatalog } from "../runtime/pi-model-catalog.js";
-import { stageBuiltinPiProvider, type BuiltinPiProviderSelection } from "../runtime/pi-provider-config.js";
-import { createNativeRuntimeAdapter } from "../runtime/runtime-adapters.js";
-import type { SetupAgentChoice } from "./setup-agent-choice.js";
+import { configureBuiltinPiProviderModel, type BuiltinPiProviderSetupSelection } from "../runtime/pi-provider-config.js";
+import { terminalSetupQuestioner, type OfficialPiAuthSelection, type SetupAgentChoice } from "./setup-agent-choice.js";
+import {
+  beginBuiltinPiCredentialTransaction,
+  createOfficialPiAuthInteraction,
+  createOfficialPiModelRuntime,
+  runOfficialPiLogin,
+  verifyOfficialPiProviderTurn,
+} from "../runtime/pi-official-auth.js";
 import * as larkinConfigImport from "../platform/config.js";
 import { resolveOfficialLarkCli } from "../app/official-lark-cli.js";
 
@@ -121,6 +127,13 @@ function larkJson(args: string[]): LarkJsonResult {
   }
 }
 
+function openAuthUrl(url: string): boolean {
+  const command = process.platform === "darwin" ? "open" : process.platform === "win32" ? "rundll32.exe" : "xdg-open";
+  const args = process.platform === "win32" ? ["url.dll,FileProtocolHandler", url] : [url];
+  const result = spawnSync(command, args, { stdio: "ignore", timeout: 5_000 });
+  return result.status === 0;
+}
+
 function listProfiles(): Profile[] {
   const result = larkJson(["profile", "list"]);
   if (!result.ok || !Array.isArray(result.json)) {
@@ -201,44 +214,15 @@ function fabricateAttachment(root: string, serverId: string): void {
   fs.writeFileSync(file, JSON.stringify(attachment, null, 2), { mode: 0o600 });
 }
 
-async function verifyBuiltinPiProviderTurn(agentId: string, model: string): Promise<void> {
-  if (process.env.LARKIN_TEST_SKIP_BUILTIN_PI_PROVIDER_TURN === "1" && process.env.LARKIN_TEST_BOT_REGISTER_MODULE) return;
-  const workspaceDir = layout.workspaceDir(agentId);
-  const stateDir = layout.agentStateDir(agentId);
-  fs.mkdirSync(workspaceDir, { recursive: true });
-  fs.mkdirSync(stateDir, { recursive: true, mode: 0o700 });
-  const env = { ...process.env, LARKIN_CONFIG_DIR: CFG_DIR, LARKIN_HOME: CFG_DIR, LARKIN_PI_DISTRIBUTION: "builtin" };
-  const adapter = createNativeRuntimeAdapter("pi", { env });
-  const readiness = await adapter.probe!({ agentId, workspaceDir, stateDir, env });
-  if (readiness.state !== "ready") throw new Error(readiness.reason || "内置 Pi provider 尚未 ready");
-  const session = await adapter.createSession({
-    agentId, workspaceDir, stateDir, model, env,
-    standingPrompt: { version: "setup-readiness-v1", content: "This is a setup readiness check. Do not use tools.", hash: "setup-readiness-v1" },
-  });
-  const events: string[] = [];
-  let timer: NodeJS.Timeout | null = null;
-  try {
-    const terminal = new Promise<void>((resolve, reject) => {
-      timer = setTimeout(() => reject(new Error("provider readiness turn 60 秒超时")), 60_000);
-      session.subscribe((event) => {
-        if (event.type === "activity" && event.activity === "text" && event.text) events.push(event.text);
-        if (event.type === "input-error" || event.type === "configuration-error" || event.type === "error") {
-          if (timer) clearTimeout(timer);
-          reject(new Error(event.message));
-        } else if (event.type === "turn-end") {
-          if (timer) clearTimeout(timer);
-          if (!events.join("").trim()) reject(new Error("provider readiness turn 未返回可认证文本"));
-          else resolve();
-        }
-      });
-    });
-    const accepted = await session.prompt({ inputId: `setup-${agentId}`, kind: "user", text: "Reply exactly: LARKIN_READY", attempt: 1 });
-    if (accepted.status !== "accepted") throw new Error(accepted.reason || "provider readiness turn 未被接受");
-    await terminal;
-  } finally {
-    if (timer) clearTimeout(timer);
-    await session.close("setup readiness complete");
+function safeProviderFailure(error: unknown): Error {
+  const message = error instanceof Error ? error.message : String(error);
+  if (/\b(?:401|403)\b|unauth|invalid.*(?:key|token)|credential/i.test(message)) {
+    return new Error("内置 Pi provider 拒绝认证（401/403）；请重新登录或检查 credential");
   }
+  if (/timeout|超时|ETIMEDOUT/i.test(message)) return new Error("内置 Pi provider readiness 超时；请检查网络和 endpoint");
+  if (/ENOTFOUND|ECONN|fetch failed|network|TLS/i.test(message)) return new Error("内置 Pi provider endpoint 不可达；请检查网络、TLS 和 Base URL");
+  if (/model|模型/i.test(message)) return new Error("内置 Pi provider 不接受所选模型；请检查 provider/model");
+  return new Error("内置 Pi provider readiness 失败；credential/config 已回滚，请检查 provider 状态后重试");
 }
 
 function printAgents(config: HydratedConfig): void {
@@ -328,9 +312,15 @@ export async function main(): Promise<void> {
   const bound = stored.agents[profile.appId];
 
   fs.mkdirSync(CFG_DIR, { recursive: true });
-  let providerTransaction: ReturnType<typeof stageBuiltinPiProvider> | null = null;
+  let providerTransaction: ReturnType<typeof beginBuiltinPiCredentialTransaction> | null = null;
   let providerPublished = false;
+  const authAlreadyCompleted = selection?.runtime === "pi" && selection.distribution === "builtin"
+    && (selection as SetupAgentChoice & { authCompleted?: true }).authCompleted === true;
+  const readinessAlreadyCompleted = authAlreadyCompleted
+    && (selection as SetupAgentChoice & { readinessCompleted?: true }).readinessCompleted === true;
+  const authAbort = new AbortController();
   const cancelProviderTransaction = (signal: NodeJS.Signals): void => {
+    authAbort.abort();
     if (!providerPublished) providerTransaction?.rollback();
     process.exit(signal === "SIGINT" ? 130 : 143);
   };
@@ -338,13 +328,40 @@ export async function main(): Promise<void> {
   const onSigterm = (): void => cancelProviderTransaction("SIGTERM");
   process.once("SIGINT", onSigint);
   process.once("SIGTERM", onSigterm);
+  let authQuestioner: ReturnType<typeof terminalSetupQuestioner> | null = null;
   try {
     providerTransaction = selection?.runtime === "pi" && selection.distribution === "builtin"
-      ? stageBuiltinPiProvider(CFG_DIR, profile.appId, selection as BuiltinPiProviderSelection)
+      && !authAlreadyCompleted ? beginBuiltinPiCredentialTransaction(CFG_DIR, profile.appId)
       : null;
     if (selection?.runtime === "pi" && selection.distribution === "builtin") {
-      say("正在验证内置 Pi provider（受控单轮，不发送飞书消息）…");
-      await verifyBuiltinPiProviderTurn(profile.appId, selection.model);
+      const official = selection.preset === "official" ? selection as OfficialPiAuthSelection : null;
+      const configured = official ? null : configureBuiltinPiProviderModel(CFG_DIR, profile.appId, selection as BuiltinPiProviderSetupSelection);
+      const providerId = official?.providerId || configured!.provider;
+      const authType = official?.authType || "api_key";
+      let piRuntime: Awaited<ReturnType<typeof createOfficialPiModelRuntime>> | null = null;
+      if (!authAlreadyCompleted) {
+        piRuntime = await createOfficialPiModelRuntime(CFG_DIR, profile.appId);
+        authQuestioner = terminalSetupQuestioner();
+        say(`正在通过捆绑官方 Pi 登录 ${providerId}（${authType}）…`);
+        try {
+          await runOfficialPiLogin(piRuntime, providerId, authType, createOfficialPiAuthInteraction({
+            questioner: authQuestioner,
+            report: (message) => say(message),
+            openUrl: openAuthUrl,
+            signal: authAbort.signal,
+          }));
+        } catch { throw new Error(`官方 Pi ${providerId} 登录失败或已取消；credential/config 未修改`); }
+      }
+      if (!readinessAlreadyCompleted) {
+        piRuntime ??= await createOfficialPiModelRuntime(CFG_DIR, profile.appId);
+        say("正在验证内置 Pi provider（受控单轮，不发送飞书消息）…");
+        try {
+          if (!(process.env.LARKIN_TEST_SKIP_BUILTIN_PI_PROVIDER_TURN === "1" && process.env.LARKIN_TEST_BOT_REGISTER_MODULE)) {
+            await verifyOfficialPiProviderTurn(piRuntime, selection.model, authAbort.signal);
+          }
+        }
+        catch (error) { throw safeProviderFailure(error); }
+      }
     }
     larkinConfig.commitSetupConfig(process.env, loaded.revision, stored);
     providerTransaction?.commit();
@@ -353,6 +370,7 @@ export async function main(): Promise<void> {
     providerTransaction?.rollback();
     throw error;
   } finally {
+    authQuestioner?.close?.();
     process.off("SIGINT", onSigint);
     process.off("SIGTERM", onSigterm);
   }

--- a/src/setup/setup-bind.ts
+++ b/src/setup/setup-bind.ts
@@ -10,6 +10,9 @@ import { fileURLToPath } from "node:url";
 import { TargetRootLayout } from "../platform/root-layout.js";
 import { planSingleRootBinding, type StoredConfig } from "./setup-binding.js";
 import { discoverPiModelCatalog } from "../runtime/pi-model-catalog.js";
+import { stageBuiltinPiProvider, type BuiltinPiProviderSelection } from "../runtime/pi-provider-config.js";
+import { createNativeRuntimeAdapter } from "../runtime/runtime-adapters.js";
+import type { SetupAgentChoice } from "./setup-agent-choice.js";
 import * as larkinConfigImport from "../platform/config.js";
 import { resolveOfficialLarkCli } from "../app/official-lark-cli.js";
 
@@ -29,6 +32,7 @@ interface HydratedAgent {
   feishuProfile: string;
   runtime: string;
   model: string;
+  piDistribution?: "external" | "builtin";
   [key: string]: unknown;
 }
 
@@ -82,6 +86,7 @@ const options = {
   agent: flag("--agent"),
   profile: flag("--profile"),
   runtime: flag("--runtime"),
+  selectionFile: flag("--selection-file"),
   yes: has("--yes"),
   list: has("--list"),
   help: has("--help") || has("-h"),
@@ -161,6 +166,23 @@ function loadConfig(): { revision: string; config: HydratedConfig } {
   return larkinConfig.loadConfig(process.env, { mint: () => crypto.randomUUID() });
 }
 
+function readSetupSelection(fileArg: string | undefined): SetupAgentChoice | null {
+  if (!fileArg) return null;
+  const file = path.resolve(fileArg);
+  if (path.dirname(file) !== path.resolve(CFG_DIR) || !/^\.setup-agent-choice-\d+-[A-Za-z0-9-]+\.json$/.test(path.basename(file))) {
+    die("setup Agent 选择文件路径无效");
+  }
+  const stat = fs.lstatSync(file);
+  if (!stat.isFile() || stat.isSymbolicLink()
+      || (typeof process.getuid === "function" && stat.uid !== process.getuid())
+      || (stat.mode & 0o777) !== 0o600) die("setup Agent 选择文件必须是当前用户拥有的 0600 普通文件");
+  const bytes = fs.readFileSync(file, "utf8");
+  fs.unlinkSync(file);
+  const raw = JSON.parse(bytes) as SetupAgentChoice;
+  if (!raw || !["pi", "codex", "claude"].includes(raw.runtime)) die("setup Agent 选择无效");
+  return raw;
+}
+
 function fabricateAttachment(root: string, serverId: string): void {
   const directory = path.join(root, "computer", "servers", serverId);
   fs.mkdirSync(directory, { recursive: true });
@@ -177,6 +199,46 @@ function fabricateAttachment(root: string, serverId: string): void {
     attachedAt: new Date().toISOString(),
   };
   fs.writeFileSync(file, JSON.stringify(attachment, null, 2), { mode: 0o600 });
+}
+
+async function verifyBuiltinPiProviderTurn(agentId: string, model: string): Promise<void> {
+  if (process.env.LARKIN_TEST_SKIP_BUILTIN_PI_PROVIDER_TURN === "1" && process.env.LARKIN_TEST_BOT_REGISTER_MODULE) return;
+  const workspaceDir = layout.workspaceDir(agentId);
+  const stateDir = layout.agentStateDir(agentId);
+  fs.mkdirSync(workspaceDir, { recursive: true });
+  fs.mkdirSync(stateDir, { recursive: true, mode: 0o700 });
+  const env = { ...process.env, LARKIN_CONFIG_DIR: CFG_DIR, LARKIN_HOME: CFG_DIR, LARKIN_PI_DISTRIBUTION: "builtin" };
+  const adapter = createNativeRuntimeAdapter("pi", { env });
+  const readiness = await adapter.probe!({ agentId, workspaceDir, stateDir, env });
+  if (readiness.state !== "ready") throw new Error(readiness.reason || "内置 Pi provider 尚未 ready");
+  const session = await adapter.createSession({
+    agentId, workspaceDir, stateDir, model, env,
+    standingPrompt: { version: "setup-readiness-v1", content: "This is a setup readiness check. Do not use tools.", hash: "setup-readiness-v1" },
+  });
+  const events: string[] = [];
+  let timer: NodeJS.Timeout | null = null;
+  try {
+    const terminal = new Promise<void>((resolve, reject) => {
+      timer = setTimeout(() => reject(new Error("provider readiness turn 60 秒超时")), 60_000);
+      session.subscribe((event) => {
+        if (event.type === "activity" && event.activity === "text" && event.text) events.push(event.text);
+        if (event.type === "input-error" || event.type === "configuration-error" || event.type === "error") {
+          if (timer) clearTimeout(timer);
+          reject(new Error(event.message));
+        } else if (event.type === "turn-end") {
+          if (timer) clearTimeout(timer);
+          if (!events.join("").trim()) reject(new Error("provider readiness turn 未返回可认证文本"));
+          else resolve();
+        }
+      });
+    });
+    const accepted = await session.prompt({ inputId: `setup-${agentId}`, kind: "user", text: "Reply exactly: LARKIN_READY", attempt: 1 });
+    if (accepted.status !== "accepted") throw new Error(accepted.reason || "provider readiness turn 未被接受");
+    await terminal;
+  } finally {
+    if (timer) clearTimeout(timer);
+    await session.close("setup readiness complete");
+  }
 }
 
 function printAgents(config: HydratedConfig): void {
@@ -216,6 +278,7 @@ export async function main(): Promise<void> {
   }
   const loaded = loadConfig();
   const config = loaded.config;
+  const selection = readSetupSelection(options.selectionFile);
   if (options.list) {
     printAgents(config);
     return;
@@ -230,12 +293,18 @@ export async function main(): Promise<void> {
 
   const requestedAgent = options.agent || profile.appId;
   const prior = config.agents[profile.appId];
-  const runtime = options.runtime || prior?.runtime || "pi";
+  const runtime = selection?.runtime || options.runtime || prior?.runtime || "pi";
+  const piDistribution = runtime === "pi"
+    ? (selection?.runtime === "pi" ? selection.distribution : prior?.piDistribution || "external")
+    : undefined;
   validateRuntime(runtime);
   const defaultModel = larkinConfig.defaultModelFor(runtime);
-  const targetModelId = prior?.runtime === runtime ? prior.model : defaultModel;
+  const selectedModel = selection?.runtime === "pi" && selection.distribution === "builtin" ? selection.model : undefined;
+  const targetModelId = selectedModel || (prior?.runtime === runtime ? prior.model : defaultModel);
   let runtimeModels = larkinConfig.loadRuntimeModels()[runtime];
-  if (runtime === "pi") {
+  if (runtime === "pi" && piDistribution === "builtin") {
+    runtimeModels = [{ id: targetModelId, supportedReasoningEfforts: [] }];
+  } else if (runtime === "pi") {
     const piCatalog = await discoverPiModelCatalog({
       cwd: layout.workspaceDir(profile.appId),
       ...(process.env.PI_CODING_AGENT_DIR ? { agentDir: process.env.PI_CODING_AGENT_DIR } : {}),
@@ -249,7 +318,9 @@ export async function main(): Promise<void> {
     config: larkinConfig.toStored(config),
     profile,
     requestedAgent,
-    runtime: options.runtime,
+    runtime: selection?.runtime || options.runtime,
+    ...(selection?.runtime === "pi" ? { piDistribution: selection.distribution } : {}),
+    ...(selectedModel ? { model: selectedModel } : {}),
     defaultModel,
     supportedReasoningEfforts: targetModel!.supportedReasoningEfforts || [],
     now: new Date().toISOString(),
@@ -257,7 +328,34 @@ export async function main(): Promise<void> {
   const bound = stored.agents[profile.appId];
 
   fs.mkdirSync(CFG_DIR, { recursive: true });
-  larkinConfig.commitSetupConfig(process.env, loaded.revision, stored);
+  let providerTransaction: ReturnType<typeof stageBuiltinPiProvider> | null = null;
+  let providerPublished = false;
+  const cancelProviderTransaction = (signal: NodeJS.Signals): void => {
+    if (!providerPublished) providerTransaction?.rollback();
+    process.exit(signal === "SIGINT" ? 130 : 143);
+  };
+  const onSigint = (): void => cancelProviderTransaction("SIGINT");
+  const onSigterm = (): void => cancelProviderTransaction("SIGTERM");
+  process.once("SIGINT", onSigint);
+  process.once("SIGTERM", onSigterm);
+  try {
+    providerTransaction = selection?.runtime === "pi" && selection.distribution === "builtin"
+      ? stageBuiltinPiProvider(CFG_DIR, profile.appId, selection as BuiltinPiProviderSelection)
+      : null;
+    if (selection?.runtime === "pi" && selection.distribution === "builtin") {
+      say("正在验证内置 Pi provider（受控单轮，不发送飞书消息）…");
+      await verifyBuiltinPiProviderTurn(profile.appId, selection.model);
+    }
+    larkinConfig.commitSetupConfig(process.env, loaded.revision, stored);
+    providerTransaction?.commit();
+    providerPublished = true;
+  } catch (error) {
+    providerTransaction?.rollback();
+    throw error;
+  } finally {
+    process.off("SIGINT", onSigint);
+    process.off("SIGTERM", onSigterm);
+  }
   fabricateAttachment(layout.root, stored.serverId);
 
   say(`\n✓ 已写配置: ${CFG_FILE}`);

--- a/src/setup/setup-binding.ts
+++ b/src/setup/setup-binding.ts
@@ -1,6 +1,7 @@
 export type StoredAgent = {
   runtime: string;
   model: string;
+  piDistribution?: "external" | "builtin";
   effort?: string;
   noMentionChats?: string[];
   mentionPolicy?: "require" | "free";
@@ -24,6 +25,7 @@ function cloneAgent(agent: StoredAgent): StoredAgent {
   return {
     runtime: agent.runtime,
     model: agent.model,
+    ...(agent.piDistribution ? { piDistribution: agent.piDistribution } : {}),
     ...(agent.effort ? { effort: agent.effort } : {}),
     ...(agent.mentionPolicy ? { mentionPolicy: agent.mentionPolicy } : {}),
     ...(Object.keys(chatMentionPolicies).length ? { chatMentionPolicies } : {}),
@@ -36,6 +38,8 @@ export function planSingleRootBinding({
   profile,
   requestedAgent,
   runtime,
+  piDistribution,
+  model,
   defaultModel,
   supportedReasoningEfforts,
   now,
@@ -44,6 +48,8 @@ export function planSingleRootBinding({
   profile: BindingProfile;
   requestedAgent?: string;
   runtime?: string;
+  piDistribution?: "external" | "builtin";
+  model?: string;
   defaultModel: string;
   supportedReasoningEfforts: readonly string[];
   now: string;
@@ -59,16 +65,20 @@ export function planSingleRootBinding({
   const agents = Object.fromEntries(Object.entries(config.agents).map(([key, agent]) => [key, cloneAgent(agent)]));
   const prior = agents[profile.appId];
   const nextRuntime = runtime || prior?.runtime || "pi";
+  const nextPiDistribution = nextRuntime === "pi"
+    ? piDistribution || (prior?.runtime === "pi" ? prior.piDistribution : undefined)
+    : undefined;
   if (prior) {
-    const { effort, ...withoutEffort } = prior;
+    const { effort, piDistribution: _priorPiDistribution, ...withoutEffort } = prior;
     agents[profile.appId] = {
       ...withoutEffort,
       runtime: nextRuntime,
-      model: prior.runtime === nextRuntime ? prior.model : defaultModel,
+      model: model || (prior.runtime === nextRuntime ? prior.model : defaultModel),
+      ...(nextPiDistribution ? { piDistribution: nextPiDistribution } : {}),
       ...(effort && supportedReasoningEfforts.includes(effort) ? { effort } : {}),
     };
   } else {
-    agents[profile.appId] = { runtime: nextRuntime, model: "default", createdAt: now };
+    agents[profile.appId] = { runtime: nextRuntime, model: model || "default", ...(nextPiDistribution ? { piDistribution: nextPiDistribution } : {}), createdAt: now };
   }
   return {
     version: 4,

--- a/test/integration/build/bun-only-runtime-contract.test.mjs
+++ b/test/integration/build/bun-only-runtime-contract.test.mjs
@@ -14,6 +14,7 @@ const BUN_RUNNER_SEAM_ALLOWLIST = [
   "test/integration/platform/process-idempotency.test.mjs",
   "test/integration/platform/process-ownership.test.mjs",
   "test/unit/agent/agent-state-store.test.mjs",
+  "test/unit/app/runtime-agent-config-async.test.mjs",
   "test/unit/app/runtime-agent-interface-v2-live-safety.test.mjs",
 ].sort();
 

--- a/test/integration/build/standalone-release.test.mjs
+++ b/test/integration/build/standalone-release.test.mjs
@@ -49,6 +49,10 @@ test.skipIf(!enabled)("native standalone release embeds Dashboard assets, instal
     const manifestA = JSON.parse(fs.readFileSync(path.join(releaseDirA, "release-manifest.json"), "utf8"));
     assert.equal(manifestA.bytecode, false);
     assert.equal(manifestA.artifacts.length, 1);
+    const noticeA = fs.readFileSync(path.join(releaseDirA, "THIRD_PARTY_NOTICES.txt"), "utf8");
+    assert.match(noticeA, /Copyright \(c\) 2025 Mario Zechner/);
+    assert.match(noticeA, /MIT License/);
+    assert.match(fs.readFileSync(path.join(releaseDirA, "SHA256SUMS"), "utf8"), /THIRD_PARTY_NOTICES\.txt/);
     const artifactA = path.join(releaseDirA, manifestA.artifacts[0].file);
     const versionA = spawnSync(artifactA, ["--version"], { encoding: "utf8", env: { PATH: "/usr/bin:/bin" } });
     assert.equal(versionA.status, 0, versionA.stderr);

--- a/test/integration/build/standalone-setup-workflow.test.mjs
+++ b/test/integration/build/standalone-setup-workflow.test.mjs
@@ -1,5 +1,5 @@
 import assert from "node:assert/strict";
-import { spawnSync } from "node:child_process";
+import { spawn, spawnSync } from "node:child_process";
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
@@ -81,6 +81,40 @@ readline.createInterface({ input: process.stdin }).on("line", (line) => {
   return executable;
 }
 
+function startProviderFixture(temp, mode = "success") {
+  const source = path.join(temp, `provider-fixture-${mode}.mjs`);
+  const portFile = path.join(temp, `provider-port-${mode}`);
+  const requestFile = path.join(temp, `provider-request-${mode}`);
+  fs.writeFileSync(source, `import fs from "node:fs";
+import http from "node:http";
+const server = http.createServer((request, response) => {
+  request.resume();
+  request.on("end", () => {
+    fs.writeFileSync(process.env.PROVIDER_REQUEST_FILE, "requested");
+    if (process.env.PROVIDER_MODE === "hang") return;
+    if (process.env.PROVIDER_MODE === "unauthorized") {
+      response.writeHead(401, { "content-type": "application/json" });
+      response.end('{"error":{"message":"invalid fixture key"}}');
+      return;
+    }
+    response.writeHead(200, { "content-type": "text/event-stream", "cache-control": "no-cache" });
+    response.write('data: {"id":"fixture","object":"chat.completion.chunk","created":1,"model":"fixture-model","choices":[{"index":0,"delta":{"role":"assistant","content":"LARKIN_READY"},"finish_reason":null}]}\\n\\n');
+    response.write('data: {"id":"fixture","object":"chat.completion.chunk","created":1,"model":"fixture-model","choices":[{"index":0,"delta":{},"finish_reason":"stop"}],"usage":{"prompt_tokens":1,"completion_tokens":1,"total_tokens":2}}\\n\\n');
+    response.end("data: [DONE]\\n\\n");
+  });
+});
+server.listen(0, "127.0.0.1", () => fs.writeFileSync(process.env.PROVIDER_PORT_FILE, String(server.address().port)));
+`, { mode: 0o600 });
+  const child = spawn(process.execPath, [source], { cwd: temp, env: {
+    ...process.env, PROVIDER_PORT_FILE: portFile, PROVIDER_REQUEST_FILE: requestFile, PROVIDER_MODE: mode,
+  }, stdio: "ignore" });
+  const sleeper = new Int32Array(new SharedArrayBuffer(4));
+  const deadline = Date.now() + 10_000;
+  while (!fs.existsSync(portFile) && Date.now() < deadline) Atomics.wait(sleeper, 0, 0, 20);
+  assert.equal(fs.existsSync(portFile), true, "local provider fixture did not become ready");
+  return { child, requestFile, baseUrl: `http://127.0.0.1:${fs.readFileSync(portFile, "utf8").trim()}/v1` };
+}
+
 test.skipIf(!enabled)("compiled setup-bind and public setup preserve Agent config and propagate lark-channel verification failures", { timeout: 180_000 }, () => {
   const temp = fs.mkdtempSync(path.join(os.tmpdir(), "larkin-standalone-setup-"));
   const releaseDir = path.join(temp, "release");
@@ -88,6 +122,7 @@ test.skipIf(!enabled)("compiled setup-bind and public setup preserve Agent confi
   const binDir = path.join(temp, "bin");
   const firstAgent = "cli_setupExistingA1";
   const secondAgent = "cli_setupAddedB2";
+  let providerFixture;
   try {
     fs.mkdirSync(configDir, { recursive: true, mode: 0o700 });
     fs.mkdirSync(binDir, { recursive: true, mode: 0o700 });
@@ -144,6 +179,78 @@ test.skipIf(!enabled)("compiled setup-bind and public setup preserve Agent confi
     assert.match(publicSetup.stderr + publicSetup.stdout, new RegExp(`Agent ${secondAgent} 已配置`));
 
     fs.writeFileSync(configFile, `${JSON.stringify(initial, null, 2)}\n`, { mode: 0o600 });
+    const builtinBin = path.join(temp, "builtin-bin");
+    fs.mkdirSync(builtinBin, { mode: 0o700 });
+    writeLarkCli(builtinBin);
+    const builtinEnv = {
+      ...baseEnv,
+      PATH: `${builtinBin}${path.delimiter}/usr/bin:/bin`,
+      SETUP_LARK_CALLS: path.join(temp, "builtin-lark-calls"),
+      LARKIN_TEST_BOT_REGISTER_MODULE: writeRegisterFixture(temp),
+      LARKIN_PI_COMMAND: path.join(temp, "definitely-not-installed-pi"),
+      LARKIN_CODEX_COMMAND: path.join(temp, "definitely-not-installed-codex"),
+      LARKIN_CLAUDE_COMMAND: path.join(temp, "definitely-not-installed-claude"),
+      LARKIN_TEST_ENABLE_AGENT_CHOICE: "1",
+    };
+    providerFixture = startProviderFixture(temp);
+    const builtinSetup = spawnSync(artifact, ["setup", "--no-start"], {
+      cwd: temp, env: builtinEnv, input: `1\n2\n5\n${providerFixture.baseUrl}\nfixture-model\nstandalone-provider-secret\n`, encoding: "utf8", timeout: 60_000,
+    });
+    checked(builtinSetup, "compiled public setup with bundled official Pi and no external Agent CLI");
+    const builtinConfigured = JSON.parse(fs.readFileSync(configFile, "utf8"));
+    assert.equal(builtinConfigured.agents[secondAgent].runtime, "pi");
+    assert.equal(builtinConfigured.agents[secondAgent].piDistribution, "builtin");
+    assert.equal(builtinConfigured.agents[secondAgent].model, "larkin-custom/fixture-model");
+    assert.doesNotMatch(fs.readFileSync(configFile, "utf8"), /standalone-provider-secret/);
+    assert.doesNotMatch(builtinSetup.stdout + builtinSetup.stderr, /standalone-provider-secret/);
+    const piAuth = path.join(configDir, "providers", "pi", secondAgent, "auth.json");
+    assert.equal(fs.statSync(path.dirname(piAuth)).mode & 0o777, 0o700);
+    assert.equal(fs.statSync(piAuth).mode & 0o777, 0o600);
+    assert.equal(JSON.parse(fs.readFileSync(piAuth, "utf8"))["larkin-custom"].key, "standalone-provider-secret");
+
+    providerFixture.child.kill();
+    providerFixture = undefined;
+    fs.writeFileSync(configFile, `${JSON.stringify(initial, null, 2)}\n`, { mode: 0o600 });
+    const oldAuth = `${JSON.stringify({ legacy: { type: "api_key", key: "old-provider-key" } }, null, 2)}\n`;
+    const piModels = path.join(path.dirname(piAuth), "models.json");
+    const oldModels = fs.readFileSync(piModels, "utf8");
+    fs.writeFileSync(piAuth, oldAuth, { mode: 0o600 });
+    providerFixture = startProviderFixture(temp, "unauthorized");
+    const rejectedSetup = spawnSync(artifact, ["setup", "--no-start"], {
+      cwd: temp, env: builtinEnv,
+      input: `1\n2\n5\n${providerFixture.baseUrl}\nfixture-model\nrejected-provider-secret\n`,
+      encoding: "utf8", timeout: 60_000,
+    });
+    assert.notEqual(rejectedSetup.status, 0, rejectedSetup.stdout + rejectedSetup.stderr);
+    assert.deepEqual(JSON.parse(fs.readFileSync(configFile, "utf8")), initial);
+    assert.equal(fs.readFileSync(piAuth, "utf8"), oldAuth, "401 must restore prior auth bytes");
+    assert.equal(fs.readFileSync(piModels, "utf8"), oldModels, "401 must restore prior model bytes");
+    assert.doesNotMatch(rejectedSetup.stdout + rejectedSetup.stderr, /rejected-provider-secret/);
+
+    providerFixture.child.kill();
+    providerFixture = startProviderFixture(temp, "hang");
+    const selectionFile = path.join(configDir, `.setup-agent-choice-${process.pid}-${Date.now()}.json`);
+    fs.writeFileSync(selectionFile, `${JSON.stringify({ runtime: "pi", distribution: "builtin", preset: "custom",
+      baseUrl: providerFixture.baseUrl, model: "larkin-custom/fixture-model", apiKey: "cancelled-provider-secret" })}\n`, { mode: 0o600 });
+    const cancelledSetup = spawn(artifact, ["__internal", "setup-bind", "--profile", secondAgent, "--agent", secondAgent,
+      "--selection-file", selectionFile, "--yes"], { cwd: temp, env: builtinEnv, stdio: "ignore" });
+    const sleeper = new Int32Array(new SharedArrayBuffer(4));
+    const requestDeadline = Date.now() + 20_000;
+    while (!fs.existsSync(providerFixture.requestFile) && Date.now() < requestDeadline) Atomics.wait(sleeper, 0, 0, 20);
+    assert.equal(fs.existsSync(providerFixture.requestFile), true, "cancel test did not reach provider verification");
+    assert.equal(JSON.parse(fs.readFileSync(piAuth, "utf8"))["larkin-custom"].key, "cancelled-provider-secret",
+      "cancel test must observe the staged credential before signalling");
+    cancelledSetup.kill("SIGTERM");
+    const rollbackDeadline = Date.now() + 10_000;
+    while (fs.readFileSync(piAuth, "utf8") !== oldAuth && Date.now() < rollbackDeadline) Atomics.wait(sleeper, 0, 0, 20);
+    assert.equal(fs.readFileSync(piAuth, "utf8"), oldAuth, "SIGTERM must restore prior auth bytes");
+    assert.equal(fs.readFileSync(piModels, "utf8"), oldModels, "SIGTERM must restore prior model bytes");
+    assert.deepEqual(JSON.parse(fs.readFileSync(configFile, "utf8")), initial);
+
+    providerFixture.child.kill();
+    providerFixture = undefined;
+
+    fs.writeFileSync(configFile, `${JSON.stringify(initial, null, 2)}\n`, { mode: 0o600 });
     fs.rmSync(baseEnv.SETUP_LARK_CALLS, { force: true });
     const publicFailed = spawnSync(artifact, ["setup", "--runtime", "codex", "--no-start"], {
       cwd: temp, env: { ...publicEnv, SETUP_FAIL_BIND_VERIFY: "1" }, encoding: "utf8", timeout: 30_000,
@@ -158,6 +265,7 @@ test.skipIf(!enabled)("compiled setup-bind and public setup preserve Agent confi
     assert.equal(fs.existsSync(path.join(configDir, "state", "agents", secondAgent, "lark-cli-config", "lark-channel", "config.json")), true,
       "verification failure must preserve the successful official workspace binding");
   } finally {
+    providerFixture?.child.kill();
     fs.rmSync(temp, { recursive: true, force: true });
   }
 });

--- a/test/integration/build/standalone-setup-workflow.test.mjs
+++ b/test/integration/build/standalone-setup-workflow.test.mjs
@@ -34,6 +34,17 @@ printf '%s\n' "$*" >> "$SETUP_LARK_CALLS"
 if [ "$1" = "profile" ] && [ "$2" = "list" ]; then
   printf '[{"name":"%s","appId":"%s","active":true}]\n' "$SETUP_APP_ID" "$SETUP_APP_ID"
 elif printf '%s\n' "$*" | grep -q '+chat-list'; then
+    if [ "$SETUP_OVERFLOW_BIND_VERIFY" = "1" ]; then
+      head -c 131072 /dev/zero | tr '\\0' x
+      exit 0
+    fi
+    if [ "$SETUP_HANG_BIND_VERIFY" = "1" ]; then
+      if [ "$SETUP_IGNORE_TERM_BIND_VERIFY" = "1" ]; then
+        exec ${JSON.stringify(process.execPath)} --eval 'const fs=require("node:fs");process.on("SIGTERM",()=>fs.writeFileSync(process.env.SETUP_TERM_MARKER,"term"));fs.writeFileSync(process.env.SETUP_IDENTITY_MARKER,"ready");setTimeout(()=>fs.writeFileSync(process.env.SETUP_LATE_WORKSPACE_MARKER,"late-workspace-write"),3000);setInterval(()=>{},1000)'
+      fi
+      : > "$SETUP_IDENTITY_MARKER"
+      while :; do sleep 1; done
+    fi
     if [ "$SETUP_FAIL_BIND_VERIFY" = "1" ] || { [ "$SETUP_FAIL_BIND_VERIFY" = "second" ] && [ "$count" -ge 1 ]; }; then
       printf '%s\n' '{"ok":false,"identity":"bot"}'
       exit 1
@@ -61,6 +72,38 @@ export function spawnSync(command, args, options) {
   return fixture;
 }
 
+function writePiAuthFixture(temp) {
+  const fixture = path.join(temp, "pi-auth-fixture.mjs");
+  fs.writeFileSync(fixture, `import fs from "node:fs";
+export function configure(runtime) {
+  runtime.registerNativeProvider({
+    id: "fixture-oauth", name: "Fixture OAuth", baseUrl: "https://fixture.invalid",
+    auth: { oauth: {
+      name: "Fixture subscription",
+      async login(interaction) {
+        const observed = [];
+        interaction.notify({ type: "info", message: "fixture info", links: [{ label: "docs", url: "https://fixture.invalid/docs?redacted=test" }] });
+        interaction.notify({ type: "auth_url", url: "https://fixture.invalid/authorize?state=fixture-state", instructions: "fixture browser" });
+        interaction.notify({ type: "device_code", userCode: "FIXTURE-CODE", verificationUri: "https://fixture.invalid/device", intervalSeconds: 1 });
+        interaction.notify({ type: "progress", message: "fixture progress" });
+        observed.push(["text", (await interaction.prompt({ type: "text", message: "fixture text" })).length]);
+        observed.push(["secret", (await interaction.prompt({ type: "secret", message: "fixture secret" })).length]);
+        observed.push(["select", await interaction.prompt({ type: "select", message: "fixture select", options: [{ id: "first", label: "First" }, { id: "second", label: "Second" }] })]);
+        observed.push(["manual_code", (await interaction.prompt({ type: "manual_code", message: "fixture manual" })).length]);
+        fs.writeFileSync(process.env.LARKIN_TEST_PI_AUTH_TRACE, JSON.stringify(observed));
+        if (process.env.LARKIN_TEST_PI_AUTH_FAIL === "1") throw new Error("controlled fixture login failure");
+        return { type: "oauth", access: "fixture-access-not-output", refresh: "fixture-refresh-not-output", expires: Date.now() + 3600000 };
+      },
+      async refresh(credential) { return credential; }, async toAuth(credential) { return { apiKey: credential.access }; },
+    } },
+    getModels() { return [{ provider: "fixture-oauth", id: "fixture-model", name: "Fixture", api: "openai-completions", baseUrl: "https://fixture.invalid", reasoning: false, input: ["text"], contextWindow: 1000, maxTokens: 100 }]; },
+    stream() { throw new Error("not used"); }, streamSimple() { throw new Error("not used"); },
+  });
+}
+`, { mode: 0o600 });
+  return fixture;
+}
+
 function writeCodexFixture(temp, binDir) {
   const source = path.join(temp, "codex-fixture.mjs");
   const executable = path.join(binDir, "codex");
@@ -82,9 +125,10 @@ readline.createInterface({ input: process.stdin }).on("line", (line) => {
 }
 
 function startProviderFixture(temp, mode = "success") {
-  const source = path.join(temp, `provider-fixture-${mode}.mjs`);
-  const portFile = path.join(temp, `provider-port-${mode}`);
-  const requestFile = path.join(temp, `provider-request-${mode}`);
+  const instance = `${mode}-${Date.now()}-${Math.random().toString(16).slice(2)}`;
+  const source = path.join(temp, `provider-fixture-${instance}.mjs`);
+  const portFile = path.join(temp, `provider-port-${instance}`);
+  const requestFile = path.join(temp, `provider-request-${instance}`);
   fs.writeFileSync(source, `import fs from "node:fs";
 import http from "node:http";
 const server = http.createServer((request, response) => {
@@ -115,7 +159,7 @@ server.listen(0, "127.0.0.1", () => fs.writeFileSync(process.env.PROVIDER_PORT_F
   return { child, requestFile, baseUrl: `http://127.0.0.1:${fs.readFileSync(portFile, "utf8").trim()}/v1` };
 }
 
-test.skipIf(!enabled)("compiled setup-bind and public setup preserve Agent config and propagate lark-channel verification failures", { timeout: 180_000 }, () => {
+test.skipIf(!enabled)("compiled setup-bind and public setup preserve Agent config and propagate lark-channel verification failures", { timeout: 180_000 }, async () => {
   const temp = fs.mkdtempSync(path.join(os.tmpdir(), "larkin-standalone-setup-"));
   const releaseDir = path.join(temp, "release");
   const configDir = path.join(temp, "config");
@@ -215,6 +259,128 @@ test.skipIf(!enabled)("compiled setup-bind and public setup preserve Agent confi
     const piModels = path.join(path.dirname(piAuth), "models.json");
     const oldModels = fs.readFileSync(piModels, "utf8");
     fs.writeFileSync(piAuth, oldAuth, { mode: 0o600 });
+
+    const managementEnv = { ...builtinEnv, LARKIN_TEST_PI_AUTH_PROVIDER_MODULE: writePiAuthFixture(temp),
+      LARKIN_TEST_PI_AUTH_TRACE: path.join(temp, "unused-management-trace.json") };
+    const managedAuth = `${JSON.stringify({
+      "fixture-oauth": { type: "oauth", access: "managed-access", refresh: "managed-refresh", expires: Date.now() + 3_600_000 },
+      legacy: { type: "api_key", key: "old-provider-key" },
+    }, null, 2)}\n`;
+    const initialConfigBytes = fs.readFileSync(configFile);
+    for (const cancellation of ["EOF", "SIGINT", "SIGTERM"]) {
+      fs.writeFileSync(piAuth, managedAuth, { mode: 0o600 });
+      fs.writeFileSync(piModels, oldModels, { mode: 0o600 });
+      fs.writeFileSync(configFile, initialConfigBytes, { mode: 0o600 });
+      if (cancellation === "EOF") {
+        const cancelled = spawnSync(artifact, ["setup", "--no-start"], {
+          cwd: temp, env: managementEnv, input: "1\n2\n7\n1\n", encoding: "utf8", timeout: 30_000,
+        });
+        assert.notEqual(cancelled.status, 0, "EOF after setup logout must cancel the setup");
+      } else {
+        const cancelled = spawn(artifact, ["setup", "--no-start"], {
+          cwd: temp, env: managementEnv, stdio: ["pipe", "pipe", "pipe"],
+        });
+        let output = "";
+        cancelled.stdout.on("data", (chunk) => { output += String(chunk); });
+        cancelled.stderr.on("data", (chunk) => { output += String(chunk); });
+        cancelled.stdin.write("1\n2\n7\n1\n");
+        const logoutDeadline = Date.now() + 20_000;
+        let observedLogout = false;
+        while (Date.now() < logoutDeadline) {
+          try { observedLogout = JSON.parse(fs.readFileSync(piAuth, "utf8"))["fixture-oauth"] === undefined; } catch { /* atomic replacement */ }
+          if (observedLogout) break;
+          await new Promise((resolve) => setTimeout(resolve, 20));
+        }
+        assert.equal(observedLogout, true, `${cancellation} test did not observe setup logout: ${output}`);
+        cancelled.kill(cancellation);
+      }
+      const rollbackDeadline = Date.now() + 10_000;
+      while (fs.readFileSync(piAuth, "utf8") !== managedAuth && Date.now() < rollbackDeadline) await new Promise((resolve) => setTimeout(resolve, 20));
+      assert.equal(fs.readFileSync(piAuth, "utf8"), managedAuth, `${cancellation} after logout must restore exact auth bytes`);
+      assert.equal(fs.readFileSync(piModels, "utf8"), oldModels, `${cancellation} after logout must restore exact model bytes`);
+      assert.deepEqual(fs.readFileSync(configFile), initialConfigBytes, `${cancellation} after logout must restore exact config bytes`);
+    }
+
+    providerFixture = startProviderFixture(temp);
+    for (const downstreamFailure of ["identity", "result-file", "identity-timeout", "identity-overflow"]) {
+      fs.writeFileSync(piAuth, oldAuth, { mode: 0o600 });
+      fs.writeFileSync(piModels, oldModels, { mode: 0o600 });
+      fs.writeFileSync(configFile, initialConfigBytes, { mode: 0o600 });
+      fs.rmSync(managementEnv.SETUP_LARK_CALLS, { force: true });
+      const transientSecret = `${downstreamFailure}-credential-must-rollback`;
+      const args = downstreamFailure === "result-file"
+        ? ["__internal", "bot-register", "--auto", "--result-file", path.join(configDir, ".setup-result-777.json")]
+        : ["setup", "--no-start"];
+      if (downstreamFailure === "result-file") {
+        fs.writeFileSync(args.at(-1), "occupied", { mode: 0o600 });
+      }
+      const failedAfterAuth = spawnSync(artifact, args, {
+        cwd: temp,
+        env: {
+          ...builtinEnv,
+          ...(downstreamFailure === "identity" ? { SETUP_FAIL_BIND_VERIFY: "1" } : {}),
+          ...(downstreamFailure === "identity-timeout" ? { LARKIN_TEST_ASYNC_IDENTITY: "1", SETUP_HANG_BIND_VERIFY: "1",
+            SETUP_IDENTITY_MARKER: path.join(temp, "identity-timeout-marker"), LARKIN_TEST_CHILD_TIMEOUT_MS: "100" } : {}),
+          ...(downstreamFailure === "identity-overflow" ? { LARKIN_TEST_ASYNC_IDENTITY: "1", SETUP_OVERFLOW_BIND_VERIFY: "1",
+            LARKIN_TEST_CHILD_MAX_OUTPUT_BYTES: "1024" } : {}),
+        },
+        input: `1\n2\n5\n${providerFixture.baseUrl}\nfixture-model\n${transientSecret}\n`,
+        encoding: "utf8", timeout: 60_000,
+      });
+      assert.notEqual(failedAfterAuth.status, 0, `${downstreamFailure} must fail after provider auth`);
+      assert.equal(fs.readFileSync(piAuth, "utf8"), oldAuth, `${downstreamFailure} must restore exact auth bytes`);
+      assert.equal(fs.readFileSync(piModels, "utf8"), oldModels, `${downstreamFailure} must restore exact model bytes`);
+      assert.doesNotMatch(failedAfterAuth.stdout + failedAfterAuth.stderr, new RegExp(transientSecret));
+      const committedConfig = JSON.parse(fs.readFileSync(configFile, "utf8"));
+      assert.ok(committedConfig.agents[secondAgent], `${downstreamFailure} failed before setup-bind commit:\n${failedAfterAuth.stdout}\n${failedAfterAuth.stderr}`);
+      assert.equal(committedConfig.agents[secondAgent].runtime, "pi",
+        `${downstreamFailure}: setup-bind canonical config is already committed by its existing contract`);
+      assert.equal(committedConfig.agents[secondAgent].piDistribution, "builtin");
+      if (downstreamFailure === "result-file") fs.rmSync(args.at(-1), { force: true });
+    }
+    for (const signal of ["SIGINT", "SIGTERM"]) {
+      fs.writeFileSync(piAuth, oldAuth, { mode: 0o600 });
+      fs.writeFileSync(piModels, oldModels, { mode: 0o600 });
+      fs.writeFileSync(configFile, initialConfigBytes, { mode: 0o600 });
+      const identityMarker = path.join(temp, `identity-${signal}`);
+      const termMarker = path.join(temp, `identity-${signal}-term`);
+      const lateWorkspaceMarker = path.join(temp, `identity-${signal}-late-workspace`);
+      const transientSecret = `identity-${signal.toLowerCase()}-credential-must-rollback`;
+      const signalled = spawn(artifact, ["__internal", "bot-register", "--auto"], {
+        cwd: temp, env: { ...builtinEnv, LARKIN_TEST_ASYNC_IDENTITY: "1", SETUP_HANG_BIND_VERIFY: "1",
+          SETUP_IDENTITY_MARKER: identityMarker, SETUP_IGNORE_TERM_BIND_VERIFY: "1", SETUP_TERM_MARKER: termMarker,
+          SETUP_LATE_WORKSPACE_MARKER: lateWorkspaceMarker }, stdio: ["pipe", "pipe", "pipe"],
+      });
+      const signalledExit = new Promise((resolve) => signalled.once("exit", resolve));
+      let signalledOutput = "";
+      signalled.stdout.on("data", (chunk) => { signalledOutput += String(chunk); });
+      signalled.stderr.on("data", (chunk) => { signalledOutput += String(chunk); });
+      signalled.stdin.end(`1\n2\n5\n${providerFixture.baseUrl}\nfixture-model\n${transientSecret}\n`);
+      const identityDeadline = Date.now() + 20_000;
+      while (!fs.existsSync(identityMarker) && Date.now() < identityDeadline) await new Promise((resolve) => setTimeout(resolve, 20));
+      assert.equal(fs.existsSync(identityMarker), true, `${signal} did not reach post-auth identity verification: ${signalledOutput}`);
+      assert.equal(JSON.parse(fs.readFileSync(piAuth, "utf8"))["larkin-custom"].key, transientSecret);
+      signalled.kill(signal);
+      const termDeadline = Date.now() + 3_000;
+      while (!fs.existsSync(termMarker) && Date.now() < termDeadline) await new Promise((resolve) => setTimeout(resolve, 20));
+      assert.equal(fs.existsSync(termMarker), true, `${signal}: identity child did not receive graceful SIGTERM`);
+      const rollbackDeadline = Date.now() + 10_000;
+      while (fs.readFileSync(piAuth, "utf8") !== oldAuth && Date.now() < rollbackDeadline) await new Promise((resolve) => setTimeout(resolve, 20));
+      assert.equal(fs.readFileSync(piAuth, "utf8"), oldAuth, `${signal} during identity must restore exact auth bytes`);
+      assert.equal(fs.readFileSync(piModels, "utf8"), oldModels, `${signal} during identity must restore exact model bytes`);
+      assert.doesNotMatch(signalledOutput, new RegExp(transientSecret));
+      const committedConfig = JSON.parse(fs.readFileSync(configFile, "utf8"));
+      assert.equal(committedConfig.agents[secondAgent].runtime, "pi", `${signal}: setup-bind config remains committed by contract`);
+      const exitCode = await signalledExit;
+      assert.equal(exitCode, signal === "SIGINT" ? 130 : 143, `${signal}: parent must exit only after child SIGKILL settles`);
+      await new Promise((resolve) => setTimeout(resolve, 2_500));
+      assert.equal(fs.existsSync(lateWorkspaceMarker), false, `${signal}: killed identity child must not write workspace state later`);
+    }
+    providerFixture.child.kill();
+    providerFixture = undefined;
+
+    fs.writeFileSync(configFile, initialConfigBytes, { mode: 0o600 });
+    fs.writeFileSync(piAuth, oldAuth, { mode: 0o600 });
     providerFixture = startProviderFixture(temp, "unauthorized");
     const rejectedSetup = spawnSync(artifact, ["setup", "--no-start"], {
       cwd: temp, env: builtinEnv,
@@ -229,23 +395,84 @@ test.skipIf(!enabled)("compiled setup-bind and public setup preserve Agent confi
 
     providerFixture.child.kill();
     providerFixture = startProviderFixture(temp, "hang");
-    const selectionFile = path.join(configDir, `.setup-agent-choice-${process.pid}-${Date.now()}.json`);
-    fs.writeFileSync(selectionFile, `${JSON.stringify({ runtime: "pi", distribution: "builtin", preset: "custom",
-      baseUrl: providerFixture.baseUrl, model: "larkin-custom/fixture-model", apiKey: "cancelled-provider-secret" })}\n`, { mode: 0o600 });
-    const cancelledSetup = spawn(artifact, ["__internal", "setup-bind", "--profile", secondAgent, "--agent", secondAgent,
-      "--selection-file", selectionFile, "--yes"], { cwd: temp, env: builtinEnv, stdio: "ignore" });
-    const sleeper = new Int32Array(new SharedArrayBuffer(4));
-    const requestDeadline = Date.now() + 20_000;
-    while (!fs.existsSync(providerFixture.requestFile) && Date.now() < requestDeadline) Atomics.wait(sleeper, 0, 0, 20);
-    assert.equal(fs.existsSync(providerFixture.requestFile), true, "cancel test did not reach provider verification");
-    assert.equal(JSON.parse(fs.readFileSync(piAuth, "utf8"))["larkin-custom"].key, "cancelled-provider-secret",
-      "cancel test must observe the staged credential before signalling");
-    cancelledSetup.kill("SIGTERM");
-    const rollbackDeadline = Date.now() + 10_000;
-    while (fs.readFileSync(piAuth, "utf8") !== oldAuth && Date.now() < rollbackDeadline) Atomics.wait(sleeper, 0, 0, 20);
-    assert.equal(fs.readFileSync(piAuth, "utf8"), oldAuth, "SIGTERM must restore prior auth bytes");
-    assert.equal(fs.readFileSync(piModels, "utf8"), oldModels, "SIGTERM must restore prior model bytes");
-    assert.deepEqual(JSON.parse(fs.readFileSync(configFile, "utf8")), initial);
+    for (const signal of ["SIGTERM", "SIGINT"]) {
+      fs.rmSync(providerFixture.requestFile, { force: true });
+      const selectionFile = path.join(configDir, `.setup-agent-choice-${process.pid}-${Date.now()}-${signal}.json`);
+      fs.writeFileSync(selectionFile, `${JSON.stringify({ runtime: "pi", distribution: "builtin", preset: "custom",
+        baseUrl: providerFixture.baseUrl, model: "larkin-custom/fixture-model" })}\n`, { mode: 0o600 });
+      const cancelledSetup = spawn(artifact, ["__internal", "setup-bind", "--profile", secondAgent, "--agent", secondAgent,
+        "--selection-file", selectionFile, "--yes"], { cwd: temp, env: builtinEnv, stdio: ["pipe", "pipe", "pipe"] });
+      let cancelledOutput = "";
+      cancelledSetup.stdout.on("data", (chunk) => { cancelledOutput += String(chunk); });
+      cancelledSetup.stderr.on("data", (chunk) => { cancelledOutput += String(chunk); });
+      const stagedSecret = `cancelled-provider-${signal.toLowerCase()}-secret`;
+      cancelledSetup.stdin.end(`${stagedSecret}\n`);
+      const requestDeadline = Date.now() + 20_000;
+      while (!fs.existsSync(providerFixture.requestFile) && Date.now() < requestDeadline) await new Promise((resolve) => setTimeout(resolve, 20));
+      assert.equal(fs.existsSync(providerFixture.requestFile), true, `${signal} cancel test did not reach provider verification: ${cancelledOutput}`);
+      assert.equal(JSON.parse(fs.readFileSync(piAuth, "utf8"))["larkin-custom"].key, stagedSecret,
+        `${signal} cancel test must observe the staged credential before signalling`);
+      cancelledSetup.kill(signal);
+      const rollbackDeadline = Date.now() + 10_000;
+      while (fs.readFileSync(piAuth, "utf8") !== oldAuth && Date.now() < rollbackDeadline) await new Promise((resolve) => setTimeout(resolve, 20));
+      assert.equal(fs.readFileSync(piAuth, "utf8"), oldAuth, `${signal} must restore prior auth bytes`);
+      assert.equal(fs.readFileSync(piModels, "utf8"), oldModels, `${signal} must restore prior model bytes`);
+      assert.deepEqual(JSON.parse(fs.readFileSync(configFile, "utf8")), initial);
+    }
+
+    fs.writeFileSync(configFile, `${JSON.stringify(initial, null, 2)}\n`, { mode: 0o600 });
+    fs.writeFileSync(piAuth, oldAuth, { mode: 0o600 });
+    fs.writeFileSync(piModels, oldModels, { mode: 0o600 });
+    const oauthSelectionFile = path.join(configDir, `.setup-agent-choice-${process.pid}-${Date.now()}-oauth.json`);
+    fs.writeFileSync(oauthSelectionFile, `${JSON.stringify({ runtime: "pi", distribution: "builtin", preset: "official",
+      providerId: "fixture-oauth", authType: "oauth", model: "fixture-oauth/fixture-model" })}\n`, { mode: 0o600 });
+    const authTrace = path.join(temp, "pi-auth-trace.json");
+    const oauthEnv = { ...builtinEnv, LARKIN_TEST_PI_AUTH_PROVIDER_MODULE: writePiAuthFixture(temp),
+      LARKIN_TEST_PI_AUTH_TRACE: authTrace, LARKIN_TEST_SKIP_BUILTIN_PI_PROVIDER_TURN: "1" };
+    const oauthSetup = spawnSync(artifact, ["__internal", "setup-bind", "--profile", secondAgent, "--agent", secondAgent,
+      "--selection-file", oauthSelectionFile, "--yes"], {
+      cwd: temp, env: oauthEnv, input: "visible text\noauth-secret-sentinel\n2\nmanual-code-sentinel\n", encoding: "utf8", timeout: 30_000,
+    });
+    checked(oauthSetup, "compiled official OAuth prompt/event bridge");
+    assert.deepEqual(JSON.parse(fs.readFileSync(authTrace, "utf8")), [
+      ["text", 12], ["secret", 21], ["select", "second"], ["manual_code", 20],
+    ]);
+    const oauthOutput = oauthSetup.stdout + oauthSetup.stderr;
+    assert.match(oauthOutput, /fixture info[\s\S]*登录地址[\s\S]*FIXTURE-CODE[\s\S]*fixture progress/);
+    assert.doesNotMatch(oauthOutput, /oauth-secret-sentinel|manual-code-sentinel|fixture-access-not-output|fixture-refresh-not-output/);
+    const oauthAuth = JSON.parse(fs.readFileSync(piAuth, "utf8"));
+    assert.equal(oauthAuth["fixture-oauth"].type, "oauth");
+    assert.equal(oauthAuth.legacy.key, "old-provider-key");
+    assert.doesNotMatch(fs.readFileSync(configFile, "utf8"), /fixture-access-not-output|fixture-refresh-not-output|oauth-secret-sentinel/);
+
+    const oauthLogout = spawnSync(artifact, ["pi-auth", "logout", "fixture-oauth", "--agent", secondAgent], {
+      cwd: temp, env: oauthEnv, encoding: "utf8", timeout: 30_000,
+    });
+    checked(oauthLogout, "compiled official OAuth logout");
+    const afterLogout = JSON.parse(fs.readFileSync(piAuth, "utf8"));
+    assert.equal(afterLogout["fixture-oauth"], undefined);
+    assert.equal(afterLogout.legacy.key, "old-provider-key");
+
+    const beforeFailedAuth = fs.readFileSync(piAuth);
+    const beforeFailedModels = fs.readFileSync(piModels);
+    const beforeFailedConfig = fs.readFileSync(configFile);
+    const modelsStore = path.join(path.dirname(piAuth), "models-store.json");
+    const beforeFailedModelsStore = fs.existsSync(modelsStore) ? fs.readFileSync(modelsStore) : null;
+    const failedSelectionFile = path.join(configDir, `.setup-agent-choice-${process.pid}-${Date.now()}-login-fail.json`);
+    fs.writeFileSync(failedSelectionFile, `${JSON.stringify({ runtime: "pi", distribution: "builtin", preset: "official",
+      providerId: "fixture-oauth", authType: "oauth", model: "fixture-oauth/fixture-model" })}\n`, { mode: 0o600 });
+    const failedLogin = spawnSync(artifact, ["__internal", "setup-bind", "--profile", secondAgent, "--agent", secondAgent,
+      "--selection-file", failedSelectionFile, "--yes"], {
+      cwd: temp, env: { ...oauthEnv, LARKIN_TEST_PI_AUTH_FAIL: "1" },
+      input: "visible text\nfailed-secret-sentinel\n1\nfailed-manual-sentinel\n", encoding: "utf8", timeout: 30_000,
+    });
+    assert.notEqual(failedLogin.status, 0);
+    assert.deepEqual(fs.readFileSync(piAuth), beforeFailedAuth, "login failure must restore exact auth bytes");
+    assert.deepEqual(fs.readFileSync(piModels), beforeFailedModels, "login failure must restore exact model bytes");
+    assert.deepEqual(fs.readFileSync(configFile), beforeFailedConfig, "login failure must restore exact config bytes");
+    assert.deepEqual(fs.existsSync(modelsStore) ? fs.readFileSync(modelsStore) : null, beforeFailedModelsStore,
+      "login failure must restore exact models-store bytes");
+    assert.doesNotMatch(failedLogin.stdout + failedLogin.stderr, /failed-secret-sentinel|failed-manual-sentinel/);
 
     providerFixture.child.kill();
     providerFixture = undefined;

--- a/test/integration/runtime/builtin-pi-local-provider.test.mjs
+++ b/test/integration/runtime/builtin-pi-local-provider.test.mjs
@@ -1,0 +1,131 @@
+import { test } from "bun:test";
+import assert from "node:assert/strict";
+import { spawn, spawnSync } from "node:child_process";
+import fs from "node:fs";
+import http from "node:http";
+import os from "node:os";
+import path from "node:path";
+import { createNativeRuntimeAdapter } from "../../../dist/runtime/runtime-adapters.mjs";
+import { PiRpcClient } from "../../../dist/runtime/pi-rpc-client.mjs";
+import { stageBuiltinPiProvider } from "../../../dist/runtime/pi-provider-config.mjs";
+
+const ROOT = path.resolve(import.meta.dirname, "../../..");
+
+async function exerciseBuiltinPiTurn(binaryEntryPath, prefix, compiled = false) {
+  const temp = fs.mkdtempSync(path.join(os.tmpdir(), prefix));
+  let observedAuthorization = "";
+  let observedModel = "";
+  const server = http.createServer((request, response) => {
+    let body = "";
+    request.setEncoding("utf8");
+    request.on("data", (chunk) => { body += chunk; });
+    request.on("end", () => {
+      observedAuthorization = String(request.headers.authorization || "");
+      try { observedModel = JSON.parse(body).model; } catch { /* assertion below */ }
+      response.writeHead(200, { "content-type": "text/event-stream", "cache-control": "no-cache" });
+      response.write(`data: ${JSON.stringify({ id: "fixture", object: "chat.completion.chunk", created: 1, model: "fixture-model", choices: [{ index: 0, delta: { role: "assistant", content: "LARKIN_READY" }, finish_reason: null }] })}\n\n`);
+      response.write(`data: ${JSON.stringify({ id: "fixture", object: "chat.completion.chunk", created: 1, model: "fixture-model", choices: [{ index: 0, delta: {}, finish_reason: "stop" }], usage: { prompt_tokens: 1, completion_tokens: 1, total_tokens: 2 } })}\n\n`);
+      response.end("data: [DONE]\n\n");
+    });
+  });
+  await new Promise((resolve, reject) => { server.once("error", reject); server.listen(0, "127.0.0.1", resolve); });
+  try {
+    fs.chmodSync(temp, 0o700);
+    const address = server.address();
+    assert.equal(typeof address, "object");
+    const agentId = "cli_builtinPiA1";
+    const transaction = stageBuiltinPiProvider(temp, agentId, {
+      distribution: "builtin", preset: "custom", baseUrl: `http://127.0.0.1:${address.port}/v1`,
+      apiKey: "fixture-provider-key", model: "fixture-model",
+    });
+    transaction.commit();
+    const workspaceDir = path.join(temp, "agents", agentId);
+    const stateDir = path.join(temp, "state", "agents", agentId);
+    fs.mkdirSync(workspaceDir, { recursive: true });
+    fs.mkdirSync(stateDir, { recursive: true });
+    const env = {
+      PATH: "/usr/bin:/bin",
+      LARKIN_CONFIG_DIR: temp,
+      LARKIN_HOME: temp,
+      LARKIN_PI_DISTRIBUTION: "builtin",
+      LARKIN_BINARY_ENTRY_PATH: binaryEntryPath,
+    };
+    if (compiled) {
+      const child = spawn(binaryEntryPath, ["__internal", "pi-rpc", "--mode", "rpc", "--no-session",
+        "--model", "larkin-custom/fixture-model"], {
+        cwd: workspaceDir,
+        env: { ...env, PI_CODING_AGENT_DIR: path.join(temp, "providers", "pi", agentId), PI_TELEMETRY: "0" },
+        stdio: ["pipe", "pipe", "pipe"],
+      });
+      const client = new PiRpcClient(child, { requestTimeoutMs: 15_000 });
+      const events = [];
+      const terminal = new Promise((resolve, reject) => {
+        const timer = setTimeout(() => reject(new Error(`timed out waiting for compiled Pi turn: ${JSON.stringify(events)}`)), 15_000);
+        client.subscribe((event) => {
+          events.push(event);
+          if (event.type === "agent_end") { clearTimeout(timer); resolve(); }
+        });
+        client.subscribeFailure((error) => { clearTimeout(timer); reject(error); });
+      });
+      const state = await client.request("get_state");
+      assert.equal(`${state.model.provider}/${state.model.id}`, "larkin-custom/fixture-model");
+      await client.request("prompt", { message: "Reply exactly LARKIN_READY" });
+      await terminal;
+      await client.close();
+      assert.equal(observedAuthorization, "Bearer fixture-provider-key");
+      assert.equal(observedModel, "fixture-model");
+      assert.equal(events.some((event) => event.type === "message_end" && JSON.stringify(event).includes("LARKIN_READY")), true);
+      assert.equal(events.some((event) => event.type === "agent_end"), true);
+      return;
+    }
+    const adapter = createNativeRuntimeAdapter("pi", { env });
+    const readiness = await adapter.probe({ agentId, workspaceDir, stateDir, env });
+    assert.equal(readiness.state, "ready");
+    assert.match(readiness.version, /official-pi 0\.83\.0 \(bundled\)/);
+    const session = await adapter.createSession({
+      agentId, workspaceDir, stateDir, model: "larkin-custom/fixture-model", standingPrompt: {
+        version: "fixture", content: "Reply concisely.", hash: "fixture",
+      }, env,
+    });
+    const events = [];
+    const terminal = new Promise((resolve, reject) => {
+      const timer = setTimeout(() => reject(new Error(`timed out waiting for bundled Pi turn: ${JSON.stringify(events)}`)), 15_000);
+      session.subscribe((event) => {
+        events.push(event);
+        if (event.type === "turn-end") { clearTimeout(timer); resolve(); }
+        if (event.type === "error") { clearTimeout(timer); reject(new Error(event.message)); }
+      });
+    });
+    assert.deepEqual(await session.prompt({ inputId: "controlled-turn", kind: "user", text: "Reply exactly LARKIN_READY", attempt: 1 }),
+      { status: "accepted", inputId: "controlled-turn" });
+    await terminal;
+    await session.close("test complete");
+    assert.equal(observedAuthorization, "Bearer fixture-provider-key");
+    assert.equal(observedModel, "fixture-model");
+    assert.equal(events.some((event) => event.type === "activity" && event.text?.includes("LARKIN_READY")), true);
+    assert.equal(events.some((event) => event.type === "turn-end"), true);
+  } finally {
+    await new Promise((resolve) => server.close(resolve));
+    fs.rmSync(temp, { recursive: true, force: true });
+  }
+}
+
+test("bundled official Pi completes a controlled turn against a local OpenAI-compatible provider without external Agent CLIs", { timeout: 30_000 }, async () => {
+  await exerciseBuiltinPiTurn(path.join(ROOT, "dist", "app", "binary-entry.mjs"), "larkin-builtin-pi-turn-");
+});
+
+const compiledEnabled = process.env.LARKIN_RUN_COMPILED_BUILTIN_PI_E2E === "1";
+test.skipIf(!compiledEnabled)("compiled single-file Larkin completes a real bundled official Pi provider turn with embedded assets", { timeout: 180_000 }, async () => {
+  const releaseDir = fs.mkdtempSync(path.join(os.tmpdir(), "larkin-compiled-builtin-pi-release-"));
+  try {
+    const build = spawnSync(process.execPath, ["scripts/release/build.ts", "--target", `${os.platform()}-${os.arch()}`,
+      "--out-dir", releaseDir, "--allow-dirty"], { cwd: ROOT, env: process.env, encoding: "utf8", timeout: 150_000 });
+    assert.equal(build.error, undefined, build.error?.message);
+    assert.equal(build.status, 0, `${build.stdout}\n${build.stderr}`);
+    const manifest = JSON.parse(fs.readFileSync(path.join(releaseDir, "release-manifest.json"), "utf8"));
+    const artifact = path.join(releaseDir, manifest.artifacts[0].file);
+    await exerciseBuiltinPiTurn(artifact, "larkin-compiled-builtin-pi-turn-", true);
+  } finally {
+    fs.rmSync(releaseDir, { recursive: true, force: true });
+  }
+});

--- a/test/live/builtin-pi-oauth-credential-live.test.mjs
+++ b/test/live/builtin-pi-oauth-credential-live.test.mjs
@@ -1,0 +1,71 @@
+import { test } from "bun:test";
+import assert from "node:assert/strict";
+import { spawn, spawnSync } from "node:child_process";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { PiRpcClient } from "../../dist/runtime/pi-rpc-client.mjs";
+
+const RUN = process.env.LARKIN_RUN_BUILTIN_PI_OAUTH_E2E === "1";
+const ROOT = path.resolve(import.meta.dirname, "../..");
+const MODEL = String(process.env.LARKIN_BUILTIN_PI_OAUTH_MODEL || "openai-codex/gpt-5.6-sol").trim();
+const PROVIDER = MODEL.split("/")[0];
+const MARKER = String(process.env.LARKIN_BUILTIN_PI_OAUTH_MARKER || "BUILTIN_PI_OAUTH_OK").trim();
+if (!/^[A-Za-z0-9][A-Za-z0-9._-]{0,127}\/[A-Za-z0-9][A-Za-z0-9._:@+\/-]{0,255}$/.test(MODEL)) throw new Error("LARKIN_BUILTIN_PI_OAUTH_MODEL must be provider/model");
+if (!/^[A-Z0-9_]{3,64}$/.test(MARKER)) throw new Error("LARKIN_BUILTIN_PI_OAUTH_MARKER must be a safe marker");
+
+test.skipIf(!RUN)("compiled bundled Pi uses an existing official OAuth credential for a real turn without Feishu", { timeout: 240_000 }, async () => {
+  const sourceInput = String(process.env.LARKIN_PI_OAUTH_CREDENTIAL_DIR || "");
+  assert.equal(sourceInput.length > 0 && path.isAbsolute(sourceInput), true,
+    "set LARKIN_PI_OAUTH_CREDENTIAL_DIR to an explicitly authorized official Pi credential directory");
+  const sourceDir = path.resolve(sourceInput);
+  assert.equal(fs.statSync(sourceDir).isDirectory(), true);
+  const sourceAuth = JSON.parse(fs.readFileSync(path.join(sourceDir, "auth.json"), "utf8"));
+  assert.equal(sourceAuth[PROVIDER]?.type, "oauth", `authorized credential must contain OAuth for ${PROVIDER}`);
+  const temp = fs.mkdtempSync(path.join(os.tmpdir(), "larkin-builtin-pi-oauth-live-"));
+  let client;
+  try {
+    const releaseDir = path.join(temp, "release");
+    const build = spawnSync(process.execPath, ["scripts/release/build.ts", "--target", `${os.platform()}-${os.arch()}`,
+      "--out-dir", releaseDir, "--allow-dirty"], { cwd: ROOT, env: process.env, encoding: "utf8", timeout: 180_000 });
+    assert.equal(build.status, 0, build.stderr || build.stdout);
+    const manifest = JSON.parse(fs.readFileSync(path.join(releaseDir, "release-manifest.json"), "utf8"));
+    const artifact = path.join(releaseDir, manifest.artifacts[0].file);
+    const agentDir = path.join(temp, "providers", "pi", "cli_oauthLiveA1");
+    const workspace = path.join(temp, "workspace");
+    fs.mkdirSync(agentDir, { recursive: true, mode: 0o700 });
+    fs.mkdirSync(workspace, { recursive: true, mode: 0o700 });
+    fs.writeFileSync(path.join(agentDir, "auth.json"), `${JSON.stringify({ [PROVIDER]: sourceAuth[PROVIDER] }, null, 2)}\n`, { mode: 0o600 });
+    const child = spawn(artifact, ["__internal", "pi-rpc", "--mode", "rpc", "--no-session", "--model", MODEL], {
+      cwd: workspace,
+      env: { HOME: temp, PATH: "/usr/bin:/bin", LARKIN_CONFIG_DIR: temp, LARKIN_HOME: temp,
+        LARKIN_PI_DISTRIBUTION: "builtin", PI_CODING_AGENT_DIR: agentDir, PI_TELEMETRY: "0" },
+      stdio: ["pipe", "pipe", "pipe"],
+    });
+    client = new PiRpcClient(child, { requestTimeoutMs: 120_000 });
+    const events = [];
+    const complete = new Promise((resolve, reject) => {
+      const timer = setTimeout(() => reject(new Error("bundled OAuth turn timed out")), 120_000);
+      client.subscribe((event) => {
+        events.push(event);
+        if (event.type === "agent_end") { clearTimeout(timer); resolve(); }
+      });
+      client.subscribeFailure((error) => { clearTimeout(timer); reject(error); });
+    });
+    await client.request("prompt", { message: `Reply exactly ${MARKER}` });
+    await complete;
+    const serialized = JSON.stringify(events);
+    assert.match(serialized, new RegExp(MARKER));
+    const usageEvents = events.filter((event) => event.type === "message_end").map((event) => ({
+      role: event.message?.role,
+      usageKeys: Object.keys(event.message?.usage || {}),
+    }));
+    assert.equal(usageEvents.some((entry) => entry.role === "assistant" && entry.usageKeys.includes("totalTokens")), true,
+      JSON.stringify(usageEvents));
+    const after = JSON.parse(fs.readFileSync(path.join(agentDir, "auth.json"), "utf8"));
+    assert.equal(after[PROVIDER]?.type, "oauth", "official request path must retain/refresh the OAuth credential in its own store");
+  } finally {
+    await client?.close().catch(() => {});
+    fs.rmSync(temp, { recursive: true, force: true });
+  }
+});

--- a/test/unit/app/pi-auth-cli.test.mjs
+++ b/test/unit/app/pi-auth-cli.test.mjs
@@ -1,0 +1,60 @@
+import { test } from "bun:test";
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+const ROOT = path.resolve(import.meta.dirname, "../../..");
+
+test("public pi-auth status is non-sensitive and logout preserves unrelated provider credentials", () => {
+  const temp = fs.mkdtempSync(path.join(os.tmpdir(), "larkin-pi-auth-cli-"));
+  const agentId = "cli_authCliA1";
+  const marker = path.join(temp, "command-marker");
+  const deepseekKey = `!touch ${marker}`;
+  const oauthAccess = "oauth-access-secret-sentinel";
+  try {
+    fs.chmodSync(temp, 0o700);
+    fs.writeFileSync(path.join(temp, "config.json"), `${JSON.stringify({
+      version: 4, serverId: "server-auth-cli", mentionPolicy: "require", activeAgent: agentId,
+      agents: { [agentId]: { runtime: "pi", piDistribution: "builtin", model: "deepseek/deepseek-v4-pro", createdAt: "2026-08-06T00:00:00.000Z" } },
+    }, null, 2)}\n`, { mode: 0o600 });
+    const directory = path.join(temp, "providers", "pi", agentId);
+    fs.mkdirSync(directory, { recursive: true, mode: 0o700 });
+    const original = {
+      deepseek: { type: "api_key", key: deepseekKey },
+      anthropic: { type: "oauth", access: oauthAccess, refresh: "oauth-refresh-secret", expires: Date.now() + 3_600_000 },
+    };
+    const authPath = path.join(directory, "auth.json");
+    const originalBytes = `${JSON.stringify(original, null, 2)}\n`;
+    fs.writeFileSync(authPath, originalBytes, { mode: 0o600 });
+    const env = { ...process.env, LARKIN_CONFIG_DIR: temp, LARKIN_HOME: temp };
+    const status = spawnSync(process.execPath, ["dist/app/binary-entry.mjs", "pi-auth", "status", "--agent", agentId, "--json"], {
+      cwd: ROOT, env, encoding: "utf8", timeout: 30_000,
+    });
+    assert.equal(status.status, 0, status.stderr);
+    const payload = JSON.parse(status.stdout);
+    assert.equal(payload.agentId, agentId);
+    assert.deepEqual(payload.credentials.map(({ providerId, credentialType, stored }) => ({ providerId, credentialType, stored })), [
+      { providerId: "anthropic", credentialType: "oauth", stored: true },
+      { providerId: "deepseek", credentialType: "api_key", stored: true },
+    ]);
+    assert.doesNotMatch(status.stdout + status.stderr, new RegExp(`${deepseekKey}|${oauthAccess}|oauth-refresh-secret`));
+    assert.equal(fs.existsSync(marker), false, "status must not execute !command API keys");
+    assert.equal(fs.readFileSync(authPath, "utf8"), originalBytes, "status must preserve exact auth bytes");
+    assert.equal(fs.existsSync(path.join(directory, "models.json")), false);
+    assert.equal(fs.existsSync(path.join(directory, "models-store.json")), false);
+
+    const logout = spawnSync(process.execPath, ["dist/app/binary-entry.mjs", "pi-auth", "logout", "deepseek", "--agent", agentId], {
+      cwd: ROOT, env, encoding: "utf8", timeout: 30_000,
+    });
+    assert.equal(logout.status, 0, logout.stderr);
+    const remaining = JSON.parse(fs.readFileSync(authPath, "utf8"));
+    assert.equal(remaining.deepseek, undefined);
+    assert.deepEqual(remaining.anthropic, original.anthropic);
+    assert.equal(fs.existsSync(marker), false, "logout must not execute the removed !command API key");
+    assert.doesNotMatch(logout.stdout + logout.stderr, new RegExp(`${deepseekKey}|${oauthAccess}|oauth-refresh-secret`));
+    assert.equal(fs.statSync(directory).mode & 0o777, 0o700);
+    assert.equal(fs.statSync(authPath).mode & 0o777, 0o600);
+  } finally { fs.rmSync(temp, { recursive: true, force: true }); }
+});

--- a/test/unit/app/runtime-agent-config-async.test.mjs
+++ b/test/unit/app/runtime-agent-config-async.test.mjs
@@ -1,0 +1,59 @@
+import { test } from "bun:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { syncAgentProfileAsync } from "../../../dist/app/runtime-agent-config.mjs";
+
+function fixture(root, mode) {
+  const agentId = "cli_asyncProfileA1";
+  const stateDir = path.join(root, "state", "agents", agentId);
+  const larkConfigDir = path.join(stateDir, "lark-cli-config");
+  const script = path.join(root, `lark-cli-${mode}.mjs`);
+  fs.writeFileSync(script, `import fs from "node:fs"; import path from "node:path";\n`
+    + `const mode=process.env.TEST_CLI_MODE;\n`
+    + `if(mode==="timeout"||mode==="abort") await new Promise(()=>{});\n`
+    + `if(mode==="overflow"){process.stdout.write("x".repeat(131072));await new Promise(r=>setTimeout(r,1000));}\n`
+    + `const dir=path.join(process.env.LARKSUITE_CLI_CONFIG_DIR,"lark-channel");fs.mkdirSync(dir,{recursive:true,mode:0o700});\n`
+    + `fs.writeFileSync(path.join(dir,"config.json"),JSON.stringify({apps:[{appId:process.env.TEST_APP_ID,appSecret:{source:"keychain",id:"appsecret:"+process.env.TEST_APP_ID},defaultAs:"bot",strictMode:"bot",users:[]}]}),{mode:0o600});\n`, { mode: 0o600 });
+  return {
+    agent: {
+      agentId, feishuAppId: agentId, feishuAppSecret: "async-secret-sentinel", feishuDomain: "https://open.feishu.cn",
+      credentialRevision: "updated:async", stateDir, larkConfigDir,
+      workspaceDir: path.join(root, "agents", agentId), runtime: "pi", model: "default", feishuProfile: agentId,
+    },
+    env: { ...process.env, LARKIN_CONFIG_DIR: root, LARKIN_BUN_TEST_RUNNER: "1", TEST_CLI_MODE: mode, TEST_APP_ID: agentId },
+    resolveOfficialCli: () => ({ command: process.execPath, argsPrefix: [script], version: "1.0.79" }),
+  };
+}
+
+test("async profile sync bounds timeout/output and cleans children on abort", { timeout: 15_000 }, async () => {
+  const temp = fs.mkdtempSync(path.join(os.tmpdir(), "larkin-profile-async-"));
+  const previousTestRunner = process.env.LARKIN_BUN_TEST_RUNNER;
+  process.env.LARKIN_BUN_TEST_RUNNER = "1";
+  try {
+    for (const mode of ["timeout", "overflow", "abort"]) {
+      const root = path.join(temp, mode);
+      fs.mkdirSync(root, { recursive: true, mode: 0o700 });
+      const input = fixture(root, mode);
+      const children = [];
+      const controller = new AbortController();
+      if (mode === "abort") setTimeout(() => controller.abort(), 100);
+      await assert.rejects(() => syncAgentProfileAsync(input.agent, input.env, {
+        forceRebind: true,
+        resolveOfficialCli: input.resolveOfficialCli,
+        timeoutMs: mode === "timeout" ? 100 : 5_000,
+        maxOutputBytes: 1024,
+        signal: controller.signal,
+        onChild(child) { children.push(child); },
+      }), mode === "timeout" ? /timed out/ : mode === "overflow" ? /bounded limit/ : /cancelled/);
+      assert.ok(children[0], `${mode} must expose its pending child`);
+      assert.equal(children.at(-1), null, `${mode} must clear the pending child`);
+      assert.notEqual(children[0].exitCode === null && children[0].signalCode === null, true, `${mode} child must terminate`);
+    }
+  } finally {
+    if (previousTestRunner === undefined) delete process.env.LARKIN_BUN_TEST_RUNNER;
+    else process.env.LARKIN_BUN_TEST_RUNNER = previousTestRunner;
+    fs.rmSync(temp, { recursive: true, force: true });
+  }
+});

--- a/test/unit/platform/pi-license-notice.test.mjs
+++ b/test/unit/platform/pi-license-notice.test.mjs
@@ -1,0 +1,42 @@
+import { test } from "bun:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+import { generateRuntimeNotices } from "../../../scripts/generate-third-party-notices.mjs";
+
+const ROOT = path.resolve(import.meta.dirname, "../../..");
+
+test("runtime notices include the bundled official Pi closure", () => {
+  const notice = generateRuntimeNotices();
+  for (const packageName of [
+    "@earendil-works/pi-coding-agent",
+    "@earendil-works/pi-agent-core",
+    "@earendil-works/pi-ai",
+    "@earendil-works/pi-tui",
+  ]) assert.match(notice, new RegExp(packageName.replace("/", "\\/")));
+  assert.match(notice, /Copyright \(c\) 2025 Mario Zechner/);
+  assert.match(notice, /Permission is hereby granted, free of charge/);
+  assert.match(notice, /THE SOFTWARE IS PROVIDED "AS IS"/);
+
+  for (const relative of ["scripts/release/build.ts", "scripts/release/assemble.ts"]) {
+    const source = fs.readFileSync(path.join(ROOT, relative), "utf8");
+    assert.match(source, /THIRD_PARTY_NOTICES\.txt/, `${relative} must redistribute the generated notice`);
+    assert.match(source, /sha256File/, `${relative} must checksum the redistributed notice`);
+  }
+});
+
+test("runtime notices are one locked superset across release target optional installs", () => {
+  const targets = [
+    new Set(["@mariozechner/clipboard", "@mariozechner/clipboard-darwin-arm64", "@mariozechner/clipboard-darwin-universal"]),
+    new Set(["@mariozechner/clipboard", "@mariozechner/clipboard-darwin-x64", "@mariozechner/clipboard-darwin-universal"]),
+    new Set(["@mariozechner/clipboard", "@mariozechner/clipboard-linux-arm64-gnu", "@mariozechner/clipboard-linux-arm64-musl"]),
+    new Set(["@mariozechner/clipboard", "@mariozechner/clipboard-linux-x64-gnu", "@mariozechner/clipboard-linux-x64-musl"]),
+    new Set(["@mariozechner/clipboard", "@mariozechner/clipboard-win32-x64-msvc"]),
+  ];
+  const rendered = targets.map((installedOptionalPackageNames) => generateRuntimeNotices({ installedOptionalPackageNames }));
+  assert.equal(new Set(rendered).size, 1, "target-specific optional installs must yield one release notice");
+  assert.equal(rendered[0], generateRuntimeNotices());
+  for (const platformPackage of [
+    "clipboard-darwin-arm64", "clipboard-darwin-x64", "clipboard-linux-x64-gnu", "clipboard-win32-x64-msvc",
+  ]) assert.match(rendered[0], new RegExp(platformPackage));
+});

--- a/test/unit/runtime/pi-model-catalog.test.mjs
+++ b/test/unit/runtime/pi-model-catalog.test.mjs
@@ -81,17 +81,19 @@ test("Pi thinking levels follow official reasoning metadata without Codex ultra"
   assert.equal(supportedPiThinkingLevels(models[1]).includes("ultra"), false);
 });
 
-test("production graph uses only local Pi RPC and never embeds an SDK", () => {
+test("production graph pins official Pi and exposes it only through the shared RPC contract", () => {
   const pkg = JSON.parse(fs.readFileSync(path.join(ROOT, "package.json"), "utf8"));
   const lock = fs.readFileSync(path.join(ROOT, "bun.lock"), "utf8");
   const adapter = fs.readFileSync(path.join(ROOT, "src/runtime/runtime-adapters.ts"), "utf8");
-  assert.equal(pkg.dependencies["@earendil-works/pi-coding-agent"], undefined);
+  const binaryEntry = fs.readFileSync(path.join(ROOT, "src/app/binary-entry.ts"), "utf8");
+  assert.equal(pkg.dependencies["@earendil-works/pi-coding-agent"], "0.83.0");
   assert.equal(pkg.dependencies["@mariozechner/pi-coding-agent"], undefined);
   assert.equal(pkg.packageManager, "bun@1.3.14");
   assert.equal(pkg.engines, undefined);
   assert.equal(pkg.scripts.preinstall, undefined);
-  assert.doesNotMatch(lock, /pi-coding-agent/);
+  assert.match(lock, /@earendil-works\/pi-coding-agent/);
   assert.doesNotMatch(adapter, /from\s+["'][^"']*pi-coding-agent/);
+  assert.match(binaryEntry, /@earendil-works\/pi-coding-agent\/rpc-entry/);
   assert.match(adapter, /--mode["'],\s*["']rpc/);
   assert.doesNotMatch(adapter, /available\s*\[\s*0\s*\]/);
 });

--- a/test/unit/runtime/pi-official-auth.test.mjs
+++ b/test/unit/runtime/pi-official-auth.test.mjs
@@ -1,0 +1,388 @@
+import { test } from "bun:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { spawn, spawnSync } from "node:child_process";
+import { pathToFileURL } from "node:url";
+import { ModelRuntime } from "@earendil-works/pi-coding-agent";
+import { syncAgentProfileAsync } from "../../../dist/app/runtime-agent-config.mjs";
+import {
+  beginBuiltinPiCredentialTransaction,
+  createOfficialPiCredentialRuntime,
+  createOfficialPiModelRuntime,
+  createOfficialPiLogoutRuntime,
+  createOfficialPiRegistryRuntime,
+  createOfficialPiAuthInteraction,
+  listOfficialPiAuthProviders,
+  logoutOfficialPiProvider,
+  officialPiAuthStatus,
+  runOfficialPiLogin,
+} from "../../../dist/runtime/pi-official-auth.mjs";
+
+const ROOT = path.resolve(import.meta.dirname, "../../..");
+
+function provider(id, name, options = {}) {
+  return {
+    id, name, auth: {
+      ...(options.apiKey === false ? {} : { apiKey: { name: options.apiKeyName || `${name} key`, ...(options.apiKeyLogin === false ? {} : { login() {} }) } }),
+      ...(options.oauth ? { oauth: { name: options.oauthName || `${name} subscription`, login() {}, refresh() {}, toAuth() {} } } : {}),
+    },
+    getModels: () => options.models || [], stream() {}, streamSimple() {},
+  };
+}
+
+test("official Pi auth registry projection is dynamic and preserves every login-capable method", async () => {
+  const fake = { getProviders: () => [
+    provider("alpha", "Alpha", { oauth: true, models: [{ provider: "alpha", id: "a-1" }] }),
+    provider("ambient", "Ambient", { apiKeyLogin: false }),
+    provider("oauth-only", "OAuth only", { apiKey: false, oauth: true }),
+  ] };
+  assert.deepEqual(listOfficialPiAuthProviders(fake), [
+    { id: "alpha", name: "Alpha", methods: [
+      { type: "api_key", name: "Alpha key" }, { type: "oauth", name: "Alpha subscription" },
+    ], models: ["alpha/a-1"], ambientOnly: false },
+    { id: "ambient", name: "Ambient", methods: [], models: [], ambientOnly: true },
+    { id: "oauth-only", name: "OAuth only", methods: [{ type: "oauth", name: "OAuth only subscription" }], models: [], ambientOnly: false },
+  ]);
+
+  const official = await ModelRuntime.create({ modelsPath: null, allowModelNetwork: false });
+  const projected = listOfficialPiAuthProviders(official);
+  const expected = official.getProviders().map((entry) => ({
+    id: entry.id,
+    types: [entry.auth.apiKey?.login ? "api_key" : null, entry.auth.oauth?.login ? "oauth" : null].filter(Boolean),
+  }));
+  assert.deepEqual(projected.map((entry) => ({ id: entry.id, types: entry.methods.map((method) => method.type) })), expected);
+});
+
+test("auth interaction bridges all official prompt and event variants without echoing secrets", async () => {
+  const asked = [];
+  const secrets = [];
+  const reports = [];
+  const opened = [];
+  const answers = ["text value", "2"];
+  const interaction = createOfficialPiAuthInteraction({
+    questioner: {
+      ask: async (prompt) => { asked.push(prompt); return answers.shift(); },
+      secret: async (prompt) => { secrets.push(prompt); return prompt.includes("manual") ? "manual-value" : "secret-value"; },
+    },
+    report: (message) => reports.push(message),
+    openUrl: (url) => { opened.push(url); return true; },
+  });
+  assert.equal(await interaction.prompt({ type: "text", message: "text" }), "text value");
+  assert.equal(await interaction.prompt({ type: "secret", message: "secret" }), "secret-value");
+  assert.equal(await interaction.prompt({ type: "select", message: "select", options: [
+    { id: "first", label: "First" }, { id: "second", label: "Second", description: "desc" },
+  ] }), "second");
+  assert.equal(await interaction.prompt({ type: "manual_code", message: "manual" }), "manual-value");
+  interaction.notify({ type: "info", message: "info", links: [{ url: "https://info.example/path?token=hidden", label: "docs" }] });
+  interaction.notify({ type: "auth_url", url: "https://login.example/authorize?state=hidden", instructions: "open it" });
+  interaction.notify({ type: "device_code", userCode: "ABCD-EFGH", verificationUri: "https://device.example/activate", intervalSeconds: 5 });
+  interaction.notify({ type: "progress", message: "waiting" });
+  assert.deepEqual(opened, ["https://login.example/authorize?state=hidden"]);
+  assert.match(asked.join("\n"), /text[\s\S]*First[\s\S]*Second[\s\S]*desc/);
+  assert.match(secrets.join("\n"), /secret[\s\S]*manual/);
+  const output = reports.join("\n");
+  assert.match(output, /info[\s\S]*docs: https:\/\/info\.example\/path/);
+  assert.match(output, /ABCD-EFGH[\s\S]*https:\/\/device\.example\/activate[\s\S]*waiting/);
+  assert.doesNotMatch(output, /token=hidden|state=hidden|secret-value|manual-value/);
+
+  const fallback = [];
+  const manual = createOfficialPiAuthInteraction({
+    questioner: { ask: async () => "", secret: async () => "" },
+    report: (message) => fallback.push(message), openUrl: () => false,
+  });
+  manual.notify({ type: "auth_url", url: "https://login.example/authorize?state=copy-me" });
+  assert.match(fallback.join("\n"), /请复制完整登录地址: https:\/\/login\.example\/authorize\?state=copy-me/);
+});
+
+test("official login delegates to ModelRuntime and cancellation reaches the provider signal", async () => {
+  const calls = [];
+  const runtime = { login: async (...args) => { calls.push(args); return { type: "oauth", access: "hidden", refresh: "hidden", expires: 1 }; } };
+  const interaction = { prompt: async () => "unused", notify() {} };
+  const credential = await runOfficialPiLogin(runtime, "alpha", "oauth", interaction);
+  assert.equal(credential.type, "oauth");
+  assert.equal(calls.length, 1);
+  assert.equal(calls[0][0], "alpha");
+  assert.equal(calls[0][1], "oauth");
+  assert.equal(calls[0][2], interaction);
+
+  const controller = new AbortController();
+  controller.abort();
+  const cancelled = createOfficialPiAuthInteraction({
+    questioner: { ask: async () => "never", secret: async () => "never" }, report() {}, signal: controller.signal,
+  });
+  await assert.rejects(() => cancelled.prompt({ type: "text", message: "cancelled" }), /cancel/i);
+});
+
+test("credential transaction restores exact bytes and preserves other Agents/providers", async () => {
+  const temp = fs.mkdtempSync(path.join(os.tmpdir(), "larkin-pi-official-auth-"));
+  try {
+    fs.chmodSync(temp, 0o700);
+    const transaction = beginBuiltinPiCredentialTransaction(temp, "cli_authA1");
+    const directory = transaction.directory;
+    fs.mkdirSync(directory, { recursive: true, mode: 0o700 });
+    fs.writeFileSync(path.join(directory, "auth.json"), '{"alpha":{"type":"api_key","key":"changed"}}\n', { mode: 0o600 });
+    fs.writeFileSync(path.join(directory, "models-store.json"), '{"changed":true}\n', { mode: 0o600 });
+    const other = path.join(temp, "providers", "pi", "cli_otherA1");
+    fs.mkdirSync(other, { recursive: true, mode: 0o700 });
+    fs.writeFileSync(path.join(other, "auth.json"), "other-agent", { mode: 0o600 });
+    transaction.rollback();
+    assert.equal(fs.existsSync(path.join(directory, "auth.json")), false);
+    assert.equal(fs.existsSync(path.join(directory, "models-store.json")), false);
+    assert.equal(fs.existsSync(directory), false, "new Agent rollback must restore the provider directory to absent");
+    assert.equal(fs.readFileSync(path.join(other, "auth.json"), "utf8"), "other-agent");
+    const noState = beginBuiltinPiCredentialTransaction(temp, "cli_noStateA1");
+    const noStateDirectory = noState.directory;
+    noState.commit();
+    assert.equal(fs.existsSync(noStateDirectory), false, "no-state commit must restore a new provider directory to absent");
+  } finally { fs.rmSync(temp, { recursive: true, force: true }); }
+});
+
+test("status is non-sensitive and logout delegates to the official runtime only for the target provider", async () => {
+  const runtime = {
+    getProviders: () => [provider("alpha", "Alpha"), provider("beta", "Beta")],
+    listCredentials: async () => [
+      { providerId: "alpha", type: "oauth" }, { providerId: "beta", type: "api_key" },
+    ],
+    checkAuth: async (id) => ({ type: id === "alpha" ? "oauth" : "api_key", source: id === "alpha" ? "OAuth" : "stored credential" }),
+    logout: async (id) => { runtime.loggedOut = id; },
+  };
+  assert.deepEqual(await officialPiAuthStatus(runtime), [
+    { providerId: "alpha", providerName: "Alpha", credentialType: "oauth", source: "OAuth", stored: true },
+    { providerId: "beta", providerName: "Beta", credentialType: "api_key", source: "stored credential", stored: true },
+  ]);
+  await logoutOfficialPiProvider(runtime, "alpha");
+  assert.equal(runtime.loggedOut, "alpha");
+});
+
+test("registry, status, and logout never execute stored API-key commands or create read-only files", async () => {
+  const temp = fs.mkdtempSync(path.join(os.tmpdir(), "larkin-pi-safe-auth-"));
+  const marker = path.join(temp, "command-marker");
+  try {
+    fs.chmodSync(temp, 0o700);
+    const absentAgent = "cli_absentAuthA1";
+    const absentDirectory = path.join(temp, "providers", "pi", absentAgent);
+    const registry = await createOfficialPiRegistryRuntime();
+    assert.ok(listOfficialPiAuthProviders(registry).length > 0);
+    assert.equal(fs.existsSync(absentDirectory), false, "registry enumeration must not create an Agent store");
+    const absentStatus = await officialPiAuthStatus(await createOfficialPiCredentialRuntime(temp, absentAgent));
+    assert.ok(Array.isArray(absentStatus));
+    assert.equal(fs.existsSync(absentDirectory), false, "read-only status must preserve absent auth/models paths");
+    await logoutOfficialPiProvider(await createOfficialPiLogoutRuntime(temp, absentAgent), "not-stored");
+    assert.equal(fs.existsSync(absentDirectory), false, "logout of an absent credential must preserve absent auth/models paths");
+
+    const agentId = "cli_maliciousAuthA1";
+    const directory = path.join(temp, "providers", "pi", agentId);
+    fs.mkdirSync(directory, { recursive: true, mode: 0o700 });
+    const malicious = { type: "api_key", key: `!touch ${marker}`, env: { sentinel: "exact-other-provider" } };
+    const target = { type: "oauth", access: "target-access", refresh: "target-refresh", expires: Date.now() + 3_600_000 };
+    const originalBytes = `${JSON.stringify({ anthropic: malicious, "openai-codex": target }, null, 4)}\n`;
+    const authPath = path.join(directory, "auth.json");
+    fs.writeFileSync(authPath, originalBytes, { mode: 0o600 });
+
+    const statusRuntime = await createOfficialPiCredentialRuntime(temp, agentId);
+    const status = await officialPiAuthStatus(statusRuntime);
+    assert.ok(status.some((entry) => entry.providerId === "anthropic" && entry.credentialType === "api_key"));
+    assert.equal(fs.existsSync(marker), false, "status must not execute !command credentials");
+    assert.equal(fs.readFileSync(authPath, "utf8"), originalBytes, "status must preserve exact auth bytes");
+    assert.equal(fs.existsSync(path.join(directory, "models.json")), false);
+    assert.equal(fs.existsSync(path.join(directory, "models-store.json")), false);
+
+    await logoutOfficialPiProvider(await createOfficialPiLogoutRuntime(temp, agentId), "openai-codex");
+    assert.equal(fs.existsSync(marker), false, "logout refresh must not execute unrelated !command credentials");
+    const remaining = JSON.parse(fs.readFileSync(authPath, "utf8"));
+    assert.equal(remaining["openai-codex"], undefined);
+    assert.deepEqual(remaining.anthropic, malicious, "logout must preserve the unrelated credential exactly");
+    assert.equal(fs.existsSync(path.join(directory, "models.json")), false);
+    assert.equal(fs.existsSync(path.join(directory, "models-store.json")), false);
+  } finally { fs.rmSync(temp, { recursive: true, force: true }); }
+});
+
+test("cross-process setup rollback serializes with ModelRuntime OAuth refresh and preserves both updates", { timeout: 30_000 }, async () => {
+  const temp = fs.mkdtempSync(path.join(os.tmpdir(), "larkin-pi-lock-barrier-"));
+  const agentId = "cli_lockBarrierA1";
+  const held = path.join(temp, "transaction-held");
+  const release = path.join(temp, "release-transaction");
+  const refreshEntered = path.join(temp, "refresh-entered");
+  const marker = path.join(temp, "command-marker");
+  const authModule = pathToFileURL(path.join(ROOT, "dist/runtime/pi-official-auth.mjs")).href;
+  const waitFor = async (file, message) => {
+    const deadline = Date.now() + 15_000;
+    while (!fs.existsSync(file) && Date.now() < deadline) await new Promise((resolve) => setTimeout(resolve, 20));
+    assert.equal(fs.existsSync(file), true, message);
+  };
+  const exited = (child) => new Promise((resolve, reject) => {
+    let stderr = "";
+    child.stderr.on("data", (chunk) => { stderr += String(chunk); });
+    child.once("error", reject);
+    child.once("exit", (code, signal) => code === 0 ? resolve() : reject(new Error(`child failed ${code}/${signal}: ${stderr}`)));
+  });
+  try {
+    fs.chmodSync(temp, 0o700);
+    const directory = path.join(temp, "providers", "pi", agentId);
+    fs.mkdirSync(directory, { recursive: true, mode: 0o700 });
+    const original = {
+      "refresh-fixture": { type: "oauth", access: "expired", refresh: "refresh-old", expires: 1 },
+      "setup-target": { type: "api_key", key: "setup-target-key" },
+      malicious: { type: "api_key", key: `!touch ${marker}` },
+    };
+    fs.writeFileSync(path.join(directory, "auth.json"), `${JSON.stringify(original, null, 2)}\n`, { mode: 0o600 });
+    const transactionScript = path.join(temp, "transaction-child.mjs");
+    fs.writeFileSync(transactionScript, `import fs from "node:fs";\nimport {beginBuiltinPiCredentialTransaction,createOfficialPiLogoutRuntime,logoutOfficialPiProvider} from ${JSON.stringify(authModule)};\n`
+      + `const [configDir,agentId,held,release]=process.argv.slice(2); const txn=beginBuiltinPiCredentialTransaction(configDir,agentId);\n`
+      + `await logoutOfficialPiProvider(await createOfficialPiLogoutRuntime(configDir,agentId),"setup-target"); fs.writeFileSync(held,"held");\n`
+      + `while(!fs.existsSync(release)) await new Promise(r=>setTimeout(r,20)); txn.rollback();\n`, { mode: 0o600 });
+    const refreshScript = path.join(temp, "refresh-child.mjs");
+    fs.writeFileSync(refreshScript, `import fs from "node:fs";\nimport {createOfficialPiModelRuntime} from ${JSON.stringify(authModule)};\n`
+      + `const [configDir,agentId,entered]=process.argv.slice(2); const runtime=await createOfficialPiModelRuntime(configDir,agentId);\n`
+      + `runtime.registerNativeProvider({id:"refresh-fixture",name:"Refresh",auth:{oauth:{name:"Refresh",async login(){throw new Error("unused")},async refresh(c){fs.writeFileSync(entered,"entered");return {...c,access:"rotated",refresh:"refresh-new",expires:Date.now()+3600000}},async toAuth(c){return {apiKey:c.access}}}},getModels(){return []},stream(){},streamSimple(){}});\n`
+      + `const auth=await runtime.getAuth("refresh-fixture",{minOAuthValidityMs:300000}); if(auth?.auth.apiKey!=="rotated") throw new Error("refresh did not rotate");\n`, { mode: 0o600 });
+
+    const transactionChild = spawn(process.execPath, [transactionScript, temp, agentId, held, release], { stdio: ["ignore", "ignore", "pipe"] });
+    const transactionExit = exited(transactionChild);
+    await waitFor(held, "setup transaction did not reach logout barrier");
+    assert.equal(JSON.parse(fs.readFileSync(path.join(directory, "auth.json"), "utf8"))["setup-target"], undefined);
+    const refreshChild = spawn(process.execPath, [refreshScript, temp, agentId, refreshEntered], { stdio: ["ignore", "ignore", "pipe"] });
+    const refreshExit = exited(refreshChild);
+    await new Promise((resolve) => setTimeout(resolve, 250));
+    assert.equal(fs.existsSync(refreshEntered), false, "OAuth refresh must block behind the setup transaction lock");
+    fs.writeFileSync(release, "release");
+    await Promise.all([transactionExit, refreshExit]);
+    const final = JSON.parse(fs.readFileSync(path.join(directory, "auth.json"), "utf8"));
+    assert.deepEqual(final["setup-target"], original["setup-target"], "setup rollback must restore its target");
+    assert.equal(final["refresh-fixture"].access, "rotated");
+    assert.equal(final["refresh-fixture"].refresh, "refresh-new");
+    assert.deepEqual(final.malicious, original.malicious);
+    assert.equal(fs.existsSync(marker), false);
+  } finally { fs.rmSync(temp, { recursive: true, force: true }); }
+});
+
+test("post-stale official AuthStorage contender blocks behind the live heartbeat then merges after release", { timeout: 60_000 }, async () => {
+  const temp = fs.mkdtempSync(path.join(os.tmpdir(), "larkin-pi-heartbeat-barrier-"));
+  const agentId = "cli_heartbeatA1";
+  const contenderStarted = path.join(temp, "contender-started");
+  const contenderWritten = path.join(temp, "contender-written");
+  const officialAuthStorageModule = pathToFileURL(path.join(ROOT,
+    "node_modules/@earendil-works/pi-coding-agent/dist/core/auth-storage.js")).href;
+  let transaction;
+  try {
+    fs.chmodSync(temp, 0o700);
+    const directory = path.join(temp, "providers", "pi", agentId);
+    fs.mkdirSync(directory, { recursive: true, mode: 0o700 });
+    const authPath = path.join(directory, "auth.json");
+    fs.writeFileSync(authPath, `${JSON.stringify({ original: { type: "api_key", key: "original-key" } }, null, 2)}\n`, { mode: 0o600 });
+    transaction = beginBuiltinPiCredentialTransaction(temp, agentId);
+
+    const stateDir = path.join(temp, "state", "agents", agentId);
+    const bindScript = path.join(temp, "slow-official-bind.mjs");
+    fs.writeFileSync(bindScript, `import fs from "node:fs"; import path from "node:path";\n`
+      + `await new Promise((resolve)=>setTimeout(resolve,35000));\n`
+      + `const dir=path.join(process.env.LARKSUITE_CLI_CONFIG_DIR,"lark-channel");fs.mkdirSync(dir,{recursive:true,mode:0o700});\n`
+      + `fs.writeFileSync(path.join(dir,"config.json"),JSON.stringify({apps:[{appId:${JSON.stringify(agentId)},appSecret:{source:"keychain",id:"appsecret:${agentId}"},defaultAs:"bot",strictMode:"bot",users:[]}]}),{mode:0o600});\n`, { mode: 0o600 });
+    const agent = {
+      agentId, feishuAppId: agentId, feishuAppSecret: "heartbeat-secret", feishuDomain: "https://open.feishu.cn",
+      credentialRevision: "updated:heartbeat", stateDir, larkConfigDir: path.join(stateDir, "lark-cli-config"),
+      workspaceDir: path.join(temp, "agents", agentId), runtime: "pi", model: "default", feishuProfile: agentId,
+    };
+    const profileSync = syncAgentProfileAsync(agent, { ...process.env, LARKIN_CONFIG_DIR: temp }, {
+      forceRebind: true, timeoutMs: 45_000,
+      resolveOfficialCli: () => ({ command: process.execPath, argsPrefix: [bindScript], version: "1.0.79" }),
+    });
+
+    await new Promise((resolve) => setTimeout(resolve, 31_500));
+    const contenderScript = path.join(temp, "official-auth-contender.mjs");
+    fs.writeFileSync(contenderScript, `import fs from "node:fs"; import {AuthStorage} from ${JSON.stringify(officialAuthStorageModule)};\n`
+      + `const [authPath,started,written]=process.argv.slice(2);fs.writeFileSync(started,"started");\n`
+      + `const storage=AuthStorage.create(authPath);await storage.modify("anthropic",async()=>({type:"api_key",key:"contender-key"}));\n`
+      + `fs.writeFileSync(written,"written");\n`, { mode: 0o600 });
+    const contender = spawn(process.execPath, [contenderScript, authPath, contenderStarted, contenderWritten], {
+      stdio: ["ignore", "ignore", "pipe"],
+    });
+    let contenderError = "";
+    contender.stderr.on("data", (chunk) => { contenderError += String(chunk); });
+    const contenderExit = new Promise((resolve, reject) => {
+      contender.once("error", reject);
+      contender.once("exit", (code, signal) => resolve({ code, signal }));
+    });
+    const startDeadline = Date.now() + 5_000;
+    while (!fs.existsSync(contenderStarted) && Date.now() < startDeadline) await new Promise((resolve) => setTimeout(resolve, 20));
+    assert.equal(fs.existsSync(contenderStarted), true, "official AuthStorage contender did not start");
+
+    await new Promise((resolve) => setTimeout(resolve, 500));
+    assert.equal(fs.existsSync(contenderWritten), false,
+      "an official AuthStorage contender first started post-stale must not acquire the live setup lock immediately");
+    assert.equal(JSON.parse(fs.readFileSync(authPath, "utf8")).anthropic, undefined);
+
+    await profileSync;
+    transaction.commit();
+    transaction = null;
+    const releasedExit = await contenderExit;
+    assert.equal(releasedExit.code, 0, `same post-stale contender failed after release ${releasedExit.signal}: ${contenderError}`);
+    const final = JSON.parse(fs.readFileSync(authPath, "utf8"));
+    assert.equal(final.original.key, "original-key", "contender merge must preserve the pre-transaction provider");
+    assert.equal(final.anthropic.key, "contender-key", "contender must write after the parent releases the live lock");
+    assert.equal(fs.existsSync(contenderWritten), true);
+  } finally {
+    transaction?.rollback();
+    fs.rmSync(temp, { recursive: true, force: true });
+  }
+});
+
+test("OAuth refresh remains owned by the official ModelRuntime request-auth path", async () => {
+  const temp = fs.mkdtempSync(path.join(os.tmpdir(), "larkin-pi-oauth-refresh-"));
+  try {
+    fs.chmodSync(temp, 0o700);
+    const directory = path.join(temp, "providers", "pi", "cli_refreshA1");
+    fs.mkdirSync(directory, { recursive: true, mode: 0o700 });
+    fs.writeFileSync(path.join(directory, "auth.json"), `${JSON.stringify({
+      "refresh-fixture": { type: "oauth", access: "expired-access", refresh: "refresh-value", expires: 1 },
+    })}\n`, { mode: 0o600 });
+    const runtime = await createOfficialPiModelRuntime(temp, "cli_refreshA1");
+    let refreshCalls = 0;
+    runtime.registerNativeProvider(provider("refresh-fixture", "Refresh Fixture", { apiKey: false, oauth: true }));
+    const registered = runtime.getProvider("refresh-fixture");
+    registered.auth.oauth.refresh = async (credential) => {
+      refreshCalls += 1;
+      return { ...credential, access: "rotated-access", refresh: "rotated-refresh", expires: Date.now() + 3_600_000 };
+    };
+    registered.auth.oauth.toAuth = async (credential) => ({ apiKey: credential.access });
+    const auth = await runtime.getAuth("refresh-fixture", { minOAuthValidityMs: 300_000 });
+    assert.equal(refreshCalls, 1);
+    assert.equal(auth.auth.apiKey, "rotated-access");
+    const stored = JSON.parse(fs.readFileSync(path.join(directory, "auth.json"), "utf8"));
+    assert.equal(stored["refresh-fixture"].access, "rotated-access");
+    assert.equal(stored["refresh-fixture"].refresh, "rotated-refresh");
+  } finally { fs.rmSync(temp, { recursive: true, force: true }); }
+});
+
+test.skipIf(!Bun.which("expect"))("real PTY bridges text/secret/select/manual_code and hides secret inputs", () => {
+  const temp = fs.mkdtempSync(path.join(os.tmpdir(), "larkin-pi-auth-pty-"));
+  const secret = "pty-auth-secret-sentinel";
+  const manual = "pty-manual-code-sentinel";
+  try {
+    const fixture = path.join(temp, "auth-pty-fixture.mjs");
+    const transcript = path.join(temp, "auth-pty-transcript.txt");
+    const expectScript = path.join(temp, "auth-pty.expect");
+    const authUrl = pathToFileURL(path.join(ROOT, "dist/runtime/pi-official-auth.mjs")).href;
+    const setupUrl = pathToFileURL(path.join(ROOT, "dist/setup/setup-agent-choice.mjs")).href;
+    fs.writeFileSync(fixture, `import {createOfficialPiAuthInteraction} from ${JSON.stringify(authUrl)};\n`
+      + `import {terminalSetupQuestioner} from ${JSON.stringify(setupUrl)};\n`
+      + `const q=terminalSetupQuestioner(); const i=createOfficialPiAuthInteraction({questioner:q,report() {}});\n`
+      + `const text=await i.prompt({type:"text",message:"TEXT_PROMPT"});\n`
+      + `const secret=await i.prompt({type:"secret",message:"SECRET_PROMPT"});\n`
+      + `const selected=await i.prompt({type:"select",message:"SELECT_PROMPT",options:[{id:"one",label:"One"},{id:"two",label:"Two"}]});\n`
+      + `const manual=await i.prompt({type:"manual_code",message:"MANUAL_PROMPT"}); q.close();\n`
+      + `console.log(JSON.stringify({text,secretLength:secret.length,selected,manualLength:manual.length}));\n`, { mode: 0o600 });
+    fs.writeFileSync(expectScript, `set timeout 15\nlog_file -noappend {${transcript}}\nspawn -noecho {${process.execPath}} {${fixture}}\n`
+      + `expect {TEXT_PROMPT}; send -- "visible-text\\r"\n`
+      + `expect {SECRET_PROMPT}; send -- "${secret}\\r"\n`
+      + `expect {SELECT_PROMPT}; send -- "2\\r"\n`
+      + `expect {MANUAL_PROMPT}; send -- "${manual}\\r"\n`
+      + `expect {*"text":"visible-text"*"secretLength":${secret.length}*"selected":"two"*"manualLength":${manual.length}*}\nexpect eof\n`, { mode: 0o600 });
+    const result = spawnSync(Bun.which("expect"), [expectScript], { cwd: temp, encoding: "utf8", timeout: 20_000 });
+    assert.equal(result.status, 0, `${result.stdout}\n${result.stderr}`);
+    const output = fs.readFileSync(transcript, "utf8");
+    assert.doesNotMatch(output, new RegExp(`${secret}|${manual}`));
+  } finally { fs.rmSync(temp, { recursive: true, force: true }); }
+});

--- a/test/unit/runtime/pi-provider-config.test.mjs
+++ b/test/unit/runtime/pi-provider-config.test.mjs
@@ -1,0 +1,89 @@
+import { test } from "bun:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import {
+  PI_PROVIDER_PRESETS,
+  piAgentDirectory,
+  stageBuiltinPiProvider,
+  validateBuiltinPiProviderSelection,
+  validatePiBaseUrl,
+} from "../../../dist/runtime/pi-provider-config.mjs";
+
+test("Pi provider presets keep the requested setup order and audited official endpoints", () => {
+  assert.deepEqual(PI_PROVIDER_PRESETS.map((item) => item.id), ["deepseek", "kimi", "minimax", "zhipu"]);
+  assert.deepEqual(PI_PROVIDER_PRESETS.map((item) => item.baseUrl), [
+    "https://api.deepseek.com",
+    "https://api.moonshot.cn/v1",
+    "https://api.minimaxi.com/anthropic",
+    "https://open.bigmodel.cn/api/coding/paas/v4",
+  ]);
+});
+
+test("custom Pi endpoint validation rejects credentials, unsafe schemes, API leaf paths, and unsafe models", () => {
+  assert.equal(validatePiBaseUrl("https://gateway.example/v1/"), "https://gateway.example/v1");
+  assert.equal(validatePiBaseUrl("http://127.0.0.1:8080/v1"), "http://127.0.0.1:8080/v1");
+  for (const value of [
+    "http://gateway.example/v1",
+    "https://key@gateway.example/v1",
+    "file:///tmp/provider",
+    "https://gateway.example/v1/chat/completions",
+    "https://gateway.example/v1?api_key=secret",
+  ]) assert.throws(() => validatePiBaseUrl(value));
+  assert.throws(() => validateBuiltinPiProviderSelection({
+    distribution: "builtin", preset: "custom", baseUrl: "https://gateway.example/v1",
+    apiKey: "secret", model: "bad model",
+  }));
+});
+
+test("Pi credential transaction uses 0700/0600, preserves unrelated providers, and keeps keys out of models.json", () => {
+  const temp = fs.mkdtempSync(path.join(os.tmpdir(), "larkin-pi-provider-"));
+  try {
+    fs.chmodSync(temp, 0o700);
+    const directory = piAgentDirectory(temp, "cli_providerA1");
+    fs.mkdirSync(directory, { recursive: true, mode: 0o700 });
+    fs.writeFileSync(path.join(directory, "auth.json"), JSON.stringify({ unrelated: { type: "api_key", key: "keep-me" } }), { mode: 0o600 });
+    fs.writeFileSync(path.join(directory, "models.json"), JSON.stringify({ providers: { unrelated: { baseUrl: "https://keep.example/v1" } } }), { mode: 0o600 });
+    const transaction = stageBuiltinPiProvider(temp, "cli_providerA1", {
+      distribution: "builtin", preset: "custom", baseUrl: "https://gateway.example/v1",
+      apiKey: "custom-super-secret", model: "acme/code-model",
+    });
+    const auth = JSON.parse(fs.readFileSync(path.join(directory, "auth.json"), "utf8"));
+    const modelsRaw = fs.readFileSync(path.join(directory, "models.json"), "utf8");
+    const models = JSON.parse(modelsRaw);
+    assert.equal(auth.unrelated.key, "keep-me");
+    assert.equal(auth["larkin-custom"].key, "custom-super-secret");
+    assert.equal(models.providers.unrelated.baseUrl, "https://keep.example/v1");
+    assert.equal(models.providers["larkin-custom"].models[0].id, "acme/code-model");
+    assert.doesNotMatch(modelsRaw, /custom-super-secret/);
+    assert.equal(fs.statSync(directory).mode & 0o777, 0o700);
+    assert.equal(fs.statSync(path.join(directory, "auth.json")).mode & 0o777, 0o600);
+    assert.equal(fs.statSync(path.join(directory, "models.json")).mode & 0o777, 0o600);
+    transaction.rollback();
+    assert.deepEqual(JSON.parse(fs.readFileSync(path.join(directory, "auth.json"), "utf8")), { unrelated: { type: "api_key", key: "keep-me" } });
+    assert.deepEqual(JSON.parse(fs.readFileSync(path.join(directory, "models.json"), "utf8")), { providers: { unrelated: { baseUrl: "https://keep.example/v1" } } });
+  } finally { fs.rmSync(temp, { recursive: true, force: true }); }
+});
+
+test("switching a preset updates only its auth entry and never removes custom models", () => {
+  const temp = fs.mkdtempSync(path.join(os.tmpdir(), "larkin-pi-preset-"));
+  try {
+    fs.chmodSync(temp, 0o700);
+    const custom = stageBuiltinPiProvider(temp, "cli_providerB2", {
+      distribution: "builtin", preset: "custom", baseUrl: "https://gateway.example/v1",
+      apiKey: "custom-key", model: "acme-code",
+    });
+    custom.commit();
+    const preset = stageBuiltinPiProvider(temp, "cli_providerB2", {
+      distribution: "builtin", preset: "deepseek", apiKey: "deepseek-key", model: "deepseek-v4-pro",
+    });
+    preset.commit();
+    const directory = piAgentDirectory(temp, "cli_providerB2");
+    const auth = JSON.parse(fs.readFileSync(path.join(directory, "auth.json"), "utf8"));
+    const models = JSON.parse(fs.readFileSync(path.join(directory, "models.json"), "utf8"));
+    assert.equal(auth["larkin-custom"].key, "custom-key");
+    assert.equal(auth.deepseek.key, "deepseek-key");
+    assert.equal(models.providers["larkin-custom"].models[0].id, "acme-code");
+  } finally { fs.rmSync(temp, { recursive: true, force: true }); }
+});

--- a/test/unit/setup/bot-register-typescript.test.mjs
+++ b/test/unit/setup/bot-register-typescript.test.mjs
@@ -23,17 +23,35 @@ test("bot-register is strict TypeScript compiled to its direct runtime entry", (
 test("registration publishes the credential before binding, then verifies the bound Bot workspace", () => {
   const source = fs.readFileSync(SOURCE, "utf8");
   const publish = source.indexOf("fs.writeFileSync(stagedBotFile");
-  const bind = source.indexOf("spawnSync(bindSpec.command, bindSpec.args");
+  const bind = source.indexOf("runBindProcess(bindSpec.command, bindSpec.args");
   const sync = source.indexOf("synchronizeAgentProfile(agent");
-  const verify = source.indexOf("spawnSync(official.command");
-  assert.equal([publish, bind, sync, verify].every((index) => index >= 0), true);
+  const verify = source.indexOf("runIdentityProcess(official.command");
+  const resultPublish = source.indexOf("fs.writeFileSync(resultFile");
+  const authCommit = source.indexOf("pendingPiAuthTransaction?.commit()");
+  const preResolve = source.indexOf("resolvedSetupOfficialCli = resolveOfficialCli({ env: process.env })");
+  const authBegin = source.indexOf("pendingPiAuthTransaction = beginBuiltinPiCredentialTransaction");
+  assert.equal([publish, bind, sync, verify, resultPublish, authCommit].every((index) => index >= 0), true);
   assert.equal(publish < bind && bind < sync && sync < verify, true);
+  assert.equal(verify < resultPublish && resultPublish < authCommit, true,
+    "credential transaction must commit only after identity and result publication");
+  assert.equal(preResolve >= 0 && preResolve < authBegin, true,
+    "the synchronous official CLI probe must complete before the credential transaction lock");
+  const transactionInterval = source.slice(authBegin, authCommit);
+  assert.doesNotMatch(transactionInterval, /resolveOfficialLarkCli\s*\(/,
+    "the active credential transaction must reuse the pre-resolved official CLI");
+  assert.doesNotMatch(transactionInterval, /spawnSync\s*\(/,
+    "production work while the credential transaction is active must remain asynchronous");
   assert.match(source, /synchronizeAgentProfile\([\s\S]*\{ forceRebind: true \}\)/,
     "new setup credentials must explicitly force one authoritative rebind");
   assert.doesNotMatch(source, /config["', ]+init/);
   assert.match(source, /mode: 0o700/);
   assert.match(source, /mode: 0o600, flag: "wx"/);
   assert.match(source, /callbacks:\s*\{ items: \["card\.action\.trigger"\] \}/);
+  assert.match(source, /systemSpawn\(command, args, \{ stdio: "ignore", shell: false \}\)/,
+    "browser launch must be non-blocking and shell-free");
+  assert.match(source, /child\.once\("error", \(\) => say\(`\[setup\].*\$\{url\}`\)\)/,
+    "browser spawn errors must retain a complete manual URL fallback");
+  assert.doesNotMatch(source.slice(source.indexOf("function openBrowser"), source.indexOf("async function runBindProcess")), /spawnSync/);
 });
 
 test("help does not create credentials or expose a browser-selection bypass", () => {

--- a/test/unit/setup/setup-agent-choice.test.mjs
+++ b/test/unit/setup/setup-agent-choice.test.mjs
@@ -21,10 +21,10 @@ function questioner(answers, secret = "test-secret") {
 test("new setup visibly offers Pi first, then external/built-in, before Codex and Claude", async () => {
   const q = questioner(["1", "2", "1", ""]);
   const choice = await collectSetupAgentChoice(q);
-  assert.deepEqual(choice, { runtime: "pi", distribution: "builtin", preset: "deepseek", apiKey: "test-secret", model: "deepseek/deepseek-v4-pro" });
+  assert.deepEqual(choice, { runtime: "pi", distribution: "builtin", preset: "deepseek", model: "deepseek/deepseek-v4-pro" });
   assert.match(q.prompts[0], /1\. Pi（推荐）[\s\S]*2\. Codex[\s\S]*3\. Claude Code/);
   assert.match(q.prompts[1], /1\. 外置 Pi[\s\S]*2\. 内置 Pi/);
-  assert.match(q.prompts[2], /DeepSeek（推荐）[\s\S]*Kimi[\s\S]*MiniMax[\s\S]*智谱[\s\S]*Custom/);
+  assert.match(q.prompts[2], /DeepSeek（推荐）[\s\S]*Kimi[\s\S]*MiniMax[\s\S]*智谱[\s\S]*Custom[\s\S]*官方 Pi provider 登录/);
 });
 
 test("existing Agent setup preserves runtime/model unless the user explicitly chooses change", async () => {
@@ -46,8 +46,38 @@ test("missing external Pi offers a bounded recovery and can switch to built-in P
   assert.equal(probes, 1);
   assert.match(reports[0], /missing.*pi not found.*install pi/);
   assert.deepEqual(choice, {
-    runtime: "pi", distribution: "builtin", preset: "deepseek", apiKey: "test-secret", model: "deepseek/deepseek-v4-pro",
+    runtime: "pi", distribution: "builtin", preset: "deepseek", model: "deepseek/deepseek-v4-pro",
   });
+});
+
+test("built-in Pi dynamically offers every official provider auth method", async () => {
+  const q = questioner(["1", "2", "6", "2", ""]);
+  const services = {
+    providers: async () => [{ id: "alpha", name: "Alpha", methods: [
+      { type: "api_key", name: "Alpha key" }, { type: "oauth", name: "Alpha subscription" },
+    ], models: ["alpha/a-1"], ambientOnly: false }],
+    status: async () => [], logout: async () => {}, report() {},
+  };
+  assert.deepEqual(await collectSetupAgentChoice(q, undefined, services), {
+    runtime: "pi", distribution: "builtin", preset: "official", providerId: "alpha", authType: "oauth", model: "alpha/a-1",
+  });
+  assert.match(q.prompts[3], /Alpha key \[api_key\][\s\S]*Alpha subscription \[oauth\]/);
+});
+
+test("built-in Pi status/logout returns to selection without exposing credential values", async () => {
+  const reports = [];
+  const loggedOut = [];
+  const q = questioner(["1", "2", "7", "1", "1", ""]);
+  const services = {
+    providers: async () => [],
+    status: async () => [{ providerId: "alpha", providerName: "Alpha", credentialType: "oauth", source: "OAuth", stored: true }],
+    logout: async (providerId) => loggedOut.push(providerId), report: (message) => reports.push(message),
+  };
+  assert.deepEqual(await collectSetupAgentChoice(q, undefined, services), {
+    runtime: "pi", distribution: "builtin", preset: "deepseek", model: "deepseek/deepseek-v4-pro",
+  });
+  assert.deepEqual(loggedOut, ["alpha"]);
+  assert.match(reports.join("\n"), /Alpha.*oauth\/OAuth[\s\S]*已退出 Alpha/);
 });
 
 test("external Pi recovery cancellation preserves config and the retry loop is bounded", async () => {

--- a/test/unit/setup/setup-agent-choice.test.mjs
+++ b/test/unit/setup/setup-agent-choice.test.mjs
@@ -1,0 +1,91 @@
+import { test } from "bun:test";
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { pathToFileURL } from "node:url";
+import { collectSetupAgentChoice, recoverUnavailableExternalPi } from "../../../dist/setup/setup-agent-choice.mjs";
+
+const ROOT = path.resolve(import.meta.dirname, "../../..");
+
+function questioner(answers, secret = "test-secret") {
+  const prompts = [];
+  return {
+    prompts,
+    ask: async (prompt) => { prompts.push(prompt); return answers.shift() ?? ""; },
+    secret: async (prompt) => { prompts.push(prompt); return secret; },
+  };
+}
+
+test("new setup visibly offers Pi first, then external/built-in, before Codex and Claude", async () => {
+  const q = questioner(["1", "2", "1", ""]);
+  const choice = await collectSetupAgentChoice(q);
+  assert.deepEqual(choice, { runtime: "pi", distribution: "builtin", preset: "deepseek", apiKey: "test-secret", model: "deepseek/deepseek-v4-pro" });
+  assert.match(q.prompts[0], /1\. Pi（推荐）[\s\S]*2\. Codex[\s\S]*3\. Claude Code/);
+  assert.match(q.prompts[1], /1\. 外置 Pi[\s\S]*2\. 内置 Pi/);
+  assert.match(q.prompts[2], /DeepSeek（推荐）[\s\S]*Kimi[\s\S]*MiniMax[\s\S]*智谱[\s\S]*Custom/);
+});
+
+test("existing Agent setup preserves runtime/model unless the user explicitly chooses change", async () => {
+  const q = questioner([""]);
+  assert.equal(await collectSetupAgentChoice(q, { runtime: "pi", model: "deepseek/deepseek-v4-pro", piDistribution: "builtin" }), null);
+  assert.match(q.prompts[0], /直接回车保留/);
+});
+
+test("missing external Pi offers a bounded recovery and can switch to built-in Pi", async () => {
+  const q = questioner(["1", "1", ""]);
+  const reports = [];
+  let probes = 0;
+  const choice = await recoverUnavailableExternalPi(
+    { runtime: "pi", distribution: "external" },
+    q,
+    async () => { probes += 1; return { state: "missing", reason: "pi not found", nextAction: "install pi" }; },
+    (message) => reports.push(message),
+  );
+  assert.equal(probes, 1);
+  assert.match(reports[0], /missing.*pi not found.*install pi/);
+  assert.deepEqual(choice, {
+    runtime: "pi", distribution: "builtin", preset: "deepseek", apiKey: "test-secret", model: "deepseek/deepseek-v4-pro",
+  });
+});
+
+test("external Pi recovery cancellation preserves config and the retry loop is bounded", async () => {
+  const cancelled = questioner(["3"]);
+  await assert.rejects(() => recoverUnavailableExternalPi(
+    { runtime: "pi", distribution: "external" }, cancelled, async () => ({ state: "incompatible" })), /未修改 Agent\/config/);
+
+  // Three re-selections of the same unavailable external Pi are allowed; a
+  // fourth probe is never attempted and no configuration is published.
+  const repeated = questioner(["2", "1", "1", "2", "1", "1", "2", "1", "1"]);
+  let probes = 0;
+  await assert.rejects(() => recoverUnavailableExternalPi(
+    { runtime: "pi", distribution: "external" }, repeated,
+    async () => { probes += 1; return { state: "missing" }; }), /达到 3 次.*未修改 Agent\/config/);
+  assert.equal(probes, 3);
+});
+
+test.skipIf(!Bun.which("expect"))("TTY API Key input is received without echo and releases stdin so the process exits", () => {
+  const temp = fs.mkdtempSync(path.join(os.tmpdir(), "larkin-setup-secret-pty-"));
+  const sentinel = "pty-secret-SENTINEL-8391";
+  try {
+    const fixture = path.join(temp, "secret-fixture.mjs");
+    const transcript = path.join(temp, "terminal-transcript.txt");
+    const expectScript = path.join(temp, "secret.expect");
+    const moduleUrl = pathToFileURL(path.join(ROOT, "dist/setup/setup-agent-choice.mjs")).href;
+    fs.writeFileSync(fixture, `import { terminalSetupQuestioner } from ${JSON.stringify(moduleUrl)};\n`
+      + `const q = terminalSetupQuestioner();\nconst value = await q.secret("API_KEY> ");\n`
+      + `process.stdout.write("RECEIVED_LENGTH=" + value.length + "\\n");\n`, { mode: 0o600 });
+    fs.writeFileSync(expectScript, `set timeout 10\nlog_file -noappend {${transcript}}\n`
+      + `spawn -noecho {${process.execPath}} {${fixture}}\nexpect {API_KEY> }\nsend -- "${sentinel}\\r"\n`
+      + `expect {RECEIVED_LENGTH=${sentinel.length}}\nexpect eof\n`, { mode: 0o600 });
+    const result = spawnSync(Bun.which("expect"), [expectScript], { cwd: temp, encoding: "utf8", timeout: 15_000 });
+    assert.equal(result.error, undefined, result.error?.message);
+    assert.equal(result.status, 0, `${result.stdout}\n${result.stderr}`);
+    const output = fs.readFileSync(transcript, "utf8");
+    assert.match(output, new RegExp(`RECEIVED_LENGTH=${sentinel.length}`));
+    assert.doesNotMatch(output, new RegExp(sentinel), "PTY transcript must not contain the API Key");
+  } finally {
+    fs.rmSync(temp, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
Closes #40

## What changed

- makes Pi the first setup choice, followed by external Pi or bundled official Pi, then Codex and Claude Code
- pins and embeds official `@earendil-works/pi-coding-agent@0.83.0`
- dynamically derives every login-capable provider/auth type from Pi's official `ModelRuntime` registry and delegates API-key/OAuth login, logout, and refresh to the official runtime
- bridges all official auth prompts (`text`, `secret`, `select`, `manual_code`) and events (`info`, `auth_url`, `device_code`, `progress`)
- adds DeepSeek (recommended), Kimi/Moonshot, MiniMax, Zhipu/BigModel, and custom OpenAI-compatible shortcuts
- adds non-sensitive `larkin pi-auth status/logout` management
- stores credentials per Agent with 0700/0600 permissions, cross-process locking shared with official Pi AuthStorage, and exact rollback across cancellation, signals, readiness, and downstream setup failures
- includes Pi assets and its full dependency-license closure in standalone publication

## Validation

- full suite: 486 unit, 167 integration (+15 opt-in skips), 9 e2e, 24 frontend; 686 pass / 15 skip / 0 fail
- official registry parity: 38 providers, 37 API-key methods, 7 OAuth methods
- focused auth/PTY/concurrency tests passed, including secret/manual-code non-echo and a post-stale official AuthStorage contender barrier
- compiled official Pi source + single-file provider E2E: 2/2
- standalone setup and release workflows passed without external Agent CLIs, including 401/readiness rollback, identity timeout/overflow, SIGINT/SIGTERM, TERM→SIGKILL child cleanup, and no delayed writes
- real compiled `openai-codex` OAuth smoke passed; source credential digest remained unchanged and no Feishu write occurred
- canonical publication/license checks cover 201 runtime package versions; Gitleaks worktree scan passed

## Impact

Users can finish setup and run an official Pi-backed Agent without installing Pi, Codex, or Claude Code separately. Bundled Pi follows the pinned official registry's auth capabilities instead of maintaining a second OAuth implementation or static auth list. Existing external Pi and configured Agents remain supported.

This remains draft because merging the release version bump can trigger publication; release/merge is intentionally outside this task.