### PR TITLE
fix(pi): tolerate prompt preflight compaction

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "larkin",
-  "version": "0.2.60",
+  "version": "0.2.61",
   "private": true,
   "larkinPackageRole": "development-source-checkout",
   "packageManager": "bun@1.3.14",

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "licenses:check": "bun run scripts/generate-third-party-notices.mjs --check",
     "test:standalone-acceptance": "LARKIN_RUN_STANDALONE_BINARY_ACCEPTANCE=1 bun test --max-concurrency 1 test/integration/build/standalone-binary-acceptance.test.mjs",
     "test:standalone-setup-workflow": "LARKIN_RUN_STANDALONE_SETUP_WORKFLOW=1 bun test --max-concurrency 1 test/integration/build/standalone-setup-workflow.test.mjs",
+    "test:pi-preflight-standalone": "LARKIN_RUN_PI_PREFLIGHT_STANDALONE=1 bun test --max-concurrency 1 test/integration/build/pi-prompt-preflight-standalone.test.mjs",
     "test:unit": "bun test --max-concurrency 1 test/unit",
     "test:frontend": "bun run vitest run --config src/dashboard/web/vitest.config.mjs",
     "test:integration": "bun test --max-concurrency 1 test/integration",

--- a/src/platform/telemetry-spool.ts
+++ b/src/platform/telemetry-spool.ts
@@ -24,9 +24,10 @@ const HEX_TRACE = /^[0-9a-f]{32}$/;
 const HEX_SPAN = /^[0-9a-f]{16}$/;
 const SPAN_NAMES = new Set(["larkin.message.process", "feishu.receive", "runtime.deliver", "agent.turn", "model.activity", "tool.execute", "inbox.consume", "feishu.send",
   "document.comment.receive", "document.comment.gate", "document.comment.pending", "document.comment.replay", "document.comment.resolve", "document.comment.inbox", "document.comment.reply",
-  "pi.rpc.submit", "pi.rpc.lifecycle", "pi.output.wait", "pi.generation", "pi.tool.wait", "pi.rpc.settle"]);
+  "pi.prompt.wait", "pi.compaction", "pi.rpc.submit", "pi.rpc.lifecycle", "pi.output.wait", "pi.generation", "pi.tool.wait", "pi.rpc.settle"]);
 const ATTRIBUTE_KEYS = new Set(["service.name", "service.version", "service.instance.id", "larkin.agent.id_hash", "messaging.message.id_hash", "larkin.message.relation", "larkin.message.source",
-  "larkin.observation.boundary", "larkin.activity.type", "larkin.filter.reason", "larkin.runtime.id", "larkin.runtime.distribution", "larkin.operation.outcome"]);
+  "larkin.observation.boundary", "larkin.activity.type", "larkin.filter.reason", "larkin.runtime.id", "larkin.runtime.distribution", "larkin.operation.outcome",
+  "larkin.pi.preflight.outcome", "larkin.pi.preflight.progress"]);
 const SENSITIVE = /(?:bearer\s|(?:api[_-]?key|authorization|password|token|secret|cookie)\s*[=:]|(?:sk|ghp|github_pat)-?[a-z0-9_-]{8})/i;
 const ABSOLUTE_PATH = /(?:^|[\s"'=])(?:\/(?!\/)[^\s"']+|[A-Za-z]:[\\/][^\s"']+)/;
 const emptyDiagnostics = (): Diagnostics => ({ droppedFiles: 0, cleanedRemnantFiles: 0, droppedSpans: 0, lastUploadAt: null, lastErrorCategory: null });
@@ -72,6 +73,8 @@ function validateAttributes(value: unknown): void {
       if (key === "larkin.runtime.id" && text !== "pi") invalidPayload();
       if (key === "larkin.runtime.distribution" && !["builtin", "external"].includes(text)) invalidPayload();
       if (key === "larkin.operation.outcome" && !["success", "error"].includes(text)) invalidPayload();
+      if (key === "larkin.pi.preflight.outcome" && !["accepted", "timeout", "error"].includes(text)) invalidPayload();
+      if (key === "larkin.pi.preflight.progress" && !["compaction", "retry"].includes(text)) invalidPayload();
     }
   }
 }

--- a/src/platform/telemetry-tracing.ts
+++ b/src/platform/telemetry-tracing.ts
@@ -58,6 +58,7 @@ interface MessageTrace {
   pi?: {
     distribution: "builtin" | "external";
     submitAt?: number; acceptedAt?: number; turnStartAt?: number; firstOutputAt?: number; completedAt?: number; settledAt?: number;
+    promptWaitSpan?: Span; compactionSpan?: Span;
     rpcSpan?: Span; lifecycleSpan?: Span; outputWaitSpan?: Span; generationSpan?: Span; toolSpan?: Span; settleSpan?: Span;
   };
 }
@@ -201,7 +202,7 @@ export function createTelemetryRuntime(config: TelemetryConfig, options: Telemet
   };
   const closePi = (current: MessageTrace, failed = false): void => {
     const state = current.pi; if (!state) return;
-    for (const key of ["rpcSpan", "lifecycleSpan", "outputWaitSpan", "generationSpan", "toolSpan", "settleSpan"] as const) {
+    for (const key of ["promptWaitSpan", "compactionSpan", "rpcSpan", "lifecycleSpan", "outputWaitSpan", "generationSpan", "toolSpan", "settleSpan"] as const) {
       const span = state[key];
       if (!span) continue;
       if (failed) span.setStatus({ code: SpanStatusCode.ERROR });
@@ -288,16 +289,38 @@ export function createTelemetryRuntime(config: TelemetryConfig, options: Telemet
           if (event.distribution !== "builtin" || state.settledAt !== undefined) return;
           const spanAttributes = { "larkin.observation.boundary": "pi_rpc", "larkin.runtime.id": "pi",
             "larkin.runtime.distribution": "builtin" };
+          const startPreflight = (name: "pi.prompt.wait" | "pi.compaction", startTime: number): Span =>
+            tracer.startSpan(name, { kind: SpanKind.INTERNAL, startTime, attributes: spanAttributes }, current.context);
           const start = (name: "pi.rpc.submit" | "pi.rpc.lifecycle" | "pi.output.wait" | "pi.generation"
             | "pi.tool.wait" | "pi.rpc.settle", startTime: number): Span | undefined => {
             if (!current.turnContext) return undefined;
             return tracer.startSpan(name, { kind: SpanKind.INTERNAL, startTime, attributes: spanAttributes }, current.turnContext);
           };
-          if (event.phase === "rpc_submit" && state.submitAt === undefined && state.acceptedAt === undefined) state.submitAt = observedAt;
+          if (event.phase === "rpc_submit" && state.submitAt === undefined && state.acceptedAt === undefined) {
+            state.submitAt = observedAt;
+            state.promptWaitSpan = startPreflight("pi.prompt.wait", observedAt);
+          }
           else if (event.phase === "rpc_accepted" && state.submitAt !== undefined && state.acceptedAt === undefined) {
             state.acceptedAt = observedAt;
+            state.promptWaitSpan?.setAttribute("larkin.pi.preflight.outcome", "accepted");
+            state.promptWaitSpan?.end(observedAt); delete state.promptWaitSpan;
+            state.compactionSpan?.end(observedAt); delete state.compactionSpan;
             if (state.rpcSpan) { state.rpcSpan.end(observedAt); delete state.rpcSpan; }
             if (current.turnContext && !state.outputWaitSpan) state.outputWaitSpan = start("pi.output.wait", observedAt);
+          } else if (event.phase === "compaction_start" && state.submitAt !== undefined && !state.compactionSpan) {
+            state.promptWaitSpan?.setAttribute("larkin.pi.preflight.progress", "compaction");
+            state.compactionSpan = startPreflight("pi.compaction", observedAt);
+          } else if (event.phase === "compaction_end") {
+            state.compactionSpan?.end(observedAt); delete state.compactionSpan;
+          } else if (event.phase === "retry_progress") {
+            state.promptWaitSpan?.setAttribute("larkin.pi.preflight.progress", "retry");
+          } else if (event.phase === "rpc_timeout" || event.phase === "rpc_error") {
+            const outcome = event.phase === "rpc_timeout" ? "timeout" : "error";
+            state.promptWaitSpan?.setAttribute("larkin.pi.preflight.outcome", outcome);
+            state.promptWaitSpan?.setStatus({ code: SpanStatusCode.ERROR });
+            state.promptWaitSpan?.end(observedAt); delete state.promptWaitSpan;
+            state.compactionSpan?.setStatus({ code: SpanStatusCode.ERROR });
+            state.compactionSpan?.end(observedAt); delete state.compactionSpan;
           } else if (event.phase === "turn_start" && state.turnStartAt === undefined) state.turnStartAt = observedAt;
           else if (event.phase === "first_output" && state.firstOutputAt === undefined && state.completedAt === undefined) {
             state.firstOutputAt = observedAt;

--- a/src/platform/telemetry-tracing.ts
+++ b/src/platform/telemetry-tracing.ts
@@ -286,9 +286,9 @@ export function createTelemetryRuntime(config: TelemetryConfig, options: Telemet
           const state = current.pi ??= { distribution: event.distribution };
           state.distribution = event.distribution;
           const observedAt = now();
-          if (event.distribution !== "builtin" || state.settledAt !== undefined) return;
+          if (state.settledAt !== undefined) return;
           const spanAttributes = { "larkin.observation.boundary": "pi_rpc", "larkin.runtime.id": "pi",
-            "larkin.runtime.distribution": "builtin" };
+            "larkin.runtime.distribution": event.distribution };
           const startPreflight = (name: "pi.prompt.wait" | "pi.compaction", startTime: number): Span =>
             tracer.startSpan(name, { kind: SpanKind.INTERNAL, startTime, attributes: spanAttributes }, current.context);
           const start = (name: "pi.rpc.submit" | "pi.rpc.lifecycle" | "pi.output.wait" | "pi.generation"
@@ -305,8 +305,10 @@ export function createTelemetryRuntime(config: TelemetryConfig, options: Telemet
             state.promptWaitSpan?.setAttribute("larkin.pi.preflight.outcome", "accepted");
             state.promptWaitSpan?.end(observedAt); delete state.promptWaitSpan;
             state.compactionSpan?.end(observedAt); delete state.compactionSpan;
-            if (state.rpcSpan) { state.rpcSpan.end(observedAt); delete state.rpcSpan; }
-            if (current.turnContext && !state.outputWaitSpan) state.outputWaitSpan = start("pi.output.wait", observedAt);
+            if (event.distribution === "builtin") {
+              if (state.rpcSpan) { state.rpcSpan.end(observedAt); delete state.rpcSpan; }
+              if (current.turnContext && !state.outputWaitSpan) state.outputWaitSpan = start("pi.output.wait", observedAt);
+            }
           } else if (event.phase === "compaction_start" && state.submitAt !== undefined && !state.compactionSpan) {
             state.promptWaitSpan?.setAttribute("larkin.pi.preflight.progress", "compaction");
             state.compactionSpan = startPreflight("pi.compaction", observedAt);
@@ -321,7 +323,9 @@ export function createTelemetryRuntime(config: TelemetryConfig, options: Telemet
             state.promptWaitSpan?.end(observedAt); delete state.promptWaitSpan;
             state.compactionSpan?.setStatus({ code: SpanStatusCode.ERROR });
             state.compactionSpan?.end(observedAt); delete state.compactionSpan;
-          } else if (event.phase === "turn_start" && state.turnStartAt === undefined) state.turnStartAt = observedAt;
+          }
+          if (event.distribution !== "builtin") return;
+          if (event.phase === "turn_start" && state.turnStartAt === undefined) state.turnStartAt = observedAt;
           else if (event.phase === "first_output" && state.firstOutputAt === undefined && state.completedAt === undefined) {
             state.firstOutputAt = observedAt;
             if (state.outputWaitSpan) { state.outputWaitSpan.end(observedAt); delete state.outputWaitSpan; }

--- a/src/runtime/pi-rpc-client.ts
+++ b/src/runtime/pi-rpc-client.ts
@@ -17,13 +17,18 @@ export interface PiRpcProcess {
 
 interface PendingRequest {
   command: string;
-  timer: NodeJS.Timeout;
+  timer?: NodeJS.Timeout;
+  startedAt: number;
+  absoluteDeadlineAt?: number;
   resolve(value: unknown): void;
   reject(error: Error): void;
 }
 
 export interface PiRpcClientOptions {
   requestTimeoutMs?: number;
+  inputTimeoutMs?: number;
+  inputProgressTimeoutMs?: number;
+  inputMaxTimeoutMs?: number;
   maxFrameBytes?: number;
   maxStderrBytes?: number;
   shutdownGraceMs?: number;
@@ -37,6 +42,9 @@ export class PiRpcClient {
   private readonly eventListeners = new Set<(event: RpcObject) => void>();
   private readonly failureListeners = new Set<(error: Error) => void>();
   private readonly requestTimeoutMs: number;
+  private readonly inputTimeoutMs: number;
+  private readonly inputProgressTimeoutMs: number;
+  private readonly inputMaxTimeoutMs: number;
   private readonly maxFrameBytes: number;
   private readonly maxStderrBytes: number;
   private readonly shutdownGraceMs: number;
@@ -49,6 +57,11 @@ export class PiRpcClient {
 
   constructor(private readonly process: PiRpcProcess, options: PiRpcClientOptions = {}) {
     this.requestTimeoutMs = options.requestTimeoutMs ?? 10_000;
+    this.inputTimeoutMs = options.inputTimeoutMs ?? 120_000;
+    this.inputProgressTimeoutMs = options.inputProgressTimeoutMs ?? 300_000;
+    this.inputMaxTimeoutMs = options.inputMaxTimeoutMs ?? 600_000;
+    if (this.requestTimeoutMs <= 0 || this.inputTimeoutMs <= 0 || this.inputProgressTimeoutMs <= 0
+      || this.inputMaxTimeoutMs < this.inputTimeoutMs) throw new Error("Pi RPC timeout options are invalid");
     this.maxFrameBytes = options.maxFrameBytes ?? 1024 * 1024;
     this.maxStderrBytes = options.maxStderrBytes ?? 64 * 1024;
     this.shutdownGraceMs = options.shutdownGraceMs ?? 2_000;
@@ -84,9 +97,15 @@ export class PiRpcClient {
     if (this.failed) return Promise.reject(this.failed);
     const id = `larkin-${++this.nextId}`;
     return new Promise<T>((resolve, reject) => {
-      const timer = setTimeout(() => this.fail(new Error(`Pi RPC ${command} timed out after ${this.requestTimeoutMs}ms`), true), this.requestTimeoutMs);
-      timer.unref?.();
-      this.pending.set(id, { command, timer, resolve: resolve as (value: unknown) => void, reject });
+      const startedAt = Date.now();
+      const input = isInputCommand(command);
+      const pending: PendingRequest = {
+        command, startedAt,
+        ...(input ? { absoluteDeadlineAt: startedAt + this.inputMaxTimeoutMs } : {}),
+        resolve: resolve as (value: unknown) => void, reject,
+      };
+      this.pending.set(id, pending);
+      this.armTimeout(id, pending, input ? this.inputTimeoutMs : this.requestTimeoutMs);
       try {
         if (!this.process.stdin || this.process.stdin.destroyed) throw new Error("stdin is unavailable");
         this.process.stdin.write(`${JSON.stringify({ id, type: command, ...fields })}\n`, (error) => {
@@ -144,7 +163,7 @@ export class PiRpcClient {
       const pending = this.pending.get(message.id);
       if (!pending) { this.protocolFailure(`unexpected response id ${message.id}`); return; }
       this.pending.delete(message.id);
-      clearTimeout(pending.timer);
+      if (pending.timer) clearTimeout(pending.timer);
       if (message.command !== pending.command) {
         pending.reject(new Error(`Pi RPC protocol error: response command ${String(message.command)} does not match ${pending.command}`));
         this.fail(new Error("Pi RPC protocol error: mismatched response command"), true);
@@ -152,7 +171,36 @@ export class PiRpcClient {
       else pending.reject(new Error(`Pi RPC ${pending.command} failed: ${String(message.error || "unknown error")}`));
       return;
     }
+    if (isInputProgress(message)) this.refreshInputDeadlines(message.type);
     for (const listener of this.eventListeners) listener(message);
+  }
+
+  private refreshInputDeadlines(eventType: string): void {
+    const graceMs = eventType === "compaction_start" || eventType.startsWith("summarization_retry_")
+      || eventType === "auto_retry_start" ? this.inputProgressTimeoutMs : this.inputTimeoutMs;
+    for (const [id, pending] of this.pending) {
+      if (!isInputCommand(pending.command)) continue;
+      this.armTimeout(id, pending, graceMs);
+    }
+  }
+
+  private armTimeout(id: string, pending: PendingRequest, requestedMs: number): void {
+    if (pending.timer) clearTimeout(pending.timer);
+    const now = Date.now();
+    const absoluteRemaining = pending.absoluteDeadlineAt === undefined ? requestedMs : pending.absoluteDeadlineAt - now;
+    const delay = Math.max(0, Math.min(requestedMs, absoluteRemaining));
+    pending.timer = setTimeout(() => {
+      if (!this.pending.has(id)) return;
+      const elapsed = Date.now() - pending.startedAt;
+      const absolute = pending.absoluteDeadlineAt !== undefined && Date.now() >= pending.absoluteDeadlineAt;
+      const error = isInputCommand(pending.command)
+        ? new Error(absolute
+          ? `Pi RPC ${pending.command} preflight timed out at absolute ${this.inputMaxTimeoutMs}ms limit`
+          : `Pi RPC ${pending.command} preflight timed out after ${elapsed}ms without progress`)
+        : new Error(`Pi RPC ${pending.command} timed out after ${this.requestTimeoutMs}ms`);
+      this.fail(error, true);
+    }, delay);
+    pending.timer.unref?.();
   }
 
   private protocolFailure(detail: string): void {
@@ -163,7 +211,7 @@ export class PiRpcClient {
     if (this.failed) return;
     this.failed = error;
     for (const pending of this.pending.values()) {
-      clearTimeout(pending.timer);
+      if (pending.timer) clearTimeout(pending.timer);
       pending.reject(error);
     }
     this.pending.clear();
@@ -200,3 +248,11 @@ export class PiRpcClient {
     return this.shutdownPromise;
   }
 }
+
+const INPUT_COMMANDS = new Set(["prompt", "steer", "follow_up"]);
+const INPUT_PROGRESS_EVENTS = new Set([
+  "compaction_start", "compaction_end", "auto_retry_start", "auto_retry_end",
+  "summarization_retry_scheduled", "summarization_retry_attempt_start", "summarization_retry_finished",
+]);
+const isInputCommand = (command: string): boolean => INPUT_COMMANDS.has(command);
+const isInputProgress = (message: RpcObject): boolean => typeof message.type === "string" && INPUT_PROGRESS_EVENTS.has(message.type);

--- a/src/runtime/runtime-adapters.ts
+++ b/src/runtime/runtime-adapters.ts
@@ -16,7 +16,7 @@ import type {
   UpstreamProviderError,
 } from "./runtime-contracts.js";
 import { isPiThinkingLevel } from "./pi-model-catalog.js";
-import { PiRpcClient } from "./pi-rpc-client.js";
+import { PiRpcClient, type PiRpcClientOptions } from "./pi-rpc-client.js";
 import { internalCommandSpec } from "../app/internal-command.js";
 import { piAgentDirectory } from "./pi-provider-config.js";
 import {
@@ -57,6 +57,7 @@ export interface PiSessionProcessLike {
 export interface NativeRuntimeAdapterDependencies {
   spawn?: (command: string, args: readonly string[], options: Record<string, unknown>) => ProcessLike;
   createPiSession?: (input: RuntimeSessionCreate) => Promise<PiSessionProcessLike>;
+  piRpcClientOptions?: PiRpcClientOptions;
   piCommand?: string;
   codexCommand?: string;
   codexModelOverride?: string;
@@ -536,6 +537,11 @@ class PiSession extends EventSession {
       }
       return { status: "accepted", inputId: input.inputId };
     } catch (error) {
+      const wasAwaiting = this.awaitingAcknowledgement.has(input.inputId);
+      if (ownsRpcObservation && wasAwaiting) this.emit({
+        type: "runtime-observation", runtime: "pi", distribution: this.distribution,
+        phase: /preflight timed out/i.test((error as Error).message) ? "rpc_timeout" : "rpc_error",
+      });
       this.awaitingAcknowledgement.delete(input.inputId);
       this.ownedInputIds.delete(input.inputId);
       this.inputEpochs.delete(input.inputId);
@@ -547,6 +553,10 @@ class PiSession extends EventSession {
     const event = raw as Record<string, any>;
     if (event?.type === "larkin_rpc_failure") {
       const message = String(event.message || "Pi RPC process failed");
+      if (this.awaitingAcknowledgement.size > 0) this.emit({
+        type: "runtime-observation", runtime: "pi", distribution: this.distribution,
+        phase: /preflight timed out/i.test(message) ? "rpc_timeout" : "rpc_error",
+      });
       for (const inputId of this.ownedInputIds) {
         if (!this.awaitingAcknowledgement.has(inputId)) this.emit({ type: "input-error", inputId, retryable: true, willRetry: true, message });
       }
@@ -559,6 +569,13 @@ class PiSession extends EventSession {
       this.activeEpoch = null;
       this.settleArmedEpoch = null;
       this.emit({ type: "error", message });
+    } else if (event?.type === "compaction_start" && this.awaitingAcknowledgement.size > 0) {
+      this.emit({ type: "runtime-observation", runtime: "pi", distribution: this.distribution, phase: "compaction_start" });
+    } else if (event?.type === "compaction_end" && this.awaitingAcknowledgement.size > 0) {
+      this.emit({ type: "runtime-observation", runtime: "pi", distribution: this.distribution, phase: "compaction_end" });
+    } else if ((event?.type === "auto_retry_start" || event?.type === "auto_retry_end"
+      || String(event?.type || "").startsWith("summarization_retry_")) && this.awaitingAcknowledgement.size > 0) {
+      this.emit({ type: "runtime-observation", runtime: "pi", distribution: this.distribution, phase: "retry_progress" });
     } else if (event?.type === "turn_start") {
       const epoch = this.oldestOwnedEpoch();
       if (epoch === null || this.activeEpoch !== null) return;
@@ -836,7 +853,7 @@ async function createPiRpcBackend(input: RuntimeSessionCreate, dependencies: Nat
     env: mergedEnv,
     stdio: ["pipe", "pipe", "pipe"],
   });
-  const client = new PiRpcClient(child);
+  const client = new PiRpcClient(child, dependencies.piRpcClientOptions);
   try {
     const [state, available] = await Promise.all([
       client.request<PiRpcState>("get_state"),

--- a/src/runtime/runtime-contracts.ts
+++ b/src/runtime/runtime-contracts.ts
@@ -39,7 +39,8 @@ export interface UpstreamProviderError {
 export type NormalizedRuntimeEvent =
   | { type: "session-init"; sessionId: string; model?: string; reasoningEffort?: string }
   | { type: "runtime-observation"; runtime: "pi"; distribution: "builtin" | "external";
-      phase: "rpc_submit" | "rpc_accepted" | "turn_start" | "first_output" | "tool_call" | "tool_result" | "completed" | "settled" }
+      phase: "rpc_submit" | "rpc_accepted" | "compaction_start" | "compaction_end" | "retry_progress"
+        | "rpc_timeout" | "rpc_error" | "turn_start" | "first_output" | "tool_call" | "tool_result" | "completed" | "settled" }
   | { type: "turn-start"; turnId?: string }
   | { type: "activity"; activity: "thinking" | "text" | "tool" | "internal"; text?: string; name?: string }
   | { type: "turn-end"; sessionId?: string; turnId?: string }

--- a/test/e2e/pi-prompt-preflight-recovery-mock-e2e.test.mjs
+++ b/test/e2e/pi-prompt-preflight-recovery-mock-e2e.test.mjs
@@ -1,0 +1,111 @@
+import assert from "node:assert/strict";
+import { EventEmitter } from "node:events";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { PassThrough } from "node:stream";
+import { test } from "bun:test";
+import { SpanKind } from "@opentelemetry/api";
+import { createAgentStateStore } from "../../dist/agent/agent-state-store.mjs";
+import { ContextPromptBuilder } from "../../dist/agent/context-prompt.mjs";
+import { createTelemetryRuntime } from "../../dist/platform/telemetry-tracing.mjs";
+import { TelemetrySpool } from "../../dist/platform/telemetry-spool.mjs";
+import { createNativeRuntimeAdapter } from "../../dist/runtime/runtime-adapters.mjs";
+import { createRuntimeHost } from "../../dist/runtime/runtime-host.mjs";
+
+class PreflightPiProcess extends EventEmitter {
+  stdout = new PassThrough();
+  stderr = new PassThrough();
+  promptCount = 0;
+  killed = [];
+  stdin = {
+    destroyed: false,
+    write: (line, callback) => {
+      const request = JSON.parse(line);
+      callback?.();
+      if (request.type === "get_state") this.respond(request, { sessionId: "PRIVATE_SESSION",
+        model: { provider: "fixture", id: "fixture-model" }, thinkingLevel: "medium" });
+      else if (request.type === "get_available_models") this.respond(request,
+        { models: [{ provider: "fixture", id: "fixture-model" }] });
+      else if (request.type === "prompt") {
+        this.promptCount += 1;
+        setTimeout(() => this.event({ type: "compaction_start", reason: "threshold" }), 10);
+        setTimeout(() => this.event({ type: "summarization_retry_scheduled", attempt: 1, maxAttempts: 3,
+          delayMs: 10, errorMessage: "PRIVATE_PROVIDER_DETAIL" }), 35);
+        setTimeout(() => this.event({ type: "compaction_end", reason: "threshold", aborted: false, willRetry: false,
+          result: { summary: "PRIVATE_SUMMARY" } }), 60);
+        setTimeout(() => this.respond(request), 65);
+      }
+      return true;
+    },
+    end() {},
+  };
+  respond(request, data) {
+    queueMicrotask(() => this.stdout.write(`${JSON.stringify({ id: request.id, type: "response", command: request.type,
+      success: true, ...(data === undefined ? {} : { data }) })}\n`));
+  }
+  event(value) { this.stdout.write(`${JSON.stringify(value)}\n`); }
+  kill(signal) { this.killed.push(signal); queueMicrotask(() => this.emit("exit", null, signal)); return true; }
+}
+
+test("production-order Pi preflight progress preserves one durable Inbox delivery until delayed acceptance", async () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "larkin-pi-preflight-e2e-"));
+  const agentId = "cli_piPreflightA1"; const messageId = "om_PRIVATE_MESSAGE";
+  const stateDir = path.join(root, "state", "agents", agentId); const workspaceDir = path.join(root, "workspace");
+  const store = createAgentStateStore(root, agentId); const child = new PreflightPiProcess(); let spawnCount = 0;
+  const previousConfigDir = process.env.LARKIN_CONFIG_DIR;
+  process.env.LARKIN_CONFIG_DIR = path.join(root, "config");
+  const telemetryConfig = { spoolDir: path.join(root, "telemetry", "spool"), headers: {}, maxBytes: 1024 * 1024,
+    maxFiles: 100, maxAgeMs: 60_000, uploadIntervalMs: 60_000, requestTimeoutMs: 2_000 };
+  const telemetry = createTelemetryRuntime(telemetryConfig, { stateDirFor: () => stateDir });
+  const native = createNativeRuntimeAdapter("pi", {
+    env: { LARKIN_PI_DISTRIBUTION: "builtin", LARKIN_CONFIG_DIR: path.join(root, "config") },
+    spawn: () => { spawnCount += 1; return child; },
+    piRpcClientOptions: { requestTimeoutMs: 5, inputTimeoutMs: 20, inputProgressTimeoutMs: 40, inputMaxTimeoutMs: 100 },
+  });
+  const adapter = { id: native.id, capabilities: native.capabilities,
+    probe: async () => ({ runtime: "pi", state: "ready" }), createSession: (input) => native.createSession(input) };
+  const host = createRuntimeHost({ adapterFor: () => adapter, promptBuilder: new ContextPromptBuilder(),
+    stateStoreFor: () => store, telemetry, retryPolicy: { baseDelayMs: 2, maxDelayMs: 2, maxAttempts: 2 },
+    assertOfficialCliReady: () => {} });
+  const target = "chat:PRIVATE_TARGET";
+  const envelope = { message_id: messageId, target, content: "PRIVATE_PROMPT_BODY", wake: true };
+  try {
+    fs.mkdirSync(workspaceDir, { recursive: true });
+    await host.start([{ agentId, name: agentId, runtime: "pi", model: "default", piDistribution: "builtin",
+      workspaceDir, stateDir, env: { LARKIN_PI_DISTRIBUTION: "builtin", LARKIN_CONFIG_DIR: path.join(root, "config") } }]);
+    store.prepareInboxDelivery(envelope); telemetry.beginMessage(agentId, messageId);
+    const delivery = telemetry.phase(messageId, "runtime.deliver", SpanKind.PRODUCER, () => host.deliver(agentId, envelope));
+    await new Promise((resolve) => setTimeout(resolve, 25));
+    assert.equal(store.readJson("runtimeDeliveries", { records: [] }).records[0].status, "submitting");
+    assert.deepEqual(store.readNdjson("inbox").map((row) => row.message_id), [messageId]);
+    const receipt = await delivery; telemetry.delivery(agentId, messageId, receipt.status);
+    assert.equal(receipt.status, "accepted");
+    assert.equal(child.promptCount, 1);
+    assert.equal(spawnCount, 1, "progressing preflight must not trigger Runtime recreation");
+    assert.equal(store.readJson("runtimeDeliveries", { records: [] }).records[0].status, "accepted");
+    child.event({ type: "turn_start", turnIndex: 0 });
+    assert.deepEqual(store.pollInbox({ target }).envelopes.map((row) => row.message_id), [messageId]);
+    child.event({ type: "agent_end", willRetry: false, messages: [{ role: "assistant", stopReason: "stop" }] });
+    child.event({ type: "agent_settled" });
+    await new Promise((resolve) => setImmediate(resolve));
+    assert.equal(store.readJson("runtimeDeliveries", { records: [] }).records[0].status, "consumed");
+    await host.shutdown("mock preflight complete"); await telemetry.shutdown();
+
+    const records = new TelemetrySpool(telemetryConfig).list();
+    const spans = records.flatMap(({ payload }) => payload.resourceSpans)
+      .flatMap((resource) => resource.scopeSpans).flatMap((scope) => scope.spans);
+    const names = spans.map((span) => span.name);
+    assert.equal(names.filter((name) => name === "pi.prompt.wait").length, 1);
+    assert.equal(names.filter((name) => name === "pi.compaction").length, 1);
+    assert.equal(names.filter((name) => name === "agent.turn").length, 1);
+    const serialized = JSON.stringify(records.map(({ payload }) => payload));
+    for (const forbidden of [agentId, messageId, target, "PRIVATE_PROMPT_BODY", "PRIVATE_PROVIDER_DETAIL", "PRIVATE_SUMMARY",
+      "PRIVATE_SESSION", root]) assert.equal(serialized.includes(forbidden), false, forbidden);
+  } finally {
+    await host.shutdown("test cleanup").catch(() => {}); await telemetry.shutdown().catch(() => {});
+    if (previousConfigDir === undefined) delete process.env.LARKIN_CONFIG_DIR;
+    else process.env.LARKIN_CONFIG_DIR = previousConfigDir;
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});

--- a/test/e2e/pi-prompt-preflight-recovery-mock-e2e.test.mjs
+++ b/test/e2e/pi-prompt-preflight-recovery-mock-e2e.test.mjs
@@ -18,6 +18,7 @@ class PreflightPiProcess extends EventEmitter {
   stderr = new PassThrough();
   promptCount = 0;
   killed = [];
+  constructor(options = {}) { super(); this.acceptPrompt = options.acceptPrompt !== false; }
   stdin = {
     destroyed: false,
     write: (line, callback) => {
@@ -29,12 +30,14 @@ class PreflightPiProcess extends EventEmitter {
         { models: [{ provider: "fixture", id: "fixture-model" }] });
       else if (request.type === "prompt") {
         this.promptCount += 1;
-        setTimeout(() => this.event({ type: "compaction_start", reason: "threshold" }), 10);
+        setTimeout(() => this.event({ type: "compaction_start", reason: "threshold" }), this.acceptPrompt ? 10 : 8);
         setTimeout(() => this.event({ type: "summarization_retry_scheduled", attempt: 1, maxAttempts: 3,
-          delayMs: 10, errorMessage: "PRIVATE_PROVIDER_DETAIL" }), 35);
-        setTimeout(() => this.event({ type: "compaction_end", reason: "threshold", aborted: false, willRetry: false,
-          result: { summary: "PRIVATE_SUMMARY" } }), 60);
-        setTimeout(() => this.respond(request), 65);
+          delayMs: 10, errorMessage: "PRIVATE_PROVIDER_DETAIL" }), this.acceptPrompt ? 35 : 22);
+        if (this.acceptPrompt) {
+          setTimeout(() => this.event({ type: "compaction_end", reason: "threshold", aborted: false, willRetry: false,
+            result: { summary: "PRIVATE_SUMMARY" } }), 60);
+          setTimeout(() => this.respond(request), 65);
+        }
       }
       return true;
     },
@@ -106,6 +109,57 @@ test("production-order Pi preflight progress preserves one durable Inbox deliver
     await host.shutdown("test cleanup").catch(() => {}); await telemetry.shutdown().catch(() => {});
     if (previousConfigDir === undefined) delete process.env.LARKIN_CONFIG_DIR;
     else process.env.LARKIN_CONFIG_DIR = previousConfigDir;
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("external Pi production-order preflight timeout stays bounded, pending, observable, and turn-free", async () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "larkin-external-pi-timeout-e2e-"));
+  const agentId = "cli_externalTimeoutA1"; const messageId = "om_PRIVATE_TIMEOUT";
+  const stateDir = path.join(root, "state", "agents", agentId); const workspaceDir = path.join(root, "workspace");
+  const store = createAgentStateStore(root, agentId); const child = new PreflightPiProcess({ acceptPrompt: false }); let spawnCount = 0;
+  const telemetryConfig = { spoolDir: path.join(root, "telemetry", "spool"), headers: {}, maxBytes: 1024 * 1024,
+    maxFiles: 100, maxAgeMs: 60_000, uploadIntervalMs: 60_000, requestTimeoutMs: 2_000 };
+  const telemetry = createTelemetryRuntime(telemetryConfig, { stateDirFor: () => stateDir });
+  const native = createNativeRuntimeAdapter("pi", {
+    spawn: () => { spawnCount += 1; return child; },
+    piRpcClientOptions: { requestTimeoutMs: 5, inputTimeoutMs: 15, inputProgressTimeoutMs: 25, inputMaxTimeoutMs: 50 },
+  });
+  const adapter = { id: native.id, capabilities: native.capabilities,
+    probe: async () => ({ runtime: "pi", state: "ready" }), createSession: (input) => native.createSession(input) };
+  const host = createRuntimeHost({ adapterFor: () => adapter, promptBuilder: new ContextPromptBuilder(),
+    stateStoreFor: () => store, telemetry, retryPolicy: { baseDelayMs: 2, maxDelayMs: 2, maxAttempts: 0 },
+    assertOfficialCliReady: () => {} });
+  const target = "chat:PRIVATE_TIMEOUT_TARGET";
+  const envelope = { message_id: messageId, target, content: "PRIVATE_TIMEOUT_BODY", wake: true };
+  try {
+    fs.mkdirSync(workspaceDir, { recursive: true });
+    await host.start([{ agentId, name: agentId, runtime: "pi", model: "default", piDistribution: "external",
+      workspaceDir, stateDir }]);
+    store.prepareInboxDelivery(envelope); telemetry.beginMessage(agentId, messageId);
+    const receipt = await telemetry.phase(messageId, "runtime.deliver", SpanKind.PRODUCER, () => host.deliver(agentId, envelope));
+    assert.equal(receipt.status, "deferred");
+    assert.match(receipt.reason, /runtime session replaced before input result/);
+    assert.equal(store.readJson("runtimeDeliveries", { records: [] }).records[0].status, "pending");
+    assert.deepEqual(store.readNdjson("inbox").map((row) => row.message_id), [messageId]);
+    assert.equal(child.promptCount, 1); assert.equal(spawnCount, 1);
+    await host.shutdown("mock timeout complete"); await telemetry.shutdown();
+    const records = new TelemetrySpool(telemetryConfig).list();
+    const spans = records.flatMap(({ payload }) => payload.resourceSpans)
+      .flatMap((resource) => resource.scopeSpans).flatMap((scope) => scope.spans);
+    const wait = spans.find((span) => span.name === "pi.prompt.wait");
+    const compaction = spans.find((span) => span.name === "pi.compaction");
+    assert.ok(wait); assert.ok(compaction);
+    assert.equal(spans.some((span) => span.name === "agent.turn"), false);
+    assert.equal(wait.status.code, 2); assert.equal(compaction.status.code, 2);
+    assert.equal(wait.attributes.find((attribute) => attribute.key === "larkin.runtime.distribution")?.value?.stringValue, "external");
+    assert.equal(wait.attributes.find((attribute) => attribute.key === "larkin.pi.preflight.outcome")?.value?.stringValue, "timeout");
+    const serialized = JSON.stringify(records.map(({ payload }) => payload));
+    for (const forbidden of [agentId, messageId, target, "PRIVATE_TIMEOUT_BODY", "PRIVATE_PROVIDER_DETAIL", root]) {
+      assert.equal(serialized.includes(forbidden), false, forbidden);
+    }
+  } finally {
+    await host.shutdown("test cleanup").catch(() => {}); await telemetry.shutdown().catch(() => {});
     fs.rmSync(root, { recursive: true, force: true });
   }
 });

--- a/test/integration/build/pi-prompt-preflight-standalone.test.mjs
+++ b/test/integration/build/pi-prompt-preflight-standalone.test.mjs
@@ -1,0 +1,191 @@
+import assert from "node:assert/strict";
+import { spawn, spawnSync } from "node:child_process";
+import { once } from "node:events";
+import fs from "node:fs";
+import net from "node:net";
+import os from "node:os";
+import path from "node:path";
+import { test } from "bun:test";
+
+const ROOT = path.resolve(import.meta.dirname, "../../..");
+const ENABLED = process.env.LARKIN_RUN_PI_PREFLIGHT_STANDALONE === "1";
+
+function checked(command, args, options, label) {
+  const result = spawnSync(command, args, { encoding: "utf8", ...options });
+  assert.equal(result.error, undefined, `${label}: ${result.error?.message || "spawn error"}`);
+  assert.equal(result.status, 0, `${label}\nstdout:\n${result.stdout || ""}\nstderr:\n${result.stderr || ""}`);
+  return result;
+}
+
+async function waitFor(read, label, timeoutMs = 20_000) {
+  const deadline = Date.now() + timeoutMs; let lastError;
+  while (Date.now() < deadline) {
+    try { const value = read(); if (value) return value; } catch (error) { lastError = error; }
+    await new Promise((resolve) => setTimeout(resolve, 50));
+  }
+  throw new Error(`timed out waiting for ${label}: ${lastError?.message || "not ready"}`);
+}
+
+async function stop(child) {
+  if (!child || child.exitCode !== null || child.signalCode !== null) return;
+  const exited = once(child, "exit"); child.kill("SIGTERM");
+  if (!await Promise.race([exited.then(() => true), new Promise((resolve) => setTimeout(() => resolve(false), 8_000))])) {
+    child.kill("SIGKILL"); await exited;
+  }
+}
+
+async function freePort() {
+  const server = net.createServer();
+  await new Promise((resolve, reject) => { server.once("error", reject); server.listen(0, "127.0.0.1", resolve); });
+  const port = server.address().port; await new Promise((resolve) => server.close(resolve)); return port;
+}
+
+function rows(file) {
+  try { return fs.readFileSync(file, "utf8").trim().split("\n").filter(Boolean).map(JSON.parse); }
+  catch { return []; }
+}
+
+function spans(spoolDir) {
+  try {
+    return fs.readdirSync(spoolDir).filter((name) => /^span-.*\.json$/.test(name))
+      .flatMap((name) => JSON.parse(fs.readFileSync(path.join(spoolDir, name), "utf8")).resourceSpans)
+      .flatMap((resource) => resource.scopeSpans).flatMap((scope) => scope.spans);
+  } catch { return []; }
+}
+
+function writeOfficialLarkCli(mockBin) {
+  const packageDir = path.join(path.dirname(mockBin), "official", "node_modules", "@larksuite", "cli");
+  const launcher = path.join(packageDir, "scripts", "run.sh");
+  fs.mkdirSync(path.dirname(launcher), { recursive: true, mode: 0o700 });
+  fs.writeFileSync(path.join(packageDir, "package.json"), JSON.stringify({
+    name: "@larksuite/cli", version: "1.0.79", bin: { "lark-cli": "scripts/run.sh" },
+  }), { mode: 0o600 });
+  fs.writeFileSync(launcher, `#!/bin/sh
+if [ "$1" = "--version" ]; then printf '1.0.79\n'; exit 0; fi
+if [ "$1" = "config" ] && [ "$2" = "bind" ] && [ "$3" = "--help" ]; then
+  printf '%s\n' 'Usage: config bind --source lark-channel --identity bot-only'; exit 0
+fi
+if [ "$1" = "config" ] && [ "$2" = "bind" ]; then
+  ${JSON.stringify(process.execPath)} --eval 'const fs=require("node:fs"),path=require("node:path"),source=JSON.parse(fs.readFileSync(process.env.LARK_CHANNEL_CONFIG,"utf8")),id=source.accounts.app.id,dir=path.join(process.env.LARKSUITE_CLI_CONFIG_DIR,"lark-channel");fs.mkdirSync(dir,{recursive:true,mode:0o700});fs.writeFileSync(path.join(dir,"config.json"),JSON.stringify({apps:[{appId:id,appSecret:{source:"keychain",id:"appsecret:"+id},defaultAs:"bot",strictMode:"bot",users:[]}]}),{mode:0o600})'
+  exit $?
+fi
+case "$*" in *+chat-list*) printf '%s\n' '{"ok":true,"identity":"bot","data":{"chats":[]}}' ;; esac
+exit 0
+`, { mode: 0o755 });
+  fs.symlinkSync(launcher, path.join(mockBin, "lark-cli"));
+}
+
+const piFixture = `import fs from "node:fs";
+import readline from "node:readline";
+if (process.argv.includes("--version")) { console.log("0.83.0"); process.exit(0); }
+const marker = process.env.PI_PREFLIGHT_MARKER;
+const record = (value) => fs.appendFileSync(marker, JSON.stringify(value) + "\\n");
+const output = (value) => process.stdout.write(JSON.stringify(value) + "\\n");
+const model = { provider: "fixture", id: "pi-preflight", reasoning: false, contextWindow: 32000 };
+record({ type: "launch", args: process.argv.slice(2) });
+readline.createInterface({ input: process.stdin }).on("line", (line) => {
+  const request = JSON.parse(line);
+  if (request.type === "get_state") return output({ id: request.id, type: "response", command: request.type, success: true,
+    data: { sessionId: "PRIVATE_STANDALONE_SESSION", model, thinkingLevel: "off", isStreaming: false } });
+  if (request.type === "get_available_models") return output({ id: request.id, type: "response", command: request.type, success: true,
+    data: { models: [model] } });
+  if (request.type !== "prompt") return;
+  record({ type: "prompt" });
+  setTimeout(() => output({ type: "compaction_start", reason: "threshold" }), 9000);
+  setTimeout(() => output({ type: "summarization_retry_scheduled", attempt: 1, maxAttempts: 3, delayMs: 50,
+    errorMessage: "PRIVATE_STANDALONE_PROVIDER_DETAIL" }), 10050);
+  setTimeout(() => output({ type: "compaction_end", reason: "threshold", aborted: false, willRetry: false,
+    result: { summary: "PRIVATE_STANDALONE_SUMMARY" } }), 10500);
+  setTimeout(() => output({ id: request.id, type: "response", command: request.type, success: true }), 11000);
+  setTimeout(() => output({ type: "turn_start", turnIndex: 0 }), 11020);
+  setTimeout(() => output({ type: "agent_end", willRetry: false, messages: [{ role: "assistant", stopReason: "stop" }] }), 13000);
+  setTimeout(() => output({ type: "agent_settled" }), 13020);
+});
+`;
+
+test.skipIf(!ENABLED)("standalone Pi keeps delayed compaction preflight pending, accepts once, consumes Inbox, and spools safe OTel", {
+  timeout: 180_000,
+}, async () => {
+  const temp = fs.mkdtempSync(path.join(os.tmpdir(), "larkin-pi-preflight-standalone-"));
+  const releaseDir = path.join(temp, "release"); const home = path.join(temp, "home");
+  const configDir = path.join(temp, "config"); const mockBin = path.join(temp, "bin");
+  const spoolDir = path.join(temp, "otel-spool"); const marker = path.join(temp, "pi-protocol.ndjson");
+  const eventFile = path.join(configDir, "events.ndjson"); const agentId = "cli_piStandaloneA1";
+  const stateDir = path.join(configDir, "state", "agents", agentId);
+  const buildEnv = { ...process.env, PATH: `${path.dirname(process.execPath)}${path.delimiter}${process.env.PATH || ""}` };
+  let service; let stdout = ""; let stderr = "";
+  try {
+    for (const directory of [home, configDir, mockBin, spoolDir]) fs.mkdirSync(directory, { recursive: true, mode: 0o700 });
+    fs.writeFileSync(eventFile, ""); fs.writeFileSync(marker, ""); writeOfficialLarkCli(mockBin);
+    checked(process.execPath, ["run", "build"], { cwd: ROOT, env: buildEnv, timeout: 120_000 }, "build production dist");
+    checked(process.execPath, ["scripts/release/build.ts", "--target", `${os.platform()}-${os.arch()}`,
+      "--out-dir", releaseDir, "--allow-dirty"], { cwd: ROOT, env: buildEnv, timeout: 120_000 }, "compile standalone");
+    const manifest = JSON.parse(fs.readFileSync(path.join(releaseDir, "release-manifest.json"), "utf8"));
+    const artifact = path.join(releaseDir, manifest.artifacts[0].file);
+    const piSource = path.join(temp, "fake-pi.mjs"); const piCommand = path.join(mockBin, "pi");
+    fs.writeFileSync(piSource, piFixture, { mode: 0o600 });
+    checked(process.execPath, ["build", piSource, "--compile", "--minify", `--outfile=${piCommand}`], {
+      cwd: temp, env: buildEnv, timeout: 60_000,
+    }, "compile fake Pi");
+    fs.writeFileSync(path.join(configDir, "config.json"), `${JSON.stringify({
+      version: 4, serverId: "pi-preflight-standalone", mentionPolicy: "free", activeAgent: agentId,
+      agents: { [agentId]: { runtime: "pi", model: "fixture/pi-preflight", piDistribution: "external" } },
+    }, null, 2)}\n`, { mode: 0o600 });
+    const botsDir = path.join(configDir, "bots"); fs.mkdirSync(botsDir, { mode: 0o700 });
+    fs.writeFileSync(path.join(botsDir, `${agentId}.json`), JSON.stringify({
+      appId: agentId, appSecret: "fixture-only-secret", tenant: "feishu",
+    }), { mode: 0o600 });
+    const env = { PATH: `${mockBin}:/usr/bin:/bin`, HOME: home, TMPDIR: os.tmpdir(), LARKIN_CONFIG_DIR: configDir,
+      LARKIN_PI_COMMAND: piCommand, LARKIN_FEISHU_EVENT_FILE: eventFile, LARKIN_DASHBOARD_PORT: String(await freePort()),
+      LARKIN_TELEMETRY_SPOOL_DIR: spoolDir, PI_PREFLIGHT_MARKER: marker };
+    service = spawn(artifact, ["start", "--dry-run"], { cwd: home, env, stdio: ["ignore", "pipe", "pipe"] });
+    service.stdout.on("data", (chunk) => { stdout += chunk; }); service.stderr.on("data", (chunk) => { stderr += chunk; });
+    const diagnostics = () => `stdout:\n${stdout}\nstderr:\n${stderr}`;
+    await waitFor(() => /agent:status .* active/.test(stderr), "standalone Pi ready").catch((error) => {
+      throw new Error(`${error.message}\n${diagnostics()}`);
+    });
+    await waitFor(() => /文件事件源\(测试\)/.test(stderr), "standalone synthetic event source").catch((error) => {
+      throw new Error(`${error.message}\n${diagnostics()}`);
+    });
+    const event = { chat_id: "oc_private", chat_type: "p2p", sender_id: "ou_private", message_id: "om_private_preflight",
+      event_id: "evt_private_preflight", content: "PRIVATE_STANDALONE_PROMPT", create_time: "1786000000000", thread_id: null,
+      _mentioned_bot: true, _mention_all: false, _sender_is_bot: false };
+    fs.appendFileSync(eventFile, `${JSON.stringify(event)}\n`);
+    await waitFor(() => rows(marker).some((row) => row.type === "prompt"), "standalone Pi prompt submission");
+    await new Promise((resolve) => setTimeout(resolve, 1000));
+    const deliveryFile = path.join(stateDir, "runtime-deliveries.json");
+    const delivery = () => JSON.parse(fs.readFileSync(deliveryFile, "utf8")).records.find((row) => row.messageId === event.message_id);
+    assert.equal(delivery()?.status, "submitting", diagnostics());
+    await waitFor(() => delivery()?.status === "accepted", "delayed standalone Pi acceptance", 15_000).catch((error) => {
+      throw new Error(`${error.message}; delivery=${JSON.stringify(delivery())}\n${diagnostics()}`);
+    });
+    assert.equal(rows(marker).filter((row) => row.type === "launch" && row.args.includes("--session-dir")).length, 1,
+      "no Runtime preflight recreation (catalog probe is separate)");
+    assert.equal(rows(marker).filter((row) => row.type === "prompt").length, 1, "one prompt submission");
+    const drained = checked(artifact, ["__internal", "agent-cli", "inbox", "poll"], {
+      cwd: home, env: { ...env, LARKIN_AGENT_ID: agentId }, timeout: 15_000,
+    }, "consume delayed standalone Inbox");
+    const poll = JSON.parse(drained.stdout);
+    assert.equal(poll.events.filter((row) => row.message_id === event.message_id).length, 1);
+    assert.equal(poll.events.filter((row) => String(row.message_id).startsWith("redeliver_")).length, 1,
+      "startup unread projection may share the same bounded poll without duplicating the source event");
+    assert.equal(poll.consumed_delivery_ids.length, 2);
+    await waitFor(() => delivery()?.status === "consumed",
+      "standalone Inbox consumption");
+    const otel = await waitFor(() => {
+      const current = spans(spoolDir); const names = new Set(current.map((span) => span.name));
+      return names.has("pi.prompt.wait") && names.has("pi.compaction") && names.has("agent.turn") ? current : null;
+    }, "standalone Pi OTel spool", 20_000);
+    const wait = otel.find((span) => span.name === "pi.prompt.wait");
+    assert.equal(wait.attributes.find((attribute) => attribute.key === "larkin.runtime.distribution")?.value?.stringValue, "external");
+    assert.equal(wait.attributes.find((attribute) => attribute.key === "larkin.pi.preflight.outcome")?.value?.stringValue, "accepted");
+    for (const name of ["pi.rpc.submit", "pi.rpc.lifecycle", "pi.output.wait", "pi.generation", "pi.tool.wait", "pi.rpc.settle"]) {
+      assert.equal(otel.some((span) => span.name === name), false, `external standalone omits ${name}`);
+    }
+    const serialized = JSON.stringify(otel);
+    for (const forbidden of [agentId, event.message_id, event.content, "PRIVATE_STANDALONE_PROVIDER_DETAIL",
+      "PRIVATE_STANDALONE_SUMMARY", "PRIVATE_STANDALONE_SESSION", temp]) assert.equal(serialized.includes(forbidden), false, forbidden);
+  } finally {
+    await stop(service); fs.rmSync(temp, { recursive: true, force: true });
+  }
+});

--- a/test/unit/runtime/pi-rpc-client.test.mjs
+++ b/test/unit/runtime/pi-rpc-client.test.mjs
@@ -61,6 +61,49 @@ test("Pi RPC request timeout is bounded and tears down the unhealthy process", a
   assert.deepEqual(child.killed, ["SIGTERM"]);
 });
 
+test("Pi RPC prompt preflight outlives the short control deadline while compaction and retry make progress", async () => {
+  const child = new FakeProcess();
+  const client = new PiRpcClient(child, {
+    requestTimeoutMs: 8,
+    inputTimeoutMs: 24,
+    inputProgressTimeoutMs: 36,
+    inputMaxTimeoutMs: 100,
+  });
+  const events = [];
+  client.subscribe((event) => events.push(event.type));
+  const pending = client.request("prompt", { message: "private body" });
+  const id = child.writes[0].id;
+  await new Promise((resolve) => setTimeout(resolve, 12));
+  child.stdout.write(`${JSON.stringify({ type: "compaction_start", reason: "threshold" })}\n`);
+  await new Promise((resolve) => setTimeout(resolve, 28));
+  child.stdout.write(`${JSON.stringify({ type: "summarization_retry_scheduled", attempt: 1, maxAttempts: 3, delayMs: 1_000, errorMessage: "private provider detail" })}\n`);
+  await new Promise((resolve) => setTimeout(resolve, 28));
+  child.stdout.write(`${JSON.stringify({ type: "compaction_end", reason: "threshold", aborted: false, willRetry: false })}\n`);
+  child.stdout.write(`${JSON.stringify({ id, type: "response", command: "prompt", success: true })}\n`);
+  await pending;
+  assert.deepEqual(events, ["compaction_start", "summarization_retry_scheduled", "compaction_end"]);
+  assert.deepEqual(child.killed, []);
+  await client.close();
+});
+
+test("Pi RPC prompt progress cannot evade its absolute preflight deadline", async () => {
+  const child = new FakeProcess();
+  const client = new PiRpcClient(child, {
+    requestTimeoutMs: 5,
+    inputTimeoutMs: 12,
+    inputProgressTimeoutMs: 24,
+    inputMaxTimeoutMs: 45,
+  });
+  const interval = setInterval(() => child.stdout.write(`${JSON.stringify({ type: "compaction_start", reason: "threshold" })}\n`), 8);
+  try {
+    await assert.rejects(client.request("prompt", { message: "private body" }), /prompt preflight timed out.*absolute 45ms/i);
+    await client.close();
+    assert.deepEqual(child.killed, ["SIGTERM"]);
+  } finally {
+    clearInterval(interval);
+  }
+});
+
 test("Pi RPC failure and close share one shutdown promise that escalates a stubborn child", async () => {
   const child = new StubbornProcess();
   const client = new PiRpcClient(child, { requestTimeoutMs: 5, shutdownGraceMs: 5 });

--- a/test/unit/runtime/runtime-adapters.test.mjs
+++ b/test/unit/runtime/runtime-adapters.test.mjs
@@ -389,6 +389,33 @@ test("Pi prompt reports acceptance only after the RPC command acknowledgement", 
   assert.deepEqual(result, { status: "accepted", inputId: "pi-input" });
 });
 
+test("bundled Pi normalizes preflight compaction, retry, and terminal timeout without payload fields or a false turn", async () => {
+  let listener; let rejectPrompt;
+  const sdk = {
+    sessionId: "pi-preflight", prompt() { return new Promise((_resolve, reject) => { rejectPrompt = reject; }); },
+    steer() {}, abort() {}, subscribe(next) { listener = next; return () => {}; },
+  };
+  const session = await createNativeRuntimeAdapter("pi", {
+    createPiSession: async () => sdk, env: { LARKIN_PI_DISTRIBUTION: "builtin" },
+  }).createSession(create());
+  const events = []; session.subscribe((event) => events.push(event));
+  const pending = session.prompt({ inputId: "PRIVATE_INPUT", kind: "user", text: "PRIVATE_PROMPT", attempt: 0 });
+  listener({ type: "compaction_start", reason: "threshold", privateSummary: "PRIVATE_SUMMARY" });
+  listener({ type: "summarization_retry_scheduled", attempt: 1, maxAttempts: 3, delayMs: 5,
+    errorMessage: "PRIVATE_PROVIDER_ERROR" });
+  listener({ type: "compaction_end", reason: "threshold", aborted: false, willRetry: false,
+    result: { summary: "PRIVATE_SUMMARY" } });
+  listener({ type: "larkin_rpc_failure", message: "Pi RPC prompt preflight timed out at absolute 600000ms limit" });
+  rejectPrompt(new Error("Pi RPC prompt preflight timed out at absolute 600000ms limit"));
+  assert.equal((await pending).status, "rejected");
+  const observations = events.filter((event) => event.type === "runtime-observation");
+  assert.deepEqual(observations.map((event) => event.phase), [
+    "rpc_submit", "compaction_start", "retry_progress", "compaction_end", "rpc_timeout",
+  ]);
+  assert.equal(events.some((event) => event.type === "turn-start"), false);
+  assert.doesNotMatch(JSON.stringify(observations), /PRIVATE|summary|provider|message|input/i);
+});
+
 test("bundled Pi emits content-free RPC timing phases while preserving normalized activity", async () => {
   let listener;
   const sdk = {

--- a/test/unit/telemetry/telemetry.test.mjs
+++ b/test/unit/telemetry/telemetry.test.mjs
@@ -146,13 +146,22 @@ test("bundled Pi preflight timeout records prompt wait and compaction without in
   }
 });
 
-test("external Pi records its distribution without claiming bundled RPC visibility", async () => {
+test("external Pi records privacy-safe preflight spans without claiming bundled turn internals", async () => {
   const root = temp(); const stateDir = path.join(root, "agent-state");
   const runtime = createTelemetryRuntime(config(root), { stateDirFor: () => stateDir });
   runtime.beginMessage("cli_external_pi", "om_external_pi");
   runtime.delivery("cli_external_pi", "om_external_pi", "accepted");
   runtime.runtimeEvent("cli_external_pi", {
     type: "runtime-observation", runtime: "pi", distribution: "external", phase: "rpc_submit",
+  });
+  runtime.runtimeEvent("cli_external_pi", {
+    type: "runtime-observation", runtime: "pi", distribution: "external", phase: "compaction_start",
+  });
+  runtime.runtimeEvent("cli_external_pi", {
+    type: "runtime-observation", runtime: "pi", distribution: "external", phase: "compaction_end",
+  });
+  runtime.runtimeEvent("cli_external_pi", {
+    type: "runtime-observation", runtime: "pi", distribution: "external", phase: "rpc_accepted",
   });
   runtime.runtimeEvent("cli_external_pi", {
     type: "runtime-observation", runtime: "pi", distribution: "external", phase: "turn_start",
@@ -166,7 +175,15 @@ test("external Pi records its distribution without claiming bundled RPC visibili
   const turn = spans.find((span) => span.name === "agent.turn");
   assert.ok(turn);
   assert.equal(turn.attributes.find((attribute) => attribute.key === "larkin.runtime.distribution")?.value?.stringValue, "external");
-  assert.equal(spans.some((span) => span.name.startsWith("pi.")), false);
+  for (const name of ["pi.prompt.wait", "pi.compaction"]) {
+    const span = spans.find((candidate) => candidate.name === name);
+    assert.ok(span, name);
+    assert.equal(span.parentSpanId, spans.find((candidate) => candidate.name === "larkin.message.process").spanId);
+    assert.equal(span.attributes.find((attribute) => attribute.key === "larkin.runtime.distribution")?.value?.stringValue, "external");
+  }
+  for (const name of ["pi.rpc.submit", "pi.rpc.lifecycle", "pi.output.wait", "pi.generation", "pi.tool.wait", "pi.rpc.settle"]) {
+    assert.equal(spans.some((span) => span.name === name), false, name);
+  }
 });
 
 test("spool survives failures, bounds retention, and export/import remains idempotent", () => {

--- a/test/unit/telemetry/telemetry.test.mjs
+++ b/test/unit/telemetry/telemetry.test.mjs
@@ -93,17 +93,55 @@ test("bundled Pi RPC spans expose queue, observed TTFT, generation, tool wait, a
   const spans = records.flatMap(({ payload }) => payload.resourceSpans)
     .flatMap((resource) => resource.scopeSpans).flatMap((scope) => scope.spans);
   const byName = Object.fromEntries(spans.map((span) => [span.name, span]));
+  const durationMs = (name) => Number((BigInt(byName[name].endTimeUnixNano) - BigInt(byName[name].startTimeUnixNano)) / 1_000_000n);
+  assert.equal(byName["pi.prompt.wait"].parentSpanId, byName["larkin.message.process"].spanId);
+  assert.equal(durationMs("pi.prompt.wait"), 11);
   for (const name of ["pi.rpc.submit", "pi.rpc.lifecycle", "pi.output.wait", "pi.generation", "pi.tool.wait", "pi.rpc.settle"]) {
     assert.ok(byName[name], `missing ${name}`);
     assert.equal(byName[name].parentSpanId, byName["agent.turn"].spanId, name);
   }
-  const durationMs = (name) => Number((BigInt(byName[name].endTimeUnixNano) - BigInt(byName[name].startTimeUnixNano)) / 1_000_000n);
   assert.deepEqual(Object.fromEntries(["pi.rpc.submit", "pi.output.wait", "pi.generation", "pi.tool.wait", "pi.rpc.settle"]
     .map((name) => [name, durationMs(name)])), {
     "pi.rpc.submit": 11, "pi.output.wait": 30, "pi.generation": 77, "pi.tool.wait": 31, "pi.rpc.settle": 13,
   });
   const serialized = JSON.stringify(records);
-  for (const forbidden of ["cli_pi_private", "doc_comment_private", "FORBIDDEN_TURN", "toolName", "prompt", "result", stateDir]) {
+  for (const forbidden of ["cli_pi_private", "doc_comment_private", "FORBIDDEN_TURN", "toolName", "PRIVATE_PROMPT_PAYLOAD", "result", stateDir]) {
+    assert.equal(serialized.includes(forbidden), false, forbidden);
+  }
+});
+
+test("bundled Pi preflight timeout records prompt wait and compaction without inventing an agent turn or leaking details", async () => {
+  const root = temp(); const stateDir = path.join(root, "agent-state"); let time = Date.now();
+  const runtime = createTelemetryRuntime(config(root), { stateDirFor: () => stateDir, now: () => time });
+  const agentId = "cli_FORBIDDEN_AGENT"; const messageId = "om_FORBIDDEN_MESSAGE";
+  const observation = (phase) => runtime.runtimeEvent(agentId, {
+    type: "runtime-observation", runtime: "pi", distribution: "builtin", phase,
+  });
+  runtime.beginMessage(agentId, messageId);
+  await runtime.phase(messageId, "runtime.deliver", SpanKind.PRODUCER, async () => {
+    observation("rpc_submit");
+    time += 12; observation("compaction_start");
+    time += 17; observation("retry_progress");
+    time += 23; observation("rpc_timeout");
+  });
+  runtime.delivery(agentId, messageId, "error");
+  await runtime.shutdown();
+
+  const records = new TelemetrySpool(config(root)).list();
+  const spans = records.flatMap(({ payload }) => payload.resourceSpans)
+    .flatMap((resource) => resource.scopeSpans).flatMap((scope) => scope.spans);
+  const byName = Object.fromEntries(spans.map((span) => [span.name, span]));
+  assert.ok(byName["pi.prompt.wait"]);
+  assert.ok(byName["pi.compaction"]);
+  assert.equal(byName["agent.turn"], undefined);
+  assert.equal(byName["pi.prompt.wait"].parentSpanId, byName["larkin.message.process"].spanId);
+  assert.equal(byName["pi.compaction"].parentSpanId, byName["larkin.message.process"].spanId);
+  assert.equal(byName["pi.prompt.wait"].status.code, 2);
+  assert.equal(byName["pi.compaction"].status.code, 2);
+  assert.equal(byName["pi.prompt.wait"].attributes.find((attribute) => attribute.key === "larkin.pi.preflight.outcome")?.value?.stringValue, "timeout");
+  assert.equal(byName["pi.prompt.wait"].attributes.find((attribute) => attribute.key === "larkin.pi.preflight.progress")?.value?.stringValue, "retry");
+  const serialized = JSON.stringify(records);
+  for (const forbidden of [agentId, messageId, "FORBIDDEN", stateDir, "PRIVATE_PROVIDER_DETAIL", "PRIVATE_CREDENTIAL"]) {
     assert.equal(serialized.includes(forbidden), false, forbidden);
   }
 });


### PR DESCRIPTION
## Summary

- keep Pi control RPCs on the short 10s deadline while giving input commands a 120s inactivity timeout
- extend the input wait on compaction/retry progress, bounded by a 600s absolute cap
- preserve the Inbox accepted boundary so pre-accept failures remain pending and accepted events are consumed exactly once
- add privacy-safe `pi.prompt.wait` and `pi.compaction` telemetry for bundled and external Pi
- bump the release version to `0.2.61`

## Validation

- full `bun run test`: frontend 24/24, integration 170 pass / 16 intentional skip, e2e 12/12, unit 0 failures
- standalone release artifact + fake Pi workflow: delayed 11s compaction/retry accepted, one prompt, one Inbox consumption, safe external OTel
- release version/publication/license checks and commit-range Gitleaks passed
- independent evaluator: no blocking or important findings

## Boundaries

The standalone workflow uses a fake Pi process; it does not call a real model or Feishu tenant. The 600s cap remains a safety bound for unusually long real-provider compaction.