### PR TITLE
fix(feishu): disable inbound message batch merge for identity consistency (#88)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "larkin",
-  "version": "0.2.77",
+  "version": "0.2.78",
   "private": false,
   "larkinPackageRole": "npm-published",
   "files": [

--- a/src/feishu/host-shell.ts
+++ b/src/feishu/host-shell.ts
@@ -753,6 +753,9 @@ export function createHostShell({
       domain: agent.feishuDomain || "https://open.feishu.cn",
       source: "larkin",
       policy: { dmMode: "open", requireMention: false, respondToMentionAll: true },
+      // issue #88：关闭 SDK 的防抖批量合并（默认 600ms），逐条投递，
+      // 保证 messageId/threadId/发送者与内容、提及永远同源（见 #66）。
+      batch: { text: { delayMs: 0 } },
       handshakeTimeoutMs: 15_000,
       keepalive: {
         enabled: true,
@@ -857,6 +860,9 @@ export function createHostShell({
         domain: agent.feishuDomain || "https://open.feishu.cn",
         source: "larkin",
         policy: { dmMode: "open", requireMention: false, respondToMentionAll: true },
+        // issue #88：关闭 SDK 的防抖批量合并（默认 600ms），逐条投递，
+        // 保证 messageId/threadId/发送者与内容、提及永远同源（见 #66）。
+        batch: { text: { delayMs: 0 } },
         handshakeTimeoutMs: 15_000,
         keepalive: { enabled: true, intervalMs: 15_000 },
         includeRawEvent: true,

--- a/test/unit/feishu/host-runtime-lifecycle.test.mjs
+++ b/test/unit/feishu/host-runtime-lifecycle.test.mjs
@@ -282,3 +282,48 @@ test("production HostShell clears eyes on inactive/error and ignores heartbeat a
     fs.rmSync(root, { recursive: true, force: true });
   }
 });
+
+test("channel options disable inbound message merging (issue #88)", async () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "larkin-no-merge-"));
+  const agentId = "cli_nomergeA1";
+  let capturedOptions = null;
+  let channelCreated = false;
+  const runtimeHost = {
+    subscribe() { return () => {}; },
+    async start() {},
+    async deliver() { throw new Error("not used"); },
+    async stop() {},
+    async shutdown() {},
+  };
+  const channelPackage = {
+    createLarkChannel(options) {
+      capturedOptions = options;
+      channelCreated = true;
+      return {
+        botIdentity: { openId: "ou_nomerge", name: "NoMerge" },
+        rawClient: null,
+        dispatcher: { register() {} },
+        on() {},
+        async connect() {},
+        async disconnect() {},
+      };
+    },
+  };
+  const agent = { agentId, name: agentId, runtime: "codex", model: "gpt", feishuAppId: agentId,
+    feishuAppSecret: "fixture-secret", feishuProfile: agentId, feishuDomain: "https://open.feishu.cn",
+    workspaceDir: path.join(root, "agents", agentId), stateDir: path.join(root, "state", "agents", agentId) };
+  const env = { LARKIN_HOME: root, LARKIN_CONFIG_DIR: root, LARKIN_SERVER_ID: "server-nomerge",
+    LARKIN_AGENTS_CONFIG: JSON.stringify([agent]), LARKIN_INBOUND_DROUGHT_SEC: "0" };
+  const host = createHostShell({ env, runtimeHost, channelPackage, eventSourceStartDelayMs: 0 });
+  try {
+    host.start();
+    const deadline = Date.now() + 2_000;
+    while (!channelCreated && Date.now() < deadline) await new Promise((resolve) => setTimeout(resolve, 5));
+    assert.equal(channelCreated, true);
+    assert.deepEqual(capturedOptions.batch, { text: { delayMs: 0 } },
+      "必须关闭 SDK 防抖批量合并，逐条投递以保持身份与内容同源（#88/#66）");
+  } finally {
+    await host.shutdown("issue88 test complete");
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
## Summary

Fixes #88 (root cause of #66): @larksuite/channel@0.4.1 buffers inbound messages per chatId and merges a debounce window (default 600ms, long text 2s, max 8 messages) into one message that keeps the LAST message identity (messageId/threadId/sender) while unioning content and mentions (mentionedBot OR). When a topic @Bot message and a following main-timeline message land in the same window, Larkin wakes on the merged event but binds the processing eye and reply target to the wrong message, losing the thread context.

Per Owner decision, the merge capability is removed instead of made identity-consistent.

## Changes

- `src/feishu/host-shell.ts`: both `createLarkChannel` call sites now pass `batch: { text: { delayMs: 0 } }` — the SDK flushes each message immediately (serialization, dedup, policy gate are kept; only batch aggregation is removed).
- `test/unit/feishu/host-runtime-lifecycle.test.mjs`: new test "channel options disable inbound message merging (issue #88)" asserts the channel is created with `batch.text.delayMs = 0`.
- Version bump `0.2.77 → 0.2.78`.

## Validation

- `bun run build` ✓
- `bun run typecheck` ✓
- `env -u LARKIN_AGENT_ID -u LARKIN_CONFIG_DIR LARKIN_BUN_TEST_RUNNER=1 bun test --max-concurrency 1 test/unit/feishu/host-runtime-lifecycle.test.mjs test/unit/feishu/host-hot-agent-attach.test.mjs test/unit/feishu/host-channel-business.test.mjs` → 19 pass / 0 fail

## Acceptance mapping (issue #88)

1. topic @Bot and following flat messages delivered separately ✓ (per-message dispatch)
2. different senders never merged ✓
3. processing eye and reply context bound to the triggering message ✓
4. config assertion test ✓
5. behavior identical on first start / reconnect / hot update (single config path) ✓
