### PR TITLE
perf(startup): parallelize agent startup and cache CLI/catalog probes

### DIFF
--- a/src/app/official-lark-cli.ts
+++ b/src/app/official-lark-cli.ts
@@ -72,7 +72,75 @@ function officialPackage(executable: string): OfficialLarkCliCommand | null {
   return null;
 }
 
-export function probeOfficialLarkCli(dependencies: OfficialLarkCliDependencies = {}): OfficialLarkCliProbe {
+/**
+ * 进程内缓存（仅生产路径，即未注入 spawn/shell 时生效）：登录 shell 探测
+ * 是阻塞 spawnSync，且用户的 .zshrc/.zprofile（nvm 等）偶发需要数十秒才能
+ * 返回，daemon 热路径上反复探测会把启动拖到分钟级。同一进程内 PATH/SHELL
+ * 不变，解析结果也不会变，因此只探测一次。
+ */
+let productionProbeKey: string | null = null;
+let productionProbe: OfficialLarkCliProbe | null = null;
+
+/** setup 安装/升级官方 CLI 后调用，使同一进程内的后续解析重新探测。 */
+export function invalidateOfficialLarkCliProbeCache(): void {
+  productionProbeKey = null;
+  productionProbe = null;
+}
+
+/** 对已确认是官方 @larksuite/cli 的入口做版本与 bind 能力验证（shell 与 PATH 两路共用）。 */
+function validateOfficialCommand(command: OfficialLarkCliCommand, env: NodeJS.ProcessEnv,
+  spawn: typeof spawnSync): OfficialLarkCliProbe {
+  if (!compatibleVersion(command.version)) return {
+    state: "outdated",
+    reason: `官方 lark-cli ${command.version} 低于最低兼容版本 ${OFFICIAL_LARK_CLI_VERSION}: ${command.command}`,
+    nextAction: `升级：${OFFICIAL_LARK_CLI_INSTALL}`,
+  };
+  const version = spawn(command.command, ["--version"], {
+    encoding: "utf8", env,
+  }) as SpawnSyncReturns<string>;
+  if (version.status !== 0 || version.error || !String(version.stdout || "").includes(command.version)) return {
+    state: "outdated",
+    reason: `官方 lark-cli 版本执行验证失败: ${command.command}`,
+    nextAction: `重新安装：${OFFICIAL_LARK_CLI_INSTALL}`,
+  };
+  const bindHelp = spawn(command.command, ["config", "bind", "--help"], {
+    encoding: "utf8", env,
+  }) as SpawnSyncReturns<string>;
+  const bindText = `${bindHelp.stdout || ""}\n${bindHelp.stderr || ""}`;
+  if (bindHelp.status !== 0 || bindHelp.error || !/--source/.test(bindText) || !/lark-channel/.test(bindText) || !/--identity/.test(bindText)) return {
+    state: "conflict",
+    reason: `官方 lark-cli 缺少 lark-channel bot-only bind 能力: ${command.command}`,
+    nextAction: `升级：${OFFICIAL_LARK_CLI_INSTALL}`,
+  };
+  return { state: "ready", command };
+}
+
+/**
+ * PATH 直接解析快路径：daemon（launchd）的 PATH 通常已包含官方 lark-cli，
+ * 此时完全不需要拉起登录 shell（这是启动变慢的主要来源之一）。
+ * 仅当 PATH 解析出可用的官方 CLI 时才返回结果；否则返回 null 回退到
+ * 登录 shell 探测（保留对 shell 自定义 PATH 环境的兼容）。
+ */
+function probePathResolution(env: NodeJS.ProcessEnv): OfficialLarkCliProbe | null {
+  const dirs = String(env.PATH || "").split(path.delimiter).filter(Boolean);
+  for (const dir of dirs) {
+    const candidate = path.resolve(dir, "lark-cli");
+    try {
+      if (!fs.statSync(candidate).isFile()) continue;
+    } catch { continue; }
+    const command = officialPackage(candidate);
+    if (!command) return null;
+    return validateOfficialCommand(command, env, spawnSync);
+  }
+  return null;
+}
+
+function probeOfficialLarkCliUncached(dependencies: OfficialLarkCliDependencies): OfficialLarkCliProbe {
+  const env = dependencies.env ?? process.env;
+  if (!dependencies.spawn && !dependencies.shell) {
+    const fromPath = probePathResolution(env);
+    if (fromPath) return fromPath;
+  }
   const executable = loginShellPath(dependencies);
   if (!executable) return {
     state: "missing",
@@ -90,24 +158,20 @@ export function probeOfficialLarkCli(dependencies: OfficialLarkCliDependencies =
     reason: `真实 login shell 的官方 @larksuite/cli ${command.version} 低于最低兼容版本 ${OFFICIAL_LARK_CLI_VERSION}`,
     nextAction: `升级：${OFFICIAL_LARK_CLI_INSTALL}`,
   };
-  const version = (dependencies.spawn ?? spawnSync)(command.command, ["--version"], {
-    encoding: "utf8", env: dependencies.env ?? process.env,
-  }) as SpawnSyncReturns<string>;
-  if (version.status !== 0 || version.error || !String(version.stdout || "").includes(command.version)) return {
-    state: "outdated",
-    reason: `官方 lark-cli 版本执行验证失败: ${command.command}`,
-    nextAction: `重新安装：${OFFICIAL_LARK_CLI_INSTALL}`,
-  };
-  const bindHelp = (dependencies.spawn ?? spawnSync)(command.command, ["config", "bind", "--help"], {
-    encoding: "utf8", env: dependencies.env ?? process.env,
-  }) as SpawnSyncReturns<string>;
-  const bindText = `${bindHelp.stdout || ""}\n${bindHelp.stderr || ""}`;
-  if (bindHelp.status !== 0 || bindHelp.error || !/--source/.test(bindText) || !/lark-channel/.test(bindText) || !/--identity/.test(bindText)) return {
-    state: "conflict",
-    reason: `官方 lark-cli 缺少 lark-channel bot-only bind 能力: ${command.command}`,
-    nextAction: `升级：${OFFICIAL_LARK_CLI_INSTALL}`,
-  };
-  return { state: "ready", command };
+  return validateOfficialCommand(command, env, dependencies.spawn ?? spawnSync);
+}
+
+export function probeOfficialLarkCli(dependencies: OfficialLarkCliDependencies = {}): OfficialLarkCliProbe {
+  if (!dependencies.spawn && !dependencies.shell) {
+    const env = dependencies.env ?? process.env;
+    const key = `${env.SHELL || ""}|${env.PATH || ""}`;
+    if (productionProbe && productionProbeKey === key) return productionProbe;
+    const probe = probeOfficialLarkCliUncached({ env });
+    productionProbeKey = key;
+    productionProbe = probe;
+    return probe;
+  }
+  return probeOfficialLarkCliUncached(dependencies);
 }
 
 export function resolveOfficialLarkCli(dependencies: OfficialLarkCliDependencies = {}): OfficialLarkCliCommand {
@@ -122,6 +186,7 @@ export function installOfficialLarkCli(dependencies: OfficialLarkCliDependencies
     encoding: "utf8", env: dependencies.env ?? process.env, stdio: "inherit",
   }) as SpawnSyncReturns<string>;
   if (result.status !== 0 || result.error) throw new Error(`官方 lark-cli 安装失败（exit=${result.status ?? "none"}）`);
+  invalidateOfficialLarkCliProbeCache();
   return resolveOfficialLarkCli(dependencies);
 }
 

--- a/src/runtime/claude-model-catalog.ts
+++ b/src/runtime/claude-model-catalog.ts
@@ -97,7 +97,30 @@ function parseCatalog(value: unknown): ClaudeModelCatalog {
   return { models, effectiveModel, defaultSupportedReasoningEfforts: efforts(defaultRow || {}) };
 }
 
+/**
+ * 进程内缓存：同一 claude 可执行文件的模型目录在进程生命周期内不变，
+ * daemon 启动时多个 claude agent 只需探测一次（每次探测都要 spawn 一个
+ * claude CLI 进程做 list_models 控制请求）。失败不缓存以便重试；测试注入
+ * runClaudeControl 时绕过缓存，保持测试隔离。
+ */
+const discoveryCache = new Map<string, Promise<ClaudeModelCatalog>>();
+
 export async function discoverClaudeModelCatalog(options: DiscoverClaudeCatalogOptions = {}): Promise<ClaudeModelCatalog> {
+  if (!options.runClaudeControl) {
+    const key = `${options.command || options.env?.LARKIN_CLAUDE_COMMAND || "claude"}`;
+    const cached = discoveryCache.get(key);
+    if (cached) return cached;
+    const pending = discoverClaudeModelCatalogUncached(options);
+    discoveryCache.set(key, pending);
+    pending.catch(() => {
+      if (discoveryCache.get(key) === pending) discoveryCache.delete(key);
+    });
+    return pending;
+  }
+  return discoverClaudeModelCatalogUncached(options);
+}
+
+async function discoverClaudeModelCatalogUncached(options: DiscoverClaudeCatalogOptions): Promise<ClaudeModelCatalog> {
   const execute = options.runClaudeControl ?? runClaudeControl;
   const request = { type: "control_request", request_id: "larkin-model-list", request: { subtype: "list_models" } };
   try {

--- a/src/runtime/codex-model-catalog.ts
+++ b/src/runtime/codex-model-catalog.ts
@@ -113,7 +113,30 @@ function parseCatalog(value: unknown): CodexModelCatalog {
   return { models, effectiveModel };
 }
 
+/**
+ * 进程内缓存：同一 codex 可执行文件的模型目录在进程生命周期内不变，
+ * daemon 启动时多个 codex agent 只需探测一次（每次探测都要 spawn 一个
+ * codex app-server 进程）。失败不缓存以便重试；测试注入 runCodexAppServer
+ * 时绕过缓存，保持测试隔离。
+ */
+const discoveryCache = new Map<string, Promise<CodexModelCatalog>>();
+
 export async function discoverCodexModelCatalog(options: DiscoverCodexCatalogOptions = {}): Promise<CodexModelCatalog> {
+  if (!options.runCodexAppServer) {
+    const key = `${options.command || options.env?.LARKIN_CODEX_COMMAND || "codex"}`;
+    const cached = discoveryCache.get(key);
+    if (cached) return cached;
+    const pending = discoverCodexModelCatalogUncached(options);
+    discoveryCache.set(key, pending);
+    pending.catch(() => {
+      if (discoveryCache.get(key) === pending) discoveryCache.delete(key);
+    });
+    return pending;
+  }
+  return discoverCodexModelCatalogUncached(options);
+}
+
+async function discoverCodexModelCatalogUncached(options: DiscoverCodexCatalogOptions): Promise<CodexModelCatalog> {
   const execute = options.runCodexAppServer ?? runCodexAppServer;
   const request = { id: "larkin-model-list", method: "model/list" as const, params: { limit: 100, includeHidden: false as const } };
   try {

--- a/src/runtime/pi-model-catalog.ts
+++ b/src/runtime/pi-model-catalog.ts
@@ -61,8 +61,32 @@ export function findExactPiModel<T extends PiModelLike>(reference: string, model
   return models.find((model) => piModelId(model) === reference);
 }
 
+/**
+ * 进程内缓存：同一个 pi 可执行文件的模型目录在进程生命周期内不变。
+ * daemon 启动时 3 个 pi agent 会各发起一次发现探测（每个都 spawn 一个 pi 进程
+ * 并做 RPC 握手，约 5s），缓存后只 spawn 一次；失败不缓存以便重试。
+ * 测试注入 options.spawn 时绕过缓存，保持测试隔离。
+ */
+const discoveryCache = new Map<string, Promise<PiModelCatalog>>();
+
 /** Discover only through Pi's structured RPC protocol; no table parsing or static fallback. */
 export async function discoverPiModelCatalog(options: DiscoverPiCatalogOptions): Promise<PiModelCatalog> {
+  if (!options.spawn) {
+    const command = options.command ?? options.env?.LARKIN_PI_COMMAND ?? process.env.LARKIN_PI_COMMAND ?? "pi";
+    const key = `${command}|${options.env?.PI_CODING_AGENT_DIR ?? ""}|${options.agentDir ?? ""}`;
+    const cached = discoveryCache.get(key);
+    if (cached) return cached;
+    const pending = discoverPiModelCatalogUncached(options);
+    discoveryCache.set(key, pending);
+    pending.catch(() => {
+      if (discoveryCache.get(key) === pending) discoveryCache.delete(key);
+    });
+    return pending;
+  }
+  return discoverPiModelCatalogUncached(options);
+}
+
+async function discoverPiModelCatalogUncached(options: DiscoverPiCatalogOptions): Promise<PiModelCatalog> {
   const spawn = options.spawn ?? ((command, args, spawnOptions) => nodeSpawn(command, [...args], spawnOptions as any) as unknown as PiRpcProcess);
   const command = options.command ?? options.env?.LARKIN_PI_COMMAND ?? process.env.LARKIN_PI_COMMAND ?? "pi";
   const child = spawn(command, ["--mode", "rpc", "--no-session"], {

--- a/src/runtime/runtime-host.ts
+++ b/src/runtime/runtime-host.ts
@@ -787,8 +787,11 @@ export function createRuntimeHost(options: {
       let activeCount = 0;
       let recoveringCount = 0;
       const startupFailures: string[] = [];
-      for (const config of configs) {
-        if (managed.has(config.agentId)) { activeCount += 1; continue; }
+      // Agents start concurrently: each Agent's runtime session is independent,
+      // and serial startup multiplied every per-Agent handshake (login-shell
+      // probe + runtime RPC discovery) by the Agent count.
+      const startups = configs.map(async (config) => {
+        if (managed.has(config.agentId)) { activeCount += 1; return; }
         const stateStore = options.stateStoreFor?.(config.agentId);
         const persisted = stateStore
           ? stateStore.withInboxTransaction(() => {
@@ -832,7 +835,8 @@ export function createRuntimeHost(options: {
             ...(error instanceof RuntimePrerequisiteError ? { readiness: error.readiness } : {}) });
         }
         agent.poller = setInterval(() => reconcileExternalConsumption(agent), 250); agent.poller.unref?.();
-      }
+      });
+      await Promise.all(startups);
       if (configs.length > 0 && activeCount === 0 && recoveringCount === 0) {
         throw new Error(`No runtime Agent started: ${startupFailures.join("; ")}`);
       }


### PR DESCRIPTION
## 问题（issue #81）

daemon 重启后 Feishu 长连接建立需要 ~105-120s。分阶段计时定位：

| 阶段 | 耗时 |
|---|---|
| 阻塞式登录 shell 探测 `spawnSync(zsh -lc command -v lark-cli)` | 偶发 ~56s（nvm/代理相关，且热路径上重复执行） |
| pi 模型目录探测（spawn pi + RPC） | ~5.9s / agent |
| session 创建 | ~7s / agent |
| 串行启动 | ×3 agents ≈ 45-50s |

## 修改

1. **runtime-host 并行启动**：`start()` 改为 `Promise.all`，各 agent 的 session 相互独立，聚合计数保留原有 no-agent-started 失败语义。
2. **official-lark-cli 免登录 shell 解析**：先按 `PATH` 直接解析并用同样的 package/version/bind 校验；仅当 PATH 无可用 CLI 时才回退登录 shell 探测（保留 shell 自定义 PATH 兼容性）。同时按进程缓存探测结果（SHELL|PATH 键），安装/升级后失效。
3. **pi/codex/claude 模型目录缓存**：按命令缓存发现结果（含 in-flight 去重，失败不缓存），N 个 agent 共享一次运行时 spawn。测试注入 runner 时绕过缓存。

## 验证

- 本地实测：kickstart → 3 条 channel 全部建立 **~36s**（原 ~105-120s）；agent active 间隔从 ~15s 降到 ~1s。
- typecheck / build / integration (173) / e2e (12) 通过；unit 579/580 —— 唯一失败与本次改动无关（`pi-subagent-injection` 测试读取真实 `~/.pi/agent/settings.json`，本机装有 pi-subagents 时失败，CI 无此文件所以是绿的）。

Closes #81