### PR TITLE
fix(processing-eye): remove 👀 on completion instead of posting ✅ DONE

### DIFF
--- a/src/feishu/host-processing-eye.ts
+++ b/src/feishu/host-processing-eye.ts
@@ -142,7 +142,7 @@ export class ProcessingEyeOrchestrator {
     });
   }
 
-  clear(agent: EyeAgent, reason?: string, options: { done?: boolean } = {}): void {
+  clear(agent: EyeAgent, reason?: string): void {
     const state = this.state.get(agent.agentId);
     if (state) {
       state.gen += 1;
@@ -151,7 +151,6 @@ export class ProcessingEyeOrchestrator {
       this.cancelCompletion(state);
     }
     const list = this.pending.get(agent.agentId) || [];
-    const completed = options.done === true && list.length > 0;
     if (!list.length) {
       this.log(`👀 清除(无待摘) agent=${agent.name} 原因=${reason || "?"}`);
       return;
@@ -165,17 +164,7 @@ export class ProcessingEyeOrchestrator {
         }
       });
     }
-    // 执行正常结束：把 👀 替换为 ✅ 已处理（issue #70），让用户/协作 Agent 看到处理完成信号。
-    if (completed) {
-      for (const { msgId } of list) {
-        this.larkApi(agent, "POST", `/open-apis/im/v1/messages/${msgId}/reactions`, { reaction_type: { emoji_type: "DONE" } }, (error, result) => {
-          if (error || result?.ok === false) {
-            this.log(`👀 完成标记失败 msg=${msgId}: ${result ? JSON.stringify(result.error || {}).slice(0, 120) : errorMessage(error)}`);
-          }
-        });
-      }
-      this.log(`👀 已完成 agent=${agent.name} n=${list.length} 原因=${reason || "?"}`);
-    }
+    // 执行结束（含正常完成）：只摘除 👀，不再追加任何完成 reaction（用户 2026-08-12 要求）。
     this.log(`👀 已摘 agent=${agent.name} n=${list.length} 原因=${reason || "?"}`);
   }
 
@@ -192,7 +181,7 @@ export class ProcessingEyeOrchestrator {
       completionTimer = this.setTimer(() => {
         const current = this.state.get(agent.agentId);
         if (current?.gen !== generation || current.completionTimer !== completionTimer) return;
-        this.clear(agent, "activity:idle(执行结束缓冲完成)", { done: true });
+        this.clear(agent, "activity:idle(执行结束缓冲完成)");
       }, 1_000);
       state.completionTimer = completionTimer;
       return;

--- a/test/unit/feishu/host-processing-eye.test.mjs
+++ b/test/unit/feishu/host-processing-eye.test.mjs
@@ -266,7 +266,7 @@ test("larkApi failure without stderr falls back to stdout head", () => {
   assert.match(errors[0], /exit=ENOENT \| partial garbage output/);
 });
 
-test("idle completion replaces the 👀 reaction with a ✅ DONE reaction (#70)", () => {
+test("idle completion removes the 👀 reaction without adding a DONE reaction (#70)", () => {
   const { eye, calls, deletes, logs, timers } = createHarness();
   eye.add(agent, "om_done");
   eye.observeActivity(agent, "working");
@@ -274,9 +274,8 @@ test("idle completion replaces the 👀 reaction with a ✅ DONE reaction (#70)"
   timers.run(timers.active(1_000)[0]);
   assert.equal(deletes().length, 1);
   const donePosts = calls.filter(({ args }) => args.includes("POST") && args.some((arg) => typeof arg === "string" && arg.includes("DONE")));
-  assert.equal(donePosts.length, 1);
-  assert.match(donePosts[0].args.at(-1), /"emoji_type"\s*:\s*"DONE"/);
-  assert.match(logs.join("\n"), /已完成/);
+  assert.equal(donePosts.length, 0, "正常结束只摘除 👀，不追加 ✅ DONE");
+  assert.match(logs.join("\n"), /已摘/);
 });
 
 test("error, offline, and fallback clears never add a DONE reaction", () => {


### PR DESCRIPTION
用户 2026-08-12 要求：执行结束不要搞成 done——正常结束时只**摘除 👀**，不再追加 ✅ DONE reaction（error/offline/15min 兜底行为不变）。

改动：
- `host-processing-eye.ts`：clear() 去掉 done 分支与 DONE POST，正常完成与其余终态一致只摘除 👀
- 测试：idle 完成用例改为断言不追加 DONE（18/18 pass）

不含 closing 关键词，issue 关闭由用户决定。