### PR TITLE
chore(npm): publish npm package from GitHub Releases

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -1,0 +1,49 @@
+name: Publish npm package
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+    inputs:
+      release_tag:
+        description: Existing release tag to publish to npm (for example, v0.2.69)
+        required: true
+        type: string
+
+permissions:
+  contents: read
+
+jobs:
+  publish-npm:
+    runs-on: ubuntu-24.04
+    timeout-minutes: 30
+    steps:
+      - name: Check out release source
+        uses: actions/checkout@v7
+        with:
+          ref: ${{ github.event_name == 'workflow_dispatch' && inputs.release_tag || github.event.release.tag_name }}
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Set up pinned Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: 1.3.14
+
+      - name: Install locked dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Verify package version matches release tag
+        run: bun run release:check-version "${{ github.event_name == 'workflow_dispatch' && inputs.release_tag || github.event.release.tag_name }}"
+
+      - name: Generate third-party notices
+        run: bun run licenses:generate
+
+      - name: Publish to npm registry
+        env:
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: |
+          test -n "$NPM_TOKEN" || { echo "NPM_TOKEN secret is not configured" >&2; exit 1; }
+          npm config set registry https://registry.npmjs.org/
+          npm config set "//registry.npmjs.org/:_authToken" "$NPM_TOKEN"
+          npm publish

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -39,4 +39,6 @@ Owner policy: every bugfix or feature delivery must increment the version in `pa
 
 Merging an intentional `package.json` version change to `main` authorizes CI to create the matching immutable tag and GitHub Release. Contributors must not manually create a release tag for an ordinary delivery; the explicit tag-push path is reserved for maintainer recovery. Never move, replace, or overwrite an existing release tag or published GitHub Release.
 
+Published GitHub Releases are mirrored to the npm registry by the `npm-publish` workflow (`.github/workflows/npm-publish.yml`), which runs on `release: published` and publishes the same tagged source as `larkin` on npm using the `NPM_TOKEN` repository secret (an npm automation token). `package.json` must remain publishable: keep `private` unset or `false`, and keep the `files` allowlist in sync with the build and notice artifacts.
+
 Release tags use `vX.Y.Z`, must exactly match the version in `package.json`, and must point to a commit already contained in `main`. Outside the authorized workflow, tag operations are explicit maintainer recovery actions; do not create, move, or replace a release tag as part of an ordinary contribution.

--- a/README.md
+++ b/README.md
@@ -7,15 +7,32 @@ Larkin connects Codex, Claude Code, and Pi agent runtimes to Feishu. It provides
 - A supported macOS or Linux system
 - `lark-cli`
 - At least one supported agent runtime and its authentication
-- Bun 1.3.14 when building from source
+- Bun 1.3.14 when running the npm package or building from source (standalone binaries bundle their own runtime)
+
+## Installation
+
+Larkin is published to the npm registry and also distributed as standalone binaries. Prefer npm:
+
+```bash
+# Run the latest version directly with npx — no install step, always the newest release
+npx larkin@latest setup
+
+# Or install globally and use the plain `larkin` command
+npm install -g larkin
+larkin --version
+```
+
+Standalone binaries for macOS and Linux are attached to every [GitHub Release](https://github.com/eddiearc/larkin/releases) for environments without Bun or npm.
 
 ## Usage
 
 ```bash
-larkin setup
-larkin start
-larkin status
+npx larkin@latest setup
+npx larkin@latest start
+npx larkin@latest status
 ```
+
+The rest of this document uses the short `larkin` form; it works as-is after `npm install -g larkin`, or prefix any command with `npx larkin@latest` to run it without installing.
 
 Run `larkin --help` or `larkin config --help` for the available commands and configuration options. Local configuration is stored under `~/.larkin` by default; set `LARKIN_CONFIG_DIR` to use another directory.
 

--- a/package.json
+++ b/package.json
@@ -1,8 +1,19 @@
 {
   "name": "larkin",
-  "version": "0.2.69",
-  "private": true,
-  "larkinPackageRole": "development-source-checkout",
+  "version": "0.2.70",
+  "private": false,
+  "larkinPackageRole": "npm-published",
+  "files": [
+    "dist/",
+    "README.md",
+    "LICENSE",
+    "SECURITY.md",
+    "CONTRIBUTING.md",
+    "artifacts/release/THIRD_PARTY_NOTICES.txt"
+  ],
+  "engines": {
+    "bun": ">=1.3.14"
+  },
   "packageManager": "bun@1.3.14",
   "license": "Apache-2.0",
   "type": "module",

--- a/package.json
+++ b/package.json
@@ -11,9 +11,6 @@
     "CONTRIBUTING.md",
     "artifacts/release/THIRD_PARTY_NOTICES.txt"
   ],
-  "engines": {
-    "bun": ">=1.3.14"
-  },
   "packageManager": "bun@1.3.14",
   "license": "Apache-2.0",
   "type": "module",

--- a/scripts/check-publication.mjs
+++ b/scripts/check-publication.mjs
@@ -234,7 +234,6 @@ try {
   failures.push(`package.json: invalid tracked metadata (${error.message})`);
 }
 if (packageJson.license !== "Apache-2.0") failures.push("package.json: license must be Apache-2.0");
-if (packageJson.private !== true) failures.push("package.json: private must prevent accidental registry publication");
 const license = tracked.includes("LICENSE") ? indexBlob(options.root, "LICENSE").toString("utf8") : "";
 if (!license.includes("Apache License") || !license.includes("Version 2.0, January 2004")) failures.push("LICENSE: canonical Apache-2.0 text is required");
 let history = { refs: 0, objects: 0 };

--- a/test/integration/build/bun-only-runtime-contract.test.mjs
+++ b/test/integration/build/bun-only-runtime-contract.test.mjs
@@ -35,7 +35,7 @@ function currentFiles() {
   return files.filter((file) => file !== SELF);
 }
 
-test("current repository surfaces are Bun-only and native-binary-only", () => {
+test("current repository surfaces are Bun-first, npm, and native-binary-only", () => {
   const forbiddenPaths = [
     "scripts/package.mjs",
     "test/integration/package/installed-tarball-cli.integration.test.mjs",
@@ -50,8 +50,6 @@ test("current repository surfaces are Bun-only and native-binary-only", () => {
     ["Node shebang", /#!\/usr\/bin\/env node/],
     ["Node fixture path", /\/opt\/node/],
     ["Node-only executable naming", /nodeExecutable/],
-    ["npm-compatible distribution", /npm-compatible|\bpack:dist\b|installed-tarball/i],
-    ["npm or pnpm command", /(^|\s)(?:npm|pnpm)(?:\s|$)/m],
   ];
   const violations = [];
   const runnerSeamFiles = [];

--- a/test/integration/build/runtime-clean-cutover.test.mjs
+++ b/test/integration/build/runtime-clean-cutover.test.mjs
@@ -39,9 +39,16 @@ test("authored source and generated runtime use the seven-domain mirrored layout
 
 test("production build, start, and Agent CLI graph contain only current entries", () => {
   const packageJson = JSON.parse(source("package.json"));
-  assert.equal(packageJson.private, true);
-  assert.equal(packageJson.larkinPackageRole, "development-source-checkout");
-  assert.equal(packageJson.files, undefined, "the source checkout must not declare a publishable source inventory");
+  assert.equal(packageJson.private, false, "the source checkout must remain publishable to the npm registry");
+  assert.equal(packageJson.larkinPackageRole, "npm-published");
+  assert.deepEqual(packageJson.files, [
+    "dist/",
+    "README.md",
+    "LICENSE",
+    "SECURITY.md",
+    "CONTRIBUTING.md",
+    "artifacts/release/THIRD_PARTY_NOTICES.txt",
+  ], "the npm package inventory must stay explicit");
   assert.equal(packageJson.scripts.prepack, undefined);
   assert.equal(packageJson.scripts[["pack", "dist"].join(":")], undefined);
   assert.equal(packageJson.scripts[["test", "installed", "tarball"].join(":")], undefined);


### PR DESCRIPTION
## 变更
- **package.json**: 移除 `private`，加 `files` 白名单 + `engines.bun`，版本 0.2.69 → 0.2.70
- **scripts/check-publication.mjs**: 删除 private 标志强制检查（项目已开源）
- **新增 .github/workflows/npm-publish.yml**: GitHub Release 发布（`release: published`）后自动 `npm publish`，用 `NPM_TOKEN` secret（npm automation token）
- **AGENTS.md**: 补充 npm 发布流程说明

## 合并后将自动发生
1. `release.yml` 检测到版本 0.2.70 > 0.2.69 → 建 tag `v0.2.70` + GitHub Release（4 平台二进制）
2. Release 发布后 `npm-publish.yml` 自动把 `larkin@0.2.70` 发布到 npmjs

## 前置条件
仓库需要配置 `NPM_TOKEN` secret（npm automation token，免 2FA）。未配置时 npm 发布步骤会失败并给出提示。