### PR TITLE
fix(windows): ACL-based credential and socket security replaces POSIX mode checks (#90)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "larkin",
-  "version": "0.2.78",
+  "version": "0.2.79",
   "private": false,
   "larkinPackageRole": "npm-published",
   "files": [

--- a/src/app/local-control.ts
+++ b/src/app/local-control.ts
@@ -7,7 +7,7 @@ import path from "node:path";
 import { readProcessState } from "../platform/process-state.js";
 import { currentProcessMetadata } from "../platform/process-inspect.cjs";
 import { processCommandToken } from "./internal-command.js";
-import { isWindows, notGroupOrWorldAccessible } from "../platform/secure-metadata.js";
+import { isWindows, notGroupOrWorldAccessible, secureWindowsDirectoryAcl } from "../platform/secure-metadata.js";
 
 export interface AgentUpsertRequest { operationId: string; agentId: string; authorization: string }
 export type AgentUpsertOperation = Pick<AgentUpsertRequest, "operationId" | "agentId">;
@@ -25,6 +25,9 @@ type AgentControlPayload = Omit<AgentUpsertRequest, "authorization"> | Omit<Sess
 
 interface ProcessBinding { pid: number; processStartToken: string }
 interface SocketBinding { device: string; inode: string; owner: string; changeTimeNs: string }
+// Windows 上 socket 无法 lstat（EACCES），用全数字占位 binding 使 authority 校验通过；
+// 该平台的安全边界是 socket root 目录的 ACL，而非 inode 身份比对。
+const WINDOWS_SOCKET_BINDING: SocketBinding = { device: "0", inode: "0", owner: "0", changeTimeNs: "0" };
 interface ControlAuthority {
   version: 2;
   token: string;
@@ -61,6 +64,12 @@ function controlSocketRoot(larkinHome: string): string {
 }
 
 function assertSecureSocketDirectory(root: string): string {
+  if (isWindows) {
+    // Windows：socket 本身无法 lstat（EACCES），安全边界是目录 ACL。
+    // 每次启动重新收紧为「当前用户 + SYSTEM」并回读校验。
+    secureWindowsDirectoryAcl(root, { label: "control socket root" });
+    return root;
+  }
   const stat = fs.lstatSync(root);
   if (!stat.isDirectory() || stat.isSymbolicLink()
       || (typeof process.getuid === "function" && stat.uid !== process.getuid())
@@ -262,6 +271,12 @@ function assertSupervisorAuthority(larkinHome: string, expectedToken?: string): 
 }
 
 function prepareSocket(socket: string): void {
+  if (isWindows) {
+    // Windows：socket 路径无法 lstat（EACCES）；尽力清除陈旧占用，失败即忽略，
+    // 由 listen 的独占语义兜底（见 listenPrivate 的 win32 分支）。
+    try { fs.unlinkSync(socket); } catch { /* ignore */ }
+    return;
+  }
   try {
     const stat = fs.lstatSync(socket);
     if (!stat.isSocket() || stat.isSymbolicLink()
@@ -286,6 +301,14 @@ async function closePrivateServer(
   socket: string,
   identity: SocketBinding | null,
 ): Promise<void> {
+  if (isWindows) {
+    // Windows：socket 无 lstat 身份可比对，直接关服并清理目录（残留由 ENOTEMPTY 忽略）。
+    if (server.listening) {
+      await new Promise<void>((resolve, reject) => server.close((error) => error ? reject(error) : resolve()));
+    }
+    cleanupSocketRoot(path.dirname(socket));
+    return;
+  }
   let shield: string | null = null;
   let closeError: unknown;
   try {
@@ -326,6 +349,22 @@ async function closePrivateServer(
 }
 
 async function listenPrivate(server: net.Server, socket: string): Promise<SocketBinding> {
+  if (isWindows) {
+    // Windows：bun 的 unix socket 可正常 listen/connect/chmod/close，但 lstatSync(socket)
+    // 抛 EACCES（socket 不是普通文件系统节点）。因此跳过 lstat 身份比对，安全边界
+    // 由 assertSecureSocketDirectory 收紧的目录 ACL 承担。
+    try {
+      await new Promise<void>((resolve, reject) => {
+        server.once("error", reject);
+        server.listen(socket, () => { server.off("error", reject); resolve(); });
+      });
+      try { fs.chmodSync(socket, 0o600); } catch { /* Windows chmod best-effort */ }
+      return WINDOWS_SOCKET_BINDING;
+    } catch (error) {
+      await closePrivateServer(server, socket, WINDOWS_SOCKET_BINDING);
+      throw error;
+    }
+  }
   let identity: SocketBinding | null = null;
   try {
     await new Promise<void>((resolve, reject) => {

--- a/src/platform/secure-metadata.ts
+++ b/src/platform/secure-metadata.ts
@@ -1,5 +1,7 @@
 import fs from "node:fs";
+import os from "node:os";
 import path from "node:path";
+import { spawnSync, type SpawnSyncReturns } from "node:child_process";
 
 /**
  * Cross-platform secure-metadata helpers. POSIX platforms enforce ownership and
@@ -35,4 +37,70 @@ export function fsyncDirectory(directory: string): void {
 /** Fsync the parent directory of `file` after rename for durability. Windows: no-op. */
 export function fsyncDirectoryOf(file: string): void {
   fsyncDirectory(path.dirname(file));
+}
+
+export interface SecureWindowsDirectoryAclOptions {
+  spawn?: typeof spawnSync;
+  label?: string;
+  username?: string;
+}
+
+const SYSTEM_SID = "*S-1-5-18";
+const ACE_LINE = /^\s*(.+?)\s*:(\((?:[A-Za-z]+)\))+\s*$/;
+
+function allowedAclPrincipal(principal: string, username: string): boolean {
+  const candidate = principal.trim().toLocaleLowerCase("en-US");
+  const user = username.toLocaleLowerCase("en-US");
+  if (!candidate) return false;
+  if (candidate === user) return true;
+  const suffix = candidate.split("\\").at(-1) ?? candidate;
+  if (suffix === user) return true;
+  if (candidate === "*s-1-5-18" || candidate === "system" || candidate === "nt authority\\system") return true;
+  return false;
+}
+
+/**
+ * 执行 Windows ACL 收紧序列（无平台守卫，供测试直接驱动与 win32 分支调用）：
+ * 1) /inheritance:r 去除继承；2) 只授予当前用户 + SYSTEM 完全控制；
+ * 3) 显式移除 Users/Authenticated Users/Everyone；4) 回读 ACL 校验，
+ * 任何残留第三方 ACE 一律 fail-closed。icacls 为 Windows 内置工具。
+ */
+export function runWindowsDirectoryAcl(directory: string, options: SecureWindowsDirectoryAclOptions = {}): void {
+  const label = options.label ?? directory;
+  const username = String(options.username ?? os.userInfo().username ?? "").trim();
+  if (!username) throw new Error(`Windows ACL 收紧失败（${label}）：无法取得当前用户名`);
+  const run = (args: readonly string[]): string => {
+    const result = (options.spawn ?? spawnSync)("icacls", [directory, ...args], {
+      encoding: "utf8", windowsHide: true, maxBuffer: 1024 * 1024,
+    }) as SpawnSyncReturns<string>;
+    if (result.error || result.status !== 0) {
+      throw new Error(`Windows ACL 收紧失败（${label}）：icacls ${args[0] ?? "查询"} 退出 ${result.status ?? "无"}${result.error ? `（${result.error.message}）` : ""}`);
+    }
+    return String(result.stdout || "");
+  };
+  run(["/inheritance:r"]);
+  run(["/grant:r", `${username}:(OI)(CI)F`, "/grant:r", `${SYSTEM_SID}:(OI)(CI)F`]);
+  run(["/remove:g", "Users", "/remove:g", "Authenticated Users", "/remove:g", "Everyone"]);
+  const listing = run([]);
+  // icacls 首行是「<路径> <首条 ACE>」同行，其余 ACE 缩进另起一行；先剥掉已知目录前缀再解析。
+  const pathPrefix = directory.toLocaleLowerCase("en-US");
+  const offenders = listing.split(/\r?\n/).map((line) => {
+    let body = line.trimStart();
+    if (body.toLocaleLowerCase("en-US").startsWith(`${pathPrefix} `)) body = body.slice(directory.length + 1).trimStart();
+    return body;
+  }).filter((line) => ACE_LINE.test(line))
+    .map((line) => (line.match(ACE_LINE) ?? ["", ""])[1])
+    .filter((principal) => !allowedAclPrincipal(principal, username));
+  if (offenders.length > 0) {
+    throw new Error(`Windows ACL 校验失败（${label}）：存在未授权访问者 ${offenders.join(", ")}`);
+  }
+}
+
+/**
+ * Windows 没有 POSIX 权限位（mode 恒为 0o666、getuid 为 undefined）：
+ * 用 runWindowsDirectoryAcl 收紧目录 ACL 并回读校验。非 win32 平台 no-op。
+ */
+export function secureWindowsDirectoryAcl(directory: string, options: SecureWindowsDirectoryAclOptions = {}): void {
+  if (!isWindows) return;
+  runWindowsDirectoryAcl(directory, options);
 }

--- a/src/setup/bot-register.ts
+++ b/src/setup/bot-register.ts
@@ -6,6 +6,7 @@ import fs from "node:fs";
 import path from "node:path";
 import { fileURLToPath, pathToFileURL } from "node:url";
 import { registerApp as channelRegisterApp } from "@larksuite/channel";
+import { isWindows, secureWindowsDirectoryAcl } from "../platform/secure-metadata.js";
 import { internalCommandSpec } from "../app/internal-command.js";
 import * as larkinConfig from "../platform/config.js";
 import { createAgentStateStore } from "../agent/agent-state-store.js";
@@ -278,6 +279,13 @@ function ensureSecureBotsDir(): string {
   const directory = path.join(CFG_DIR, "bots");
   try { fs.mkdirSync(directory, { mode: 0o700 }); }
   catch (error) { if ((error as NodeJS.ErrnoException)?.code !== "EEXIST") throw error; }
+  if (isWindows) {
+    // Windows 无 POSIX 权限位（mode 恒 0o666）：改用 icacls 收紧 CFG_DIR 与 bots 目录
+    // 的 ACL 为「当前用户 + SYSTEM」并回读校验，fail-closed。
+    secureWindowsDirectoryAcl(CFG_DIR, { label: "Larkin 配置目录" });
+    secureWindowsDirectoryAcl(directory, { label: "bots 凭证目录" });
+    return directory;
+  }
   const stat = fs.lstatSync(directory);
   if (!stat.isDirectory() || stat.isSymbolicLink()
       || (typeof process.getuid === "function" && stat.uid !== process.getuid())

--- a/test/unit/platform/secure-metadata.test.mjs
+++ b/test/unit/platform/secure-metadata.test.mjs
@@ -1,0 +1,89 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import { test } from "bun:test";
+import { pathToFileURL } from "node:url";
+import path from "node:path";
+
+const ROOT = path.resolve(path.dirname(new URL(import.meta.url).pathname), "..", "..", "..");
+const secure = await import(pathToFileURL(path.join(ROOT, "dist/platform/secure-metadata.mjs")).href);
+
+// secureWindowsDirectoryAcl 在非 win32 平台是 no-op；这里直接驱动导出的
+// runWindowsDirectoryAcl（无平台守卫），用真实 icacls 输出形状验证收紧序列与回读校验。
+// 所有用例注入 username=administrator 使校验确定化。
+// 真实 icacls 输出格式：首行「<路径> <首条 ACE>」同行，其余 ACE 缩进另起一行。
+const icaclsListing = (entries) => `${entries.map((e, i) => i === 0 ? `C:\\cfg ${e}` : `        ${e}`).join("\n")}\n\nSuccessfully processed 1 files.\n`;
+
+const fixedUser = "administrator";
+
+function sequenceSpawn() {
+  const calls = [];
+  const spawn = (command, args) => {
+    calls.push({ command, args });
+    const head = args[1];
+    if (head === "/inheritance:r") return { status: 0, stdout: "", stderr: "", error: undefined };
+    if (head === "/grant:r") return { status: 0, stdout: "", stderr: "", error: undefined };
+    if (head === "/remove:g") return { status: 0, stdout: "", stderr: "", error: undefined };
+    return { status: 0, stdout: icaclsListing([
+      `${fixedUser}:(F)`,
+      `${fixedUser}:(OI)(CI)(F)`,
+      "NT AUTHORITY\\SYSTEM:(OI)(CI)(F)",
+    ]), stderr: "", error: undefined };
+  };
+  return { calls, spawn };
+}
+
+test("Windows ACL helper runs the tighten sequence and accepts user+SYSTEM only", () => {
+  const { calls, spawn } = sequenceSpawn();
+  secure.runWindowsDirectoryAcl("C:\\cfg", { spawn, label: "测试目录", username: fixedUser });
+  assert.deepEqual(calls.map((c) => c.args[1]), [
+    "/inheritance:r",
+    "/grant:r",
+    "/remove:g",
+    undefined,
+  ]);
+  assert.equal(calls[1].args[2], "administrator:(OI)(CI)F");
+  assert.equal(calls[1].args[4], "*S-1-5-18:(OI)(CI)F");
+  assert.equal(calls[0].args[0], "C:\\cfg");
+});
+
+test("Windows ACL helper fails closed on any foreign ACE", () => {
+  const spawn = (command, args) => {
+    const head = args[1];
+    if (head === undefined) {
+      return { status: 0, stdout: icaclsListing([
+        `${fixedUser}:(F)`,
+        `${fixedUser}:(OI)(CI)(F)`,
+        "NT AUTHORITY\\SYSTEM:(OI)(CI)(F)",
+        "BUILTIN\\Users:(RX)",
+      ]), stderr: "", error: undefined };
+    }
+    return { status: 0, stdout: "", stderr: "", error: undefined };
+  };
+  assert.throws(() => secure.runWindowsDirectoryAcl("C:\\cfg", { spawn, label: "测试目录", username: fixedUser }), /BUILTIN\\Users/);
+});
+
+test("Windows ACL helper fails closed when icacls exits non-zero", () => {
+  const spawn = () => ({ status: 1, stdout: "", stderr: "boom", error: undefined });
+  assert.throws(() => secure.runWindowsDirectoryAcl("C:\\cfg", { spawn, label: "测试目录", username: fixedUser }), /icacls \/inheritance:r 退出 1/);
+});
+
+test("Windows ACL helper tolerates machine-qualified current user", () => {
+  const spawn = (command, args) => {
+    const head = args[1];
+    if (head === undefined) {
+      return { status: 0, stdout: icaclsListing([
+        "EDDIE-HOME\\administrator:(F)",
+        "EDDIE-HOME\\administrator:(OI)(CI)(F)",
+        "*S-1-5-18:(OI)(CI)(F)",
+      ]), stderr: "", error: undefined };
+    }
+    return { status: 0, stdout: "", stderr: "", error: undefined };
+  };
+  secure.runWindowsDirectoryAcl("C:\\cfg", { spawn, label: "测试目录", username: fixedUser });
+});
+
+test("local-control compiles the win32 socket branches (ACL root + placeholder binding)", () => {
+  const built = fs.readFileSync(path.join(ROOT, "dist/app/local-control.mjs"), "utf8");
+  assert.match(built, /WINDOWS_SOCKET_BINDING/);
+  assert.match(built, /secureWindowsDirectoryAcl/);
+});


### PR DESCRIPTION
## Summary

Fixes #90 — the Windows POSIX-permission blockers confirmed by end-to-end testing on a real Windows 11 machine (eddie-home, Tailscale/SSH).

Windows has no POSIX permission bits: `getuid` is undefined, directory `mode & 0o777` is always `0o666`, and `lstatSync` on a bun unix socket throws EACCES. The existing POSIX checks therefore fail on Windows:

1. `ensureSecureBotsDir` (setup/bot-register) hard-requires mode `0o700` → setup dies on Windows (v0.2.77 known defect, reproduced on the real machine).
2. local-control socket identity checks call `lstatSync(socket)` → EACCES → supervisor/daemon control channel cannot start on Windows (bun itself supports listen/connect/chmod/close — verified on the real machine).

## Changes

- `src/platform/secure-metadata.ts`: new `secureWindowsDirectoryAcl` (win32-guarded) + `runWindowsDirectoryAcl` (unguarded runner for tests). Uses the built-in `icacls`: remove inheritance, grant only current user + SYSTEM, explicitly remove Users/Authenticated Users/Everyone, then read back and fail closed on any residual foreign ACE. Parser handles the real icacls output shape (path + first ACE on one line), verified against actual Chinese-locale Windows output.
- `src/setup/bot-register.ts`: `ensureSecureBotsDir` on win32 tightens ACLs of CFG_DIR and the bots directory instead of the POSIX 0700 check (POSIX path unchanged).
- `src/app/local-control.ts`: win32 branches for `assertSecureSocketDirectory` (ACL-tightened socket root is the security boundary), `prepareSocket` (no lstat; best-effort unlink), `listenPrivate` (skip lstat identity; chmod best-effort; all-numeric placeholder binding), `closePrivateServer` (no shield/lstat dance).
- Tests: `test/unit/platform/secure-metadata.test.mjs` — tighten sequence + fail-closed verification (injected icacls, real output shapes incl. machine-qualified principal and path-prefixed first line), plus a compile assertion that local-control carries the win32 branches.
- Version bump `0.2.78 → 0.2.79`.

## Validation

- `bun run build` ✓, `bun run typecheck` ✓
- `bun test --max-concurrency 1 test/unit/platform/secure-metadata.test.mjs test/unit/setup/bot-register-typescript.test.mjs` → 15 pass / 0 fail
- `env -u LARKIN_AGENT_ID -u LARKIN_CONFIG_DIR LARKIN_BUN_TEST_RUNNER=1 bun test --max-concurrency 1 test/unit/app/local-control.test.mjs` → 7 pass / 1 fail; the 1 failure ("local control keeps upsert ID idempotency…" child JSON EOF) is pre-existing on this branch (reproduced with this change stashed) and environmental.
- Real Windows 11 machine: icacls tighten sequence produces exactly `NT AUTHORITY\SYSTEM` + `EDDIE-HOME\Administrator` ACEs; bun probe confirms listen/client-connect/chmod/close all OK, only `lstatSync(socket)` fails EACCES (which the win32 branches now avoid).

## Notes

- Full Windows E2E of `larkin setup` with real Feishu credentials still requires the Owner to run setup on the machine (out of scope for remote automated testing).
