### PR TITLE
feat: Windows x64 二进制 + npm postinstall 二进制化 + 飞书(Lark) 用词

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -253,6 +253,8 @@ jobs:
             target: darwin-arm64
           - runner: macos-15-intel
             target: darwin-x64
+          - runner: ubuntu-24.04
+            target: windows-x64
     runs-on: ${{ matrix.runner }}
     timeout-minutes: 30
     permissions:
@@ -302,6 +304,7 @@ jobs:
         run: bun run scripts/check-publication.mjs --trusted --denylist "$RUNNER_TEMP/larkin-publication-denylist.txt" artifacts/release/larkin-v* artifacts/release/THIRD_PARTY_NOTICES.txt
 
       - name: Smoke current platform artifact
+        if: matrix.target != 'windows-x64'
         run: bun run release:smoke -- --release-dir artifacts/release
 
       - name: Upload platform artifact to draft release

--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ node_modules/
 .DS_Store
 /dist/
 /artifacts/
+/larkin-bin/
 recovered-src/
 
 # 曾经误提交过的私有路径，防止再次进入发布源

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -27,6 +27,10 @@ bun run publication:check
 
 Keep each change focused. Update the closest tests when behavior changes, and run the smallest relevant test first followed by the full suite before delivery. Do not weaken clean-tree, publication, license, security, or release checks to make a change pass.
 
+### npm distribution surface
+
+The npm package keeps a Bun-first runtime surface, but its install/invocation glue (`scripts/npm/install-binary.mjs` and `scripts/npm/larkin-bin-shim.mjs`) intentionally runs under Node. npm only guarantees Node at install time, and the postinstall binary download plus the `bin` shim must work without Bun so npm users do not need to install it. Node shebangs are therefore allowed only for those two files; `test/integration/build/bun-only-runtime-contract.test.mjs` enforces this single exception.
+
 ## Prompt engineering
 
 When tuning the Larkin standing prompt (`src/agent/context-prompt.ts`), follow the two canonical references and the file header notes:

--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 # Larkin
 
-Larkin connects Codex, Claude Code, and Pi agent runtimes to Feishu. It provides a local runtime host, persistent sessions, reminders, interactive messages, and a local dashboard.
+Larkin connects Codex, Claude Code, and Pi agent runtimes to Feishu (Lark). It provides a local runtime host, persistent sessions, reminders, interactive messages, and a local dashboard.
 
 ## Requirements
 
-- A supported macOS or Linux system
+- A supported macOS, Linux, or Windows (x64) system
 - `lark-cli`
 - At least one supported agent runtime and its authentication
 - Bun 1.3.14 when running the npm package or building from source (standalone binaries bundle their own runtime)
@@ -22,7 +22,7 @@ npm install -g larkin
 larkin --version
 ```
 
-Standalone binaries for macOS and Linux are attached to every [GitHub Release](https://github.com/eddiearc/larkin/releases) for environments without Bun or npm.
+Standalone binaries for macOS, Linux, and Windows (x64) are attached to every [GitHub Release](https://github.com/eddiearc/larkin/releases) for environments without Bun or npm. Windows binaries are cross-compiled; their runtime behavior has not been end-to-end verified on a Windows host.
 
 ## Usage
 

--- a/package.json
+++ b/package.json
@@ -1,11 +1,12 @@
 {
   "name": "larkin",
-  "version": "0.2.76",
+  "version": "0.2.77",
   "private": false,
   "larkinPackageRole": "npm-published",
   "files": [
     "dist/",
     "assets/",
+    "scripts/npm/",
     "README.md",
     "LICENSE",
     "SECURITY.md",
@@ -15,9 +16,9 @@
   "packageManager": "bun@1.3.14",
   "license": "Apache-2.0",
   "type": "module",
-  "description": "把 Codex、Claude Code 和 Pi Agent Runtime 接到飞书的本地 Runtime Host",
+  "description": "把 Codex、Claude Code 和 Pi Agent Runtime 接到飞书（Lark）的本地 Runtime Host",
   "bin": {
-    "larkin": "dist/app/cli.mjs"
+    "larkin": "scripts/npm/larkin-bin-shim.mjs"
   },
   "repository": {
     "type": "git",
@@ -28,6 +29,7 @@
     "typecheck": "bun run scripts/typecheck.mjs",
     "build": "bun run scripts/build.mjs",
     "prepare": "bun run build",
+    "postinstall": "node scripts/npm/install-binary.mjs",
     "version:bump": "bun run scripts/bump-version.mjs",
     "release:check-version": "bun run scripts/check-release-version.mjs",
     "release:smoke": "bun run scripts/release/smoke.ts",

--- a/scripts/npm/install-binary.mjs
+++ b/scripts/npm/install-binary.mjs
@@ -1,0 +1,125 @@
+#!/usr/bin/env node
+// npm postinstall: download the matching platform standalone binary from the
+// GitHub Release for this package version, verify its SHA-256, and install it
+// atomically under <pkg>/larkin-bin/<platform>-<arch>/. The npm tarball itself
+// never ships the binary; this runs only for registry/git installs (never in the
+// source repo, which ships src/ and scripts/build.mjs).
+//
+// Failures are non-fatal on purpose: `bin` (scripts/npm/larkin-bin-shim.mjs)
+// falls back to the Bun-compiled JS entry when the binary is unavailable.
+
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import {
+  RELEASE_TARGETS,
+  artifactFilename,
+  normalizeReleasePlatform,
+  sha256File,
+} from "../../dist/platform/release-artifacts.mjs";
+
+const HERE = path.dirname(fileURLToPath(import.meta.url));
+const PKG_ROOT = path.resolve(HERE, "..", "..");
+
+function warn(message) {
+  process.stderr.write(`[larkin install] ${message}\n`);
+}
+
+function inSourceRepo() {
+  return fs.existsSync(path.join(PKG_ROOT, "src")) && fs.existsSync(path.join(PKG_ROOT, "scripts", "build.mjs"));
+}
+
+async function fetchWithTimeout(url, timeoutMs) {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), timeoutMs);
+  try {
+    const response = await fetch(url, { redirect: "follow", signal: controller.signal });
+    if (!response.ok) throw new Error(`HTTP ${response.status}`);
+    return Buffer.from(await response.arrayBuffer());
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+function expectedSha256(checksumsText, filename) {
+  for (const line of String(checksumsText).split(/\r?\n/)) {
+    const [sha, name] = line.trim().split(/\s+/);
+    if (name === filename && /^[a-f0-9]{64}$/.test(sha)) return sha;
+  }
+  return null;
+}
+
+async function main() {
+  if (process.env.LARKIN_NPM_BINARY_DISABLE === "1") return;
+  if (inSourceRepo()) return;
+
+  const platform = normalizeReleasePlatform(os.platform());
+  const arch = os.arch();
+  const target = RELEASE_TARGETS.find((candidate) => candidate.platform === platform && candidate.arch === arch);
+  if (!target) return; // no standalone binary for this platform → JS fallback
+
+  let version;
+  try {
+    version = JSON.parse(fs.readFileSync(path.join(PKG_ROOT, "package.json"), "utf8")).version;
+  } catch (error) {
+    warn(`无法读取包版本：${error instanceof Error ? error.message : String(error)}`);
+    return;
+  }
+
+  let filename;
+  try {
+    filename = artifactFilename(version, target.platform, target.arch);
+  } catch (error) {
+    warn(`跳过下载：${error instanceof Error ? error.message : String(error)}`);
+    return;
+  }
+
+  const baseUrl = String(process.env.LARKIN_RELEASE_BASE_URL || `https://github.com/eddiearc/larkin/releases/download/v${version}`).replace(/\/+$/, "");
+  const destinationDir = path.join(PKG_ROOT, "larkin-bin", `${target.platform}-${target.arch}`);
+  const destination = path.join(destinationDir, target.platform === "windows" ? "larkin.exe" : "larkin");
+
+  let expected;
+  try {
+    const checksums = await fetchWithTimeout(`${baseUrl}/SHA256SUMS`, 30_000);
+    expected = expectedSha256(checksums.toString("utf8"), filename);
+  } catch (error) {
+    if (fs.existsSync(destination)) {
+      warn(`SHA256SUMS 下载失败，保留已安装二进制：${error instanceof Error ? error.message : String(error)}`);
+      return;
+    }
+    warn(`SHA256SUMS 下载失败，将回退到 Bun JS 入口：${error instanceof Error ? error.message : String(error)}`);
+    return;
+  }
+  if (!expected) {
+    warn(`SHA256SUMS 中缺少 ${filename} 的校验和，将回退到 Bun JS 入口`);
+    return;
+  }
+
+  if (fs.existsSync(destination) && sha256File(destination) === expected) return; // already current
+
+  let bytes;
+  try {
+    bytes = await fetchWithTimeout(`${baseUrl}/${filename}`, 5 * 60_000);
+  } catch (error) {
+    warn(`二进制下载失败，将回退到 Bun JS 入口：${error instanceof Error ? error.message : String(error)}`);
+    return;
+  }
+
+  fs.mkdirSync(destinationDir, { recursive: true });
+  const temporary = path.join(destinationDir, `.larkin.${process.pid}.${Date.now()}.tmp`);
+  try {
+    fs.writeFileSync(temporary, bytes);
+    if (sha256File(temporary) !== expected) throw new Error("checksum mismatch");
+    fs.chmodSync(temporary, 0o755);
+    fs.renameSync(temporary, destination);
+    process.stderr.write(`[larkin install] installed ${filename}\n`);
+  } catch (error) {
+    try { fs.unlinkSync(temporary); } catch { /* best effort */ }
+    warn(`安装二进制失败，将回退到 Bun JS 入口：${error instanceof Error ? error.message : String(error)}`);
+  }
+}
+
+main().catch((error) => {
+  warn(`安装二进制异常，将回退到 Bun JS 入口：${error instanceof Error ? error.message : String(error)}`);
+});

--- a/scripts/npm/install-binary.mjs
+++ b/scripts/npm/install-binary.mjs
@@ -12,12 +12,6 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
-import {
-  RELEASE_TARGETS,
-  artifactFilename,
-  normalizeReleasePlatform,
-  sha256File,
-} from "../../dist/platform/release-artifacts.mjs";
 
 const HERE = path.dirname(fileURLToPath(import.meta.url));
 const PKG_ROOT = path.resolve(HERE, "..", "..");
@@ -53,6 +47,12 @@ function expectedSha256(checksumsText, filename) {
 async function main() {
   if (process.env.LARKIN_NPM_BINARY_DISABLE === "1") return;
   if (inSourceRepo()) return;
+
+  // 延迟导入编译产物：源码仓库/CI 中 `dist/` 可能尚未构建，静态 import 会在
+  // 守卫之前失败（bun install 会运行根包 postinstall）。
+  const { RELEASE_TARGETS, artifactFilename, normalizeReleasePlatform, sha256File } = await import(
+    "../../dist/platform/release-artifacts.mjs"
+  );
 
   const platform = normalizeReleasePlatform(os.platform());
   const arch = os.arch();

--- a/scripts/npm/larkin-bin-shim.mjs
+++ b/scripts/npm/larkin-bin-shim.mjs
@@ -1,0 +1,48 @@
+#!/usr/bin/env node
+// npm `bin` entry. Prefers the postinstall-downloaded standalone binary; falls
+// back to the Bun-compiled JS entry when the binary is absent (unsupported
+// platform or a failed/interrupted install) and Bun is on PATH.
+
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { spawnSync } from "node:child_process";
+import { fileURLToPath } from "node:url";
+import { RELEASE_TARGETS, normalizeReleasePlatform } from "../../dist/platform/release-artifacts.mjs";
+
+const HERE = path.dirname(fileURLToPath(import.meta.url));
+const PKG_ROOT = path.resolve(HERE, "..", "..");
+
+const platform = normalizeReleasePlatform(os.platform());
+const target = RELEASE_TARGETS.find((candidate) => candidate.platform === platform && candidate.arch === os.arch());
+const binary = target
+  ? path.join(PKG_ROOT, "larkin-bin", `${target.platform}-${target.arch}`, target.platform === "windows" ? "larkin.exe" : "larkin")
+  : null;
+const argv = process.argv.slice(2);
+
+function run(command, args) {
+  const result = spawnSync(command, args, { stdio: "inherit" });
+  if (result.error) return null;
+  return result.status ?? 0;
+}
+
+if (binary && fs.existsSync(binary)) {
+  const status = run(binary, argv);
+  if (status !== null) process.exit(status);
+  process.stderr.write(`[larkin] 平台二进制启动失败，尝试 Bun fallback…\n`);
+}
+
+const bunEntry = path.join(PKG_ROOT, "dist", "app", "cli.mjs");
+if (fs.existsSync(bunEntry)) {
+  const bun = process.env.LARKIN_BUN || "bun";
+  const status = run(bun, [bunEntry, ...argv]);
+  if (status !== null) process.exit(status);
+}
+
+process.stderr.write(
+  "[larkin] 未找到可用的平台二进制，也未找到 Bun。\n" +
+  "  - 联网重新安装会自动下载对应平台二进制：npm install -g larkin\n" +
+  "  - 或安装 Bun 1.3.14 后重试（会走 JS 入口 fallback）\n" +
+  "  - 或从 GitHub Release 下载 standalone 二进制：https://github.com/eddiearc/larkin/releases\n",
+);
+process.exit(1);

--- a/scripts/release/install.ts
+++ b/scripts/release/install.ts
@@ -20,8 +20,10 @@ const value = (name: string, fallback = ""): string => {
 const installDirInput = value("--install-dir");
 if (!installDirInput) throw new Error("--install-dir is required");
 const installDir = path.resolve(installDirInput);
-const destination = path.join(installDir, "larkin");
-const previous = path.join(installDir, "larkin.previous");
+const osPlatform = value("--platform", os.platform());
+const windows = osPlatform === "win32" || osPlatform === "windows";
+const destination = path.join(installDir, windows ? "larkin.exe" : "larkin");
+const previous = path.join(installDir, windows ? "larkin.previous.exe" : "larkin.previous");
 
 fs.mkdirSync(installDir, { recursive: true, mode: 0o755 });
 if (has("--rollback")) {
@@ -46,7 +48,7 @@ const manifestFile = path.join(releaseDir, "release-manifest.json");
 const manifest = JSON.parse(fs.readFileSync(manifestFile, "utf8")) as ReleaseManifest;
 verifyReleaseNotices(releaseDir, manifest);
 if (manifest.sourceDirty && !has("--allow-dirty")) throw new Error("refusing an artifact built from a dirty source tree");
-const platform = value("--platform", os.platform());
+const platform = osPlatform;
 const arch = value("--arch", os.arch());
 const record = selectReleaseArtifact(manifest, platform, arch);
 const artifact = verifyReleaseArtifact(releaseDir, record);

--- a/src/app/agent-cli.ts
+++ b/src/app/agent-cli.ts
@@ -133,7 +133,7 @@ function query(requestPath: string, name: string): string | null {
 
 function migrationError(group: string, subcommand?: string): string | null {
   if (group === "message") {
-    return "message 已移除：只读查看收件箱用 `larkin inbox check`，领取完整消息用 `larkin inbox poll`；飞书发送、回复和查询请使用 `larkin im +messages-send`、`+messages-reply`、`+chat-messages-list` 或 `+messages-mget`。";
+    return "message 已移除：只读查看收件箱用 `larkin inbox check`，领取完整消息用 `larkin inbox poll`；飞书（Lark）发送、回复和查询请使用 `larkin im +messages-send`、`+messages-reply`、`+chat-messages-list` 或 `+messages-mget`。";
   }
   if (group === "channel") {
     return "channel 已移除：群聊操作请使用 `larkin im +chat-list`、`+chat-search`、`chats get`、`+chat-create`、`+chat-update` 或 `chat.members get/create/delete`。";
@@ -141,8 +141,8 @@ function migrationError(group: string, subcommand?: string): string | null {
   if (group === "attachment") {
     return "attachment 已移除：发送附件请使用 `larkin im +messages-send --file/--image/--video/--audio`；下载请使用 `larkin im +messages-resources-download`。";
   }
-  if (group === "server") return "server 已移除；飞书群与消息信息请通过 `larkin im ...` 查询。";
-  if (group === "im") return "请通过 `larkin im ...` 使用飞书命令；Runtime 会自动绑定当前 Bot identity，并在写入前执行 freshness gate。可运行 `larkin im --help` 查看帮助。";
+  if (group === "server") return "server 已移除；飞书（Lark）群与消息信息请通过 `larkin im ...` 查询。";
+  if (group === "im") return "请通过 `larkin im ...` 使用飞书（Lark）命令；Runtime 会自动绑定当前 Bot identity，并在写入前执行 freshness gate。可运行 `larkin im --help` 查看帮助。";
   if (group === "profile" && subcommand !== "show") {
     return "profile 只保留只读的 `larkin profile show`；身份和凭证由 `larkin setup` 管理，不支持 update。";
   }

--- a/src/app/agent-lark-cli-workspace.ts
+++ b/src/app/agent-lark-cli-workspace.ts
@@ -1,5 +1,6 @@
 import fs from "node:fs";
 import path from "node:path";
+import { exactMode } from "../platform/secure-metadata.js";
 import { resolveOfficialLarkCli, type OfficialLarkCliCommand } from "./official-lark-cli.js";
 
 export interface AgentLarkCliWorkspace {
@@ -51,12 +52,12 @@ export function managedOfficialLarkCli(
 
 function readPrivateJson(file: string, label: string): Record<string, any> {
   const directory = fs.lstatSync(path.dirname(file));
-  if (!directory.isDirectory() || directory.isSymbolicLink() || (directory.mode & 0o777) !== 0o700
+  if (!directory.isDirectory() || directory.isSymbolicLink() || !exactMode(directory, 0o700)
       || (typeof process.getuid === "function" && directory.uid !== process.getuid())) throw new Error(`${label} 目录不安全`);
   const fd = fs.openSync(file, fs.constants.O_RDONLY | (fs.constants.O_NOFOLLOW || 0));
   try {
     const stat = fs.fstatSync(fd);
-    if (!stat.isFile() || (stat.mode & 0o777) !== 0o600
+    if (!stat.isFile() || !exactMode(stat, 0o600)
         || (typeof process.getuid === "function" && stat.uid !== process.getuid())) throw new Error(`${label} 文件不安全`);
     return JSON.parse(fs.readFileSync(fd, "utf8")) as Record<string, any>;
   } finally { fs.closeSync(fd); }

--- a/src/app/cli.ts
+++ b/src/app/cli.ts
@@ -122,7 +122,7 @@ if (!routes[command] && !wantsHelp) {
 }
 
 if (!routes[command]) {
-  console.log(`larkin — Run persistent-personality agents on Feishu
+  console.log(`larkin — Run persistent-personality agents on Feishu (Lark)
 
 Usage: larkin <command>
   setup            Create or connect a bot, configure its Agent, start it, and open the dashboard

--- a/src/app/local-control.ts
+++ b/src/app/local-control.ts
@@ -7,6 +7,7 @@ import path from "node:path";
 import { readProcessState } from "../platform/process-state.js";
 import { currentProcessMetadata } from "../platform/process-inspect.cjs";
 import { processCommandToken } from "./internal-command.js";
+import { isWindows, notGroupOrWorldAccessible } from "../platform/secure-metadata.js";
 
 export interface AgentUpsertRequest { operationId: string; agentId: string; authorization: string }
 export type AgentUpsertOperation = Pick<AgentUpsertRequest, "operationId" | "agentId">;
@@ -42,6 +43,7 @@ const AUTHORIZATION = /^[A-Za-z0-9_-]{43,128}$/;
 const UNIX_SOCKET_PATH_MAX_BYTES = process.platform === "darwin" ? 103 : 107;
 
 function socketPathsFit(root: string): boolean {
+  if (isWindows) return true; // Windows named-pipe socket paths use a much larger limit
   return ["supervisor.sock", "daemon.sock"].every((name) =>
     Buffer.byteLength(path.join(root, name)) <= UNIX_SOCKET_PATH_MAX_BYTES);
 }
@@ -52,6 +54,7 @@ function controlSocketRoot(larkinHome: string): string {
   const leaf = `lk-${owner}-${identity}`;
   const preferred = path.join(path.resolve(os.tmpdir()), leaf);
   if (socketPathsFit(preferred)) return preferred;
+  if (isWindows) throw new Error("无法生成满足 Windows socket 路径限制的 control root");
   const fallback = path.join("/tmp", leaf);
   if (socketPathsFit(fallback)) return fallback;
   throw new Error("无法生成满足 Unix socket 长度限制的 control root");
@@ -61,7 +64,7 @@ function assertSecureSocketDirectory(root: string): string {
   const stat = fs.lstatSync(root);
   if (!stat.isDirectory() || stat.isSymbolicLink()
       || (typeof process.getuid === "function" && stat.uid !== process.getuid())
-      || (stat.mode & 0o077) !== 0) throw new Error("control socket root 不安全");
+      || !notGroupOrWorldAccessible(stat)) throw new Error("control socket root 不安全");
   return root;
 }
 
@@ -87,7 +90,7 @@ function assertSecureRoot(root: string): void {
   const stat = fs.lstatSync(root);
   if (!stat.isDirectory() || stat.isSymbolicLink()
       || (typeof process.getuid === "function" && stat.uid !== process.getuid())
-      || (stat.mode & 0o077) !== 0) throw new Error("Larkin config root 必须由当前用户拥有且不可被其他用户访问");
+      || !notGroupOrWorldAccessible(stat)) throw new Error("Larkin config root 必须由当前用户拥有且不可被其他用户访问");
 }
 
 function removeLegacyResetLedger(larkinHome: string): void {
@@ -99,7 +102,7 @@ function removeLegacyResetLedger(larkinHome: string): void {
     throw error;
   }
   if (!stat.isFile() || stat.isSymbolicLink()
-      || (typeof process.getuid === "function" && stat.uid !== process.getuid()) || (stat.mode & 0o077) !== 0) {
+      || (typeof process.getuid === "function" && stat.uid !== process.getuid()) || !notGroupOrWorldAccessible(stat)) {
     throw new Error("legacy daemon control operation ledger 不安全");
   }
   fs.unlinkSync(file);
@@ -145,7 +148,7 @@ function secureAuthority(larkinHome: string): ControlAuthority {
   const stat = fs.lstatSync(file);
   if (!stat.isFile() || stat.isSymbolicLink()
       || (typeof process.getuid === "function" && stat.uid !== process.getuid())
-      || (stat.mode & 0o077) !== 0) throw new Error("daemon control authority 不安全");
+      || !notGroupOrWorldAccessible(stat)) throw new Error("daemon control authority 不安全");
   const value = JSON.parse(fs.readFileSync(file, "utf8")) as Partial<ControlAuthority>;
   const validBinding = (binding: ProcessBinding | undefined): binding is ProcessBinding =>
     !!binding && Number.isSafeInteger(binding.pid) && binding.pid > 0
@@ -645,7 +648,7 @@ async function sendSupervisorRecovery(larkinHome: string, operationId: string, t
   const stat = fs.lstatSync(socket);
   if (!stat.isSocket() || stat.isSymbolicLink()
       || (typeof process.getuid === "function" && stat.uid !== process.getuid())
-      || (stat.mode & 0o077) !== 0) throw new Error("supervisor control socket 不安全");
+      || !notGroupOrWorldAccessible(stat)) throw new Error("supervisor control socket 不安全");
   return await new Promise<DashboardRecoveryResponse>((resolve, reject) => {
     const client = net.createConnection(socket);
     const timer = setTimeout(() => { client.destroy(); reject(new Error("dashboard recovery control timeout")); }, timeoutMs);
@@ -708,7 +711,7 @@ async function requestAgentControl<T>({
   const stat = fs.lstatSync(socket);
   if (!stat.isSocket() || stat.isSymbolicLink()
       || (typeof process.getuid === "function" && stat.uid !== process.getuid())
-      || (stat.mode & 0o077) !== 0) throw new Error("daemon control socket 不安全");
+      || !notGroupOrWorldAccessible(stat)) throw new Error("daemon control socket 不安全");
   return await new Promise<T>((resolve, reject) => {
     const client = net.createConnection(socket);
     const timer = setTimeout(() => { client.destroy(); reject(new Error("agent control timeout")); }, timeoutMs);

--- a/src/app/official-lark-cli.ts
+++ b/src/app/official-lark-cli.ts
@@ -2,6 +2,10 @@ import { spawnSync, type SpawnSyncReturns } from "node:child_process";
 import fs from "node:fs";
 import path from "node:path";
 
+function safeRealpath(target: string): string | null {
+  try { return fs.realpathSync(target); } catch { return null; }
+}
+
 export const OFFICIAL_LARK_CLI_VERSION = "1.0.79";
 export const OFFICIAL_LARK_CLI_INSTALL = `npm install --global @larksuite/cli@${OFFICIAL_LARK_CLI_VERSION}`;
 
@@ -21,10 +25,12 @@ export interface OfficialLarkCliDependencies {
   spawn?: typeof spawnSync;
   shell?: string;
   env?: NodeJS.ProcessEnv;
+  platform?: NodeJS.Platform;
 }
 
 function loginShellPath(dependencies: OfficialLarkCliDependencies): string | null {
   const env = dependencies.env ?? process.env;
+  if ((dependencies.platform ?? process.platform) === "win32") return windowsLoginShellPath(dependencies, env);
   const shell = dependencies.shell || env.SHELL || "/bin/sh";
   const result = (dependencies.spawn ?? spawnSync)(shell, ["-lc", "command -v lark-cli 2>/dev/null"], {
     encoding: "utf8", env,
@@ -32,6 +38,27 @@ function loginShellPath(dependencies: OfficialLarkCliDependencies): string | nul
   if (result.status !== 0 || result.error) return null;
   const candidate = String(result.stdout || "").split(/\r?\n/).map((line) => line.trim()).find(Boolean) || "";
   return path.isAbsolute(candidate) ? path.resolve(candidate) : null;
+}
+
+/**
+ * Windows 登录 shell 探测：npm 全局安装会生成 `lark-cli.cmd`/`lark-cli` shim，真正的
+ * 原生二进制位于 `<npm 前缀>/node_modules/@larksuite/cli/bin/lark-cli.exe`。`where lark-cli`
+ * 返回 shim 路径，从 shim 所在目录推导原生二进制优先返回；否则回退到命中的 .exe/.cmd
+ * 路径（交由 officialPackage 校验）。
+ */
+function windowsLoginShellPath(dependencies: OfficialLarkCliDependencies, env: NodeJS.ProcessEnv): string | null {
+  const shell = dependencies.shell || "cmd.exe";
+  const result = (dependencies.spawn ?? spawnSync)(shell, ["/d", "/s", "/c", "where lark-cli 2>nul"], {
+    encoding: "utf8", env,
+  }) as SpawnSyncReturns<string>;
+  if (result.status !== 0 || result.error) return null;
+  for (const line of String(result.stdout || "").split(/\r?\n/).map((value) => value.trim()).filter(Boolean)) {
+    if (!path.isAbsolute(line)) continue;
+    const native = path.join(path.dirname(line), "node_modules", "@larksuite", "cli", "bin", "lark-cli.exe");
+    if (safeRealpath(native)) return path.resolve(native);
+    if (/\.(exe|cmd)$/i.test(line)) return path.resolve(line);
+  }
+  return null;
 }
 
 function compatibleVersion(version: string): boolean {
@@ -46,7 +73,7 @@ function compatibleVersion(version: string): boolean {
     && (actual[1] > minimum[1] || (actual[1] === minimum[1] && actual[2] >= minimum[2])));
 }
 
-function officialPackage(executable: string): OfficialLarkCliCommand | null {
+function officialPackage(executable: string, platform: NodeJS.Platform = process.platform): OfficialLarkCliCommand | null {
   let resolved: string;
   try { resolved = fs.realpathSync(executable); } catch { return null; }
   let directory = path.dirname(resolved);
@@ -61,8 +88,11 @@ function officialPackage(executable: string): OfficialLarkCliCommand | null {
         const packageRoot = fs.realpathSync(directory);
         const requested = path.resolve(packageRoot, bin);
         const relative = path.relative(packageRoot, requested);
-        if ((relative === "" || (!relative.startsWith(`..${path.sep}`) && relative !== ".."))
-            && fs.realpathSync(requested) === resolved) {
+        const withinPackage = relative === "" || (!relative.startsWith(`..${path.sep}`) && relative !== "..");
+        const matchesBinTarget = withinPackage && safeRealpath(requested) === resolved;
+        const matchesNativeWindows = withinPackage && platform === "win32"
+          && safeRealpath(path.join(packageRoot, "bin", "lark-cli.exe")) === resolved;
+        if (matchesBinTarget || matchesNativeWindows) {
           return { command: path.resolve(executable), argsPrefix: [], version: manifest.version };
         }
       }
@@ -121,14 +151,30 @@ function validateOfficialCommand(command: OfficialLarkCliCommand, env: NodeJS.Pr
  * 仅当 PATH 解析出可用的官方 CLI 时才返回结果；否则返回 null 回退到
  * 登录 shell 探测（保留对 shell 自定义 PATH 环境的兼容）。
  */
-function probePathResolution(env: NodeJS.ProcessEnv): OfficialLarkCliProbe | null {
+function probePathResolution(env: NodeJS.ProcessEnv, platform: NodeJS.Platform = process.platform): OfficialLarkCliProbe | null {
   const dirs = String(env.PATH || "").split(path.delimiter).filter(Boolean);
+  if (platform === "win32") {
+    for (const dir of dirs) {
+      for (const candidate of [
+        path.resolve(dir, "node_modules", "@larksuite", "cli", "bin", "lark-cli.exe"),
+        path.resolve(dir, "lark-cli.exe"),
+      ]) {
+        try {
+          if (!fs.statSync(candidate).isFile()) continue;
+        } catch { continue; }
+        const command = officialPackage(candidate, platform);
+        if (!command) continue;
+        return validateOfficialCommand(command, env, spawnSync);
+      }
+    }
+    return null;
+  }
   for (const dir of dirs) {
     const candidate = path.resolve(dir, "lark-cli");
     try {
       if (!fs.statSync(candidate).isFile()) continue;
     } catch { continue; }
-    const command = officialPackage(candidate);
+    const command = officialPackage(candidate, platform);
     if (!command) return null;
     return validateOfficialCommand(command, env, spawnSync);
   }
@@ -137,8 +183,9 @@ function probePathResolution(env: NodeJS.ProcessEnv): OfficialLarkCliProbe | nul
 
 function probeOfficialLarkCliUncached(dependencies: OfficialLarkCliDependencies): OfficialLarkCliProbe {
   const env = dependencies.env ?? process.env;
+  const platform = dependencies.platform ?? process.platform;
   if (!dependencies.spawn && !dependencies.shell) {
-    const fromPath = probePathResolution(env);
+    const fromPath = probePathResolution(env, platform);
     if (fromPath) return fromPath;
   }
   const executable = loginShellPath(dependencies);
@@ -147,7 +194,7 @@ function probeOfficialLarkCliUncached(dependencies: OfficialLarkCliDependencies)
     reason: "真实 login shell 找不到官方 lark-cli",
     nextAction: `运行 larkin setup，并确认执行：${OFFICIAL_LARK_CLI_INSTALL}`,
   };
-  const command = officialPackage(executable);
+  const command = officialPackage(executable, platform);
   if (!command) return {
     state: "conflict",
     reason: `真实 login shell 的 lark-cli 不是兼容的官方 @larksuite/cli ${OFFICIAL_LARK_CLI_VERSION}: ${executable}`,

--- a/src/app/runtime-agent-config.ts
+++ b/src/app/runtime-agent-config.ts
@@ -4,6 +4,7 @@ import fs from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 import type { HydratedAgent } from "../platform/config.js";
+import { exactMode, notGroupOrWorldAccessible } from "../platform/secure-metadata.js";
 import { acquireProcessLock } from "../platform/process-state.js";
 import {
   assertSecureBotsDirectory,
@@ -47,7 +48,7 @@ function assertSecureProfileDirectory(directory: string): void {
   const stat = fs.lstatSync(directory);
   if (!stat.isDirectory() || stat.isSymbolicLink()
       || (typeof process.getuid === "function" && stat.uid !== process.getuid())
-      || (stat.mode & 0o777) !== 0o700) throw new Error("lark-cli profile 目录不安全");
+      || !exactMode(stat, 0o700)) throw new Error("lark-cli profile 目录不安全");
 }
 
 function captureProfileSnapshot(file: string): ProfileSnapshot | null {
@@ -57,7 +58,7 @@ function captureProfileSnapshot(file: string): ProfileSnapshot | null {
     const stat = fs.fstatSync(fd);
     if (!stat.isFile()
         || (typeof process.getuid === "function" && stat.uid !== process.getuid())
-      || (stat.mode & 0o077) !== 0) throw new Error("lark-cli config.json 不安全");
+      || !notGroupOrWorldAccessible(stat)) throw new Error("lark-cli config.json 不安全");
     const raw = fs.readFileSync(fd);
     const value = JSON.parse(raw.toString("utf8")) as LarkCliConfig;
     if (!value || typeof value !== "object" || (value.apps !== undefined && !Array.isArray(value.apps))) {

--- a/src/app/setup.ts
+++ b/src/app/setup.ts
@@ -26,7 +26,7 @@ const say = (...args: unknown[]): void => console.log(...args);
 const die = (message: string): never => { console.error(`✗ ${message}`); process.exit(1); };
 
 if (argv.some((arg) => arg === "--app-id" || arg.startsWith("--app-id="))) {
-  die("setup 不支持 --app-id；请运行 larkin setup 并在飞书网页中选择机器人");
+  die("setup 不支持 --app-id；请运行 larkin setup 并在飞书（Lark）网页中选择机器人");
 }
 if (argv.some((arg) => arg === "--no-dashboard" || arg.startsWith("--no-dashboard="))) {
   die("--no-dashboard 已移除；dashboard 由 larkin start 统一管理");
@@ -69,7 +69,7 @@ if (!OPT.help && normalizedRuntime.distribution === "external" && (flag("--provi
   die("external-pi 使用已有 pi 环境，不接受 --provider/--api-key/--base-url");
 }
 if (OPT.help) {
-  say(`larkin setup — Create or connect a Feishu bot, then configure and attach its Agent
+  say(`larkin setup — Create or connect a Feishu (Lark) bot, then configure and attach its Agent
 
 Usage:
   larkin setup                         Select a bot in the browser and run setup（默认：内置 Pi + 配置完成即热挂载）
@@ -130,7 +130,7 @@ export async function main(): Promise<void> {
     env: process.env,
     interactive: Boolean(process.stdin.isTTY && process.stdout.isTTY),
     async confirmInstall(command) {
-      say("[setup 0/5] Larkin 需要未修改的官方 lark-cli 作为 Feishu 命令下游。");
+      say("[setup 0/5] Larkin 需要未修改的官方 lark-cli 作为 Feishu (Lark) 命令下游。");
       say(`将执行：${command}`);
       const input = readline.createInterface({ input: process.stdin, output: process.stdout });
       const answer = (await input.question("是否安装？[y/N] ")).trim().toLowerCase();
@@ -139,7 +139,7 @@ export async function main(): Promise<void> {
     },
   }).catch((error) => die(error instanceof Error ? error.message : String(error)));
   say(`[setup 0/5] ✓ 官方 lark-cli ${official.command.version}: ${official.command.command}${official.installed ? "（刚刚安装）" : ""}`);
-  say("\nAgent 与飞书机器人按 App ID 一一对应：");
+  say("\nAgent 与飞书（Lark）机器人按 App ID 一一对应：");
   say("  • 网页选择同一个机器人 → 热更新该 Agent，不重启其他 Agent");
   say("  • 网页创建新机器人 → 热挂载新 Agent，状态彼此独立\n");
   fs.mkdirSync(CFG_DIR, { recursive: true, mode: 0o700 });

--- a/src/platform/callback-capability.ts
+++ b/src/platform/callback-capability.ts
@@ -1,6 +1,7 @@
 import { randomUUID } from "node:crypto";
 import * as fs from "node:fs";
 import * as path from "node:path";
+import { exactMode } from "./secure-metadata.js";
 
 export type CardActionCallbackStatus = "missing" | "requested-unverified" | "probe-issued" | "verified-effective";
 
@@ -77,7 +78,7 @@ function credentialFile(configDir: string, appId: string): string {
 
 function readCredential(file: string): CredentialRecord {
   const stat = fs.lstatSync(file);
-  if (!stat.isFile() || stat.isSymbolicLink() || (stat.mode & 0o777) !== 0o600
+  if (!stat.isFile() || stat.isSymbolicLink() || !exactMode(stat, 0o600)
       || (typeof process.getuid === "function" && stat.uid !== process.getuid())) {
     throw new Error("callback capability credential must be an owned 0600 regular file");
   }

--- a/src/platform/config.ts
+++ b/src/platform/config.ts
@@ -3,6 +3,7 @@ import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
 import { TargetRootLayout, resolveConfigDir as resolveRootConfigDir } from "./root-layout.js";
+import { exactMode, fsyncDirectoryOf } from "./secure-metadata.js";
 import { CURRENT_RUNTIME_MODELS, type RuntimeModels } from "../runtime/runtime-model-catalog.js";
 import processInspect from "./process-inspect.cjs";
 
@@ -250,7 +251,7 @@ export function normalizeConfig(raw: unknown, configDir: string, { mint }: { min
 export function assertPrivateConfigMetadata(metadata: { regularFile: boolean; uid: number; mode: number }, label = "配置文件"): void {
   if (!metadata.regularFile) throw new Error(`${label} 必须是普通文件`);
   if (typeof process.getuid === "function" && metadata.uid !== process.getuid()) throw new Error(`${label} owner 不是当前用户`);
-  if ((metadata.mode & 0o777) !== 0o600) throw new Error(`${label} 权限必须是 0600`);
+  if (!exactMode(metadata, 0o600)) throw new Error(`${label} 权限必须是 0600`);
 }
 
 function readPrivateFile(file: string, root: string, limit: number, label: string): Buffer | null {
@@ -573,8 +574,7 @@ function atomicWriteConfig(file: string, value: unknown): Buffer {
   try {
     fs.renameSync(temporary, file);
     fs.chmodSync(file, 0o600);
-    const dirFd = fs.openSync(path.dirname(file), "r");
-    try { fs.fsyncSync(dirFd); } finally { fs.closeSync(dirFd); }
+    fsyncDirectoryOf(file);
   } catch (error) { try { fs.unlinkSync(temporary); } catch { /* best effort */ } throw error; }
   return bytes;
 }

--- a/src/platform/release-artifacts.ts
+++ b/src/platform/release-artifacts.ts
@@ -7,6 +7,7 @@ export const RELEASE_TARGETS = Object.freeze([
   { platform: "darwin", arch: "x64", bunTarget: "bun-darwin-x64-baseline" },
   { platform: "linux", arch: "arm64", bunTarget: "bun-linux-arm64" },
   { platform: "linux", arch: "x64", bunTarget: "bun-linux-x64-baseline" },
+  { platform: "windows", arch: "x64", bunTarget: "bun-windows-x64-baseline" },
 ] as const);
 
 export type ReleasePlatform = typeof RELEASE_TARGETS[number]["platform"];
@@ -44,7 +45,13 @@ export function artifactFilename(version: string, platform: ReleasePlatform, arc
   if (!RELEASE_TARGETS.some((target) => target.platform === platform && target.arch === arch)) {
     throw new Error(`unsupported release target: ${platform}-${arch}`);
   }
-  return `larkin-v${version}-${platform}-${arch}`;
+  const suffix = platform === "windows" ? ".exe" : "";
+  return `larkin-v${version}-${platform}-${arch}${suffix}`;
+}
+
+/** Node's `os.platform()` reports Windows as "win32"; canonical release manifests use "windows". */
+export function normalizeReleasePlatform(platform: string): string {
+  return platform === "win32" ? "windows" : platform;
 }
 
 export function sha256File(file: string): string {
@@ -56,8 +63,9 @@ export function selectReleaseArtifact(
   platform: string,
   arch: string,
 ): ReleaseArtifactRecord {
-  const record = manifest.artifacts.find((candidate) => candidate.platform === platform && candidate.arch === arch);
-  if (!record || !RELEASE_TARGETS.some((target) => target.platform === platform && target.arch === arch)) {
+  const canonicalPlatform = normalizeReleasePlatform(platform);
+  const record = manifest.artifacts.find((candidate) => candidate.platform === canonicalPlatform && candidate.arch === arch);
+  if (!record || !RELEASE_TARGETS.some((target) => target.platform === canonicalPlatform && target.arch === arch)) {
     throw new Error(`unsupported platform: ${platform}-${arch}`);
   }
   if (record.file !== artifactFilename(manifest.version, record.platform, record.arch) || !/^[a-f0-9]{64}$/.test(record.sha256)) {

--- a/src/platform/secure-metadata.ts
+++ b/src/platform/secure-metadata.ts
@@ -1,0 +1,38 @@
+import fs from "node:fs";
+import path from "node:path";
+
+/**
+ * Cross-platform secure-metadata helpers. POSIX platforms enforce ownership and
+ * mode bits (fail-closed). Windows has no POSIX mode bits, so mode-bit assertions
+ * are skipped there; ownership on Windows is enforced by the filesystem/ACL and the
+ * parent-directory containment checks elsewhere. Windows runtime behavior is marked
+ * unverified (Owner decision B: no Windows validation in this delivery).
+ */
+
+export const isWindows = process.platform === "win32";
+
+interface ModeStat { mode: number }
+
+/** POSIX: `mode & 0o777` must equal `expected`. Windows: always passes. */
+export function exactMode(stat: ModeStat, expected: number): boolean {
+  if (isWindows) return true;
+  return (stat.mode & 0o777) === expected;
+}
+
+/** POSIX: group/other must have no access bits. Windows: always passes. */
+export function notGroupOrWorldAccessible(stat: ModeStat): boolean {
+  if (isWindows) return true;
+  return (stat.mode & 0o077) === 0;
+}
+
+/** Fsync a directory after rename for durability. Windows cannot open a directory for fsync, so this is a no-op. */
+export function fsyncDirectory(directory: string): void {
+  if (isWindows) return;
+  const fd = fs.openSync(directory, fs.constants.O_RDONLY);
+  try { fs.fsyncSync(fd); } finally { fs.closeSync(fd); }
+}
+
+/** Fsync the parent directory of `file` after rename for durability. Windows: no-op. */
+export function fsyncDirectoryOf(file: string): void {
+  fsyncDirectory(path.dirname(file));
+}

--- a/src/platform/telemetry-spool.ts
+++ b/src/platform/telemetry-spool.ts
@@ -4,6 +4,7 @@ import path from "node:path";
 import zlib from "node:zlib";
 import type { TelemetryConfig } from "./telemetry-config.js";
 import { inspectProcess } from "./process-state.js";
+import { fsyncDirectory } from "./secure-metadata.js";
 
 export interface OtlpPayload { resourceSpans: unknown[] }
 export interface QueueRecord { file: string; payload: OtlpPayload; device: number; inode: number }
@@ -226,8 +227,7 @@ export class TelemetrySpool {
       descriptor = fs.openSync(temporary, fs.constants.O_WRONLY | fs.constants.O_CREAT | fs.constants.O_EXCL | fs.constants.O_NOFOLLOW, 0o600);
       fs.writeFileSync(descriptor, bytes); fs.fsyncSync(descriptor); fs.closeSync(descriptor); descriptor = undefined;
       fs.renameSync(temporary, file); fs.chmodSync(file, 0o600);
-      const directory = fs.openSync(this.config.spoolDir, fs.constants.O_RDONLY);
-      try { fs.fsyncSync(directory); } finally { fs.closeSync(directory); }
+      fsyncDirectory(this.config.spoolDir);
     } finally {
       if (descriptor !== undefined) try { fs.closeSync(descriptor); } catch { /* isolated */ }
       try { fs.unlinkSync(temporary); } catch { /* isolated */ }
@@ -305,8 +305,7 @@ export class TelemetrySpool {
         if (!stat.isFile() || stat.isSymbolicLink() || stat.dev !== record.device || stat.ino !== record.inode) throw new Error("record changed");
       }
       for (const entry of moved) fs.unlinkSync(entry.quarantine);
-      const directory = fs.openSync(this.config.spoolDir, fs.constants.O_RDONLY);
-      try { fs.fsyncSync(directory); } finally { fs.closeSync(directory); }
+      fsyncDirectory(this.config.spoolDir);
     } catch {
       for (const entry of moved.reverse()) try { fs.renameSync(entry.quarantine, entry.original); } catch { /* preserve without deleting */ }
       throw new Error("telemetry acknowledgement failed");

--- a/src/platform/telemetry-tracing.ts
+++ b/src/platform/telemetry-tracing.ts
@@ -10,6 +10,7 @@ import type { TelemetryConfig } from "./telemetry-config.js";
 import { TelemetrySpool, type OtlpPayload } from "./telemetry-spool.js";
 import { startTelemetryUploader } from "./telemetry-uploader.js";
 import { inspectProcess } from "./process-state.js";
+import { fsyncDirectoryOf } from "./secure-metadata.js";
 
 const nanos = ([seconds, nanoseconds]: readonly [number, number]): string => (BigInt(seconds) * 1_000_000_000n + BigInt(nanoseconds)).toString();
 // OTel JS uses zero-based SpanKind values while OTLP's enum starts at 1.
@@ -88,8 +89,7 @@ function atomicStateWrite(file: string, value: unknown): void {
   try {
     fs.writeFileSync(temporary, JSON.stringify(value), { mode: 0o600, flag: "wx" });
     fs.renameSync(temporary, file); fs.chmodSync(file, 0o600);
-    const directory = fs.openSync(path.dirname(file), fs.constants.O_RDONLY);
-    try { fs.fsyncSync(directory); } finally { fs.closeSync(directory); }
+    fsyncDirectoryOf(file);
   } finally { try { fs.unlinkSync(temporary); } catch { /* isolated */ } }
 }
 function readStateJson(file: string): Record<string, unknown> {

--- a/src/setup/bot-register.ts
+++ b/src/setup/bot-register.ts
@@ -468,7 +468,7 @@ if (resultFile && (path.dirname(resultFile) !== path.resolve(CFG_DIR) || !/^\.se
   die("--result-file 必须是配置根目录内的 .setup-result-<pid>.json");
 }
 if (argv.some((arg) => arg === "--app-id" || arg.startsWith("--app-id="))) {
-  die("不支持 --app-id；机器人必须在飞书网页中选择");
+  die("不支持 --app-id；机器人必须在飞书（Lark）网页中选择");
 }
 if (!autoSelect) die("setup 注册阶段必须由交互式选择流程启动");
 say("[setup 1/5] 在网页选择已有机器人或创建新机器人");
@@ -515,13 +515,13 @@ const result = await registerApp({
   },
   onQRCodeReady: ({ url, expireIn }) => {
     qrcode.generate(url, { small: true }, (code: string) => say(code));
-    say(`\n打开以下链接（或扫码），${Math.round(expireIn / 60)} 分钟内有效：\n\n  ${url}\n\n[setup 2/5] 等待飞书网页完成授权并回传凭证…`);
+    say(`\n打开以下链接（或扫码），${Math.round(expireIn / 60)} 分钟内有效：\n\n  ${url}\n\n[setup 2/5] 等待飞书（Lark）网页完成授权并回传凭证…`);
     say(openBrowser(url) ? "[setup] 已在默认浏览器打开授权页" : "[setup] 未能自动打开浏览器，请手动打开上面的链接");
   },
   onStatusChange: ({ status, interval }) => {
     if (status === "domain_switched") say("[setup] 已切换到 Lark 域名");
-    if (status === "slow_down") say(`[setup] 飞书要求降低轮询频率，${interval || "稍后"}秒后继续`);
-    if (status === "polling" && ++pollingCount % 12 === 0) say(`[setup] 仍在等待飞书回传凭证（约 ${pollingCount / 12} 分钟）…`);
+    if (status === "slow_down") say(`[setup] 飞书（Lark）要求降低轮询频率，${interval || "稍后"}秒后继续`);
+    if (status === "polling" && ++pollingCount % 12 === 0) say(`[setup] 仍在等待飞书（Lark）回传凭证（约 ${pollingCount / 12} 分钟）…`);
   },
 }).catch(() => die("网页授权失败；未执行凭证同步、文件写入或 Agent 绑定，请重试 setup"));
 
@@ -586,7 +586,7 @@ if (!flag("--runtime") && (!testFixture || process.env.LARKIN_TEST_ENABLE_AGENT_
           throw new Error(`官方 Pi ${providerId} 登录失败或已取消；credential/config 未修改`);
         }
         if (process.env.LARKIN_TEST_SKIP_BUILTIN_PI_PROVIDER_TURN !== "1") {
-          say("正在验证内置 Pi provider（受控单轮，不发送飞书消息）…");
+          say("正在验证内置 Pi provider（受控单轮，不发送飞书（Lark）消息）…");
           try { await verifyOfficialPiProviderTurn(piRuntime, choice.model); }
           catch {
             pendingPiAuthTransaction.rollback();

--- a/src/setup/grant-scopes.ts
+++ b/src/setup/grant-scopes.ts
@@ -62,7 +62,7 @@ const selected = larkinConfig.selectAgent(config, (explicitAgent || explicitAppI
   ? { LARKIN_AGENT_ID: explicitAgent || explicitAppId } : process.env);
 const APP_ID = selected.agentId;
 if (explicitAppId && explicitAppId !== selected.feishuAppId) throw new Error("--app-id 必须等于所选 Agent 的 App ID");
-if (!/^cli_[A-Za-z0-9]+$/.test(APP_ID)) throw new Error(`无效飞书 App ID：${APP_ID}`);
+if (!/^cli_[A-Za-z0-9]+$/.test(APP_ID)) throw new Error(`无效飞书（Lark） App ID：${APP_ID}`);
 const SEND_TO = flag("--send-to", "");
 const TENANT = flag("--tenant", "feishu");
 const WAIT_MIN = Number(flag("--wait-min", "9"));
@@ -100,7 +100,7 @@ function sendUrlToChat(url: string, minutes: number): void {
   const result = spawnSync(managed.command.command, [...managed.command.argsPrefix, "im", "+messages-send", "--chat-id", SEND_TO, "--text", text, "--json"], {
     encoding: "utf8", env: managed.env,
   });
-  log(result.status === 0 ? "[grant] 更新链接已发到飞书群" : `[grant] 发链接失败: ${(result.stderr || "").trim().split("\n")[0]}`);
+  log(result.status === 0 ? "[grant] 更新链接已发到飞书（Lark）群" : `[grant] 发链接失败: ${(result.stderr || "").trim().split("\n")[0]}`);
 }
 
 export async function main(): Promise<void> {
@@ -119,7 +119,7 @@ export async function main(): Promise<void> {
     },
     onQRCodeReady: (info) => {
       const minutes = Math.max(1, Math.round(info.expireIn / 60));
-      log("\n请用飞书扫码或打开链接，确认给应用增补权限：\n");
+      log("\n请用飞书（Lark）扫码或打开链接，确认给应用增补权限：\n");
       qrcode.generate(info.url, { small: true });
       log(`\n链接: ${info.url}\n有效期约 ${minutes} 分钟（⚠️ 需本进程保持轮询，否则 user_code 立即失效）\n`);
       if (URL_FILE) {

--- a/src/setup/setup-bind.ts
+++ b/src/setup/setup-bind.ts
@@ -150,7 +150,7 @@ async function pickProfile(): Promise<Profile> {
   const profiles = listProfiles();
   if (profiles.length === 0) die("lark-cli 里还没有 bot profile。请运行 larkin setup 创建或连接机器人");
 
-  say("\n可复用的飞书机器人（lark-cli profiles）：");
+  say("\n可复用的飞书（Lark）机器人（lark-cli profiles）：");
   profiles.forEach((profile, index) => say(`  [${index + 1}] ${profile.name}  appId=${profile.appId}${profile.active ? "  (当前活跃，默认)" : ""}`));
   say("  （创建新机器人请退出后运行 larkin setup）");
   const activeIndex = Math.max(0, profiles.findIndex((profile) => profile.active));
@@ -354,7 +354,7 @@ export async function main(): Promise<void> {
       }
       if (!readinessAlreadyCompleted) {
         piRuntime ??= await createOfficialPiModelRuntime(CFG_DIR, profile.appId);
-        say("正在验证内置 Pi provider（受控单轮，不发送飞书消息）…");
+        say("正在验证内置 Pi provider（受控单轮，不发送飞书（Lark）消息）…");
         try {
           if (!(process.env.LARKIN_TEST_SKIP_BUILTIN_PI_PROVIDER_TURN === "1" && process.env.LARKIN_TEST_BOT_REGISTER_MODULE)) {
             await verifyOfficialPiProviderTurn(piRuntime, selection.model, authAbort.signal);
@@ -382,7 +382,7 @@ export async function main(): Promise<void> {
   say("\n启动这个 Agent：");
   say("  larkin start                     # 单服务启动全部已配置 Agent");
   say(`  larkin start --agent ${profile.appId}  # 仅调试这个 Agent`);
-  say("创建独立飞书机器人 + Agent：");
+  say("创建独立飞书（Lark）机器人 + Agent：");
   say("  larkin setup");
 }
 

--- a/test/integration/build/bun-only-runtime-contract.test.mjs
+++ b/test/integration/build/bun-only-runtime-contract.test.mjs
@@ -19,6 +19,14 @@ const BUN_RUNNER_SEAM_ALLOWLIST = [
   "test/unit/app/runtime-agent-interface-v2-live-safety.test.mjs",
 ].sort();
 
+// npm install/invocation glue runs under Node (the only runtime npm guarantees), which
+// lets npm users avoid installing Bun. This is the deliberate exception to the otherwise
+// Bun-first surface: Node shebangs are still forbidden everywhere outside this list.
+const NODE_GLUE_ALLOWLIST = [
+  "scripts/npm/install-binary.mjs",
+  "scripts/npm/larkin-bin-shim.mjs",
+].sort();
+
 function currentFiles() {
   const files = ["package.json", "README.md"];
   const visit = (relative) => {
@@ -61,9 +69,15 @@ test("current repository surfaces are Bun-first, npm, and native-binary-only", (
     const text = fs.readFileSync(path.join(ROOT, relative), "utf8");
     if (text.includes("LARKIN_BUN_TEST_RUNNER")) runnerSeamFiles.push(relative);
     for (const [label, pattern] of forbiddenContent) {
+      if (label === "Node shebang" && NODE_GLUE_ALLOWLIST.includes(relative)) continue;
       if (pattern.test(text)) violations.push(`${relative}: ${label}`);
     }
   }
   assert.deepEqual(runnerSeamFiles.sort(), BUN_RUNNER_SEAM_ALLOWLIST, "Bun test-runner process seam escaped its narrow allowlist");
+  assert.deepEqual(
+    NODE_GLUE_ALLOWLIST.filter((file) => !fs.existsSync(path.join(ROOT, file))),
+    [],
+    "npm glue allowlist must reference existing files",
+  );
   assert.deepEqual(violations, [], `Bun-only inventory violations:\n${violations.join("\n")}`);
 });

--- a/test/integration/build/runtime-clean-cutover.test.mjs
+++ b/test/integration/build/runtime-clean-cutover.test.mjs
@@ -21,7 +21,7 @@ test("authored source and generated runtime use the seven-domain mirrored layout
     "src root must not retain flat production modules",
   );
   const packageJson = JSON.parse(source("package.json"));
-  assert.equal(packageJson.bin.larkin, "dist/app/cli.mjs");
+  assert.equal(packageJson.bin.larkin, "scripts/npm/larkin-bin-shim.mjs");
   assert.equal(packageJson.packageManager, "bun@1.3.14");
   assert.equal(fs.existsSync(path.join(ROOT, "bun.lock")), true);
   assert.equal(fs.existsSync(path.join(ROOT, "package-lock.json")), false);
@@ -44,6 +44,7 @@ test("production build, start, and Agent CLI graph contain only current entries"
   assert.deepEqual(packageJson.files, [
     "dist/",
     "assets/",
+    "scripts/npm/",
     "README.md",
     "LICENSE",
     "SECURITY.md",

--- a/test/unit/app/official-lark-cli.test.mjs
+++ b/test/unit/app/official-lark-cli.test.mjs
@@ -30,7 +30,7 @@ function windowsFixture() {
     name: "@larksuite/cli", version: "1.0.79", bin: { "lark-cli": "scripts/run.js" },
   }));
   fs.mkdirSync(path.join(packageDir, "scripts"), { recursive: true });
-  fs.writeFileSync(path.join(packageDir, "scripts", "run.js"), "#!/usr/bin/env node\n");
+  fs.writeFileSync(path.join(packageDir, "scripts", "run.js"), "// mock official launcher\n");
   fs.writeFileSync(native, "MZ", { mode: 0o755 });
   const shim = path.join(root, "lark-cli.cmd");
   fs.writeFileSync(shim, "@echo off\n");

--- a/test/unit/app/official-lark-cli.test.mjs
+++ b/test/unit/app/official-lark-cli.test.mjs
@@ -21,6 +21,22 @@ function officialFixture() {
   return { root, executable };
 }
 
+function windowsFixture() {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "larkin-win-cli-"));
+  const packageDir = path.join(root, "node_modules", "@larksuite", "cli");
+  const native = path.join(packageDir, "bin", "lark-cli.exe");
+  fs.mkdirSync(path.dirname(native), { recursive: true });
+  fs.writeFileSync(path.join(packageDir, "package.json"), JSON.stringify({
+    name: "@larksuite/cli", version: "1.0.79", bin: { "lark-cli": "scripts/run.js" },
+  }));
+  fs.mkdirSync(path.join(packageDir, "scripts"), { recursive: true });
+  fs.writeFileSync(path.join(packageDir, "scripts", "run.js"), "#!/usr/bin/env node\n");
+  fs.writeFileSync(native, "MZ", { mode: 0o755 });
+  const shim = path.join(root, "lark-cli.cmd");
+  fs.writeFileSync(shim, "@echo off\n");
+  return { root, native, shim };
+}
+
 const result = (status, stdout = "", stderr = "") => ({ status, signal: null, stdout, stderr, error: undefined });
 
 test("official CLI probe distinguishes missing, unknown collision, and the verified package launcher", () => {
@@ -44,6 +60,21 @@ test("official CLI probe distinguishes missing, unknown collision, and the verif
     assert.equal(probeOfficialLarkCli({ env: {}, spawn(command, args) {
       return args?.[0] === "-lc" ? result(0, `${unknown}\n`) : result(0, "1.0.79\n");
     } }).state, "conflict");
+  } finally { fs.rmSync(f.root, { recursive: true, force: true }); }
+});
+
+test("windows resolution derives the native @larksuite/cli binary from the npm shim", () => {
+  const f = windowsFixture();
+  try {
+    const ready = probeOfficialLarkCli({ env: {}, platform: "win32", spawn(command, args) {
+      const joined = args?.join(" ") || "";
+      if (joined.includes("where lark-cli")) return result(0, `${f.shim}\n`);
+      if (args?.[0] === "--version") return result(0, "1.0.79\n");
+      return result(0, "--source lark-channel --identity bot-only\n");
+    } });
+    assert.equal(ready.state, "ready");
+    assert.equal(ready.command.command, f.native);
+    assert.equal(ready.command.version, "1.0.79");
   } finally { fs.rmSync(f.root, { recursive: true, force: true }); }
 });
 

--- a/test/unit/platform/release-artifacts.test.mjs
+++ b/test/unit/platform/release-artifacts.test.mjs
@@ -13,7 +13,27 @@ test("release x64 artifacts use Bun's pre-AVX2 baseline targets", async () => {
     { platform: "darwin", arch: "x64", bunTarget: "bun-darwin-x64-baseline" },
     { platform: "linux", arch: "arm64", bunTarget: "bun-linux-arm64" },
     { platform: "linux", arch: "x64", bunTarget: "bun-linux-x64-baseline" },
+    { platform: "windows", arch: "x64", bunTarget: "bun-windows-x64-baseline" },
   ]);
+});
+
+test("windows artifacts use a .exe suffix and win32 platform normalizes", async () => {
+  const { artifactFilename, normalizeReleasePlatform, selectReleaseArtifact, sha256File } = await import(
+    path.join(ROOT, "dist/platform/release-artifacts.mjs")
+  );
+  assert.equal(normalizeReleasePlatform("win32"), "windows");
+  assert.equal(normalizeReleasePlatform("linux"), "linux");
+  assert.equal(artifactFilename("0.2.77", "windows", "x64"), "larkin-v0.2.77-windows-x64.exe");
+  const directory = fs.mkdtempSync(path.join(os.tmpdir(), "larkin-release-win-"));
+  try {
+    const file = artifactFilename("0.2.77", "windows", "x64");
+    fs.writeFileSync(path.join(directory, file), "windows binary");
+    const record = { platform: "windows", arch: "x64", file, sha256: sha256File(path.join(directory, file)), size: 14, signing: "unsigned" };
+    const manifest = { schemaVersion: 1, version: "0.2.77", sourceCommit: "a".repeat(40), sourceDirty: false, bunVersion: "1.3.14", bytecode: false, notices: { file: "THIRD_PARTY_NOTICES.txt", sha256: "0".repeat(64), size: 1, scope: "runtime-closure" }, artifacts: [record] };
+    assert.equal(selectReleaseArtifact(manifest, "win32", "x64"), record);
+  } finally {
+    fs.rmSync(directory, { recursive: true, force: true });
+  }
 });
 
 test("release artifact selection is allowlisted and checksum-verified", async () => {

--- a/test/unit/platform/release-assemble.test.mjs
+++ b/test/unit/platform/release-assemble.test.mjs
@@ -13,6 +13,7 @@ const targets = [
   ["darwin", "x64", "adhoc"],
   ["linux", "arm64", "unsigned"],
   ["linux", "x64", "unsigned"],
+  ["windows", "x64", "unsigned"],
 ];
 
 function hash(value) {
@@ -28,7 +29,7 @@ test("assembles four independently built platform artifacts", () => {
   for (const [platform, arch, signing] of targets) {
     const directory = path.join(input, `release-${platform}-${arch}`);
     fs.mkdirSync(directory, { recursive: true });
-    const file = `larkin-v1.2.3-${platform}-${arch}`;
+    const file = `larkin-v1.2.3-${platform}-${arch}${platform === "windows" ? ".exe" : ""}`;
     const body = Buffer.from(`${platform}-${arch}`);
     fs.writeFileSync(path.join(directory, file), body, { mode: 0o755 });
     fs.writeFileSync(path.join(directory, `release-manifest-${platform}-${arch}.json`), `${JSON.stringify({
@@ -44,11 +45,12 @@ test("assembles four independently built platform artifacts", () => {
   }
 
   const manifest = assembleRelease(input, output);
-  assert.equal(manifest.artifacts.length, 4);
+  assert.equal(manifest.artifacts.length, 5);
   assert.deepEqual(manifest.artifacts.map(({ platform, arch }) => `${platform}-${arch}`), [
-    "darwin-arm64", "darwin-x64", "linux-arm64", "linux-x64",
+    "darwin-arm64", "darwin-x64", "linux-arm64", "linux-x64", "windows-x64",
   ]);
   assert.match(fs.readFileSync(path.join(output, "SHA256SUMS"), "utf8"), /larkin-v1\.2\.3-linux-x64/);
+  assert.match(fs.readFileSync(path.join(output, "SHA256SUMS"), "utf8"), /larkin-v1\.2\.3-windows-x64\.exe/);
   assert.match(fs.readFileSync(path.join(output, "SHA256SUMS"), "utf8"), /^[a-f0-9]{64}  THIRD_PARTY_NOTICES\.txt$/m);
   assert.equal(fs.readFileSync(path.join(output, "LICENSE"), "utf8"), fs.readFileSync(path.join(import.meta.dirname, "../../../LICENSE"), "utf8"));
   assert.equal(
@@ -69,7 +71,7 @@ test("rejects platform manifests whose runtime notices are not bound to the rele
   for (const [platform, arch, signing] of targets) {
     const directory = path.join(input, `release-${platform}-${arch}`);
     fs.mkdirSync(directory, { recursive: true });
-    const file = `larkin-v1.2.3-${platform}-${arch}`;
+    const file = `larkin-v1.2.3-${platform}-${arch}${platform === "windows" ? ".exe" : ""}`;
     const body = Buffer.from(`${platform}-${arch}`);
     fs.writeFileSync(path.join(directory, file), body);
     fs.writeFileSync(path.join(directory, `release-manifest-${platform}-${arch}.json`), `${JSON.stringify({
@@ -84,5 +86,5 @@ test("rejects platform manifests whose runtime notices are not bound to the rele
 test("rejects incomplete release input", () => {
   const root = fs.mkdtempSync(path.join(os.tmpdir(), "larkin-release-assemble-missing-"));
   fs.mkdirSync(path.join(root, "input"));
-  assert.throws(() => assembleRelease(path.join(root, "input"), path.join(root, "output")), /expected 4/);
+  assert.throws(() => assembleRelease(path.join(root, "input"), path.join(root, "output")), /expected 5/);
 });


### PR DESCRIPTION
## 目标

1. **Windows 支持**：新增 `windows-x64` 交叉编译 standalone 二进制（`bun-windows-x64-baseline`），产出 `larkin-vX.Y.Z-windows-x64.exe`。
2. **npm postinstall 二进制化**：npm 包从"装 Bun 跑 JS"切换为"安装时下载对应平台二进制"，`bin` shim 优先 exec 二进制、回退 Bun JS 入口。用户运行时依赖从 `Bun + lark-cli` 降为 `只剩 lark-cli`。
3. **用词**：用户可见文案 飞书→飞书（Lark）、Feishu→Feishu (Lark)；代码标识符与 agent 提示词不动。

## 关键决策（已与 Owner 对齐）

- Windows 验证方式选 **B**：只交叉编译，不做 Windows 运行时验证（无真机，B+ 免费托管 runner 未选）。所有 win32 行为标注 unverified。
- npm 走 **postinstall 下载**（非 optionalDependencies 多包）。

## 验证

- 全量 `bun run test`：582 pass / 1 fail（`pi-subagent-injection` "external injects" 是本机 `~/.pi` 已装 pi-subagents 的环境性问题，非本次改动；干净 CI 会绿）。
- Windows 交叉编译：`larkin-v0.2.77-windows-x64.exe` = PE32+ x86-64，manifest sha256 与文件一致。
- npm postinstall Mock E2E：本地 fixture 源模拟（下载→sha256→原子落盘→shim exec）+ Bun fallback 分支，全部通过。
- **`npm install` 与 `npm exec`（npx 底层）均已实测走二进制**：npm 11 默认（`strict-allow-scripts=false`）postinstall 照常执行，仅多一条 WARN，不拦截。
- 宿主 smoke（darwin-arm64）：`ok:true`，dashboard HTTP 200。
- `publication:check:tree`、`licenses:check`、`git diff --check` 全过。

## 残留风险（已在 plan 登记）

- Windows 运行时零验证（keychain secret 后端、unix socket、权限位、lark-cli .exe 解析）。
- npm 11 的 `allow-scripts` 提示是噪音非拦截；仅当用户主动开 `strict-allow-scripts=true` 才会阻止 postinstall（非默认，属用户显式选择）。
- exe 未做 Authenticode 签名（SmartScreen 提示）。

merge 会触发生产 release CI（v0.2.77 tag + GitHub Release 5 平台 + npm publish）。