### PR TITLE
fix(npm): ship assets/larkin-mark.svg so Dashboard favicon/brand logo resolves

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "larkinPackageRole": "npm-published",
   "files": [
     "dist/",
+    "assets/",
     "README.md",
     "LICENSE",
     "SECURITY.md",

--- a/test/integration/build/runtime-clean-cutover.test.mjs
+++ b/test/integration/build/runtime-clean-cutover.test.mjs
@@ -43,6 +43,7 @@ test("production build, start, and Agent CLI graph contain only current entries"
   assert.equal(packageJson.larkinPackageRole, "npm-published");
   assert.deepEqual(packageJson.files, [
     "dist/",
+    "assets/",
     "README.md",
     "LICENSE",
     "SECURITY.md",


### PR DESCRIPTION
## 问题（issue #82）

npm 安装方式下 `/assets/larkin-mark.svg` 404，Dashboard favicon 与侧栏品牌 logo 消失。

根因：`package.json` 的 `files` 只包含 `dist/`；`dashboardAsset()` 的磁盘回退路径是 `<root>/assets/larkin-mark.svg`，只有 standalone 二进制（内嵌资产）和仓库源码运行正常，npm 包从第一个 npm 版本（0.2.70）起一直缺这个文件。

## 修复

`files` 增加 `"assets/"`（一行）。

## 验证

- 本地：把 `assets/larkin-mark.svg` 复制到已安装 npm 包根目录后，路由返回 `200 image/svg+xml`。
- `npm pack --dry-run` 可见 tarball 中包含 `assets/larkin-mark.svg`（发布后由 npm-publish workflow 生效）。

Closes #82