### PR TITLE
fix(windows): Pi credential dirs use ACL instead of POSIX mode checks (#90 follow-up)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "larkin",
-  "version": "0.2.79",
+  "version": "0.2.80",
   "private": false,
   "larkinPackageRole": "npm-published",
   "files": [

--- a/src/runtime/pi-official-auth.ts
+++ b/src/runtime/pi-official-auth.ts
@@ -2,6 +2,7 @@ import fs from "node:fs";
 import path from "node:path";
 import crypto from "node:crypto";
 import { pathToFileURL } from "node:url";
+import { isWindows, secureWindowsDirectoryAcl } from "../platform/secure-metadata.js";
 // proper-lockfile does not publish TypeScript declarations.
 // @ts-expect-error bundled CommonJS dependency
 import properLockfile from "proper-lockfile";
@@ -69,6 +70,11 @@ function ensureLockDirectory(lockPath: string): void {
   const directory = path.dirname(lockPath);
   fs.mkdirSync(directory, { recursive: true, mode: 0o700 });
   fs.chmodSync(directory, 0o700);
+  if (isWindows) {
+    // Windows 无 POSIX 权限位（mode 恒 0o666）：改用 icacls 收紧 ACL 并回读校验。
+    secureWindowsDirectoryAcl(directory, { label: "Pi credential lock 目录" });
+    return;
+  }
   const stat = fs.lstatSync(directory);
   if (!stat.isDirectory() || stat.isSymbolicLink()
       || (typeof process.getuid === "function" && stat.uid !== process.getuid())
@@ -119,6 +125,11 @@ function ensurePrivateDirectory(directory: string): void {
   fs.chmodSync(path.dirname(directory), 0o700);
   fs.mkdirSync(directory, { recursive: true, mode: 0o700 });
   fs.chmodSync(directory, 0o700);
+  if (isWindows) {
+    // Windows 无 POSIX 权限位：icacls 收紧为「当前用户 + SYSTEM」并回读校验。
+    secureWindowsDirectoryAcl(directory, { label: "Pi official credential 目录" });
+    return;
+  }
   const stat = fs.lstatSync(directory);
   if (!stat.isDirectory() || stat.isSymbolicLink()
       || (typeof process.getuid === "function" && stat.uid !== process.getuid())
@@ -132,7 +143,7 @@ function safeRead(file: string): Buffer | null {
     const stat = fs.lstatSync(file);
     if (!stat.isFile() || stat.isSymbolicLink()
         || (typeof process.getuid === "function" && stat.uid !== process.getuid())
-        || (stat.mode & 0o777) !== 0o600) throw new Error(`unsafe Pi auth file: ${path.basename(file)}`);
+        || (!isWindows && (stat.mode & 0o777) !== 0o600)) throw new Error(`unsafe Pi auth file: ${path.basename(file)}`);
     return fs.readFileSync(file);
   } catch (error) {
     if ((error as NodeJS.ErrnoException).code === "ENOENT") return null;

--- a/src/runtime/pi-provider-config.ts
+++ b/src/runtime/pi-provider-config.ts
@@ -1,6 +1,7 @@
 import crypto from "node:crypto";
 import fs from "node:fs";
 import path from "node:path";
+import { isWindows, secureWindowsDirectoryAcl } from "../platform/secure-metadata.js";
 
 export type PiDistribution = "external" | "builtin";
 export const BUNDLED_PI_VERSION = "0.83.0";
@@ -114,6 +115,11 @@ export function piAgentDirectory(configDir: string, agentId: string): string {
 }
 
 function assertPrivateDirectory(directory: string): void {
+  if (isWindows) {
+    // Windows 无 POSIX 权限位：icacls 收紧为「当前用户 + SYSTEM」并回读校验。
+    secureWindowsDirectoryAcl(directory, { label: "Pi provider 凭证目录" });
+    return;
+  }
   const stat = fs.lstatSync(directory);
   if (!stat.isDirectory() || stat.isSymbolicLink()
       || (typeof process.getuid === "function" && stat.uid !== process.getuid())
@@ -146,7 +152,7 @@ function readSnapshot(file: string): Buffer | null {
     const stat = fs.lstatSync(file);
     if (!stat.isFile() || stat.isSymbolicLink()
         || (typeof process.getuid === "function" && stat.uid !== process.getuid())
-        || (stat.mode & 0o777) !== 0o600) throw new Error(`Pi provider 文件不安全: ${path.basename(file)}`);
+        || (!isWindows && (stat.mode & 0o777) !== 0o600)) throw new Error(`Pi provider 文件不安全: ${path.basename(file)}`);
     return fs.readFileSync(file);
   } catch (error) {
     if ((error as NodeJS.ErrnoException).code === "ENOENT") return null;


### PR DESCRIPTION
## Summary

0.2.79 的 PR #92 漏掉了两处 Pi 凭证路径的纯 POSIX 检查。Windows/NTFS 没有 POSIX 权限位（目录 mode 恒 0o666、chmod 是 no-op），内置 Pi 的 setup 与 pi-auth 在 Windows 上必挂——真机复现：`Pi official credential directory must be an owned 0700 directory`。

## Changes

- `src/runtime/pi-official-auth.ts`：`ensureLockDirectory` / `ensurePrivateDirectory` 在 win32 改用 `secureWindowsDirectoryAcl`（icacls 收紧为「当前用户 + SYSTEM」并回读校验）；`safeRead` 的 0600 文件位检查在 win32 跳过（文件安全由目录 ACL 承担）。
- `src/runtime/pi-provider-config.ts`：`assertPrivateDirectory` 同样加 ACL 分支；`readSnapshot` 的 0600 检查 win32 跳过。
- POSIX 分支行为完全不变。
- 版本 0.2.79 → 0.2.80。

## Validation

- `bun run build` ✓ `bun run typecheck` ✓
- `bun test --max-concurrency 1 test/unit/platform/secure-metadata.test.mjs test/unit/setup/bot-register-typescript.test.mjs test/unit/runtime/pi-provider-config.test.mjs` → 19 pass / 0 fail
- ACL helper 已在中文 Windows 真机实测（icacls 输出只剩 SYSTEM + Administrator 两个 ACE，解析器按真实输出格式实现）。

## Notes

- Windows 真机上完整 setup（内置 Pi）的重跑验证需要发布后的 0.2.80 二进制。