### PR TITLE
Release v0.2.75

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "larkin",
-  "version": "0.2.74",
+  "version": "0.2.75",
   "private": false,
   "larkinPackageRole": "npm-published",
   "files": [


### PR DESCRIPTION
发布 0.2.75。

包含：
- #83 perf(startup)：并行化 agent 启动 + 缓存 CLI/目录探测（daemon 重启连接从 ~105-120s 降到 ~36s）
- #84 fix(npm)：npm 包附带 assets/larkin-mark.svg，修复 Dashboard favicon/logo 404（#82）

合并后将触发 Publish release 工作流自动打 tag v0.2.75 并发布 npm。