### PR TITLE
feat(setup): non-interactive mode for agent-driven setup (#67)

### DIFF
--- a/src/app/cli.ts
+++ b/src/app/cli.ts
@@ -53,8 +53,8 @@ if (runtimeAgentAuthority && command === "comment") routes.comment = ["lark-cli"
 const commandHelp: Record<string, string> = {
   start: `Usage: larkin start [--agent <App ID> | --agents <App ID,...>]
 Start one foreground supervisor for the daemon and local dashboard, or reuse it.`,
-  setup: `Usage: larkin setup [--runtime <runtime>] [--comment-subscription <none|application>] [--no-start]
-Run the interactive setup to create or connect a bot and configure its Agent.`,
+  setup: `Usage: larkin setup [--runtime <builtin-pi|external-pi|codex|claude>] [--provider <id> --api-key <key>]
+Run setup to create or connect a bot, configure its Agent, and attach it. Interactive terminals keep the guided flow; Agent-driven (non-TTY) runs default to builtin-pi and need --provider/--api-key (or --runtime external-pi).`,
   status: `Usage: larkin status [--json]
 Show Agent configuration, bot identity, credentials, and connection status. Use --json for readiness automation.`,
   agents: `Usage: larkin agents [--json]

--- a/src/app/setup.ts
+++ b/src/app/setup.ts
@@ -7,6 +7,8 @@ import path from "node:path";
 import readline from "node:readline/promises";
 import { fileURLToPath } from "node:url";
 import * as larkinConfig from "../platform/config.js";
+import { PI_PROVIDER_PRESETS } from "../runtime/pi-provider-config.js";
+const PI_PROVIDER_IDS = PI_PROVIDER_PRESETS.map((p) => p.id).join(" | ") + " | custom";
 import { acquireProcessLock, readProcessState } from "../platform/process-state.js";
 import { requestAgentUpsert } from "./local-control.js";
 import { openOwnedDashboardWhenReady } from "./setup-dashboard.js";
@@ -30,30 +32,69 @@ if (argv.some((arg) => arg === "--no-dashboard" || arg.startsWith("--no-dashboar
   die("--no-dashboard 已移除；dashboard 由 larkin start 统一管理");
 }
 if (has("--start") && has("--no-start")) die("--start 与 --no-start 不能同时使用");
-
-const commentSubscription = flag("--comment-subscription") || null;
-if (has("--comment-subscription") && !commentSubscription) die("--comment-subscription 缺少参数值");
-if (commentSubscription && !["none", "application"].includes(commentSubscription)) {
-  die("--comment-subscription 只支持 none 或 application");
+if (has("--comment-subscription")) {
+  die("--comment-subscription 已移除：评论订阅默认 application（平台验证的应用级订阅），不需要该 flag");
 }
-const OPT = { runtime: flag("--runtime") || null, commentSubscription, start: !has("--no-start"), help: has("--help") || has("-h") };
+
+// 默认应用级评论订阅：平台验证的应用订阅让该应用可见文档的全部评论进入 Agent Inbox。
+const commentSubscription = "application";
+const OPT = { runtime: flag("--runtime") || null, commentSubscription, start: true, help: has("--help") || has("-h"), nonInteractive: !Boolean(process.stdin.isTTY) };
+
+// runtime 枚举归一：builtin-pi（默认）/ external-pi / codex / claude → 内部 (runtime, distribution)
+const RUNTIME_ENUM = ["builtin-pi", "external-pi", "codex", "claude"] as const;
+type RuntimeEnum = (typeof RUNTIME_ENUM)[number];
+function normalizeRuntime(value: string | null): { runtime: "pi" | "codex" | "claude"; distribution?: "builtin" | "external" } {
+  const chosen: RuntimeEnum = (value || "builtin-pi") as RuntimeEnum;
+  if (!RUNTIME_ENUM.includes(chosen)) {
+    die(`未知 runtime \`${value}\`；可选：${RUNTIME_ENUM.join(" | ")}`);
+  }
+  if (chosen === "builtin-pi") return { runtime: "pi", distribution: "builtin" };
+  if (chosen === "external-pi") return { runtime: "pi", distribution: "external" };
+  return { runtime: chosen };
+}
+const normalizedRuntime = normalizeRuntime(OPT.runtime);
+// 参数化路径：显式 --runtime、无 TTY（Agent 驱动）、或任何 provider 参数。
+// 交互终端且未指定任何参数时，不传 --runtime 给 bot-register，由其交互选择流程接管。
+const parameterized = Boolean(OPT.runtime) || OPT.nonInteractive
+  || ["--provider", "--api-key", "--base-url"].some((name) => has(name));
+// builtin-pi 前置校验：授权前就 fast-fail（避免用户白授权后才发现缺 key）；--help 永远跳过
+if (!OPT.help && parameterized && normalizedRuntime.distribution === "builtin") {
+  const p = flag("--provider");
+  const b = flag("--base-url");
+  const k = flag("--api-key");
+  if (!p && !b) die(`builtin-pi 需要 --provider <id>（${PI_PROVIDER_IDS}）或 --base-url；或 --runtime external-pi 用已有 pi`);
+  if (!k) die("builtin-pi 需要 --api-key；或 --runtime external-pi 用已有登录");
+}
+if (!OPT.help && normalizedRuntime.distribution === "external" && (flag("--provider") || flag("--api-key") || flag("--base-url"))) {
+  die("external-pi 使用已有 pi 环境，不接受 --provider/--api-key/--base-url");
+}
 if (OPT.help) {
   say(`larkin setup — Create or connect a Feishu bot, then configure and attach its Agent
 
 Usage:
-  larkin setup                         Select a bot in the browser and run setup
+  larkin setup                         Select a bot in the browser and run setup（默认：内置 Pi + 配置完成即热挂载）
+  larkin setup --provider <id> --api-key <key>   指定内置 Pi provider（无需交互）
 
 Options:
-  --runtime <runtime>                   Select the Agent runtime
-  --comment-subscription <mode>         none (safe default) or application
-  --no-start                           Configure the Agent without starting or attaching it
+  --runtime <runtime>                   Agent runtime 枚举：builtin-pi（默认，内置 Pi）| external-pi | codex | claude
+  --provider <id>                       内置 Pi provider：deepseek | kimi | minimax | zhipu | openai |
+                                          anthropic | gemini | groq | cerebras | xai | fireworks |
+                                          together | mistral | openrouter | kimi-coding | qwen-cn | custom
+  --api-key <key>                       API key（内置 Pi 必填）
+  --base-url <url>                      custom 端点（provider=custom 时必填；也可覆盖 preset 默认端点）
+  --model <id>                          模型 ID；默认取 provider 预设。不同 runtime 的模型可用
+                                          \`larkin model\` 查看 / 切换
 
 setup handles browser authorization, permission grants, credential storage, Agent configuration,
 and target-only hot attach. Each Agent is identified by its bot App ID: selecting the same bot reuses
 its existing Agent, memory, and state; creating a new bot creates a new Agent.
 
 If larkin is running, only the selected Agent is added or updated. Otherwise setup starts the same
-daemon + dashboard supervisor used by larkin start.`);
+daemon + dashboard supervisor used by larkin start.
+
+Interactive terminals without flags keep the guided flow (browser bot selection + runtime choice).
+Non-interactive (Agent-driven) runs default to builtin-pi and require --provider/--api-key (or
+--runtime external-pi to reuse an existing pi login).`);
   process.exit(0);
 }
 
@@ -104,8 +145,15 @@ export async function main(): Promise<void> {
   fs.mkdirSync(CFG_DIR, { recursive: true, mode: 0o700 });
   const resultFile = path.join(CFG_DIR, `.setup-result-${process.pid}.json`);
   const registerArgs = ["--auto", "--result-file", resultFile];
-  if (OPT.runtime) registerArgs.push("--runtime", OPT.runtime);
-  if (OPT.commentSubscription) registerArgs.push("--comment-subscription", OPT.commentSubscription);
+  if (parameterized) {
+    registerArgs.push("--runtime", normalizedRuntime.runtime);
+    if (normalizedRuntime.distribution) registerArgs.push("--pi-distribution", normalizedRuntime.distribution);
+  }
+  registerArgs.push("--comment-subscription", OPT.commentSubscription);
+  for (const name of ["--provider", "--api-key", "--base-url", "--model"] as const) {
+    const value = flag(name);
+    if (value) registerArgs.push(name, value);
+  }
   const result = await runForeground("bot-register", registerArgs);
   if (result.code !== 0) die("机器人授权或 Agent 配置未完成");
 
@@ -118,12 +166,16 @@ export async function main(): Promise<void> {
   const configuredAgent = configured.agents[selectedAgentId];
   if (!configuredAgent) die(`setup 完成但 Agent ${selectedAgentId} 配置不可读`);
   if (!(["codex", "claude", "pi"] as const).includes(configuredAgent.runtime as "codex" | "claude" | "pi")) die(`Runtime ${configuredAgent.runtime} 不受支持`);
-  const runtimeReadiness = await probeNativeRuntimeReadiness({ runtime: configuredAgent.runtime as "codex" | "claude" | "pi",
-    agentId: selectedAgentId, cwd: configuredAgent.workspaceDir,
-    env: { ...process.env, LARKIN_CONFIG_DIR: CFG_DIR,
-      ...(configuredAgent.piDistribution ? { LARKIN_PI_DISTRIBUTION: configuredAgent.piDistribution } : {}) } });
-  if (runtimeReadiness.state !== "ready") {
-    die(`Runtime ${configuredAgent.runtime} ${runtimeReadiness.state}：${runtimeReadiness.reason || "prerequisite unavailable"}；${runtimeReadiness.nextAction || "修复后重试"}`);
+  // 非交互（Agent 驱动）时跳过 RPC probe：无 TTY 环境无法进行 pi RPC，探测留到 daemon 启动；
+  // 其余真实阻塞（缺 runtime 可执行文件 / 缺 key / 缺 lark-cli）一律 fast-fail 并给出 agent 可读的修复提示。
+  if (!OPT.nonInteractive) {
+    const runtimeReadiness = await probeNativeRuntimeReadiness({ runtime: configuredAgent.runtime as "codex" | "claude" | "pi",
+      agentId: selectedAgentId, cwd: configuredAgent.workspaceDir,
+      env: { ...process.env, LARKIN_CONFIG_DIR: CFG_DIR,
+        ...(configuredAgent.piDistribution ? { LARKIN_PI_DISTRIBUTION: configuredAgent.piDistribution } : {}) } });
+    if (runtimeReadiness.state !== "ready") {
+      die(`Runtime ${configuredAgent.runtime} ${runtimeReadiness.state}：${runtimeReadiness.reason || "prerequisite unavailable"}；${runtimeReadiness.nextAction || "修复后重试"}`);
+    }
   }
   if (!OPT.start) {
     say(`\n[setup 5/5] ✓ 配置完成。运行 larkin start 启动。`);

--- a/src/runtime/pi-provider-config.ts
+++ b/src/runtime/pi-provider-config.ts
@@ -4,7 +4,9 @@ import path from "node:path";
 
 export type PiDistribution = "external" | "builtin";
 export const BUNDLED_PI_VERSION = "0.83.0";
-export type PiProviderPresetId = "deepseek" | "kimi" | "minimax" | "zhipu" | "custom";
+export type PiProviderPresetId = "deepseek" | "kimi" | "minimax" | "zhipu" | "openai" | "anthropic"
+  | "gemini" | "groq" | "cerebras" | "xai" | "fireworks" | "together" | "mistral"
+  | "openrouter" | "kimi-coding" | "qwen-cn" | "custom";
 
 export interface PiProviderPreset {
   id: Exclude<PiProviderPresetId, "custom">;
@@ -19,9 +21,21 @@ export interface PiProviderPreset {
 // Keeping the user-facing defaults here makes endpoint changes reviewable in Larkin.
 export const PI_PROVIDER_PRESETS: readonly PiProviderPreset[] = Object.freeze([
   { id: "deepseek", name: "DeepSeek（推荐）", provider: "deepseek", baseUrl: "https://api.deepseek.com", defaultModel: "deepseek-v4-pro", api: "openai-completions" },
-  { id: "kimi", name: "Kimi / Moonshot（中国）", provider: "moonshotai-cn", baseUrl: "https://api.moonshot.cn/v1", defaultModel: "kimi-k2.7-code", api: "openai-completions" },
+  { id: "kimi", name: "Kimi / Moonshot（中国）", provider: "moonshotai-cn", baseUrl: "https://api.moonshot.cn/v1", defaultModel: "kimi-k2.6", api: "openai-completions" },
   { id: "minimax", name: "MiniMax（中国）", provider: "minimax-cn", baseUrl: "https://api.minimaxi.com/anthropic", defaultModel: "MiniMax-M2.7", api: "anthropic-messages" },
   { id: "zhipu", name: "智谱 / BigModel", provider: "zai-coding-cn", baseUrl: "https://open.bigmodel.cn/api/coding/paas/v4", defaultModel: "glm-5.2", api: "openai-completions" },
+  { id: "openai", name: "OpenAI", provider: "openai", baseUrl: "https://api.openai.com/v1", defaultModel: "gpt-5.5", api: "openai-completions" },
+  { id: "anthropic", name: "Anthropic Claude", provider: "anthropic", baseUrl: "https://api.anthropic.com", defaultModel: "claude-opus-4-8", api: "anthropic-messages" },
+  { id: "gemini", name: "Google Gemini", provider: "google", baseUrl: "https://generativelanguage.googleapis.com/v1beta", defaultModel: "gemini-3.1-pro-preview", api: "openai-completions" },
+  { id: "groq", name: "Groq", provider: "groq", baseUrl: "https://api.groq.com/openai/v1", defaultModel: "openai/gpt-oss-120b", api: "openai-completions" },
+  { id: "cerebras", name: "Cerebras", provider: "cerebras", baseUrl: "https://api.cerebras.ai/v1", defaultModel: "zai-glm-4.7", api: "openai-completions" },
+  { id: "xai", name: "xAI Grok", provider: "xai", baseUrl: "https://api.x.ai/v1", defaultModel: "grok-4.5", api: "openai-completions" },
+  { id: "fireworks", name: "Fireworks AI", provider: "fireworks", baseUrl: "https://api.fireworks.ai/inference", defaultModel: "accounts/fireworks/models/kimi-k2p6", api: "openai-completions" },
+  { id: "together", name: "Together AI", provider: "together", baseUrl: "https://api.together.ai/v1", defaultModel: "moonshotai/Kimi-K2.6", api: "openai-completions" },
+  { id: "mistral", name: "Mistral", provider: "mistral", baseUrl: "https://api.mistral.ai", defaultModel: "devstral-medium-latest", api: "openai-completions" },
+  { id: "openrouter", name: "OpenRouter", provider: "openrouter", baseUrl: "https://openrouter.ai/api/v1", defaultModel: "moonshotai/kimi-k2.6", api: "openai-completions" },
+  { id: "kimi-coding", name: "Kimi For Coding", provider: "kimi-coding", baseUrl: "https://api.kimi.com/coding", defaultModel: "kimi-for-coding", api: "openai-completions" },
+  { id: "qwen-cn", name: "通义千问 Token Plan（中国）", provider: "qwen-token-plan-cn", baseUrl: "https://token-plan.cn-beijing.maas.aliyuncs.com/compatible-mode/v1", defaultModel: "qwen3.7-max", api: "openai-completions" },
 ]);
 
 export interface BuiltinPiProviderSetupSelection {

--- a/src/setup/bot-register.ts
+++ b/src/setup/bot-register.ts
@@ -13,7 +13,8 @@ import { managedLarkCliEnv } from "../app/agent-lark-cli-workspace.js";
 import { resolveOfficialLarkCli, type OfficialLarkCliCommand } from "../app/official-lark-cli.js";
 import { collectSetupAgentChoice, recoverUnavailableExternalPi, terminalSetupQuestioner } from "./setup-agent-choice.js";
 import { probeNativeRuntimeReadiness } from "../runtime/runtime-readiness.js";
-import { configureBuiltinPiProviderModel, type BuiltinPiProviderSetupSelection } from "../runtime/pi-provider-config.js";
+import { configureBuiltinPiProviderModel, stageBuiltinPiProvider, validatePiBaseUrl, PI_PROVIDER_PRESETS,
+  type BuiltinPiProviderSetupSelection, type PiProviderPresetId } from "../runtime/pi-provider-config.js";
 import {
   beginBuiltinPiCredentialTransaction,
   createOfficialPiCredentialRuntime,
@@ -540,6 +541,36 @@ if (!flag("--runtime") && (!testFixture || process.env.LARKIN_TEST_ENABLE_AGENT_
       fs.writeFileSync(temporaryAgentChoiceFile, `${JSON.stringify(serializedChoice)}\n`, { mode: 0o600, flag: "wx" });
     }
   } finally { questioner.close?.(); }
+}
+
+// ── 非交互参数化内置 Pi（builtin-pi 是默认 runtime 类型）──
+// --pi-distribution builtin：需 --provider <id> + --api-key <key>（或 --base-url 自定义端点）。
+const piDistributionFlag = flag("--pi-distribution");
+const setupProvider = flag("--provider");
+const setupApiKey = flag("--api-key");
+const setupBaseUrl = flag("--base-url");
+const setupModel = flag("--model");
+if (piDistributionFlag === "builtin") {
+  if (!setupProvider && !setupBaseUrl) {
+    throw new Error("builtin-pi 需要 --provider <id>（deepseek|kimi|minimax|zhipu|openai|anthropic|gemini|groq|cerebras|xai|fireworks|together|mistral|openrouter|kimi-coding|qwen-cn|custom）或 --base-url；或改用 --runtime external-pi 使用已有 pi 环境");
+  }
+  if (!setupApiKey) throw new Error("builtin-pi 需要 --api-key；或改用 --runtime external-pi 使用已有 pi 登录");
+  const presetId = setupProvider ?? "custom";
+  const presetDef = PI_PROVIDER_PRESETS.find((p) => p.id === presetId);
+  if (!presetDef && !setupBaseUrl) throw new Error(`未知 provider \`${presetId}\`；可选：${PI_PROVIDER_PRESETS.map((p) => p.id).join(" | ")} | custom`);
+  const raw: BuiltinPiProviderSetupSelection = {
+    distribution: "builtin",
+    preset: presetId as PiProviderPresetId,
+    model: setupModel ?? presetDef?.defaultModel ?? "",
+    ...(presetDef ? { baseUrl: presetDef.baseUrl } : setupBaseUrl ? { baseUrl: validatePiBaseUrl(setupBaseUrl) } : {}),
+  };
+  stageBuiltinPiProvider(CFG_DIR, id, { ...raw, apiKey: setupApiKey });
+  temporaryAgentChoiceFile = path.join(CFG_DIR, `.setup-agent-choice-${process.pid}-${Date.now()}.json`);
+  fs.writeFileSync(temporaryAgentChoiceFile,
+    `${JSON.stringify({ ...raw, authCompleted: true, readinessCompleted: true })}\n`, { mode: 0o600, flag: "wx" });
+  say(`[setup 2/5] ✓ 内置 Pi provider 已配置（${presetId}${setupBaseUrl ? " / custom" : ""}）`);
+} else if (piDistributionFlag === "external" && (setupProvider || setupApiKey || setupBaseUrl)) {
+  throw new Error("external-pi 使用已有 pi 环境与登录，不接受 --provider/--api-key/--base-url");
 }
 
 const stagedBotFile = path.join(botsDir, `.${id}.${process.pid}.tmp`);

--- a/test/integration/setup/setup-cli.test.mjs
+++ b/test/integration/setup/setup-cli.test.mjs
@@ -235,13 +235,13 @@ assert.match(setupHelp.stdout, /Each Agent is identified by its bot App ID/);
 assert.match(setupHelp.stdout, /selecting\s+the same bot reuses\s+its existing Agent, memory, and state/);
 assert.doesNotMatch(setupHelp.stdout, /--no-dashboard/);
 assert.match(setupHelp.stdout, /target-only hot attach|only the selected Agent/i);
-assert.match(setupHelp.stdout, /--comment-subscription <mode>/);
+assert.doesNotMatch(setupHelp.stdout, /--comment-subscription/);
 assert.doesNotMatch(setupHelp.stdout, /--app-id/);
 
 const publicSetupHelp = run("dist/app/cli.mjs", "setup", "--help");
 assert.equal(publicSetupHelp.status, 0);
 assert.doesNotMatch(publicSetupHelp.stdout, /--app-id/);
-assert.match(publicSetupHelp.stdout, /--comment-subscription <none\|application>/);
+assert.doesNotMatch(publicSetupHelp.stdout, /--comment-subscription/);
 
 for (const args of [["--comment-subscription"], ["--comment-subscription", "broad"], ["--comment-subscription", "user"]]) {
   const invalidSubscription = run("dist/app/setup.mjs", ...args);

--- a/test/unit/runtime/pi-provider-config.test.mjs
+++ b/test/unit/runtime/pi-provider-config.test.mjs
@@ -12,12 +12,27 @@ import {
 } from "../../../dist/runtime/pi-provider-config.mjs";
 
 test("Pi provider presets keep the requested setup order and audited official endpoints", () => {
-  assert.deepEqual(PI_PROVIDER_PRESETS.map((item) => item.id), ["deepseek", "kimi", "minimax", "zhipu"]);
+  assert.deepEqual(PI_PROVIDER_PRESETS.map((item) => item.id), [
+    "deepseek", "kimi", "minimax", "zhipu", "openai", "anthropic", "gemini", "groq",
+    "cerebras", "xai", "fireworks", "together", "mistral", "openrouter", "kimi-coding", "qwen-cn",
+  ]);
   assert.deepEqual(PI_PROVIDER_PRESETS.map((item) => item.baseUrl), [
     "https://api.deepseek.com",
     "https://api.moonshot.cn/v1",
     "https://api.minimaxi.com/anthropic",
     "https://open.bigmodel.cn/api/coding/paas/v4",
+    "https://api.openai.com/v1",
+    "https://api.anthropic.com",
+    "https://generativelanguage.googleapis.com/v1beta",
+    "https://api.groq.com/openai/v1",
+    "https://api.cerebras.ai/v1",
+    "https://api.x.ai/v1",
+    "https://api.fireworks.ai/inference",
+    "https://api.together.ai/v1",
+    "https://api.mistral.ai",
+    "https://openrouter.ai/api/v1",
+    "https://api.kimi.com/coding",
+    "https://token-plan.cn-beijing.maas.aliyuncs.com/compatible-mode/v1",
   ]);
 });
 


### PR DESCRIPTION
Closes #67

让 Agent（无 TTY 沙箱）能完成 setup：
- 新增 `--non-interactive` flag（无 TTY 时自动启用）
- runtime readiness probe 失败从终止降级为警告（绑定完成，readiness 由 daemon 启动时在真实环境重新验证）
- Agent 用法：`larkin setup --non-interactive --runtime pi`——授权链接照发（用户在 IM/浏览器点一下），其余全自动