### PR TITLE
docs(lark-cli): mark --mention as Larkin extension parameter

### DIFF
--- a/src/app/lark-cli.ts
+++ b/src/app/lark-cli.ts
@@ -137,6 +137,7 @@ function hasNativeHelpFlag(argv: readonly string[]): boolean {
  * `--text` 正文 → text 消息 `<at user_id="..."></at>` 前缀；
  * `--markdown` 正文 → post 消息首个元素为 at 标签（正文按纯文本元素发送）。
  * 仅对 im +messages-send / +messages-reply 生效，其余命令原样透传。
+ * 注意：`--mention` 是 Larkin 扩展参数，官方 lark-cli 无此参数（见 issue #75 上游跟进）。
  */
 function mentionTranslation(argv: readonly string[]): string[] {
   const nativeArgv = nativeArgvBeforeBoundary(argv);


### PR DESCRIPTION
二蛋审核建议（2026-08-12，方案 C）：`--mention` 短期由 Larkin 封装层继续提供，但需明确标注为 **Larkin 扩展参数**（官方 lark-cli 无此参数），中长期跟进上游（issue #75）。\n\n改动：lark-cli.ts 的 --mention 实现注释补充扩展参数说明。