### PR TITLE
fix(windows): guard remaining POSIX file-mode checks in setup path (#94)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "larkin",
-  "version": "0.2.80",
+  "version": "0.2.81",
   "private": false,
   "larkinPackageRole": "npm-published",
   "files": [

--- a/src/setup/run-credential-preflight.ts
+++ b/src/setup/run-credential-preflight.ts
@@ -1,5 +1,6 @@
 import fs from "node:fs";
 import path from "node:path";
+import { isWindows } from "../platform/secure-metadata.js";
 
 import {
   callbackCapability,
@@ -69,7 +70,8 @@ export function validCredentialRecord(value: unknown, appId: string): value is B
 }
 
 function isOwnedWithExactMode(stat: fs.Stats, mode: number): boolean {
-  return (typeof process.getuid !== "function" || stat.uid === process.getuid()) && (stat.mode & 0o777) === mode;
+  return (typeof process.getuid !== "function" || stat.uid === process.getuid())
+    && (isWindows || (stat.mode & 0o777) === mode);
 }
 
 export function assertSecureBotsDirectory(botsDir: string): void {

--- a/src/setup/setup-bind.ts
+++ b/src/setup/setup-bind.ts
@@ -7,6 +7,7 @@ import fs from "node:fs";
 import path from "node:path";
 import readline from "node:readline";
 import { fileURLToPath } from "node:url";
+import { isWindows } from "../platform/secure-metadata.js";
 import { TargetRootLayout } from "../platform/root-layout.js";
 import { planSingleRootBinding, type StoredConfig } from "./setup-binding.js";
 import { discoverPiModelCatalog } from "../runtime/pi-model-catalog.js";
@@ -188,7 +189,7 @@ function readSetupSelection(fileArg: string | undefined): SetupAgentChoice | nul
   const stat = fs.lstatSync(file);
   if (!stat.isFile() || stat.isSymbolicLink()
       || (typeof process.getuid === "function" && stat.uid !== process.getuid())
-      || (stat.mode & 0o777) !== 0o600) die("setup Agent 选择文件必须是当前用户拥有的 0600 普通文件");
+      || (!isWindows && (stat.mode & 0o777) !== 0o600)) die("setup Agent 选择文件必须是当前用户拥有的 0600 普通文件");
   const bytes = fs.readFileSync(file, "utf8");
   fs.unlinkSync(file);
   const raw = JSON.parse(bytes) as SetupAgentChoice;


### PR DESCRIPTION
Windows 实机 setup（v0.2.80）继续暴露两处同类漏网（#94 同类）：setup-bind.ts 的 Agent 选择文件 0600 检查、run-credential-preflight.ts 的 isOwnedWithExactMode mode 位检查。win32 跳过 mode 位（目录 ACL 承担安全），uid 守卫保留。版本 0.2.80 → 0.2.81。验证：typecheck/build ✓、setup+runtime+platform 单测 32/32 ✓。