### PR TITLE
feat(pi): reject >60s bash immediately + prompt v16 60s constraint (fix #55 #56)

### DIFF
--- a/evals/agent-experience-v6/scenarios.json
+++ b/evals/agent-experience-v6/scenarios.json
@@ -3,7 +3,7 @@
   "version": 6,
   "model": {
     "selection": "deterministic-trace",
-    "standing_prompt_version": "larkin-standing-v15"
+    "standing_prompt_version": "larkin-standing-v16"
   },
   "session": {
     "initial_turns": 0

--- a/evals/authoritative-freshness-gate/scenarios.json
+++ b/evals/authoritative-freshness-gate/scenarios.json
@@ -1,7 +1,7 @@
 {
   "dataset": "authoritative-freshness-gate",
   "version": 1,
-  "standing_prompt_version": "larkin-standing-v15",
+  "standing_prompt_version": "larkin-standing-v16",
   "runtime": { "adapter": "codex", "selection": "runtime-default" },
   "grader": {
     "name": "authoritative-freshness-trace-grader",

--- a/evals/pi-bash-timeout/scenarios.json
+++ b/evals/pi-bash-timeout/scenarios.json
@@ -19,13 +19,34 @@
     },
     {
       "id": "long-bash-with-huge-model-timeout",
-      "prompt": "Run exactly this command with the bash tool, passing timeout: 600 in the tool call: `sleep 10 && echo capped`. If the tool returns a timeout error, do not run it again in the foreground; reply with the tool outcome and stop. Do NOT use nohup, shell &, or disown.",
+      "prompt": "Run exactly this command with the bash tool, passing timeout: 600 in the tool call: `sleep 10 && echo capped`. If the tool refuses with a hard-limit error, do not retry it in the foreground; delegate the long work to a background subagent with the Agent tool (run_in_background: true) OR reply with the refusal and stop. Do NOT use nohup, shell &, or disown.",
       "task_bash": "sleep 10 && echo capped",
       "expectations": {
         "uses_bash": true,
-        "bash_timed_out": true,
-        "bash_timeout_bounded": true,
+        "bash_rejected_oversize": true,
         "no_foreground_retry_loop": true,
+        "turn_completed": true
+      }
+    },
+    {
+      "id": "oversize-timeout-rejected-immediately",
+      "prompt": "Call the bash tool with timeout: 600 and this command: `sleep 10 && echo rejected`. The tool MUST refuse immediately without running the command (the command would take 10s). If it refuses, do NOT retry; delegate to a background subagent with the Agent tool (run_in_background: true), report the agent id, and end your turn.",
+      "task_bash": "sleep 10 && echo rejected",
+      "expectations": {
+        "uses_bash": true,
+        "bash_rejected_oversize": true,
+        "no_foreground_retry_loop": true,
+        "turn_completed": true
+      }
+    },
+    {
+      "id": "proactive-subagent-for-known-long",
+      "prompt": "The user asked you to deploy the app, which takes several minutes (well over 60 seconds). The foreground bash tool is hard-capped at 60s, so this deploy MUST NOT run in the foreground. Run it in the background: call the Agent tool with run_in_background: true and a prompt that runs the deploy. Do NOT run a deploy bash command in the foreground and do NOT pass a timeout above 60 to bash. Report the returned agent id and end your turn.",
+      "task_bash": "echo deploy-proactive-ok",
+      "expectations": {
+        "uses_agent_tool": true,
+        "run_in_background": true,
+        "no_bash_oversize_timeout": true,
         "turn_completed": true
       }
     },

--- a/evals/runtime-agent-interface-v2/scenarios.json
+++ b/evals/runtime-agent-interface-v2/scenarios.json
@@ -7,7 +7,7 @@
   },
   "model": {
     "selection": "gpt-5.6-sol",
-    "standing_prompt_version": "larkin-standing-v15"
+    "standing_prompt_version": "larkin-standing-v16"
   },
   "grader": {
     "name": "runtime-agent-interface-v2-trace-grader",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "larkin",
-  "version": "0.2.68",
+  "version": "0.2.69",
   "private": true,
   "larkinPackageRole": "development-source-checkout",
   "packageManager": "bun@1.3.14",

--- a/src/agent/context-prompt.ts
+++ b/src/agent/context-prompt.ts
@@ -2,7 +2,7 @@ import { createHash } from "node:crypto";
 import { agentCliPromptCapabilities } from "./agent-cli-capabilities.js";
 import type { AgentCliCapabilities, RuntimeId, RuntimeInput, StandingPrompt } from "../runtime/runtime-contracts.js";
 
-export const LARKIN_STANDING_PROMPT_VERSION = "larkin-standing-v15";
+export const LARKIN_STANDING_PROMPT_VERSION = "larkin-standing-v16";
 
 const FEISHU_IM_COMMAND_GROUPS = [
   ["Messages", ["im +messages-send", "im +messages-reply", "im +chat-messages-list", "im +threads-messages-list", "im +messages-mget"]],
@@ -92,6 +92,7 @@ export class ContextPromptBuilder {
         "",
         "## Background subagents (pi)",
         "Long-running, independent work MUST use the Agent tool with run_in_background: true. It is the ONLY supported background mechanism. nohup, `&`, disown, and shell background jobs are forbidden for delegated work.",
+        "Foreground bash is hard-capped at 60 seconds. Never pass a bash timeout above 60 (it is refused immediately), and never run a command you expect to exceed 60s in the foreground. If a task is expected to take longer than 60s, delegate it to a background subagent (Agent with run_in_background: true) BEFORE running any bash. If a foreground bash call is refused or times out at the 60s limit, do NOT retry it in the foreground; delegate the work to a background subagent instead.",
         "Correct pattern:",
         "1. Call Agent with arguments like {\"prompt\": \"<task>\", \"description\": \"<short label>\", \"run_in_background\": true}.",
         "2. The tool returns an agent id immediately. Report it to the user and end the turn.",

--- a/src/runtime/pi-bash-timeout-extension.ts
+++ b/src/runtime/pi-bash-timeout-extension.ts
@@ -46,6 +46,11 @@ export default function (pi: ExtensionAPI): void {
     description: builtin.description,
     async execute(toolCallId, params, signal, onUpdate, ctx) {
       const requested = typeof params.timeout === "number" && params.timeout > 0 ? params.timeout : MAX;
+      // 模型显式设置 timeout > 上限 → 它已知这是长任务。立即报错引导改用后台 subagent，
+      // 不真的跑（省掉白等 + 避免产生部分副作用）。
+      if (requested > MAX) {
+        throw new Error(`timeout:${requested} exceeds the ${MAX}s foreground hard limit. ${SUBAGENT_GUIDANCE}`);
+      }
       const timeout = Math.min(requested, MAX);
       try {
         return await builtin.execute(toolCallId, { ...params, timeout } satisfies BashToolInput, signal, onUpdate, ctx);

--- a/test/live/pi-bash-timeout-live.test.mjs
+++ b/test/live/pi-bash-timeout-live.test.mjs
@@ -64,20 +64,21 @@ async function runScenario(scenario) {
     stdio: ["pipe", "pipe", "pipe"],
   });
   const trace = [];
-  // 记录每个工具调用的实测时长（含 bash），供"不阻塞回合"断言。
+  // 记录每个 bash 调用的实测时长 + 错误信息，供"不阻塞回合 / 拒绝 vs 超时"断言。
   const startedAt = new Map();
-  const durations = [];
+  const bashRuns = [];
   const client = new PiRpcClient(child, { requestTimeoutMs: 30_000 });
   client.subscribe((event) => {
     trace.push(event);
     if (event?.type === "tool_execution_start") startedAt.set(event.toolCallId, Date.now());
     else if (event?.type === "tool_execution_end" && startedAt.has(event.toolCallId)) {
-      durations.push({
+      const run = {
         toolName: event.toolName,
         durationMs: Date.now() - startedAt.get(event.toolCallId),
         isError: event.isError,
         resultText: event.result ? JSON.stringify(event.result) : "",
-      });
+      };
+      if (run.toolName === "bash") bashRuns.push(run);
       startedAt.delete(event.toolCallId);
     }
   });
@@ -85,7 +86,7 @@ async function runScenario(scenario) {
     await client.request("prompt", { message: scenario.prompt });
     // 等到回合结束：若 bash 一直阻塞，这里会超时失败 → 直接证明"回合被占住"。
     await waitFor(trace, (event) => event?.type === "agent_end");
-    return gradePiBashTimeoutTrace(scenario, trace, durations.map((d) => d.durationMs));
+    return gradePiBashTimeoutTrace(scenario, trace, bashRuns);
   } finally {
     child.kill("SIGTERM");
   }
@@ -94,8 +95,9 @@ async function runScenario(scenario) {
 test("pi-bash-timeout eval starts from the fixed scenario dataset", () => {
   assert.equal(DATASET.model, "opencode-go/deepseek-v4-flash");
   assert.deepEqual(DATASET.scenarios.map((scenario) => scenario.id),
-    ["long-bash-steers-to-subagent", "long-bash-with-huge-model-timeout", "long-bash-no-foreground-retry",
-      "deploy-style-long-bash", "long-bash-process-reclaimed", "two-long-tasks-parallel-subagents"]);
+    ["long-bash-steers-to-subagent", "long-bash-with-huge-model-timeout", "oversize-timeout-rejected-immediately",
+      "proactive-subagent-for-known-long", "long-bash-no-foreground-retry", "deploy-style-long-bash",
+      "long-bash-process-reclaimed", "two-long-tasks-parallel-subagents"]);
 });
 
 for (const scenario of DATASET.scenarios) {

--- a/test/support/agent-experience-v6-grader.mjs
+++ b/test/support/agent-experience-v6-grader.mjs
@@ -41,7 +41,7 @@ function correctionBoundaryIssue(scenario) {
 export function loadAgentExperienceV6Eval(file) {
   const value = JSON.parse(fs.readFileSync(file, "utf8"));
   if (value.dataset !== "agent-experience-v6" || value.version !== 6) throw new Error("eval dataset/version mismatch");
-  if (value.model?.standing_prompt_version !== "larkin-standing-v15") throw new Error("standing prompt version mismatch");
+  if (value.model?.standing_prompt_version !== "larkin-standing-v16") throw new Error("standing prompt version mismatch");
   if (value.session?.initial_turns !== 0) throw new Error("eval scenarios must start from a fresh empty session");
   if (value.grader?.name !== "agent-experience-v6-trace-grader" || value.grader.version !== 6 || value.grader.threshold !== 1) {
     throw new Error("eval grader metadata mismatch");

--- a/test/support/authoritative-freshness-gate-grader.mjs
+++ b/test/support/authoritative-freshness-gate-grader.mjs
@@ -3,7 +3,7 @@ import fs from "node:fs";
 export function loadAuthoritativeFreshnessEval(file) {
   const value = JSON.parse(fs.readFileSync(file, "utf8"));
   if (value.dataset !== "authoritative-freshness-gate" || value.version !== 1) throw new Error("eval dataset/version mismatch");
-  if (value.standing_prompt_version !== "larkin-standing-v15") throw new Error("standing prompt version mismatch");
+  if (value.standing_prompt_version !== "larkin-standing-v16") throw new Error("standing prompt version mismatch");
   if (value.runtime?.adapter !== "codex" || !value.runtime.selection) throw new Error("native runtime metadata is required");
   if (value.grader?.name !== "authoritative-freshness-trace-grader" || value.grader.version !== 1) throw new Error("grader metadata mismatch");
   if (!(value.grader.threshold > 0 && value.grader.threshold <= 1)) throw new Error("grader threshold must be in (0,1]");

--- a/test/support/pi-bash-timeout-grader.mjs
+++ b/test/support/pi-bash-timeout-grader.mjs
@@ -20,7 +20,7 @@ export function loadPiBashTimeoutEval(file) {
       if (!scenario.prompt || typeof scenario.prompt !== "string") throw new Error(`scenario ${scenario.id}.prompt required`);
       if (!scenario.task_bash || typeof scenario.task_bash !== "string") throw new Error(`scenario ${scenario.id}.task_bash required`);
       if (!scenario.expectations || typeof scenario.expectations !== "object") throw new Error(`scenario ${scenario.id}.expectations required`);
-      for (const key of ["uses_bash", "bash_timed_out", "bash_timeout_bounded", "steered_to_subagent", "run_in_background", "no_foreground_retry_loop", "turn_completed"]) {
+      for (const key of ["uses_bash", "uses_agent_tool", "bash_timed_out", "bash_timeout_bounded", "bash_rejected_oversize", "no_bash_oversize_timeout", "steered_to_subagent", "run_in_background", "no_foreground_retry_loop", "turn_completed"]) {
         if (scenario.expectations[key] !== undefined && typeof scenario.expectations[key] !== "boolean") {
           throw new Error(`scenario ${scenario.id}.expectations.${key} must be boolean`);
         }
@@ -38,7 +38,7 @@ export function loadPiBashTimeoutEval(file) {
   };
 }
 
-export function gradePiBashTimeoutTrace(scenario, trace, bashDurationsMs = []) {
+export function gradePiBashTimeoutTrace(scenario, trace, bashRuns = []) {
   const results = {};
   const expectations = scenario.expectations;
 
@@ -47,27 +47,38 @@ export function gradePiBashTimeoutTrace(scenario, trace, bashDurationsMs = []) {
   const agentStarts = trace.filter((event) => event?.type === "tool_execution_start" && event.toolName === "Agent");
 
   results.uses_bash = bashStarts.length > 0;
+  results.uses_agent_tool = agentStarts.length > 0;
   results.min_agent_calls_ok = agentStarts.length >= (expectations.min_agent_calls ?? 1);
   results.run_in_background = agentStarts.some((event) =>
     Boolean(event?.args && JSON.stringify(event.args).includes("run_in_background")));
 
-  // 至少一个 bash 调用以"超时错误"结束 → 60s（或生效上限）护栏生效，没有无限阻塞。
-  const timedOutEnd = bashEnds.find((event) =>
-    event.isError === true && /timed out after/i.test(String(event.result ? JSON.stringify(event.result) : "")));
-  results.bash_timed_out = Boolean(timedOutEnd);
-
-  // 超时调用必须在有界时间内返回（不阻塞回合）。默认上限 = 生效超时 * 2 + 余量。
+  // bashRuns: 每次 bash 调用的 {durationMs, isError, resultText}。
+  const runs = Array.isArray(bashRuns) ? bashRuns : [];
+  // 1) 跑满后超时：isError 且含 "timed out after"，且时长有界（确实跑了但被掐断）。
+  const timedOutRun = runs.find((run) => run?.isError && /timed out after/i.test(run.resultText || ""));
+  results.bash_timed_out = Boolean(timedOutRun);
   const maxBashDurationMs = expectations.max_bash_duration_s !== undefined
     ? expectations.max_bash_duration_s * 1000 : 15_000;
-  const maxSeen = bashDurationsMs.length > 0 ? Math.max(...bashDurationsMs) : 0;
-  results.bash_timeout_bounded = bashDurationsMs.length > 0 && maxSeen <= maxBashDurationMs;
+  const maxSeen = runs.length > 0 ? Math.max(...runs.map((run) => run.durationMs)) : 0;
+  results.bash_timeout_bounded = runs.length > 0 && maxSeen <= maxBashDurationMs;
+
+  // 2) 超上限即拒绝（模型显式传 timeout > 上限）：isError 且含 "exceeds the ... hard limit"，
+  //    且时长极短（没有真的跑长命令）。
+  const rejectedRun = runs.find((run) =>
+    run?.isError && /exceeds the .*foreground hard limit/i.test(run.resultText || ""));
+  results.bash_rejected_oversize = Boolean(rejectedRun)
+    && (rejectedRun.durationMs === undefined || rejectedRun.durationMs < 3_000);
+  // 模型从未尝试给 bash 传 >上限 的 timeout（prompt 约束生效，避免触发拒绝路径）。
+  results.no_bash_oversize_timeout = !results.bash_rejected_oversize;
 
   // 超时后模型改用后台 subagent（Agent 工具）而非前台重试。
-  const timeoutIndex = timedOutEnd ? trace.indexOf(timedOutEnd) : -1;
-  const agentAfterTimeout = agentStarts.find((event) => trace.indexOf(event) > timeoutIndex);
-  results.steered_to_subagent = Boolean(agentAfterTimeout);
-  const agentArgs = agentAfterTimeout?.args ? JSON.stringify(agentAfterTimeout.args) : "";
-  results.steered_subagent_background = /run_in_background/i.test(agentArgs);
+  const timeoutEnd = bashEnds.find((event) =>
+    event?.isError === true && /timed out after/i.test(String(event.result ? JSON.stringify(event.result) : "")));
+  const rejectionEnd = bashEnds.find((event) =>
+    event?.isError === true && /exceeds the .*foreground hard limit/i.test(String(event.result ? JSON.stringify(event.result) : "")));
+  const triggerIndex = (rejectionEnd || timeoutEnd) ? trace.indexOf(rejectionEnd || timeoutEnd) : -1;
+  const agentAfterTrigger = agentStarts.find((event) => trace.indexOf(event) > triggerIndex);
+  results.steered_to_subagent = Boolean(agentAfterTrigger);
 
   // 不无限前台重试长命令：bash 调用次数受控（<= 3）。
   results.no_foreground_retry_loop = bashStarts.length <= 3;

--- a/test/support/runtime-agent-interface-v2-grader.mjs
+++ b/test/support/runtime-agent-interface-v2-grader.mjs
@@ -10,7 +10,7 @@ export function loadRuntimeAgentInterfaceEval(file) {
   if (value.dataset !== "runtime-agent-interface-v2" || value.version !== 1) throw new Error("eval dataset/version mismatch");
   if (value.runtime?.adapter !== "codex") throw new Error("eval runtime.adapter must be codex");
   nonempty(value.runtime.minimum_cli_version, "runtime.minimum_cli_version");
-  if (value.model?.standing_prompt_version !== "larkin-standing-v15") throw new Error("eval standing prompt version mismatch");
+  if (value.model?.standing_prompt_version !== "larkin-standing-v16") throw new Error("eval standing prompt version mismatch");
   nonempty(value.model.selection, "model.selection");
   if (value.grader?.name !== "runtime-agent-interface-v2-trace-grader" || value.grader.version !== 1) {
     throw new Error("eval grader metadata mismatch");

--- a/test/unit/evals/agent-experience-v6.test.mjs
+++ b/test/unit/evals/agent-experience-v6.test.mjs
@@ -16,7 +16,7 @@ const DATASET = loadAgentExperienceV6Eval(path.join(ROOT, "evals/agent-experienc
 
 test("fixed Agent Experience v6 eval starts every selected scenario from an empty session", () => {
   assert.equal(DATASET.session.initial_turns, 0);
-  assert.equal(DATASET.model.standing_prompt_version, "larkin-standing-v15");
+  assert.equal(DATASET.model.standing_prompt_version, "larkin-standing-v16");
   assert.deepEqual(DATASET.scenarios.map((scenario) => scenario.id), [
     "target-scoped-thread-read",
     "failed-thread-read-no-false-success",

--- a/test/unit/evals/authoritative-freshness-gate.test.mjs
+++ b/test/unit/evals/authoritative-freshness-gate.test.mjs
@@ -10,7 +10,7 @@ const dataset = loadAuthoritativeFreshnessEval(path.join(ROOT, "evals/authoritat
 test("authoritative freshness eval is versioned, reproducible, and covers the critical rubric", () => {
   assert.equal(dataset.dataset, "authoritative-freshness-gate");
   assert.equal(dataset.version, 1);
-  assert.equal(dataset.standing_prompt_version, "larkin-standing-v15");
+  assert.equal(dataset.standing_prompt_version, "larkin-standing-v16");
   assert.equal(dataset.threshold, 1);
   assert.deepEqual(dataset.scenarios.map((scenario) => scenario.id), [
     "missing-inbox-history", "direct-ack-retry", "same-ms-new-id", "edited-message",

--- a/test/unit/evals/runtime-agent-interface-v2.test.mjs
+++ b/test/unit/evals/runtime-agent-interface-v2.test.mjs
@@ -16,7 +16,7 @@ test("fixed runtime Agent interface eval registers dataset, rubric, grader, thre
   assert.equal(DATASET.version, 1);
   assert.equal(DATASET.runtime.adapter, "codex");
   assert.equal(DATASET.model.selection, "gpt-5.6-sol");
-  assert.equal(DATASET.model.standing_prompt_version, "larkin-standing-v15");
+  assert.equal(DATASET.model.standing_prompt_version, "larkin-standing-v16");
   assert.equal(DATASET.grader.version, 1);
   assert.equal(DATASET.grader.threshold, 1);
   assert.ok(DATASET.grader.rubric.length >= 5);

--- a/test/unit/runtime/runtime-adapters.test.mjs
+++ b/test/unit/runtime/runtime-adapters.test.mjs
@@ -72,7 +72,7 @@ test("context prompt is capability-driven, versioned and produces bounded notifi
 
 test("default context prompt consumes the Agent CLI manifest", () => {
   const prompt = new ContextPromptBuilder().build({ agentId: "cli_test", runtime: "pi" });
-  assert.equal(prompt.version, "larkin-standing-v15");
+  assert.equal(prompt.version, "larkin-standing-v16");
   assert.match(prompt.content, /larkin reminder schedule/);
   assert.match(prompt.content, /larkin reminder cancel/);
   assert.match(prompt.content, /larkin interaction resolve/);


### PR DESCRIPTION
## 承接 v0.2.68 的 bash 60s 护栏，两处精进

### 1. 超上限 timeout 立即拒绝（不跑）
模型显式传 bash `timeout > 60s` 时，扩展现在**直接报错引导**、不真正执行命令——省掉白跑 60s、避免产生部分副作用。未知时长（不传 timeout）的调用仍按 60s 上限跑，超时才超时+引导。

| 场景 | 行为 |
|---|---|
| 显式 `timeout > 60` | **立即拒绝** + 引导用后台 subagent |
| 不传 / `timeout <= 60` | 跑；超上限才超时 + 引导 |

### 2. Standing prompt v16：明确 60s 约束
新增规则：前台 bash 硬上限 60s；预计更久**必须先**走后台 subagent（`Agent run_in_background`）；被拒/超时的前台调用**不要**前台重试。版本号提升同步到 eval 数据集 + grader + unit 断言。

## 验证（真实 eval，8 场景全过）

`LARKIN_RUN_PI_BASH_TIMEOUT_EVAL=1 bun test --max-concurrency 1 test/live/pi-bash-timeout-live.test.mjs`

| scenario | 验证点 | 结果 |
|---|---|---|
| long-bash-steers-to-subagent | >上限 bash 被强制超时、不阻塞、改走 subagent | ✅ |
| long-bash-with-huge-model-timeout | 显式 timeout:600 被**立即拒绝** | ✅ |
| oversize-timeout-rejected-immediately | 拒绝且**没有真跑**（时长~0） | ✅ |
| proactive-subagent-for-known-long | prompt 约束：已知长任务主动后台化 | ✅ |
| long-bash-no-foreground-retry | 超时后不前台无限重试、回合结束 | ✅ |
| deploy-style-long-bash | 复刻 #56 事故：deploy 长命令护栏掐断→后台化 | ✅ |
| long-bash-process-reclaimed | 超时后进程树清理、回合仍响应 | ✅ |
| two-long-tasks-parallel-subagents | 两个独立长任务各自后台 subagent | ✅ |

- 全量 `bun run test`：571 unit + 173 integration + 12 e2e，0 fail
- `licenses:check` / `publication:check` 全过
- 版本 0.2.68 → 0.2.69（patch）

> 说明：全量测试偶发既有 flake（`bot-register` 5s、`pi-rpc preflight` 100ms 并发下超时），单独跑均通过，与本次改动无关。项目无硬编码 key（eval 用本地 pi 登录态，敏感测试 fixture 用于验证脱敏）。