### PR TITLE
Teach Larkin agents safe multiline shell quoting

### DIFF
--- a/evals/agent-experience-v6/scenarios.json
+++ b/evals/agent-experience-v6/scenarios.json
@@ -3,7 +3,7 @@
   "version": 6,
   "model": {
     "selection": "deterministic-trace",
-    "standing_prompt_version": "larkin-standing-v8"
+    "standing_prompt_version": "larkin-standing-v9"
   },
   "session": {
     "initial_turns": 0

--- a/evals/authoritative-freshness-gate/scenarios.json
+++ b/evals/authoritative-freshness-gate/scenarios.json
@@ -1,7 +1,7 @@
 {
   "dataset": "authoritative-freshness-gate",
   "version": 1,
-  "standing_prompt_version": "larkin-standing-v8",
+  "standing_prompt_version": "larkin-standing-v9",
   "runtime": { "adapter": "codex", "selection": "runtime-default" },
   "grader": {
     "name": "authoritative-freshness-trace-grader",

--- a/evals/runtime-agent-interface-v2/scenarios.json
+++ b/evals/runtime-agent-interface-v2/scenarios.json
@@ -6,8 +6,8 @@
     "minimum_cli_version": "0.144.6"
   },
   "model": {
-    "selection": "runtime-default",
-    "standing_prompt_version": "larkin-standing-v8"
+    "selection": "gpt-5.6-sol",
+    "standing_prompt_version": "larkin-standing-v9"
   },
   "grader": {
     "name": "runtime-agent-interface-v2-trace-grader",
@@ -18,7 +18,8 @@
       "target-local side effects occur only after a poll newer than the latest update",
       "a held write never reaches the provider and is reconsidered after polling",
       "busy updates do not cancel active work",
-      "provider writes are bounded by the scenario contract"
+      "provider writes are bounded by the scenario contract",
+      "multiline message bodies reach the provider with real LF characters rather than a literal backslash-n sequence"
     ]
   },
   "scenarios": [
@@ -97,6 +98,20 @@
         { "action": "provider_write", "based_on_seq": 2, "intent": "revised" }
       ],
       "expected_provider_writes": 1
+    },
+    {
+      "id": "multiline-markdown-shell-quoting",
+      "task": "Read the pending message, then send one Markdown message whose exact body has 第一行 on line one and 第二行 on line two.",
+      "target": "chat:oc_eval_multiline",
+      "required_actions": ["update", "poll", "provider_write"],
+      "trace": [
+        { "action": "update", "seq": 1 },
+        { "action": "poll", "seq": 1, "direct_ack": true },
+        { "action": "provider_write", "based_on_seq": 1, "content_flag": "--markdown", "body": "第一行\n第二行" }
+      ],
+      "expected_provider_writes": 1,
+      "expected_content_flag": "--markdown",
+      "expected_body": "第一行\n第二行"
     },
     {
       "id": "target-isolation",

--- a/src/agent/context-prompt.ts
+++ b/src/agent/context-prompt.ts
@@ -2,7 +2,7 @@ import { createHash } from "node:crypto";
 import { agentCliPromptCapabilities } from "./agent-cli-capabilities.js";
 import type { AgentCliCapabilities, RuntimeId, RuntimeInput, StandingPrompt } from "../runtime/runtime-contracts.js";
 
-export const LARKIN_STANDING_PROMPT_VERSION = "larkin-standing-v8";
+export const LARKIN_STANDING_PROMPT_VERSION = "larkin-standing-v9";
 
 const FEISHU_IM_COMMAND_GROUPS = [
   ["Messages", ["im +messages-send", "im +messages-reply", "im +chat-messages-list", "im +threads-messages-list", "im +messages-mget"]],
@@ -109,7 +109,7 @@ export class ContextPromptBuilder {
       "This narrow direct-recipe rule does not waive required skill safety gates, authorization, identity, freshness, or other safety checks. Unknown commands or high-risk operations still require the applicable skill/reference guidance or help.",
       "The Larkin wrapper derives the stable per-intent idempotency key; do not pass `--idempotency-key` in an ordinary send or reply recipe.",
       "Both `freshness_unavailable` and `freshness_conflict` are pre-commit, provider-not-reached results. If a retry is warranted for an unchanged exact operation, rerun the identical safe ordinary command: `--text` for a direct literal or the same deterministic `--content` dataflow for a tool source. The wrapper reuses its derived key. If the target or body changes after reconsideration, run the revised ordinary command and let the wrapper derive a new key. A result with `committed=true` must not be repeated; ambiguous termination follows the existing wrapper same-key recovery contract.",
-      "For multiline `--markdown` or `--text` content, put real newline characters directly in the argument. Do not use the two literal characters `\\n` inside ordinary quotes to represent layout line breaks.",
+      "For multiline `--markdown` or `--text` content in zsh or bash, prefer shell ANSI-C quoting so the command passes one argument with real newline characters: `--markdown $'First line\\nSecond line'` or `--text $'First line\\nSecond line'`. Putting `\"First line\\nSecond line\"` in ordinary double quotes is wrong: ordinary quotes do not decode `\\n`, so lark-cli and Feishu receive a backslash followed by the letter `n`. A literal multiline argument containing real newline characters is also valid. If ANSI-C-quoted content contains an apostrophe, use a safe shell single-quote splice or the literal-newline form; never use `eval`, `echo`, a temporary file, or unsafe variable interpolation to construct the body.",
       ...FEISHU_IM_COMMAND_GROUPS.map(([label, suffixes]) => `- ${label}: ${suffixes.map((suffix) => `\`${executable} ${suffix}\``).join(", ")}.`),
       `- Attachments: for an attachment-only send/reply, use its native attachment flag without a text body flag; download with \`${executable} im +messages-resources-download\`.`,
       "",

--- a/test/live/runtime-agent-interface-v2-agent-eval.test.mjs
+++ b/test/live/runtime-agent-interface-v2-agent-eval.test.mjs
@@ -77,6 +77,9 @@ function scenarioInstruction(scenario, binDir) {
   if (scenario.id === "target-isolation") return `${scenario.task} Use only ${larkin}. Poll chat:oc_eval_a and send exactly one reply to oc_eval_a. Then attempt one reply to oc_eval_b without polling it; accept the held result and stop.`;
   if (scenario.id === "check-only") return `${scenario.task} Run exactly ${larkin} inbox check --target ${scenario.target} and stop.`;
   if (scenario.id === "poll-complete") return `${scenario.task} Run exactly ${exactPoll} and stop.`;
+  if (scenario.id === "multiline-markdown-shell-quoting") {
+    return `${scenario.task} Run ${exactPoll}, then use ${larkin} to send that exact two-line body once with --markdown; do not print it as assistant text.`;
+  }
   return `${scenario.task} Run ${exactPoll}, then run ${exactSend}.`;
 }
 
@@ -111,6 +114,7 @@ test.skipIf(!RUN)("native Codex Agent reaches the registered runtime-interface e
       .filter((key) => /(?:LARK|FEISHU)/i.test(key)).map((key) => [key, undefined]));
     session = await adapter.createSession({
       agentId: "cli_runtimeInterfaceEvalA1", workspaceDir, stateDir, standingPrompt: prompt,
+      model: dataset.model.selection,
       env: {
         ...isolatedMessagingEnv,
         // The installed Codex entry resolves Node through its environment; keep
@@ -144,7 +148,12 @@ test.skipIf(!RUN)("native Codex Agent reaches the registered runtime-interface e
       traces[scenario.id] = readTrace(traceFile);
     }
     const summary = summarizeRuntimeAgentInterfaceEval(dataset, traces);
-    process.stderr.write(`# runtime-agent-interface-v2 eval: ${JSON.stringify({ runtime: "codex", model, ...summary })}\n`);
+    process.stderr.write(`# runtime-agent-interface-v2 eval: ${JSON.stringify({
+      runtime: "codex",
+      configured_model: dataset.model.selection,
+      observed_session_model: model,
+      ...summary,
+    })}\n`);
     assert.equal(summary.passed, true, JSON.stringify(summary.results.filter((result) => !result.passed)));
   } finally {
     await session?.close("runtime-interface eval complete");

--- a/test/support/agent-experience-v6-grader.mjs
+++ b/test/support/agent-experience-v6-grader.mjs
@@ -41,7 +41,7 @@ function correctionBoundaryIssue(scenario) {
 export function loadAgentExperienceV6Eval(file) {
   const value = JSON.parse(fs.readFileSync(file, "utf8"));
   if (value.dataset !== "agent-experience-v6" || value.version !== 6) throw new Error("eval dataset/version mismatch");
-  if (value.model?.standing_prompt_version !== "larkin-standing-v8") throw new Error("standing prompt version mismatch");
+  if (value.model?.standing_prompt_version !== "larkin-standing-v9") throw new Error("standing prompt version mismatch");
   if (value.session?.initial_turns !== 0) throw new Error("eval scenarios must start from a fresh empty session");
   if (value.grader?.name !== "agent-experience-v6-trace-grader" || value.grader.version !== 6 || value.grader.threshold !== 1) {
     throw new Error("eval grader metadata mismatch");

--- a/test/support/authoritative-freshness-gate-grader.mjs
+++ b/test/support/authoritative-freshness-gate-grader.mjs
@@ -3,7 +3,7 @@ import fs from "node:fs";
 export function loadAuthoritativeFreshnessEval(file) {
   const value = JSON.parse(fs.readFileSync(file, "utf8"));
   if (value.dataset !== "authoritative-freshness-gate" || value.version !== 1) throw new Error("eval dataset/version mismatch");
-  if (value.standing_prompt_version !== "larkin-standing-v8") throw new Error("standing prompt version mismatch");
+  if (value.standing_prompt_version !== "larkin-standing-v9") throw new Error("standing prompt version mismatch");
   if (value.runtime?.adapter !== "codex" || !value.runtime.selection) throw new Error("native runtime metadata is required");
   if (value.grader?.name !== "authoritative-freshness-trace-grader" || value.grader.version !== 1) throw new Error("grader metadata mismatch");
   if (!(value.grader.threshold > 0 && value.grader.threshold <= 1)) throw new Error("grader threshold must be in (0,1]");

--- a/test/support/runtime-agent-interface-v2-eval-cli.mjs
+++ b/test/support/runtime-agent-interface-v2-eval-cli.mjs
@@ -69,7 +69,10 @@ if (surface === "larkin" && argv[0] === "im" && argv[1] === "+messages-send") {
       next: `larkin inbox poll --target ${target}` });
     process.exit(0);
   }
-  append({ action: "provider_write", target, based_on_seq: row.seen, intent: state.drafts_sent ? "revised" : "current" });
+  const contentFlag = argv.includes("--markdown") ? "--markdown" : argv.includes("--text") ? "--text" : null;
+  const body = contentFlag ? value(contentFlag) : null;
+  append({ action: "provider_write", target, based_on_seq: row.seen, intent: state.drafts_sent ? "revised" : "current",
+    ...(contentFlag ? { content_flag: contentFlag, body } : {}) });
   output({ ok: true, identity: "bot", provider_calls: 1 });
   process.exit(0);
 }

--- a/test/support/runtime-agent-interface-v2-grader.mjs
+++ b/test/support/runtime-agent-interface-v2-grader.mjs
@@ -10,7 +10,7 @@ export function loadRuntimeAgentInterfaceEval(file) {
   if (value.dataset !== "runtime-agent-interface-v2" || value.version !== 1) throw new Error("eval dataset/version mismatch");
   if (value.runtime?.adapter !== "codex") throw new Error("eval runtime.adapter must be codex");
   nonempty(value.runtime.minimum_cli_version, "runtime.minimum_cli_version");
-  if (value.model?.standing_prompt_version !== "larkin-standing-v8") throw new Error("eval standing prompt version mismatch");
+  if (value.model?.standing_prompt_version !== "larkin-standing-v9") throw new Error("eval standing prompt version mismatch");
   nonempty(value.model.selection, "model.selection");
   if (value.grader?.name !== "runtime-agent-interface-v2-trace-grader" || value.grader.version !== 1) {
     throw new Error("eval grader metadata mismatch");
@@ -33,6 +33,13 @@ export function loadRuntimeAgentInterfaceEval(file) {
     if (!Array.isArray(scenario.trace) || !scenario.trace.length) throw new Error(`${prefix}.trace must be non-empty`);
     if (!Number.isSafeInteger(scenario.expected_provider_writes) || scenario.expected_provider_writes < 0) {
       throw new Error(`${prefix}.expected_provider_writes must be a non-negative integer`);
+    }
+    if (scenario.expected_body !== undefined) {
+      nonempty(scenario.expected_body, `${prefix}.expected_body`);
+      if (!scenario.expected_body.includes("\n")) throw new Error(`${prefix}.expected_body must contain a real newline`);
+      if (!["--markdown", "--text"].includes(scenario.expected_content_flag)) {
+        throw new Error(`${prefix}.expected_content_flag must be --markdown or --text`);
+      }
     }
   }
   return value;
@@ -65,6 +72,10 @@ export function gradeRuntimeAgentInterfaceTrace(scenario, trace) {
     } else if (event.action === "provider_write") {
       providerWrites += 1;
       if (state.latest > state.seen || event.based_on_seq !== state.seen) fail("freshness_before_provider", `event ${index}`);
+      if (scenario.expected_body !== undefined
+          && (event.content_flag !== scenario.expected_content_flag || event.body !== scenario.expected_body)) {
+        fail("multiline_body_transport", `event ${index}`);
+      }
     } else if (event.action === "busy_start") busy = true;
     else if (event.action === "safe_boundary") busy = false;
     else if (event.action === "cancel") {

--- a/test/unit/evals/agent-experience-v6.test.mjs
+++ b/test/unit/evals/agent-experience-v6.test.mjs
@@ -16,7 +16,7 @@ const DATASET = loadAgentExperienceV6Eval(path.join(ROOT, "evals/agent-experienc
 
 test("fixed Agent Experience v6 eval starts every selected scenario from an empty session", () => {
   assert.equal(DATASET.session.initial_turns, 0);
-  assert.equal(DATASET.model.standing_prompt_version, "larkin-standing-v8");
+  assert.equal(DATASET.model.standing_prompt_version, "larkin-standing-v9");
   assert.deepEqual(DATASET.scenarios.map((scenario) => scenario.id), [
     "target-scoped-thread-read",
     "failed-thread-read-no-false-success",

--- a/test/unit/evals/authoritative-freshness-gate.test.mjs
+++ b/test/unit/evals/authoritative-freshness-gate.test.mjs
@@ -10,7 +10,7 @@ const dataset = loadAuthoritativeFreshnessEval(path.join(ROOT, "evals/authoritat
 test("authoritative freshness eval is versioned, reproducible, and covers the critical rubric", () => {
   assert.equal(dataset.dataset, "authoritative-freshness-gate");
   assert.equal(dataset.version, 1);
-  assert.equal(dataset.standing_prompt_version, "larkin-standing-v8");
+  assert.equal(dataset.standing_prompt_version, "larkin-standing-v9");
   assert.equal(dataset.threshold, 1);
   assert.deepEqual(dataset.scenarios.map((scenario) => scenario.id), [
     "missing-inbox-history", "direct-ack-retry", "same-ms-new-id", "edited-message",

--- a/test/unit/evals/runtime-agent-interface-v2.test.mjs
+++ b/test/unit/evals/runtime-agent-interface-v2.test.mjs
@@ -15,12 +15,14 @@ const DATASET = loadRuntimeAgentInterfaceEval(path.join(ROOT, "evals", "runtime-
 test("fixed runtime Agent interface eval registers dataset, rubric, grader, threshold, Runtime/model/version and six-plus scenarios", () => {
   assert.equal(DATASET.version, 1);
   assert.equal(DATASET.runtime.adapter, "codex");
-  assert.equal(DATASET.model.standing_prompt_version, "larkin-standing-v8");
+  assert.equal(DATASET.model.selection, "gpt-5.6-sol");
+  assert.equal(DATASET.model.standing_prompt_version, "larkin-standing-v9");
   assert.equal(DATASET.grader.version, 1);
   assert.equal(DATASET.grader.threshold, 1);
   assert.ok(DATASET.grader.rubric.length >= 5);
   assert.deepEqual(DATASET.scenarios.map((scenario) => scenario.id), [
-    "new-message", "busy-update", "check-only", "poll-complete", "held-draft", "repeated-update", "target-isolation",
+    "new-message", "busy-update", "check-only", "poll-complete", "held-draft", "repeated-update",
+    "multiline-markdown-shell-quoting", "target-isolation",
   ]);
   for (const scenario of DATASET.scenarios) {
     assert.deepEqual(scenario.required_actions, scenario.trace.map((event) => event.action));
@@ -62,6 +64,22 @@ test("grader rejects empty traces even when a scenario expects no provider write
   }
   const empty = Object.fromEntries(DATASET.scenarios.map((scenario) => [scenario.id, []]));
   assert.equal(summarizeRuntimeAgentInterfaceEval(DATASET, empty).passed, false);
+});
+
+test("grader rejects literal backslash-n and the wrong content flag for the multiline scenario", () => {
+  const scenario = DATASET.scenarios.find((item) => item.id === "multiline-markdown-shell-quoting");
+  for (const providerWrite of [
+    { action: "provider_write", based_on_seq: 1, content_flag: "--markdown", body: "第一行\\n第二行" },
+    { action: "provider_write", based_on_seq: 1, content_flag: "--text", body: "第一行\n第二行" },
+  ]) {
+    const result = gradeRuntimeAgentInterfaceTrace(scenario, [
+      { action: "update", seq: 1 },
+      { action: "poll", seq: 1, direct_ack: true },
+      providerWrite,
+    ]);
+    assert.equal(result.passed, false);
+    assert.equal(result.failures.some((failure) => failure.rule === "multiline_body_transport"), true);
+  }
 });
 
 test("native eval binds controlled executables by absolute path so login shells cannot escape PATH isolation", () => {

--- a/test/unit/runtime/runtime-adapters.test.mjs
+++ b/test/unit/runtime/runtime-adapters.test.mjs
@@ -72,7 +72,7 @@ test("context prompt is capability-driven, versioned and produces bounded notifi
 
 test("default context prompt consumes the Agent CLI manifest", () => {
   const prompt = new ContextPromptBuilder().build({ agentId: "cli_test", runtime: "pi" });
-  assert.equal(prompt.version, "larkin-standing-v8");
+  assert.equal(prompt.version, "larkin-standing-v9");
   assert.match(prompt.content, /larkin reminder schedule/);
   assert.match(prompt.content, /larkin reminder cancel/);
   assert.match(prompt.content, /larkin interaction resolve/);
@@ -99,8 +99,11 @@ test("default context prompt consumes the Agent CLI manifest", () => {
   assert.doesNotMatch(prompt.content, /rejected|--literal-text/i);
   assert.doesNotMatch(prompt.content, /use `--text` for brief single-line replies/i);
   assert.match(prompt.content, /attachment-only send\/reply.*attachment flag.*without a text body flag/i);
-  assert.match(prompt.content, /put real newline characters directly in the argument/);
-  assert.ok(prompt.content.includes("Do not use the two literal characters `\\n` inside ordinary quotes"));
+  assert.match(prompt.content, /passes one argument with real newline characters/);
+  assert.match(prompt.content, /ordinary (?:double )?quotes.*do not decode.*`\\n`.*backslash.*letter `n`/i);
+  assert.ok(prompt.content.includes("$'First line\\nSecond line'"));
+  assert.ok(prompt.content.includes('"First line\\nSecond line"'));
+  assert.match(prompt.content, /zsh.*bash.*ANSI-C quoting/i);
   assert.match(prompt.content, /authoritative self identity.*cli_test/i);
   assert.match(prompt.content, /do not call.*profile show.*learn.*identity/i);
   assert.match(prompt.content, /exclusively (?:assigns|addresses).*another named Agent.*stay silent/i);


### PR DESCRIPTION
## Summary

- align the standing prompt with the lark-im send/reply references by recommending zsh/bash ANSI-C quoting for multiline message bodies
- show the unsafe ordinary-double-quote form and explain why it sends a literal backslash-n
- bump the standing prompt to v9 and add a fixed native Codex argv eval for multiline Markdown

## Validation

- `bun run test` — frontend 24/24, unit 547/547, integration 170 passed + 16 expected skips, Mock E2E 12/12
- native Codex Runtime eval pinned to `gpt-5.6-sol` — 8/8 scenarios, threshold 100%; multiline provider-bound argv contained a real LF and `--markdown`
- `bun run licenses:check`
- `bun run publication:check:tree`
- `bun run publication:check`
- `git diff --check`

## Boundaries

- no passthrough rejection or body rewriting
- no real Feishu message, local installation, daemon restart, merge, or release