### PR TITLE
feat(pi): prompt v17 keeps thread-source replies in-thread + prompt-eng guidance (fix #54)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -27,6 +27,15 @@ bun run publication:check
 
 Keep each change focused. Update the closest tests when behavior changes, and run the smallest relevant test first followed by the full suite before delivery. Do not weaken clean-tree, publication, license, security, or release checks to make a change pass.
 
+## Prompt engineering
+
+When tuning the Larkin standing prompt (`src/agent/context-prompt.ts`), follow the two canonical references and the file header notes:
+
+- OpenAI Prompt Engineering Guide: <https://platform.openai.com/docs/guides/prompt-engineering>
+- Anthropic Prompt Engineering overview: <https://docs.anthropic.com/en/docs/build-with-claude/prompt-engineering/overview>
+
+Standing rules: prefer structural signals (target/source fields) over model inference; give exact recipe templates plus constraints; keep fail-closed/idempotent/freshness semantics; bump `LARKIN_STANDING_PROMPT_VERSION` on every substantive change and update the affected eval datasets, graders, and assertions; validate behavior changes with the fixed-scenario evals. Do not add new Markdown docs; keep guidance as file-header comments or in this file.
+
 ## Repository hygiene
 
 Never commit credentials, tokens, private keys, local configuration, user data, private filesystem paths, or restricted publication inputs. Do not commit generated `dist/`, release `artifacts/`, dependency directories, or local caches. The repository intentionally contains no `docs/` or `.claude/` tree; do not add unapproved Markdown files.

--- a/evals/agent-experience-v6/scenarios.json
+++ b/evals/agent-experience-v6/scenarios.json
@@ -3,7 +3,7 @@
   "version": 6,
   "model": {
     "selection": "deterministic-trace",
-    "standing_prompt_version": "larkin-standing-v16"
+    "standing_prompt_version": "larkin-standing-v17"
   },
   "session": {
     "initial_turns": 0
@@ -170,6 +170,46 @@
           "command": "larkin im +messages-reply --message-id om_eval_topic_reply --text '收到：“A/B”' --reply-in-thread --json",
           "message_id": "om_eval_topic_reply",
           "transported_text": "收到：“A/B”",
+          "shell_interpolation": false,
+          "exit_code": 0
+        }
+      ]
+    },
+    {
+      "id": "thread-source-reply-stays-in-thread",
+      "task": "A canonical Inbox event target is a thread: thread:oc_eval_thread_reply:omt_eval_thread_reply. The source message lives inside a thread, so the reply MUST stay in that same thread even though no in-thread word is used. Poll the known thread target, then reply to its real om_ message with the exact literal 收到（thread） using the thread reply recipe. Do not fall back to the chat main timeline.",
+      "expected": {
+        "max_tool_calls": 2,
+        "exact_tool_calls": 2,
+        "provider_writes": 1,
+        "write_exit_code": 0,
+        "poll_before_write": true,
+        "ordered_commands": [
+          "larkin inbox poll --target thread:oc_eval_thread_reply:omt_eval_thread_reply --limit 1",
+          "larkin im +messages-reply --message-id om_eval_thread_reply --text '收到（thread）' --reply-in-thread --json"
+        ],
+        "ordered_command_exit_code": 0,
+        "reply_anchor": {
+          "poll_command": "larkin inbox poll --target thread:oc_eval_thread_reply:omt_eval_thread_reply --limit 1",
+          "write_command": "larkin im +messages-reply --message-id om_eval_thread_reply --text '收到（thread）' --reply-in-thread --json"
+        },
+        "forbidden_command_fragments": ["--help", " -h", "--markdown", "--idempotency-key"],
+        "forbidden_read_path_fragments": ["SKILL.md", "/references/"],
+        "exact_text": "收到（thread）",
+        "shell_interpolation": false
+      },
+      "trace": [
+        {
+          "action": "tool",
+          "command": "larkin inbox poll --target thread:oc_eval_thread_reply:omt_eval_thread_reply --limit 1",
+          "exit_code": 0,
+          "message_id": "om_eval_thread_reply"
+        },
+        {
+          "action": "provider_write",
+          "command": "larkin im +messages-reply --message-id om_eval_thread_reply --text '收到（thread）' --reply-in-thread --json",
+          "message_id": "om_eval_thread_reply",
+          "transported_text": "收到（thread）",
           "shell_interpolation": false,
           "exit_code": 0
         }

--- a/evals/authoritative-freshness-gate/scenarios.json
+++ b/evals/authoritative-freshness-gate/scenarios.json
@@ -1,7 +1,7 @@
 {
   "dataset": "authoritative-freshness-gate",
   "version": 1,
-  "standing_prompt_version": "larkin-standing-v16",
+  "standing_prompt_version": "larkin-standing-v17",
   "runtime": { "adapter": "codex", "selection": "runtime-default" },
   "grader": {
     "name": "authoritative-freshness-trace-grader",

--- a/evals/runtime-agent-interface-v2/scenarios.json
+++ b/evals/runtime-agent-interface-v2/scenarios.json
@@ -7,7 +7,7 @@
   },
   "model": {
     "selection": "gpt-5.6-sol",
-    "standing_prompt_version": "larkin-standing-v16"
+    "standing_prompt_version": "larkin-standing-v17"
   },
   "grader": {
     "name": "runtime-agent-interface-v2-trace-grader",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "larkin",
-  "version": "0.2.70",
+  "version": "0.2.71",
   "private": false,
   "larkinPackageRole": "npm-published",
   "files": [

--- a/src/agent/context-prompt.ts
+++ b/src/agent/context-prompt.ts
@@ -2,7 +2,21 @@ import { createHash } from "node:crypto";
 import { agentCliPromptCapabilities } from "./agent-cli-capabilities.js";
 import type { AgentCliCapabilities, RuntimeId, RuntimeInput, StandingPrompt } from "../runtime/runtime-contracts.js";
 
-export const LARKIN_STANDING_PROMPT_VERSION = "larkin-standing-v16";
+/**
+ * Standing prompt 工程（调 prompt 时先读）：
+ * - OpenAI Prompt Engineering Guide: https://platform.openai.com/docs/guides/prompt-engineering
+ * - Anthropic Prompt Engineering overview: https://docs.anthropic.com/en/docs/build-with-claude/prompt-engineering/overview
+ *
+ * 本文件维护的核心调优原则：
+ * 1. 明确目标与边界：每条规则写明“何时触发 / 做什么 / 禁止什么”，避免歧义与过度推断。
+ * 2. 结构性信号优先于推断：能用来源/目标字段（如 thread target）做权威判定的，不要依赖模型从措辞推断。
+ * 3. 精确 recipe：关键操作给完整命令模板 + 约束（如 exact literal、fail-closed、确定性 --jq 数据流）。
+ * 4. 幂等与安全：idempotency、freshness 前置检查、不可重复提交、脱敏、失败可见（fail visibly）。
+ * 5. 版本化：每次实质改动 bump LARKIN_STANDING_PROMPT_VERSION，并同步 eval 数据集/graders/断言。
+ * 6. 用 eval 验证：行为变化必须配套固定场景 + rubric（evals/*、test/support/*-grader.mjs、live 测试）。
+ */
+
+export const LARKIN_STANDING_PROMPT_VERSION = "larkin-standing-v17";
 
 const FEISHU_IM_COMMAND_GROUPS = [
   ["Messages", ["im +messages-send", "im +messages-reply", "im +chat-messages-list", "im +threads-messages-list", "im +messages-mget"]],
@@ -122,8 +136,8 @@ export class ContextPromptBuilder {
       "For exact text supplied directly in the current instruction or Inbox event, pass the body unchanged as one literal `--text` argument. A direct literal must not use command substitution, backticks, `eval`, `echo`, or an unquoted variable; if it cannot be represented safely, stop and report the limitation instead of normalizing it.",
       "An explicit exact or verbatim direct literal uses `--text` and overrides the regular markdown default.",
       `For a common exact send with a confirmed chat id, use the complete schematic recipe \`${executable} im +messages-send --chat-id <confirmed_chat_id> --text '<exact_body_as_one_literal_argument>' --json\`; replace each placeholder with the corresponding confirmed or exact literal value.`,
-      `For an ordinary current Inbox exact reply when the user or event does not explicitly request a topic, in-thread, or thread reply, after the required poll use this complete canonical recipe: \`${executable} im +messages-reply --message-id <real_om_message_id> --text '<exact_body_as_one_literal_argument>' --json\`. Replace the placeholders with the polled id and unchanged exact literal, and omit \`--reply-in-thread\` so the reply stays on the original chat main timeline.`,
-      `Only when the user or current Inbox event explicitly asks for a topic, in-thread, or thread reply may you use this known canonical recipe after the required poll: \`${executable} im +messages-reply --message-id <real_om_message_id> --text '<exact_body_as_one_literal_argument>' --reply-in-thread --json\`. You must not infer a topic request from available thread metadata, the source message id, or ordinary reply wording; replace the placeholders only with the real \`om_\` id returned by that poll and the unchanged exact literal.`,
+      `A reply's target is governed by the source's thread membership, a structural Inbox fact, not a guess. When the current Inbox event or poll identifies the source as a thread (\`thread:<chat_id>:<thread_id>\` target, or the polled message carries a \`thread_id\`), your reply MUST stay in that same thread: after the required poll use \`${executable} im +messages-reply --message-id <real_om_message_id> --text '<exact_body_as_one_literal_argument>' --reply-in-thread --json\`. For a chat-level source (no thread) with no explicit in-thread request, reply to the main timeline with the same recipe but omit \`--reply-in-thread\`; replace the placeholders only with the real \`om_\` id returned by that poll and the unchanged exact literal.`,
+      `Use the \`--reply-in-thread\` recipe only when the source is a thread or the user or current Inbox event explicitly asks for a topic, in-thread, or thread reply. Never invent a topic request from ordinary reply wording or a bare source message id: the thread decision comes only from the source message's actual thread membership (\`thread:\` target or polled \`thread_id\`) or an explicit request, never from wording alone.`,
       "This exact topic-reply recipe has exactly one post-poll model tool call and must not read or re-read a skill or reference, open help, or perform any other discovery. Without a `freshness_conflict` it uses two total model tool calls including the poll. If the first write instead returns a nonzero pre-commit, provider-not-reached `freshness_conflict`, reconsider its bounded context and, only if the exact operation remains unchanged, retry the identical command once; this is the only allowed extra call and produces exactly three total model tool calls including the poll.",
       "For tool-sourced exact or verbatim text from a Feishu result, do not copy or retype it into `--text`; you must use the deterministic native `--jq` to `--content` dataflow below.",
       "Choose exactly one source selector from the identifier the task starts with, and never switch selectors after reading. The inner read in the selected composite replaces any separate scoped history read; it must not follow a preview read.",

--- a/test/support/agent-experience-v6-grader.mjs
+++ b/test/support/agent-experience-v6-grader.mjs
@@ -41,7 +41,7 @@ function correctionBoundaryIssue(scenario) {
 export function loadAgentExperienceV6Eval(file) {
   const value = JSON.parse(fs.readFileSync(file, "utf8"));
   if (value.dataset !== "agent-experience-v6" || value.version !== 6) throw new Error("eval dataset/version mismatch");
-  if (value.model?.standing_prompt_version !== "larkin-standing-v16") throw new Error("standing prompt version mismatch");
+  if (value.model?.standing_prompt_version !== "larkin-standing-v17") throw new Error("standing prompt version mismatch");
   if (value.session?.initial_turns !== 0) throw new Error("eval scenarios must start from a fresh empty session");
   if (value.grader?.name !== "agent-experience-v6-trace-grader" || value.grader.version !== 6 || value.grader.threshold !== 1) {
     throw new Error("eval grader metadata mismatch");

--- a/test/support/authoritative-freshness-gate-grader.mjs
+++ b/test/support/authoritative-freshness-gate-grader.mjs
@@ -3,7 +3,7 @@ import fs from "node:fs";
 export function loadAuthoritativeFreshnessEval(file) {
   const value = JSON.parse(fs.readFileSync(file, "utf8"));
   if (value.dataset !== "authoritative-freshness-gate" || value.version !== 1) throw new Error("eval dataset/version mismatch");
-  if (value.standing_prompt_version !== "larkin-standing-v16") throw new Error("standing prompt version mismatch");
+  if (value.standing_prompt_version !== "larkin-standing-v17") throw new Error("standing prompt version mismatch");
   if (value.runtime?.adapter !== "codex" || !value.runtime.selection) throw new Error("native runtime metadata is required");
   if (value.grader?.name !== "authoritative-freshness-trace-grader" || value.grader.version !== 1) throw new Error("grader metadata mismatch");
   if (!(value.grader.threshold > 0 && value.grader.threshold <= 1)) throw new Error("grader threshold must be in (0,1]");

--- a/test/support/runtime-agent-interface-v2-grader.mjs
+++ b/test/support/runtime-agent-interface-v2-grader.mjs
@@ -10,7 +10,7 @@ export function loadRuntimeAgentInterfaceEval(file) {
   if (value.dataset !== "runtime-agent-interface-v2" || value.version !== 1) throw new Error("eval dataset/version mismatch");
   if (value.runtime?.adapter !== "codex") throw new Error("eval runtime.adapter must be codex");
   nonempty(value.runtime.minimum_cli_version, "runtime.minimum_cli_version");
-  if (value.model?.standing_prompt_version !== "larkin-standing-v16") throw new Error("eval standing prompt version mismatch");
+  if (value.model?.standing_prompt_version !== "larkin-standing-v17") throw new Error("eval standing prompt version mismatch");
   nonempty(value.model.selection, "model.selection");
   if (value.grader?.name !== "runtime-agent-interface-v2-trace-grader" || value.grader.version !== 1) {
     throw new Error("eval grader metadata mismatch");

--- a/test/unit/evals/agent-experience-v6.test.mjs
+++ b/test/unit/evals/agent-experience-v6.test.mjs
@@ -16,13 +16,14 @@ const DATASET = loadAgentExperienceV6Eval(path.join(ROOT, "evals/agent-experienc
 
 test("fixed Agent Experience v6 eval starts every selected scenario from an empty session", () => {
   assert.equal(DATASET.session.initial_turns, 0);
-  assert.equal(DATASET.model.standing_prompt_version, "larkin-standing-v16");
+  assert.equal(DATASET.model.standing_prompt_version, "larkin-standing-v17");
   assert.deepEqual(DATASET.scenarios.map((scenario) => scenario.id), [
     "target-scoped-thread-read",
     "failed-thread-read-no-false-success",
     "exact-text-punctuation",
     "exact-reply-no-help",
     "explicit-topic-exact-reply",
+    "thread-source-reply-stays-in-thread",
     "same-human-correction-precedence",
     "precommit-exact-reply-safe-retry",
     "tool-sourced-verbatim-thread-reply",
@@ -66,17 +67,21 @@ test("standing prompt deletion counterfactual protects the known group user/bot 
 
 test("standing prompt deletion counterfactual protects the ordinary current-Inbox exact reply recipe", () => {
   const prompt = new ContextPromptBuilder().build({ agentId: "cli_eval", runtime: "pi" }).content;
+  assert.match(prompt, /source's thread membership.*structural Inbox fact.*not a guess/i);
   assert.match(prompt,
-    /ordinary current Inbox.*exact reply.*does not explicitly request.*topic.*in-thread.*messages-reply --message-id <real_om_message_id> --text '<exact_body_as_one_literal_argument>' --json/i);
+    /messages-reply --message-id <real_om_message_id> --text '<exact_body_as_one_literal_argument>'/i);
   assert.match(prompt,
-    /omit.*--reply-in-thread.*original.*chat.*main timeline/i);
+    /chat-level source.*no thread.*omit.*--reply-in-thread/i);
 });
 
 test("standing prompt deletion counterfactual protects the explicitly requested exact topic reply recipe", () => {
   const prompt = new ContextPromptBuilder().build({ agentId: "cli_eval", runtime: "pi" }).content;
   assert.match(prompt,
-    /only when.*user.*current Inbox event.*explicitly.*topic.*in-thread.*thread reply.*messages-reply --message-id <real_om_message_id> --text '<exact_body_as_one_literal_argument>' --reply-in-thread --json/i);
-  assert.match(prompt, /must not infer.*thread metadata.*message id.*ordinary reply/i);
+    /MUST stay in that same thread.*messages-reply --message-id <real_om_message_id> --text '<exact_body_as_one_literal_argument>' --reply-in-thread --json/i);
+  assert.match(prompt,
+    /Use the .--reply-in-thread. recipe only when the source is a thread or the user or current Inbox event explicitly asks.*topic.*in-thread.*thread reply/i);
+  assert.match(prompt,
+    /Never invent a topic request from ordinary reply wording or a bare source message id/i);
   assert.match(prompt,
     /exactly one post-poll.*model tool call.*must not.*skill.*reference.*help.*discovery/i);
   assert.match(prompt,

--- a/test/unit/evals/authoritative-freshness-gate.test.mjs
+++ b/test/unit/evals/authoritative-freshness-gate.test.mjs
@@ -10,7 +10,7 @@ const dataset = loadAuthoritativeFreshnessEval(path.join(ROOT, "evals/authoritat
 test("authoritative freshness eval is versioned, reproducible, and covers the critical rubric", () => {
   assert.equal(dataset.dataset, "authoritative-freshness-gate");
   assert.equal(dataset.version, 1);
-  assert.equal(dataset.standing_prompt_version, "larkin-standing-v16");
+  assert.equal(dataset.standing_prompt_version, "larkin-standing-v17");
   assert.equal(dataset.threshold, 1);
   assert.deepEqual(dataset.scenarios.map((scenario) => scenario.id), [
     "missing-inbox-history", "direct-ack-retry", "same-ms-new-id", "edited-message",

--- a/test/unit/evals/runtime-agent-interface-v2.test.mjs
+++ b/test/unit/evals/runtime-agent-interface-v2.test.mjs
@@ -16,7 +16,7 @@ test("fixed runtime Agent interface eval registers dataset, rubric, grader, thre
   assert.equal(DATASET.version, 1);
   assert.equal(DATASET.runtime.adapter, "codex");
   assert.equal(DATASET.model.selection, "gpt-5.6-sol");
-  assert.equal(DATASET.model.standing_prompt_version, "larkin-standing-v16");
+  assert.equal(DATASET.model.standing_prompt_version, "larkin-standing-v17");
   assert.equal(DATASET.grader.version, 1);
   assert.equal(DATASET.grader.threshold, 1);
   assert.ok(DATASET.grader.rubric.length >= 5);

--- a/test/unit/runtime/runtime-adapters.test.mjs
+++ b/test/unit/runtime/runtime-adapters.test.mjs
@@ -72,7 +72,7 @@ test("context prompt is capability-driven, versioned and produces bounded notifi
 
 test("default context prompt consumes the Agent CLI manifest", () => {
   const prompt = new ContextPromptBuilder().build({ agentId: "cli_test", runtime: "pi" });
-  assert.equal(prompt.version, "larkin-standing-v16");
+  assert.equal(prompt.version, "larkin-standing-v17");
   assert.match(prompt.content, /larkin reminder schedule/);
   assert.match(prompt.content, /larkin reminder cancel/);
   assert.match(prompt.content, /larkin interaction resolve/);
@@ -150,11 +150,11 @@ test("default context prompt consumes the Agent CLI manifest", () => {
   assert.match(prompt.content, /inner read.*replaces.*separate.*history read/i);
   assert.match(prompt.content, /must not.*unquoted.*substitution.*`eval`.*`echo`.*`2>&1`.*temporary/i);
   assert.match(prompt.content,
-    /larkin im \+messages-reply --message-id <real_om_message_id> --text '<exact_body_as_one_literal_argument>' --json/i);
+    /source's thread membership.*structural Inbox fact.*not a guess.*MUST stay in that same thread.*messages-reply --message-id <real_om_message_id> --text '<exact_body_as_one_literal_argument>' --reply-in-thread --json.*chat-level source.*omit.*--reply-in-thread/i);
   assert.match(prompt.content,
-    /ordinary current Inbox.*exact reply.*does not explicitly request.*topic.*in-thread.*larkin im \+messages-reply --message-id <real_om_message_id> --text '<exact_body_as_one_literal_argument>' --json.*omit.*--reply-in-thread.*original.*chat.*main timeline/i);
+    /chat-level source.*no thread.*main timeline.*omit.*--reply-in-thread/i);
   assert.match(prompt.content,
-    /only when.*user.*current Inbox event.*explicitly.*topic.*in-thread.*thread reply.*larkin im \+messages-reply --message-id <real_om_message_id> --text '<exact_body_as_one_literal_argument>' --reply-in-thread --json.*must not infer.*thread metadata.*message id.*ordinary reply/i);
+    /Use the .--reply-in-thread. recipe only when the source is a thread or the user or current Inbox event explicitly asks.*topic.*in-thread.*thread reply.*Never invent a topic request from ordinary reply wording or a bare source message id.*thread membership.*thread:.*target.*thread_id.*explicit request.*never from wording alone/i);
   assert.match(prompt.content,
     /exactly one post-poll.*model tool call.*must not.*skill.*reference.*help.*discovery.*without.*freshness_conflict.*two.*model tool calls.*pre-commit.*provider-not-reached.*retry.*identical.*three.*model tool calls/i);
   assert.match(prompt.content,


### PR DESCRIPTION
## 问题（#54）

Agent 收到来自 thread 的消息后，回复不一致地落在群**主时间线**而非原 thread。根因：standing prompt v16 默认"落主时间线 + 禁止从 thread 元数据推断"，与 raft 的"thread_target 权威下发"背道而驰。

## 方案（prompt v16 → v17，对齐 raft 的结构即权威）

回复目标由**来源的 thread 成员身份**决定（结构事实，非推断）：
- 来源是 thread（`thread:<chat>:<thread>` 目标，或 poll 到带 `thread_id` 的消息）→ 回复**必须** `--reply-in-thread` 留在同一 thread。
- 来源是 chat 级（无 thread）且无显式话题要求 → 落主时间线（省略 `--reply-in-thread`），**保留自由在其他群/主时间线回复的灵活性**。
- fail-closed：不凭普通措辞/来源 message id 臆造 topic；thread 判定只来自消息 thread 成员身份或显式要求。

## 验证

- 新增 eval 场景 `thread-source-reply-stays-in-thread`（agent-experience-v6）：thread 来源、无显式"话题内"措辞 → 必须 `--reply-in-thread`（正是之前的 bug 场景）。
- unit 全绿：571 pass 0 fail；agent-experience-v6 + runtime-adapters 相关断言已同步 v17。
- licenses + publication 检查通过。
- 附带：`context-prompt.ts` 头注释 + `AGENTS.md` 新增 prompt engineering 小节（OpenAI / Anthropic 两篇文章 + 调优原则）。
- 版本 0.2.69 → 0.2.70（patch）。

> 说明：全量测试仍偶发既有 bot-register flake（并发负载下 >5s），`strict-production-cutover.test.mjs` 单独跑 31/31 全过，与本次改动无关。