### PR TITLE
Release v0.2.62

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "larkin",
-  "version": "0.2.61",
+  "version": "0.2.62",
   "private": true,
   "larkinPackageRole": "development-source-checkout",
   "packageManager": "bun@1.3.14",


### PR DESCRIPTION
## Summary

- publish the PR #47 multiline shell-quoting fix that merged without its required patch version increment
- bump only the root package version from `0.2.61` to `0.2.62`
- leave product behavior and the lockfile unchanged

## Validation

- `bun install --frozen-lockfile`
- `bun run release:check-version v0.2.62`
- `bun run test`
- `bun run licenses:check`
- `bun run publication:check:tree`
- `bun run publication:check`
- darwin-arm64 release build and `bun run release:smoke -- --release-dir artifacts/release`
- `git diff --check`

## Release

Merging this intentional `package.json` version change to `main` authorizes the existing workflow to create immutable tag and GitHub Release `v0.2.62`.