### PR TITLE
fix(ci): grant actions:write so Publish release can dispatch npm-publish

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -328,6 +328,7 @@ jobs:
     runs-on: ubuntu-24.04
     permissions:
       contents: write
+      actions: write
     defaults:
       run:
         working-directory: release-source

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "larkin",
-  "version": "0.2.71",
+  "version": "0.2.72",
   "private": false,
   "larkinPackageRole": "npm-published",
   "files": [


### PR DESCRIPTION
## 问题

`Publish release` 工作流触发 npm 发布用 `gh workflow run "Publish npm package"`（workflow_dispatch），但 `publish` job 只声明 `permissions: contents: write`。dispatch 一个 workflow 需要 token 有 **`actions: write`**，于是报 `HTTP 403: Resource not accessible by integration`，npm 包发不出去。

（补充：`release: published` 事件对 GITHUB_TOKEN 创建的 release 不会触发，防循环机制，所以必须靠手动 dispatch——这条链必须修好。）

## 修复

`release.yml` 的 `publish` job 权限加 `actions: write`。`NPM_TOKEN` secret 已配置，无需改动。

## 验证

合并后 `main` 的 `package.json` 变更会触发 `Publish release` → 现在能成功 dispatch `Publish npm package` → 发 v0.2.72 到 npm。端到端验证。版本 0.2.71 → 0.2.72。