### PR TITLE
Release v0.2.73: supervisor crash-loop fix + setup bot identity

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "larkin",
-  "version": "0.2.72",
+  "version": "0.2.73",
   "private": false,
   "larkinPackageRole": "npm-published",
   "files": [

--- a/src/app/lark-cli.ts
+++ b/src/app/lark-cli.ts
@@ -53,6 +53,7 @@ const MANAGEMENT_COMMANDS = new Set(["auth", "config", "profile", "update", "ins
 const USER_ONLY_COMMANDS = new Set(["attendance", "mail", "okr"]);
 const POLICY_VALUE_FLAGS = new Set([
   "--as", "--profile", "--config-dir", "--agent", "--chat-id", "--user-id", "--message-id", "--idempotency-key", "--thread-id",
+  "--mention",
 ]);
 const PROTECTED_VALUE_FLAGS = new Set([
   ...POLICY_VALUE_FLAGS,
@@ -128,6 +129,54 @@ function protectedSyntaxTokens(argv: readonly string[]): string[] {
 
 function hasNativeHelpFlag(argv: readonly string[]): boolean {
   return protectedSyntaxTokens(argv).some((argument) => HELP_FLAGS.has(argument));
+}
+
+/**
+ * Agent 间协作唤醒（#69）：把 `--mention <open_id>` 翻译成真实的飞书 mention 元素。
+ * 纯文本 @ 不会产生 mention 事件，目标 agent 不会被唤醒；
+ * `--text` 正文 → text 消息 `<at user_id="..."></at>` 前缀；
+ * `--markdown` 正文 → post 消息首个元素为 at 标签（正文按纯文本元素发送）。
+ * 仅对 im +messages-send / +messages-reply 生效，其余命令原样透传。
+ */
+function mentionTranslation(argv: readonly string[]): string[] {
+  const nativeArgv = nativeArgvBeforeBoundary(argv);
+  if (nativeArgv[0] !== "im"
+      || (nativeArgv[1] !== "+messages-send" && nativeArgv[1] !== "+messages-reply")
+      || hasNativeHelpFlag(argv)) return [...argv];
+  const parsed = parsePolicyArgv(argv);
+  if (parsed.error || !parsed.flags.has("--mention")) return [...argv];
+  const mention = parsed.flags.get("--mention")!;
+  if (!/^ou_[A-Za-z0-9]+$/.test(mention)) {
+    throw new Error("--mention 需要有效的 open_id（ou_ 开头）");
+  }
+  const rawText = rawFlagValue(argv, "--text");
+  const rawMarkdown = rawFlagValue(argv, "--markdown");
+  const text = rawText !== null && !rawText.startsWith("-") ? rawText : null;
+  const markdown = rawMarkdown !== null && !rawMarkdown.startsWith("-") ? rawMarkdown : null;
+  if (nativeArgv.some((argument) => argument === "--content" || argument.startsWith("--content="))) {
+    throw new Error("--mention 不能与 --content 同时使用（会重写消息正文）");
+  }
+  if (text !== null && markdown !== null) throw new Error("--mention 与 --text/--markdown 只能二选一");
+  if (text === null && markdown === null) throw new Error("--mention 需要 --text 或 --markdown 正文");
+  const body = (text ?? markdown ?? "").trim();
+  if (!body) throw new Error("--mention 的正文不能为空");
+  const content = text !== null
+    ? JSON.stringify({ text: `<at user_id="${mention}"></at> ${body}` })
+    : JSON.stringify({ zh_cn: { title: "", content: [[{ tag: "at", user_id: mention }], [{ tag: "text", text: body }]] } });
+  const next: string[] = [];
+  for (let index = 0; index < argv.length; index += 1) {
+    const argument = argv[index];
+    const consumed = ["--mention", "--text", "--markdown"].find((name) => argument === name || argument.startsWith(`${name}=`));
+    if (consumed) {
+      if (argument === consumed) index += 1;
+      continue;
+    }
+    next.push(argument);
+  }
+  const boundary = next.indexOf("--");
+  const insertion = boundary < 0 ? next.length : boundary;
+  next.splice(insertion, 0, "--content", content, "--msg-type", text !== null ? "text" : "post");
+  return next;
 }
 
 function protectedOperations(argv: readonly string[]): ProtectedOperation[] {
@@ -732,12 +781,18 @@ export function runLarkCli(
   argv: readonly string[], env: Env = process.env, dependencies: LarkCliLauncherDependencies = {},
 ): number {
   const io = dependencies.io ?? defaultIo();
+  let effectiveArgv: readonly string[];
+  try { effectiveArgv = mentionTranslation(argv); }
+  catch (error) {
+    io.stderr(`lark-cli: ${error instanceof Error ? error.message : String(error)}\n`);
+    return 2;
+  }
   const runtimeAgentId = larkinConfig.resolveRuntimeAuthority(env);
   if (!runtimeAgentId) {
     try {
       const nativeDependencies = dependencies.nativeCommand ? dependencies
         : { ...dependencies, nativeCommand: resolveOfficialLarkCli({ spawn: dependencies.spawn, env }) };
-      return spawnNative(argv, env, io, nativeDependencies);
+      return spawnNative(effectiveArgv, env, io, nativeDependencies);
     } catch (error) {
       io.stderr(`lark-cli: ${error instanceof Error ? error.message : String(error)}\n`);
       return 1;
@@ -752,7 +807,7 @@ export function runLarkCli(
     io.stderr(`lark-cli: ${error instanceof Error ? error.message : String(error)}\n`);
     return 2;
   }
-  const decision = classifyLarkCliCommand(argv);
+  const decision = classifyLarkCliCommand(effectiveArgv);
   if (decision.kind === "denied") {
     io.stderr(`lark-cli: ${decision.reason}\n`);
     return 2;
@@ -784,9 +839,9 @@ export function runLarkCli(
       return 2;
     }
   }
-  if (decision.kind === "passthrough") return passthroughWithObservation(argv, privateEnv, io, nativeDependencies, store);
+  if (decision.kind === "passthrough") return passthroughWithObservation(effectiveArgv, privateEnv, io, nativeDependencies, store);
   try {
-    const target = guardedTarget(decision, argv, store);
+    const target = guardedTarget(decision, effectiveArgv, store);
     const targetKey = serializeFeishuImTarget(target);
     const generation = freshnessGeneration(privateEnv);
     const seen = store.readFreshnessCursor<FeishuImCursor>(targetKey, generation);
@@ -804,7 +859,7 @@ export function runLarkCli(
       store.mergeFreshnessCursor(targetKey, gated.current, mergeFeishuImCursor, generation);
       return 3;
     }
-    const write = callNative(botArgv(argv, intentId(targetKey, gated.current, argv)), privateEnv, io, nativeDependencies);
+    const write = callNative(botArgv(effectiveArgv, intentId(targetKey, gated.current, effectiveArgv)), privateEnv, io, nativeDependencies);
     if (!write.error && write.status === 0 && !observeSuccessfulWrite(write, target, targetKey, store, generation)) {
       const responseMessage = writeResponseMessage(write);
       try {
@@ -840,10 +895,16 @@ export function runLarkCli(
 }
 
 export async function runLarkCliProcess(argv: readonly string[], env: Env = process.env): Promise<number> {
+  let effectiveArgv: readonly string[];
+  try { effectiveArgv = mentionTranslation(argv); }
+  catch (error) {
+    process.stderr.write(`lark-cli: ${error instanceof Error ? error.message : String(error)}\n`);
+    return 2;
+  }
   const runtimeAgentId = larkinConfig.resolveRuntimeAuthority(env);
   if (!runtimeAgentId) {
     try {
-      return await spawnNativeTransparent(argv, env, resolveOfficialLarkCli({ env }));
+      return await spawnNativeTransparent(effectiveArgv, env, resolveOfficialLarkCli({ env }));
     } catch (error) {
       process.stderr.write(`lark-cli: ${error instanceof Error ? error.message : String(error)}\n`);
       return 1;
@@ -853,16 +914,16 @@ export async function runLarkCliProcess(argv: readonly string[], env: Env = proc
     const { config } = larkinConfig.loadConfig(env);
     const agent = larkinConfig.selectAgent(config, { ...env, LARKIN_AGENT_ID: runtimeAgentId });
     assertAgentWorkspaceBound(agent);
-    const decision = classifyLarkCliCommand(argv);
-    if (decision.kind === "passthrough" && !requiresCapturedPassthrough(argv)) {
+    const decision = classifyLarkCliCommand(effectiveArgv);
+    if (decision.kind === "passthrough" && !requiresCapturedPassthrough(effectiveArgv)) {
       const privateEnv = managedLarkCliEnv(agent, { ...env, LARKIN_AGENT_ID: agent.agentId });
-      return await spawnNativeTransparent(argv, privateEnv, resolveOfficialLarkCli({ env: privateEnv }));
+      return await spawnNativeTransparent(effectiveArgv, privateEnv, resolveOfficialLarkCli({ env: privateEnv }));
     }
   } catch (error) {
     process.stderr.write(`lark-cli: ${error instanceof Error ? error.message : String(error)}\n`);
     return 2;
   }
-  return runLarkCli(argv, env);
+  return runLarkCli(effectiveArgv, env);
 }
 
 export async function main(argv = process.argv.slice(2), env: Env = process.env): Promise<never> {

--- a/src/app/local-control.ts
+++ b/src/app/local-control.ts
@@ -171,6 +171,27 @@ function secureAuthority(larkinHome: string): ControlAuthority {
   return value as ControlAuthority;
 }
 
+// The authority file is the single trust anchor between supervisor and daemon.
+// If it goes missing while the supervisor stays up (e.g. a crashed restart
+// cycle deleted it), the daemon re-establishes it from the supervisor's process
+// state instead of dying at startup and crash-looping. Only a missing file is
+// healed; a token mismatch stays fail-closed.
+function secureAuthorityOrRecover(larkinHome: string, authorityToken: string): ControlAuthority {
+  try {
+    return secureAuthority(larkinHome);
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code !== "ENOENT") throw error;
+    const supervisor = readProcessState(larkinHome).supervisor;
+    if (supervisor.state !== "owned" || !supervisor.pid || !supervisor.processStartToken) throw error;
+    initializeControlAuthority(
+      larkinHome,
+      { pid: Number(supervisor.pid), processStartToken: supervisor.processStartToken },
+      authorityToken,
+    );
+    return secureAuthority(larkinHome);
+  }
+}
+
 function sameSecret(left: string, right: string): boolean {
   const a = Buffer.from(left);
   const b = Buffer.from(right);
@@ -323,12 +344,16 @@ async function listenPrivate(server: net.Server, socket: string): Promise<Socket
   }
 }
 
-export function initializeControlAuthority(larkinHome: string, supervisor: ProcessBinding): string {
+function writeControlAuthority(larkinHome: string, authority: ControlAuthority): void {
+  atomicWritePrivateJson(controlAuthorityPath(larkinHome), authority);
+}
+
+export function initializeControlAuthority(larkinHome: string, supervisor: ProcessBinding, explicitToken?: string): string {
   fs.mkdirSync(larkinHome, { recursive: true, mode: 0o700 });
   assertSecureRoot(larkinHome);
   const socketRoot = ensureSecureSocketRoot(larkinHome);
-  const token = crypto.randomBytes(32).toString("base64url");
-  atomicWritePrivateJson(controlAuthorityPath(larkinHome), {
+  const token = explicitToken ?? crypto.randomBytes(32).toString("base64url");
+  writeControlAuthority(larkinHome, {
     version: 2,
     token,
     socketRoot,
@@ -462,7 +487,7 @@ export function createAgentControlServer({
       fs.mkdirSync(larkinHome, { recursive: true, mode: 0o700 });
       assertSecureRoot(larkinHome);
       removeLegacyResetLedger(larkinHome);
-      const authority = secureAuthority(larkinHome);
+      const authority = secureAuthorityOrRecover(larkinHome, authorityToken);
       if (!sameSecret(authority.token, authorityToken)) throw new Error("daemon control authorization 不匹配");
       const supervisor = readProcessState(larkinHome).supervisor;
       if (supervisor.state !== "owned" || !bindingMatches(authority.supervisor, supervisor)) {

--- a/src/app/local-control.ts
+++ b/src/app/local-control.ts
@@ -181,6 +181,12 @@ function secureAuthorityOrRecover(larkinHome: string, authorityToken: string): C
     return secureAuthority(larkinHome);
   } catch (error) {
     if ((error as NodeJS.ErrnoException).code !== "ENOENT") throw error;
+    // The real trust anchor is the supervisor identity: recovery only proceeds
+    // when supervisor-status.json describes a live, token-carrying supervisor
+    // process, and the token written here is the one that supervisor injected
+    // into this daemon. The sameSecret check after recovery is a tautology for
+    // the missing-file case; the supervisor's own control-server start re-verifies
+    // the file against its token, so a forged file still fails closed there.
     const supervisor = readProcessState(larkinHome).supervisor;
     if (supervisor.state !== "owned" || !supervisor.pid || !supervisor.processStartToken) throw error;
     initializeControlAuthority(

--- a/src/app/run.ts
+++ b/src/app/run.ts
@@ -187,6 +187,10 @@ export async function main(): Promise<void> {
 
   let stopping = false;
   let dashboard: ChildProcess | null = null;
+  // Set when the daemon-restart path stops the dashboard on purpose (port
+  // handover). Its exit is then not a crash and must not count against the
+  // dashboard recovery budget nor spawn a duplicate dashboard.
+  let intentionalDashboardExit: ChildProcess | null = null;
   let dashboardRestartTimer: NodeJS.Timeout | null = null;
   const dashboardCrashes: number[] = [];
   const dashboardScript = process.env.LARKIN_FEISHU_DRYRUN === "1" && process.env.LARKIN_TEST_DASHBOARD_SCRIPT
@@ -225,18 +229,26 @@ export async function main(): Promise<void> {
       daemonRestartTimer = setTimeout(() => {
         daemonRestartTimer = null;
         if (stopping) return;
-        // The fresh daemon re-registers its control authority; drop the stale one.
-        try { removeControlAuthority(configDir, controlToken); } catch { /* best effort */ }
-        // Dashboard state is coupled to the daemon; restart it alongside.
+        // Keep the control authority intact: the fresh daemon extends it with its
+        // own binding and replaces the stale control socket via prepareSocket.
+        // Deleting it here makes the daemon's startup fail closed (secureAuthority
+        // ENOENT), so every relaunch would crash and the supervisor would loop
+        // forever (observed in production as daemon 异常退出 2/3 repeats).
+        // Dashboard state is coupled to the daemon; restart it alongside, but let
+        // the old dashboard release the dashboard port first: its intentional
+        // stop is not a crash and the replacement starts from the exit handler.
         const oldDashboard = dashboard;
         if (oldDashboard && oldDashboard.exitCode === null && oldDashboard.signalCode === null) {
+          intentionalDashboardExit = oldDashboard;
+          dashboard = null;
           oldDashboard.kill("SIGTERM");
+        } else {
+          launchDashboard();
         }
         if (dashboardRestartTimer) { clearTimeout(dashboardRestartTimer); dashboardRestartTimer = null; }
         dashboardCrashes.length = 0;
         launchDaemon();
         writeSupervisorStatus(statusFile, supervisor, { daemonPid: daemon.pid });
-        launchDashboard();
       }, delay);
     });
   };
@@ -255,6 +267,13 @@ export async function main(): Promise<void> {
     ownedChild.once("exit", () => {
       if (dashboard === ownedChild) dashboard = null;
       if (stopping) return;
+      if (intentionalDashboardExit === ownedChild) {
+        // Stopped on purpose by the daemon-restart path; bring the replacement
+        // up now that the dashboard port is free.
+        intentionalDashboardExit = null;
+        if (!stopping && daemon.exitCode === null && dashboard === null) launchDashboard();
+        return;
+      }
       const now = Date.now();
       dashboardCrashes.push(now);
       while (dashboardCrashes[0] < now - 60_000) dashboardCrashes.shift();

--- a/src/app/run.ts
+++ b/src/app/run.ts
@@ -242,6 +242,15 @@ export async function main(): Promise<void> {
           intentionalDashboardExit = oldDashboard;
           dashboard = null;
           oldDashboard.kill("SIGTERM");
+          // If the old dashboard ignores SIGTERM (observed in production holding
+          // the dashboard port for minutes), escalate so the port is released
+          // and the replacement can start. unref keeps an ignored dashboard from
+          // delaying supervisor shutdown.
+          const escalate = setTimeout(() => {
+            if (oldDashboard.exitCode === null && oldDashboard.signalCode === null) oldDashboard.kill("SIGKILL");
+          }, 5_000);
+          escalate.unref?.();
+          oldDashboard.once("exit", () => clearTimeout(escalate));
         } else {
           launchDashboard();
         }
@@ -308,7 +317,15 @@ export async function main(): Promise<void> {
   const requestStop = (signal: NodeJS.Signals): void => {
     if (stopping) return;
     stopping = true;
-    if (daemon.exitCode === null && daemon.signalCode === null) daemon.kill(signal);
+    if (daemonRestartTimer) { clearTimeout(daemonRestartTimer); daemonRestartTimer = null; }
+    if (daemon.exitCode === null && daemon.signalCode === null) {
+      daemon.kill(signal);
+    } else {
+      // The daemon already exited and the supervisor is inside the restart
+      // backoff window; the pending timer would never fire again (stopping is
+      // set), so resolve the final result now instead of awaiting forever.
+      resolveDaemonFinal?.({ code: daemon.exitCode, signal: daemon.signalCode });
+    }
   };
   process.once("SIGINT", () => requestStop("SIGINT"));
   process.once("SIGTERM", () => requestStop("SIGTERM"));

--- a/src/feishu/host-processing-eye.ts
+++ b/src/feishu/host-processing-eye.ts
@@ -142,7 +142,7 @@ export class ProcessingEyeOrchestrator {
     });
   }
 
-  clear(agent: EyeAgent, reason?: string): void {
+  clear(agent: EyeAgent, reason?: string, options: { done?: boolean } = {}): void {
     const state = this.state.get(agent.agentId);
     if (state) {
       state.gen += 1;
@@ -151,6 +151,7 @@ export class ProcessingEyeOrchestrator {
       this.cancelCompletion(state);
     }
     const list = this.pending.get(agent.agentId) || [];
+    const completed = options.done === true && list.length > 0;
     if (!list.length) {
       this.log(`👀 清除(无待摘) agent=${agent.name} 原因=${reason || "?"}`);
       return;
@@ -163,6 +164,17 @@ export class ProcessingEyeOrchestrator {
           this.log(`👀 摘除失败 msg=${msgId}: ${result ? JSON.stringify(result.error || {}).slice(0, 120) : errorMessage(error)}`);
         }
       });
+    }
+    // 执行正常结束：把 👀 替换为 ✅ 已处理（issue #70），让用户/协作 Agent 看到处理完成信号。
+    if (completed) {
+      for (const { msgId } of list) {
+        this.larkApi(agent, "POST", `/open-apis/im/v1/messages/${msgId}/reactions`, { reaction_type: { emoji_type: "DONE" } }, (error, result) => {
+          if (error || result?.ok === false) {
+            this.log(`👀 完成标记失败 msg=${msgId}: ${result ? JSON.stringify(result.error || {}).slice(0, 120) : errorMessage(error)}`);
+          }
+        });
+      }
+      this.log(`👀 已完成 agent=${agent.name} n=${list.length} 原因=${reason || "?"}`);
     }
     this.log(`👀 已摘 agent=${agent.name} n=${list.length} 原因=${reason || "?"}`);
   }
@@ -180,7 +192,7 @@ export class ProcessingEyeOrchestrator {
       completionTimer = this.setTimer(() => {
         const current = this.state.get(agent.agentId);
         if (current?.gen !== generation || current.completionTimer !== completionTimer) return;
-        this.clear(agent, "activity:idle(执行结束缓冲完成)");
+        this.clear(agent, "activity:idle(执行结束缓冲完成)", { done: true });
       }, 1_000);
       state.completionTimer = completionTimer;
       return;

--- a/src/feishu/host-shell.ts
+++ b/src/feishu/host-shell.ts
@@ -438,7 +438,7 @@ export function createHostShell({
           excerpt: safeConversationExcerpt(event.content, 180),
           at: new Date().toISOString(),
         }, 30);
-        if (envelope.sender_type === "human") processingEyes.add(agent, String(envelope.message_id || ""));
+        if (envelope.sender_type === "human" || envelope.sender_type === "agent") processingEyes.add(agent, String(envelope.message_id || ""));
         if (receipt.status === "deferred") log(`Runtime 暂缓投递，消息保留在 inbox seq=${envelope.seq}: ${receipt.reason}`);
       }
     } catch (error) {

--- a/src/platform/process-inspect.cts
+++ b/src/platform/process-inspect.cts
@@ -25,7 +25,7 @@ function pidAlive(pid: unknown, kill: typeof process.kill = process.kill): boole
   }
 }
 
-function inspectUnix(pid: number): ProcessInspection {
+function inspectUnixOnce(pid: number): ProcessInspection {
   const env = { ...process.env, LC_ALL: "C", LANG: "C" };
   const state = spawnSync("ps", ["-ww", "-p", String(pid), "-o", "stat="], { encoding: "utf8", env });
   const started = spawnSync("ps", ["-ww", "-p", String(pid), "-o", "lstart="], { encoding: "utf8", env });
@@ -45,6 +45,19 @@ function inspectUnix(pid: number): ProcessInspection {
   // state (notably a Bun test parent and a normal Bun child). The value is an
   // opaque identity token, so preserve the stable kernel-provided text.
   return { ok: true, command: commandText, startToken: startedText };
+}
+
+function inspectUnix(pid: number): ProcessInspection {
+  // ps(1) can transiently return empty lstart/command output for a live process
+  // (observed in production as "ps metadata incomplete" taking down the daemon).
+  // Retry briefly so a one-off glitch cannot kill the runtime; liveness is
+  // re-checked on every attempt, so a genuine exit still resolves immediately.
+  for (let attempt = 0; ; attempt += 1) {
+    const result = inspectUnixOnce(pid);
+    if (result.ok || result.dead || attempt >= 2) return result;
+    const deadline = Date.now() + 50 * (attempt + 1);
+    while (Date.now() < deadline) { /* bounded busy wait; ps glitches are sub-second */ }
+  }
 }
 
 function inspectWindows(pid: number): ProcessInspection {

--- a/src/setup/bot-register.ts
+++ b/src/setup/bot-register.ts
@@ -8,6 +8,7 @@ import { fileURLToPath, pathToFileURL } from "node:url";
 import { registerApp as channelRegisterApp } from "@larksuite/channel";
 import { internalCommandSpec } from "../app/internal-command.js";
 import * as larkinConfig from "../platform/config.js";
+import { createAgentStateStore } from "../agent/agent-state-store.js";
 import { hydrateRuntimeAgent, syncAgentProfile, syncAgentProfileAsync } from "../app/runtime-agent-config.js";
 import { managedLarkCliEnv } from "../app/agent-lark-cli-workspace.js";
 import { resolveOfficialLarkCli, type OfficialLarkCliCommand } from "../app/official-lark-cli.js";
@@ -390,6 +391,59 @@ async function runIdentityProcess(command: string, args: readonly string[], env:
   return runBoundedCliProcess(command, args, env, "Bot identity verification");
 }
 
+/**
+ * 官方 lark-cli 的 `api` 透传只映射响应的 data 字段，而 /open-apis/bot/v3/info 的
+ * bot 对象在顶层（{code, msg, bot}），无法经 lark-cli 读取。这里直接用刚发布的
+ * bot 凭证做一次受限的 HTTP 获取，用于 setup 完成即写入 bot-identity（不依赖首次连接）。
+ */
+interface BotInfoPayload { open_id?: string; app_name?: string; avatar_url?: string }
+
+async function fetchBotInfoViaHttp(appId: string, tenant: "feishu" | "lark" | undefined): Promise<BotInfoPayload | null> {
+  let credential: { appSecret?: unknown };
+  try {
+    credential = JSON.parse(fs.readFileSync(path.join(ensureSecureBotsDir(), `${appId}.json`), "utf8")) as { appSecret?: unknown };
+  } catch { return null; }
+  if (typeof credential.appSecret !== "string" || !credential.appSecret) return null;
+  const base = tenant === "lark" ? "https://open.larksuite.com" : "https://open.feishu.cn";
+  try {
+    const tokenResponse = await fetch(`${base}/open-apis/auth/v3/tenant_access_token/internal`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ app_id: appId, app_secret: credential.appSecret }),
+      signal: AbortSignal.timeout(15_000),
+    });
+    const tokenPayload = await tokenResponse.json() as { code?: unknown; tenant_access_token?: unknown };
+    if (tokenPayload.code !== 0 || typeof tokenPayload.tenant_access_token !== "string") return null;
+    const infoResponse = await fetch(`${base}/open-apis/bot/v3/info`, {
+      headers: { authorization: `Bearer ${tokenPayload.tenant_access_token}` },
+      signal: AbortSignal.timeout(15_000),
+    });
+    const infoPayload = await infoResponse.json() as { code?: unknown; bot?: { open_id?: unknown; app_name?: unknown; avatar_url?: unknown } };
+    if (infoPayload.code !== 0 || !infoPayload.bot || typeof infoPayload.bot !== "object") return null;
+    return {
+      open_id: typeof infoPayload.bot.open_id === "string" ? infoPayload.bot.open_id : undefined,
+      app_name: typeof infoPayload.bot.app_name === "string" ? infoPayload.bot.app_name : undefined,
+      avatar_url: typeof infoPayload.bot.avatar_url === "string" ? infoPayload.bot.avatar_url : undefined,
+    };
+  } catch { return null; }
+}
+
+/**
+ * 允许被添加进群：把应用可用范围设为全员可见（更新后线上立即生效）。
+ * 前提是授权确认页勾选了 admin:app.visibility；未勾选时给出可执行提示，不阻断 setup。
+ */
+async function ensureAppVisibleToAll(id: string, official: OfficialLarkCliCommand, cliEnv: NodeJS.ProcessEnv): Promise<boolean> {
+  const result = await runBoundedCliProcess(official.command,
+    [...official.argsPrefix, "api", "PATCH", `/open-apis/application/v6/applications/${id}/visibility`,
+      "--as", "bot", "--data", JSON.stringify({ is_visible_to_all: true }), "--json"],
+    cliEnv, "App visibility grant");
+  if (result.status !== 0) return false;
+  try {
+    const envelope = JSON.parse(result.stdout || "") as { ok?: unknown };
+    return envelope?.ok === true;
+  } catch { return false; }
+}
+
 export async function main(): Promise<void> {
 if (has("--help") || has("-h")) {
   say(`setup 内部机器人注册阶段
@@ -430,14 +484,19 @@ const TENANT_SCOPES = [
   "im:message.p2p_msg:readonly",
   "im:message.group_at_msg:readonly",
   "im:message.group_msg",
+  "im:message:send_as_bot",
   "im:chat:readonly",
   "im:chat:create",
   "im:chat:update",
+  "im:chat.group_info:readonly",
   "im:chat.members:read",
   "im:chat.members:write_only",
+  "im:chat:operate_as_owner",
   "im:resource",
   "application:application:self_manage",
   "contact:user.employee_id:readonly",
+  // 允许 setup 把应用可用范围设为全员可见：任何成员都能把 bot 加进自己的群（修复 230003 类场景）
+  "admin:app.visibility",
   // drive.notice.comment_add_v1 and the stable comment read/reply APIs are
   // currently delivered by Feishu under the aggregate drive tenant scope.
   "drive:drive",
@@ -665,6 +724,37 @@ try {
     } else {
       say(`✓ ${reconciled.dimension} 维度文档评论订阅已取消并由 subscription_status 验证；仅 @Bot 评论进入 Inbox。`);
     }
+  }
+
+  // ── setup 完成即主动写入 bot 身份（不再等首次连接）──
+  // 新 bot 在首次连接前，dashboard/agents 就能显示名字与头像（原：未连接过、无身份缓存）。
+  try {
+    const botInfo = await fetchBotInfoViaHttp(id, tenant);
+    if (botInfo?.open_id) {
+      const store = createAgentStateStore(CFG_DIR, id);
+      store.writeJson("botIdentity", {
+        open_id: botInfo.open_id,
+        name: botInfo.app_name || null,
+        avatar_url: botInfo.avatar_url || null,
+        updated_at: new Date().toISOString(),
+      });
+      say(`✓ bot 身份已写入 state：${botInfo.app_name || "?"}（${botInfo.open_id}）`);
+    } else {
+      say("! bot 身份接口暂未返回完整信息；首次连接后会自动补写");
+    }
+  } catch (error) {
+    say(`! bot 身份主动写入失败（首次连接后会自动补写）：${errorMessage(error)}`);
+  }
+
+  // ── 允许被添加进群：应用可用范围设为全员可见（更新后线上立即生效，best-effort）──
+  try {
+    if (await ensureAppVisibleToAll(id, official, cliEnv)) {
+      say("✓ 应用可用范围已设为全员可见：任何成员都可以把该 bot 添加进自己的群");
+    } else {
+      say("! 未能自动设为全员可见（可能未确认 admin:app.visibility 权限）；如成员无法把 bot 加进群，请在开发者后台「应用发布 → 版本管理与发布」把可用范围设为全部成员，或确认权限后重跑 setup");
+    }
+  } catch (error) {
+    say(`! 自动设置全员可见未完成（${errorMessage(error)}）；可在开发者后台配置可用范围，或确认 admin:app.visibility 后重跑 setup`);
   }
 } catch (error) {
   const diagnostic = errorMessage(error);

--- a/src/setup/grant-scopes.ts
+++ b/src/setup/grant-scopes.ts
@@ -69,11 +69,23 @@ const WAIT_MIN = Number(flag("--wait-min", "9"));
 const URL_FILE = flag("--url-file", "");
 
 const TENANT_SCOPES = [
-  "im:message:readonly",
+  "im:message",
+  "im:message.p2p_msg:readonly",
+  "im:message.group_at_msg:readonly",
+  "im:message.group_msg",
+  "im:message:send_as_bot",
   "im:chat:readonly",
   "im:chat",
+  "im:chat:create",
+  "im:chat:update",
   "im:chat.group_info:readonly",
   "im:chat.members:read",
+  "im:chat.members:write_only",
+  "im:chat:operate_as_owner",
+  "im:resource",
+  "application:application:self_manage",
+  "contact:user.employee_id:readonly",
+  "admin:app.visibility",
   "drive:drive",
   "docs:document.comment:read",
   "docs:document.comment:create",
@@ -83,7 +95,7 @@ const log = (...args: unknown[]): void => { process.stderr.write(`${args.join(" 
 
 function sendUrlToChat(url: string, minutes: number): void {
   if (!SEND_TO) return;
-  const text = `🔐 larkin 给机器人【${APP_ID}】增补读取权限。\n请【应用 owner 本人】打开下面链接确认(约 ${minutes} 分钟内有效)，勾选并确认这些权限：\n${TENANT_SCOPES.join("、")}\n\n${url}\n\n确认后我会自动接上并重试读取。`;
+  const text = `🔐 larkin 给机器人【${APP_ID}】增补权限。\n请【应用 owner 本人】打开下面链接确认(约 ${minutes} 分钟内有效)，勾选并确认这些权限：\n${TENANT_SCOPES.join("、")}\n\n${url}\n\n确认后我会自动接上并重试读取。`;
   const managed = resolveManagedOfficialCli(selected, process.env);
   const result = spawnSync(managed.command.command, [...managed.command.argsPrefix, "im", "+messages-send", "--chat-id", SEND_TO, "--text", text, "--json"], {
     encoding: "utf8", env: managed.env,

--- a/test/integration/build/bun-only-runtime-contract.test.mjs
+++ b/test/integration/build/bun-only-runtime-contract.test.mjs
@@ -14,6 +14,7 @@ const BUN_RUNNER_SEAM_ALLOWLIST = [
   "test/integration/platform/process-idempotency.test.mjs",
   "test/integration/platform/process-ownership.test.mjs",
   "test/unit/agent/agent-state-store.test.mjs",
+  "test/unit/app/local-control.test.mjs",
   "test/unit/app/runtime-agent-config-async.test.mjs",
   "test/unit/app/runtime-agent-interface-v2-live-safety.test.mjs",
 ].sort();

--- a/test/unit/app/lark-cli-launcher.test.mjs
+++ b/test/unit/app/lark-cli-launcher.test.mjs
@@ -311,3 +311,53 @@ test("provider failure and ambiguous termination retain a stable idempotency key
     assert.match(keys[0], /^larkin-[0-9a-f]{32}$/);
   } finally { fs.rmSync(f.root, { recursive: true, force: true }); }
 });
+
+test("--mention translates plain text into a real Feishu mention element (#69)", () => {
+  const f = fixture();
+  try {
+    // --text → text 消息，<at user_id> 前缀；guard 与幂等键照常生效。
+    const result = f.run(["im", "+messages-send", "--chat-id", "oc_mention", "--mention", "ou_mention123", "--text", "hello"]);
+    assert.deepEqual({ code: result.code, stdout: result.stdout, stderr: result.stderr }, {
+      code: 7, stdout: "native-out\n", stderr: "native-err\n",
+    });
+    assert.deepEqual(f.calls.map((call) => call.args[2]), ["GET", "+messages-send"]);
+    const write = f.calls[1].args;
+    const content = write[write.indexOf("--content") + 1];
+    assert.equal(JSON.parse(content).text, '<at user_id="ou_mention123"></at> hello');
+    assert.equal(write[write.indexOf("--msg-type") + 1], "text");
+    assert.equal(write.includes("--mention"), false);
+    assert.equal(write.includes("--text"), false);
+
+    // --markdown → post 消息，首个元素为 at 标签（reply 目标须先入 Inbox）。
+    f.store.appendInboxOnce({
+      message_id: "om_mention", target: "chat:oc_mention", target_seq: 1, seq: 1,
+      sender_type: "agent", sender_id: "ou_other", channel_type: "channel",
+      content: "source", timestamp: new Date().toISOString(),
+    });
+    const markdown = f.run(["im", "+messages-reply", "--message-id", "om_mention", "--mention", "ou_mention123", "--markdown", "**hi**"]);
+    assert.equal(markdown.code, 7);
+    const replyWrite = f.calls.at(-1).args;
+    const replyContent = JSON.parse(replyWrite[replyWrite.indexOf("--content") + 1]);
+    assert.deepEqual(replyContent.zh_cn.content[0], [{ tag: "at", user_id: "ou_mention123" }]);
+    assert.equal(replyWrite[replyWrite.indexOf("--msg-type") + 1], "post");
+  } finally { fs.rmSync(f.root, { recursive: true, force: true }); }
+});
+
+test("--mention rejects invalid ids, missing bodies, and content conflicts before any provider call", () => {
+  const f = fixture();
+  try {
+    for (const argv of [
+      ["im", "+messages-send", "--chat-id", "oc_x", "--mention", "not-an-id", "--text", "hi"],
+      ["im", "+messages-send", "--chat-id", "oc_x", "--mention", "ou_ok123"],
+      ["im", "+messages-send", "--chat-id", "oc_x", "--mention", "ou_ok123", "--text", "a", "--markdown", "b"],
+      ["im", "+messages-send", "--chat-id", "oc_x", "--mention", "ou_ok123", "--content", "{}"],
+    ]) {
+      const res = f.run(argv);
+      assert.equal(res.code, 2, argv.join(" "));
+      assert.match(res.stderr, /--mention/);
+    }
+    assert.equal(f.calls.length, 0);
+    // 非 im +messages-send/reply 命令不受影响，--mention 原样透传。
+    assert.equal(launcher.classifyLarkCliCommand(["im", "+chat-list", "--mention", "ou_ok123"]).kind, "passthrough");
+  } finally { fs.rmSync(f.root, { recursive: true, force: true }); }
+});

--- a/test/unit/app/local-control.test.mjs
+++ b/test/unit/app/local-control.test.mjs
@@ -395,3 +395,44 @@ test("normal supervisor and daemon close preserve replacement servers at the sam
     fs.rmSync(root, { recursive: true, force: true });
   }
 });
+
+test("daemon control server heals a missing authority file from the supervisor record", async () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "larkin-control-heal-"));
+  fs.chmodSync(root, 0o700);
+  const previousTestRunner = process.env.LARKIN_BUN_TEST_RUNNER;
+  process.env.LARKIN_BUN_TEST_RUNNER = "1";
+  // The supervisor record must describe a real process whose command line
+  // carries its command token; mirror the harness by spawning one.
+  const supervisor = spawn(process.execPath, ["-e", "setInterval(() => {}, 1000)", "app/run.mjs"], { stdio: "ignore" });
+  try {
+    await new Promise((resolve) => setTimeout(resolve, 150));
+    const inspected = inspectProcess(supervisor.pid);
+    assert.equal(inspected.ok, true, JSON.stringify(inspected));
+    // Regression: a daemon restart path once deleted daemon-control-auth.json
+    // while the supervisor stayed up; every relaunched daemon then crashed at
+    // secureAuthority() (ENOENT) and the supervisor looped forever. The daemon
+    // must re-establish the authority from supervisor-status.json instead.
+    const token = initializeControlAuthority(root, { pid: supervisor.pid, processStartToken: inspected.startToken });
+    fs.writeFileSync(path.join(root, "supervisor-status.json"), JSON.stringify({
+      pid: supervisor.pid,
+      commandToken: "app/run.mjs",
+      processStartToken: inspected.startToken,
+      nonce: "test-supervisor",
+    }), { mode: 0o600 });
+    const authorityFile = path.join(root, "daemon-control-auth.json");
+    fs.rmSync(authorityFile);
+    assert.equal(fs.existsSync(authorityFile), false, "precondition: authority file missing");
+    const server = createAgentControlServer({ larkinHome: root, authorityToken: token, async upsert() {} });
+    await server.start();
+    const healed = JSON.parse(fs.readFileSync(authorityFile, "utf8"));
+    assert.equal(healed.token, token, "recovery reuses the supervisor-known token");
+    assert.deepEqual(healed.supervisor, { pid: supervisor.pid, processStartToken: inspected.startToken });
+    assert.equal(healed.daemon.pid, process.pid, "recovered authority records the daemon binding");
+    await server.close();
+  } finally {
+    if (previousTestRunner === undefined) delete process.env.LARKIN_BUN_TEST_RUNNER;
+    else process.env.LARKIN_BUN_TEST_RUNNER = previousTestRunner;
+    if (supervisor.exitCode === null) supervisor.kill("SIGTERM");
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});

--- a/test/unit/feishu/host-processing-eye.test.mjs
+++ b/test/unit/feishu/host-processing-eye.test.mjs
@@ -265,3 +265,33 @@ test("larkApi failure without stderr falls back to stdout head", () => {
   eye.larkApi(agent, "GET", "/open-apis/im/v1/messages/om_fail2", null);
   assert.match(errors[0], /exit=ENOENT \| partial garbage output/);
 });
+
+test("idle completion replaces the 👀 reaction with a ✅ DONE reaction (#70)", () => {
+  const { eye, calls, deletes, logs, timers } = createHarness();
+  eye.add(agent, "om_done");
+  eye.observeActivity(agent, "working");
+  eye.observeActivity(agent, "idle");
+  timers.run(timers.active(1_000)[0]);
+  assert.equal(deletes().length, 1);
+  const donePosts = calls.filter(({ args }) => args.includes("POST") && args.some((arg) => typeof arg === "string" && arg.includes("DONE")));
+  assert.equal(donePosts.length, 1);
+  assert.match(donePosts[0].args.at(-1), /"emoji_type"\s*:\s*"DONE"/);
+  assert.match(logs.join("\n"), /已完成/);
+});
+
+test("error, offline, and fallback clears never add a DONE reaction", () => {
+  for (const terminal of ["error", "offline"]) {
+    const { eye, calls, deletes } = createHarness();
+    eye.add(agent, `om_${terminal}`);
+    eye.observeActivity(agent, "working");
+    eye.observeActivity(agent, terminal);
+    assert.equal(deletes().length, 1, terminal);
+    assert.equal(calls.filter(({ args }) => args.some((arg) => typeof arg === "string" && arg.includes("DONE"))).length, 0, terminal);
+  }
+
+  const { eye, calls, deletes, timers } = createHarness();
+  eye.add(agent, "om_fallback_done");
+  timers.run(timers.active(15 * 60 * 1_000)[0]);
+  assert.equal(deletes().length, 1);
+  assert.equal(calls.filter(({ args }) => args.some((arg) => typeof arg === "string" && arg.includes("DONE"))).length, 0);
+});


### PR DESCRIPTION
合并到 main 的内容（相对 main 的 4 个 commit）：
- 4244180 feat(setup): bot identity at setup, full scopes + visibility (#68 follow-up)
- 50f86c0 fix(supervisor): stop daemon crash-loop after control authority loss（生产事故：daemon-control-auth.json 被重启路径删除导致 ENOENT 崩溃循环）
- f77aaca fix(supervisor): dashboard SIGKILL 升级 + 重启 backoff 窗口关闭挂起（kimi-k3 review 补丁）
- a2a6525 Release v0.2.73