### PR TITLE
chore: make GitHub detect larkin as TypeScript (map test/tooling .mjs)

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,11 @@
+# GitHub language detection (Linguist) overrides.
+#
+# The product is TypeScript, but most tests and build tooling run as plain
+# ESM/CJS (`.mjs`/`.cjs`). By extension those would be counted as JavaScript and
+# dominate the language breakdown, so GitHub labels this repo "JavaScript".
+# Map them to TypeScript so Linguist reports the project as TypeScript.
+
+test/**/*.mjs          linguist-language=TypeScript
+test/**/*.cjs          linguist-language=TypeScript
+scripts/**/*.mjs       linguist-language=TypeScript
+src/dashboard/**/*.mjs linguist-language=TypeScript


### PR DESCRIPTION
## 问题

GitHub 把 larkin 识别为 **JavaScript** 项目，实际是 TypeScript 项目。

**根因**：GitHub Linguist 按扩展名统计行数。提交里 `.mjs`（JS）有 32,456 行 > `.ts`（TS）22,908 行，而 168 个 `.mjs` 里 **156 个是 `test/` 下的测试**（unit/integration/support/live/e2e），加上 scripts/ 构建脚本和 dashboard 配置，把 JS 顶过了 TS。

排除 `test/` 后产品源码：TS ~23.6k 行 vs JS ~1.4k 行 → 本质是 TypeScript 项目。

## 方案

新增 `.gitattributes`，用 `linguist-language=TypeScript` 把测试/工具/配置的 `.mjs`/`.cjs` 映射成 TypeScript，让 Linguist 正确判定。

```gitattributes
test/**/*.mjs          linguist-language=TypeScript
test/**/*.cjs          linguist-language=TypeScript
scripts/**/*.mjs       linguist-language=TypeScript
src/dashboard/**/*.mjs linguist-language=TypeScript
```

验证：`git check-attr` 已确认这些路径被正确映射。合并后 GitHub 语言标签应变为 TypeScript。