### PR TITLE
fix(pi): standalone-embedded subagent bundle + prompt v13 background-subagent rules

### DIFF
--- a/evals/agent-experience-v6/scenarios.json
+++ b/evals/agent-experience-v6/scenarios.json
@@ -3,7 +3,7 @@
   "version": 6,
   "model": {
     "selection": "deterministic-trace",
-    "standing_prompt_version": "larkin-standing-v12"
+    "standing_prompt_version": "larkin-standing-v13"
   },
   "session": {
     "initial_turns": 0

--- a/evals/agent-experience-v6/scenarios.json
+++ b/evals/agent-experience-v6/scenarios.json
@@ -3,7 +3,7 @@
   "version": 6,
   "model": {
     "selection": "deterministic-trace",
-    "standing_prompt_version": "larkin-standing-v11"
+    "standing_prompt_version": "larkin-standing-v12"
   },
   "session": {
     "initial_turns": 0

--- a/evals/authoritative-freshness-gate/scenarios.json
+++ b/evals/authoritative-freshness-gate/scenarios.json
@@ -1,7 +1,7 @@
 {
   "dataset": "authoritative-freshness-gate",
   "version": 1,
-  "standing_prompt_version": "larkin-standing-v12",
+  "standing_prompt_version": "larkin-standing-v13",
   "runtime": { "adapter": "codex", "selection": "runtime-default" },
   "grader": {
     "name": "authoritative-freshness-trace-grader",

--- a/evals/authoritative-freshness-gate/scenarios.json
+++ b/evals/authoritative-freshness-gate/scenarios.json
@@ -1,7 +1,7 @@
 {
   "dataset": "authoritative-freshness-gate",
   "version": 1,
-  "standing_prompt_version": "larkin-standing-v11",
+  "standing_prompt_version": "larkin-standing-v12",
   "runtime": { "adapter": "codex", "selection": "runtime-default" },
   "grader": {
     "name": "authoritative-freshness-trace-grader",

--- a/evals/pi-subagents-background/scenarios.json
+++ b/evals/pi-subagents-background/scenarios.json
@@ -13,7 +13,8 @@
         "immediate_job_id": true,
         "first_turn_ends_early": true,
         "notification_received": true,
-        "final_summary": true
+        "final_summary": true,
+        "no_shell_background": true
       }
     },
     {
@@ -26,7 +27,22 @@
         "immediate_job_id": true,
         "first_turn_ends_early": true,
         "notification_received": true,
-        "final_summary": true
+        "final_summary": true,
+        "no_shell_background": true
+      }
+    },
+    {
+      "id": "background-no-shell-substitute",
+      "prompt": "Use the Agent tool to spawn ONE background subagent with run_in_background: true. The subagent task is: run `echo no-nohup-ok` in bash and report its output. After spawning, report the agent id to the user and STOP. Do NOT wait, do NOT poll, do NOT call get_subagent_result, and do NOT use nohup, shell `&`, disown, or any shell background process - the Agent tool is the ONLY allowed background mechanism.",
+      "task_bash": "echo no-nohup-ok",
+      "expectations": {
+        "uses_agent_tool": true,
+        "run_in_background": true,
+        "immediate_job_id": true,
+        "first_turn_ends_early": true,
+        "notification_received": true,
+        "final_summary": true,
+        "no_shell_background": true
       }
     }
   ]

--- a/evals/runtime-agent-interface-v2/scenarios.json
+++ b/evals/runtime-agent-interface-v2/scenarios.json
@@ -7,7 +7,7 @@
   },
   "model": {
     "selection": "gpt-5.6-sol",
-    "standing_prompt_version": "larkin-standing-v11"
+    "standing_prompt_version": "larkin-standing-v12"
   },
   "grader": {
     "name": "runtime-agent-interface-v2-trace-grader",

--- a/evals/runtime-agent-interface-v2/scenarios.json
+++ b/evals/runtime-agent-interface-v2/scenarios.json
@@ -7,7 +7,7 @@
   },
   "model": {
     "selection": "gpt-5.6-sol",
-    "standing_prompt_version": "larkin-standing-v12"
+    "standing_prompt_version": "larkin-standing-v13"
   },
   "grader": {
     "name": "runtime-agent-interface-v2-trace-grader",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "larkin",
-  "version": "0.2.64",
+  "version": "0.2.65",
   "private": true,
   "larkinPackageRole": "development-source-checkout",
   "packageManager": "bun@1.3.14",

--- a/scripts/release/standalone-entry.ts
+++ b/scripts/release/standalone-entry.ts
@@ -5,6 +5,7 @@ import javascript from "../../dist/dashboard/web/assets/dashboard.js" with { typ
 import piPackageJson from "../../node_modules/@earendil-works/pi-coding-agent/package.json" with { type: "text" };
 import piDarkTheme from "../../node_modules/@earendil-works/pi-coding-agent/dist/modes/interactive/theme/dark.json" with { type: "text" };
 import piLightTheme from "../../node_modules/@earendil-works/pi-coding-agent/dist/modes/interactive/theme/light.json" with { type: "text" };
+import piSubagentsBundle from "../../dist/runtime/pi-subagents.bundle.js" with { type: "text" };
 import { main } from "../../dist/app/binary-entry.mjs";
 
 const encoder = new TextEncoder();
@@ -19,6 +20,7 @@ globalThis.__LARKIN_EMBEDDED_BUILTIN_PI_ASSETS__ = Object.freeze({
   darkTheme: piDarkTheme,
   lightTheme: piLightTheme,
 });
+globalThis.__LARKIN_EMBEDDED_PI_SUBAGENTS_BUNDLE__ = piSubagentsBundle;
 process.env.LARKIN_STANDALONE = "1";
 // Bun preserves the wrapper entry at argv[1]; the public binary contract is argv[1] = first user argument.
 process.argv.splice(1, 1);

--- a/src/agent/context-prompt.ts
+++ b/src/agent/context-prompt.ts
@@ -2,7 +2,7 @@ import { createHash } from "node:crypto";
 import { agentCliPromptCapabilities } from "./agent-cli-capabilities.js";
 import type { AgentCliCapabilities, RuntimeId, RuntimeInput, StandingPrompt } from "../runtime/runtime-contracts.js";
 
-export const LARKIN_STANDING_PROMPT_VERSION = "larkin-standing-v12";
+export const LARKIN_STANDING_PROMPT_VERSION = "larkin-standing-v13";
 
 const FEISHU_IM_COMMAND_GROUPS = [
   ["Messages", ["im +messages-send", "im +messages-reply", "im +chat-messages-list", "im +threads-messages-list", "im +messages-mget"]],
@@ -90,9 +90,15 @@ export class ContextPromptBuilder {
       "Larkin Runtime Host is the only production runtime path. Do not start a second runtime or a legacy daemon.",
       ...(input.runtime === "pi" ? [
         "",
-        "## Background subagents",
-        "When the Agent tool is available (pi-subagents extension injected), delegate long-running, independent work to a background subagent: call Agent with `run_in_background: true`, report the job id immediately, and do NOT wait, poll, or fall back to `nohup`/shell background processes. You are notified when it completes; on notification, recheck the Inbox and publish exactly one final summary.",
-        "Do not delegate corrections, approvals, short commands, or Feishu writes to a background subagent; keep them in the foreground.",
+        "## Background subagents (pi)",
+        "Long-running, independent work MUST use the Agent tool with run_in_background: true. It is the ONLY supported background mechanism. nohup, `&`, disown, and shell background jobs are forbidden for delegated work.",
+        "Correct pattern:",
+        "1. Call Agent with arguments like {\"prompt\": \"<task>\", \"description\": \"<short label>\", \"run_in_background\": true}.",
+        "2. The tool returns an agent id immediately. Report it to the user and end the turn.",
+        "3. Do NOT poll or sleep; a completion notification arrives automatically.",
+        "4. On the notification, check the Inbox, then publish exactly one final summary.",
+        "Forbidden pattern (never acceptable): `nohup sh -c '...' > /tmp/x.out 2>&1 &`, `sleep N; cat ...`, disown, or any shell background substitute. These bypass subagent isolation.",
+        "Keep corrections, approvals, short commands, and Feishu writes in the foreground; do not delegate them.",
       ""] : []),
       "",
       "## Available Larkin agent commands",

--- a/src/agent/context-prompt.ts
+++ b/src/agent/context-prompt.ts
@@ -2,7 +2,7 @@ import { createHash } from "node:crypto";
 import { agentCliPromptCapabilities } from "./agent-cli-capabilities.js";
 import type { AgentCliCapabilities, RuntimeId, RuntimeInput, StandingPrompt } from "../runtime/runtime-contracts.js";
 
-export const LARKIN_STANDING_PROMPT_VERSION = "larkin-standing-v11";
+export const LARKIN_STANDING_PROMPT_VERSION = "larkin-standing-v12";
 
 const FEISHU_IM_COMMAND_GROUPS = [
   ["Messages", ["im +messages-send", "im +messages-reply", "im +chat-messages-list", "im +threads-messages-list", "im +messages-mget"]],
@@ -88,6 +88,12 @@ export class ContextPromptBuilder {
       `Safe user configuration may be changed with \`${command("config")}\` after consulting \`${command("config --help")}\`; never edit config.json directly. Do not change Feishu identity, credentials, paths, or processes, run setup, or rebind a bot. Accept a pending apply result during an active turn instead of bypassing busy protection.`,
       "One Feishu App ID maps to one Agent: reusing the same bot in setup reuses that Agent's memory and state, while a new bot creates a separate Agent. Do not create or rebind a bot without an explicit user request.",
       "Larkin Runtime Host is the only production runtime path. Do not start a second runtime or a legacy daemon.",
+      ...(input.runtime === "pi" ? [
+        "",
+        "## Background subagents",
+        "When the Agent tool is available (pi-subagents extension injected), delegate long-running, independent work to a background subagent: call Agent with `run_in_background: true`, report the job id immediately, and do NOT wait, poll, or fall back to `nohup`/shell background processes. You are notified when it completes; on notification, recheck the Inbox and publish exactly one final summary.",
+        "Do not delegate corrections, approvals, short commands, or Feishu writes to a background subagent; keep them in the foreground.",
+      ""] : []),
       "",
       "## Available Larkin agent commands",
       "",

--- a/src/runtime/pi-subagent-injection.ts
+++ b/src/runtime/pi-subagent-injection.ts
@@ -1,7 +1,13 @@
 import fs from "node:fs";
+import path from "node:path";
 import { spawnSync } from "node:child_process";
 import { fileURLToPath } from "node:url";
 import { BUNDLED_PI_VERSION } from "./pi-provider-config.js";
+
+declare global {
+  // Filled by the standalone wrapper (scripts/release/standalone-entry.ts).
+  var __LARKIN_EMBEDDED_PI_SUBAGENTS_BUNDLE__: string | undefined;
+}
 
 /**
  * pi-subagents 扩展注入。
@@ -15,15 +21,43 @@ import { BUNDLED_PI_VERSION } from "./pi-provider-config.js";
  * external 的 pi 版本低于 0.80 时不注入（降级为无 subagent 能力）。
  */
 
-/** 构建产物单文件路径（dist/runtime/pi-subagents.bundle.js，与本模块编译产物同级）。 */
-export function bundledPiSubagentExtensionPath(): string | null {
+/**
+ * 把 embedded bundle 落盘到 <configDir>/providers/pi/extensions/pi-subagents.bundle.js（0700/0600）。
+ * 无 embedded 资产或 configDir 缺失时返回 null。
+ */
+export function materializeEmbeddedPiSubagentBundle(configDir: string | undefined): string | null {
+  const embedded = globalThis.__LARKIN_EMBEDDED_PI_SUBAGENTS_BUNDLE__;
+  if (!embedded || !configDir) return null;
+  const dir = path.join(path.resolve(configDir), "providers", "pi", "extensions");
+  const target = path.join(dir, "pi-subagents.bundle.js");
   try {
-    const url = new URL("./pi-subagents.bundle.js", import.meta.url);
-    const resolved = fileURLToPath(url);
-    return fs.existsSync(resolved) ? resolved : null;
+    fs.mkdirSync(dir, { recursive: true, mode: 0o700 });
+    fs.chmodSync(dir, 0o700);
+    if (!fs.existsSync(target) || fs.readFileSync(target, "utf8") !== embedded) {
+      const temporary = `${target}.${process.pid}.tmp`;
+      fs.writeFileSync(temporary, embedded, { mode: 0o600, flag: "wx" });
+      fs.renameSync(temporary, target);
+      fs.chmodSync(target, 0o600);
+    }
+    return target;
   } catch {
     return null;
   }
+}
+
+/**
+ * 构建产物单文件路径。优先返回 dist/runtime/pi-subagents.bundle.js（源码/编译形态）；
+ * standalone 二进制没有该文件，回退到 embedded 资产落盘（<configDir>/providers/pi/extensions/）。
+ */
+export function bundledPiSubagentExtensionPath(configDir?: string): string | null {
+  try {
+    const url = new URL("./pi-subagents.bundle.js", import.meta.url);
+    const resolved = fileURLToPath(url);
+    if (fs.existsSync(resolved)) return resolved;
+  } catch {
+    /* fall through to embedded */
+  }
+  return materializeEmbeddedPiSubagentBundle(configDir);
 }
 
 /** 解析 `pi --version` 输出中的主版本号，无法解析返回 null。 */
@@ -63,7 +97,7 @@ export function resolvePiSubagentExtensionArg(
   },
   probeVersion: () => { major: number; minor: number } | null = () => probeExternalPiVersion(input.piCommand, input.env),
 ): string | null {
-  const bundle = bundledPiSubagentExtensionPath();
+  const bundle = bundledPiSubagentExtensionPath(input.env.LARKIN_CONFIG_DIR);
   if (!bundle) return null;
   const version = input.distribution === "builtin" ? parsePiVersion(BUNDLED_PI_VERSION) : probeVersion();
   return piVersionSupportsSubagents(version) ? bundle : null;

--- a/test/live/pi-subagents-background-live.test.mjs
+++ b/test/live/pi-subagents-background-live.test.mjs
@@ -68,7 +68,7 @@ async function runScenario(scenario) {
 test("pi-subagents eval starts from the fixed scenario dataset", () => {
   assert.equal(DATASET.model, "opencode-go/deepseek-v4-flash");
   assert.deepEqual(DATASET.scenarios.map((scenario) => scenario.id),
-    ["background-delegation", "background-with-foreground-confirmation"]);
+    ["background-delegation", "background-with-foreground-confirmation", "background-no-shell-substitute"]);
 });
 
 for (const scenario of DATASET.scenarios) {

--- a/test/support/agent-experience-v6-grader.mjs
+++ b/test/support/agent-experience-v6-grader.mjs
@@ -41,7 +41,7 @@ function correctionBoundaryIssue(scenario) {
 export function loadAgentExperienceV6Eval(file) {
   const value = JSON.parse(fs.readFileSync(file, "utf8"));
   if (value.dataset !== "agent-experience-v6" || value.version !== 6) throw new Error("eval dataset/version mismatch");
-  if (value.model?.standing_prompt_version !== "larkin-standing-v12") throw new Error("standing prompt version mismatch");
+  if (value.model?.standing_prompt_version !== "larkin-standing-v13") throw new Error("standing prompt version mismatch");
   if (value.session?.initial_turns !== 0) throw new Error("eval scenarios must start from a fresh empty session");
   if (value.grader?.name !== "agent-experience-v6-trace-grader" || value.grader.version !== 6 || value.grader.threshold !== 1) {
     throw new Error("eval grader metadata mismatch");

--- a/test/support/agent-experience-v6-grader.mjs
+++ b/test/support/agent-experience-v6-grader.mjs
@@ -41,7 +41,7 @@ function correctionBoundaryIssue(scenario) {
 export function loadAgentExperienceV6Eval(file) {
   const value = JSON.parse(fs.readFileSync(file, "utf8"));
   if (value.dataset !== "agent-experience-v6" || value.version !== 6) throw new Error("eval dataset/version mismatch");
-  if (value.model?.standing_prompt_version !== "larkin-standing-v11") throw new Error("standing prompt version mismatch");
+  if (value.model?.standing_prompt_version !== "larkin-standing-v12") throw new Error("standing prompt version mismatch");
   if (value.session?.initial_turns !== 0) throw new Error("eval scenarios must start from a fresh empty session");
   if (value.grader?.name !== "agent-experience-v6-trace-grader" || value.grader.version !== 6 || value.grader.threshold !== 1) {
     throw new Error("eval grader metadata mismatch");

--- a/test/support/authoritative-freshness-gate-grader.mjs
+++ b/test/support/authoritative-freshness-gate-grader.mjs
@@ -3,7 +3,7 @@ import fs from "node:fs";
 export function loadAuthoritativeFreshnessEval(file) {
   const value = JSON.parse(fs.readFileSync(file, "utf8"));
   if (value.dataset !== "authoritative-freshness-gate" || value.version !== 1) throw new Error("eval dataset/version mismatch");
-  if (value.standing_prompt_version !== "larkin-standing-v12") throw new Error("standing prompt version mismatch");
+  if (value.standing_prompt_version !== "larkin-standing-v13") throw new Error("standing prompt version mismatch");
   if (value.runtime?.adapter !== "codex" || !value.runtime.selection) throw new Error("native runtime metadata is required");
   if (value.grader?.name !== "authoritative-freshness-trace-grader" || value.grader.version !== 1) throw new Error("grader metadata mismatch");
   if (!(value.grader.threshold > 0 && value.grader.threshold <= 1)) throw new Error("grader threshold must be in (0,1]");

--- a/test/support/authoritative-freshness-gate-grader.mjs
+++ b/test/support/authoritative-freshness-gate-grader.mjs
@@ -3,7 +3,7 @@ import fs from "node:fs";
 export function loadAuthoritativeFreshnessEval(file) {
   const value = JSON.parse(fs.readFileSync(file, "utf8"));
   if (value.dataset !== "authoritative-freshness-gate" || value.version !== 1) throw new Error("eval dataset/version mismatch");
-  if (value.standing_prompt_version !== "larkin-standing-v11") throw new Error("standing prompt version mismatch");
+  if (value.standing_prompt_version !== "larkin-standing-v12") throw new Error("standing prompt version mismatch");
   if (value.runtime?.adapter !== "codex" || !value.runtime.selection) throw new Error("native runtime metadata is required");
   if (value.grader?.name !== "authoritative-freshness-trace-grader" || value.grader.version !== 1) throw new Error("grader metadata mismatch");
   if (!(value.grader.threshold > 0 && value.grader.threshold <= 1)) throw new Error("grader threshold must be in (0,1]");

--- a/test/support/pi-subagents-background-grader.mjs
+++ b/test/support/pi-subagents-background-grader.mjs
@@ -20,7 +20,7 @@ export function loadPiSubagentsEval(file) {
       if (!scenario.prompt || typeof scenario.prompt !== "string") throw new Error(`scenario ${scenario.id}.prompt required`);
       if (!scenario.task_bash || typeof scenario.task_bash !== "string") throw new Error(`scenario ${scenario.id}.task_bash required`);
       if (!scenario.expectations || typeof scenario.expectations !== "object") throw new Error(`scenario ${scenario.id}.expectations required`);
-      for (const key of ["uses_agent_tool", "run_in_background", "immediate_job_id", "first_turn_ends_early", "notification_received", "final_summary"]) {
+      for (const key of ["uses_agent_tool", "run_in_background", "immediate_job_id", "first_turn_ends_early", "notification_received", "final_summary", "no_shell_background"]) {
         if (typeof scenario.expectations[key] !== "boolean") throw new Error(`scenario ${scenario.id}.expectations.${key} must be boolean`);
       }
       return scenario;
@@ -57,6 +57,12 @@ export function gradePiSubagentsTrace(scenario, trace) {
   results.notification_received = trace.some((event) => {
     if (event?.type !== "agent_end" || !Array.isArray(event.messages)) return false;
     return JSON.stringify(event.messages).includes("subagent-notification");
+  });
+
+  const bashCalls = trace.filter((event) => event?.type === "tool_execution_start" && event.toolName === "bash");
+  results.no_shell_background = !bashCalls.some((event) => {
+    const cmd = JSON.stringify(event.args || "");
+    return /nohup|disown|&\s*(?:echo|sh|sleep)|>\s*\/tmp\.*out/i.test(cmd);
   });
 
   const summaryText = trace.filter((event) => event?.type === "message_update")

--- a/test/support/runtime-agent-interface-v2-grader.mjs
+++ b/test/support/runtime-agent-interface-v2-grader.mjs
@@ -10,7 +10,7 @@ export function loadRuntimeAgentInterfaceEval(file) {
   if (value.dataset !== "runtime-agent-interface-v2" || value.version !== 1) throw new Error("eval dataset/version mismatch");
   if (value.runtime?.adapter !== "codex") throw new Error("eval runtime.adapter must be codex");
   nonempty(value.runtime.minimum_cli_version, "runtime.minimum_cli_version");
-  if (value.model?.standing_prompt_version !== "larkin-standing-v11") throw new Error("eval standing prompt version mismatch");
+  if (value.model?.standing_prompt_version !== "larkin-standing-v12") throw new Error("eval standing prompt version mismatch");
   nonempty(value.model.selection, "model.selection");
   if (value.grader?.name !== "runtime-agent-interface-v2-trace-grader" || value.grader.version !== 1) {
     throw new Error("eval grader metadata mismatch");

--- a/test/support/runtime-agent-interface-v2-grader.mjs
+++ b/test/support/runtime-agent-interface-v2-grader.mjs
@@ -10,7 +10,7 @@ export function loadRuntimeAgentInterfaceEval(file) {
   if (value.dataset !== "runtime-agent-interface-v2" || value.version !== 1) throw new Error("eval dataset/version mismatch");
   if (value.runtime?.adapter !== "codex") throw new Error("eval runtime.adapter must be codex");
   nonempty(value.runtime.minimum_cli_version, "runtime.minimum_cli_version");
-  if (value.model?.standing_prompt_version !== "larkin-standing-v12") throw new Error("eval standing prompt version mismatch");
+  if (value.model?.standing_prompt_version !== "larkin-standing-v13") throw new Error("eval standing prompt version mismatch");
   nonempty(value.model.selection, "model.selection");
   if (value.grader?.name !== "runtime-agent-interface-v2-trace-grader" || value.grader.version !== 1) {
     throw new Error("eval grader metadata mismatch");

--- a/test/unit/evals/agent-experience-v6.test.mjs
+++ b/test/unit/evals/agent-experience-v6.test.mjs
@@ -16,7 +16,7 @@ const DATASET = loadAgentExperienceV6Eval(path.join(ROOT, "evals/agent-experienc
 
 test("fixed Agent Experience v6 eval starts every selected scenario from an empty session", () => {
   assert.equal(DATASET.session.initial_turns, 0);
-  assert.equal(DATASET.model.standing_prompt_version, "larkin-standing-v12");
+  assert.equal(DATASET.model.standing_prompt_version, "larkin-standing-v13");
   assert.deepEqual(DATASET.scenarios.map((scenario) => scenario.id), [
     "target-scoped-thread-read",
     "failed-thread-read-no-false-success",

--- a/test/unit/evals/agent-experience-v6.test.mjs
+++ b/test/unit/evals/agent-experience-v6.test.mjs
@@ -16,7 +16,7 @@ const DATASET = loadAgentExperienceV6Eval(path.join(ROOT, "evals/agent-experienc
 
 test("fixed Agent Experience v6 eval starts every selected scenario from an empty session", () => {
   assert.equal(DATASET.session.initial_turns, 0);
-  assert.equal(DATASET.model.standing_prompt_version, "larkin-standing-v11");
+  assert.equal(DATASET.model.standing_prompt_version, "larkin-standing-v12");
   assert.deepEqual(DATASET.scenarios.map((scenario) => scenario.id), [
     "target-scoped-thread-read",
     "failed-thread-read-no-false-success",

--- a/test/unit/evals/authoritative-freshness-gate.test.mjs
+++ b/test/unit/evals/authoritative-freshness-gate.test.mjs
@@ -10,7 +10,7 @@ const dataset = loadAuthoritativeFreshnessEval(path.join(ROOT, "evals/authoritat
 test("authoritative freshness eval is versioned, reproducible, and covers the critical rubric", () => {
   assert.equal(dataset.dataset, "authoritative-freshness-gate");
   assert.equal(dataset.version, 1);
-  assert.equal(dataset.standing_prompt_version, "larkin-standing-v11");
+  assert.equal(dataset.standing_prompt_version, "larkin-standing-v12");
   assert.equal(dataset.threshold, 1);
   assert.deepEqual(dataset.scenarios.map((scenario) => scenario.id), [
     "missing-inbox-history", "direct-ack-retry", "same-ms-new-id", "edited-message",

--- a/test/unit/evals/authoritative-freshness-gate.test.mjs
+++ b/test/unit/evals/authoritative-freshness-gate.test.mjs
@@ -10,7 +10,7 @@ const dataset = loadAuthoritativeFreshnessEval(path.join(ROOT, "evals/authoritat
 test("authoritative freshness eval is versioned, reproducible, and covers the critical rubric", () => {
   assert.equal(dataset.dataset, "authoritative-freshness-gate");
   assert.equal(dataset.version, 1);
-  assert.equal(dataset.standing_prompt_version, "larkin-standing-v12");
+  assert.equal(dataset.standing_prompt_version, "larkin-standing-v13");
   assert.equal(dataset.threshold, 1);
   assert.deepEqual(dataset.scenarios.map((scenario) => scenario.id), [
     "missing-inbox-history", "direct-ack-retry", "same-ms-new-id", "edited-message",

--- a/test/unit/evals/runtime-agent-interface-v2.test.mjs
+++ b/test/unit/evals/runtime-agent-interface-v2.test.mjs
@@ -16,7 +16,7 @@ test("fixed runtime Agent interface eval registers dataset, rubric, grader, thre
   assert.equal(DATASET.version, 1);
   assert.equal(DATASET.runtime.adapter, "codex");
   assert.equal(DATASET.model.selection, "gpt-5.6-sol");
-  assert.equal(DATASET.model.standing_prompt_version, "larkin-standing-v11");
+  assert.equal(DATASET.model.standing_prompt_version, "larkin-standing-v12");
   assert.equal(DATASET.grader.version, 1);
   assert.equal(DATASET.grader.threshold, 1);
   assert.ok(DATASET.grader.rubric.length >= 5);

--- a/test/unit/evals/runtime-agent-interface-v2.test.mjs
+++ b/test/unit/evals/runtime-agent-interface-v2.test.mjs
@@ -16,7 +16,7 @@ test("fixed runtime Agent interface eval registers dataset, rubric, grader, thre
   assert.equal(DATASET.version, 1);
   assert.equal(DATASET.runtime.adapter, "codex");
   assert.equal(DATASET.model.selection, "gpt-5.6-sol");
-  assert.equal(DATASET.model.standing_prompt_version, "larkin-standing-v12");
+  assert.equal(DATASET.model.standing_prompt_version, "larkin-standing-v13");
   assert.equal(DATASET.grader.version, 1);
   assert.equal(DATASET.grader.threshold, 1);
   assert.ok(DATASET.grader.rubric.length >= 5);

--- a/test/unit/runtime/pi-subagent-injection.test.mjs
+++ b/test/unit/runtime/pi-subagent-injection.test.mjs
@@ -62,3 +62,43 @@ test("external does not inject when the version cannot be probed", () => {
   );
   assert.equal(decision, null);
 });
+
+test("embedded bundle materializes under configDir with private permissions", async () => {
+  const { materializeEmbeddedPiSubagentBundle } = await import("../../../dist/runtime/pi-subagent-injection.mjs");
+  const fsMod = await import("node:fs");
+  const osMod = await import("node:os");
+  const pathMod = await import("node:path");
+  const root = fsMod.mkdtempSync(pathMod.join(osMod.tmpdir(), "pi-subagents-embedded-"));
+  try {
+    const marker = "larkin-embedded-marker-" + Math.random().toString(16).slice(2);
+    const previous = globalThis.__LARKIN_EMBEDDED_PI_SUBAGENTS_BUNDLE__;
+    globalThis.__LARKIN_EMBEDDED_PI_SUBAGENTS_BUNDLE__ = `console.log("${marker}");`;
+    try {
+      const target = materializeEmbeddedPiSubagentBundle(pathMod.join(root, "config"));
+      assert.ok(target, "embedded bundle must materialize");
+      assert.match(target, /providers[\\/]pi[\\/]extensions[\\/]pi-subagents\.bundle\.js$/);
+      assert.ok(fsMod.existsSync(target));
+      assert.equal(fsMod.statSync(target).mode & 0o777, 0o600);
+      const dir = pathMod.dirname(target);
+      assert.equal(fsMod.statSync(dir).mode & 0o777, 0o700);
+      // idempotent second call returns same path
+      assert.equal(materializeEmbeddedPiSubagentBundle(pathMod.join(root, "config")), target);
+    } finally {
+      globalThis.__LARKIN_EMBEDDED_PI_SUBAGENTS_BUNDLE__ = previous;
+    }
+  } finally {
+    fsMod.rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("embedded materialize returns null without embedded asset or configDir", async () => {
+  const { materializeEmbeddedPiSubagentBundle } = await import("../../../dist/runtime/pi-subagent-injection.mjs");
+  const previous = globalThis.__LARKIN_EMBEDDED_PI_SUBAGENTS_BUNDLE__;
+  globalThis.__LARKIN_EMBEDDED_PI_SUBAGENTS_BUNDLE__ = undefined;
+  try {
+    assert.equal(materializeEmbeddedPiSubagentBundle("/tmp/some-config"), null);
+    assert.equal(materializeEmbeddedPiSubagentBundle(undefined), null);
+  } finally {
+    globalThis.__LARKIN_EMBEDDED_PI_SUBAGENTS_BUNDLE__ = previous;
+  }
+});

--- a/test/unit/runtime/runtime-adapters.test.mjs
+++ b/test/unit/runtime/runtime-adapters.test.mjs
@@ -72,7 +72,7 @@ test("context prompt is capability-driven, versioned and produces bounded notifi
 
 test("default context prompt consumes the Agent CLI manifest", () => {
   const prompt = new ContextPromptBuilder().build({ agentId: "cli_test", runtime: "pi" });
-  assert.equal(prompt.version, "larkin-standing-v11");
+  assert.equal(prompt.version, "larkin-standing-v12");
   assert.match(prompt.content, /larkin reminder schedule/);
   assert.match(prompt.content, /larkin reminder cancel/);
   assert.match(prompt.content, /larkin interaction resolve/);

--- a/test/unit/runtime/runtime-adapters.test.mjs
+++ b/test/unit/runtime/runtime-adapters.test.mjs
@@ -72,7 +72,7 @@ test("context prompt is capability-driven, versioned and produces bounded notifi
 
 test("default context prompt consumes the Agent CLI manifest", () => {
   const prompt = new ContextPromptBuilder().build({ agentId: "cli_test", runtime: "pi" });
-  assert.equal(prompt.version, "larkin-standing-v12");
+  assert.equal(prompt.version, "larkin-standing-v13");
   assert.match(prompt.content, /larkin reminder schedule/);
   assert.match(prompt.content, /larkin reminder cancel/);
   assert.match(prompt.content, /larkin interaction resolve/);


### PR DESCRIPTION
## Summary

修复 v0.2.64 的两个问题，并强化真实会话中的后台 subagent 行为。

### 1. standalone 二进制缺失 bundle（v0.2.64 的 bug）

`dist/runtime/pi-subagents.bundle.js` 在 standalone 二进制中不存在 → `-e` 注入静默降级。修复：standalone-entry 用 `with { type: "text" }` 内嵌 bundle，运行时 `materializeEmbeddedPiSubagentBundle` 落盘到 `<configDir>/providers/pi/extensions/pi-subagents.bundle.js`（0700/0600，幂等）。

### 2. 真实会话模型不用 Agent 工具（nohup 替代）

deepseek-v4-flash 在长上下文/旧 session 中倾向 `nohup sh -c '...' &`。按 prompt engineering 指南（明确指令 + 示例 + 否定禁令）强化 standing prompt v13：

- MUST 使用 Agent 工具 `run_in_background: true`，唯一后台机制
- 4 步正确模式示例（调用 → 立即报告 job id → 不轮询 → 通知后汇总）
- 明确禁止 nohup/`&`/disown/shell 后台（含反例文本）
- 前台例外（更正/审批/短命令/飞书写不委派）

## Validation

- 全量 `bun run test` EXIT=0（746+ 用例）
- Eval 3 场景（新增 `background-no-shell-substitute`，rubric 含 `no_shell_background`）：3/3 rate 1.0
- **真实飞书回归**（家庭管家，旧 session 含 nohup 先例）：Agent 工具被调用、job id 立即返回、完成通知自动汇总、输出 `agent-tool-ok` ✓
- `-e` 注入在真实 pi 进程命令行确认：`pi --mode rpc ... -e <configDir>/providers/pi/extensions/pi-subagents.bundle.js`

## Notes

- 版本 0.2.64 → 0.2.65（patch）