### PR TITLE
fix(setup): non-interactive builtin-pi choice file carries runtime:pi (#94)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "larkin",
-  "version": "0.2.81",
+  "version": "0.2.82",
   "private": false,
   "larkinPackageRole": "npm-published",
   "files": [

--- a/src/setup/bot-register.ts
+++ b/src/setup/bot-register.ts
@@ -634,7 +634,7 @@ if (piDistributionFlag === "builtin") {
   stageBuiltinPiProvider(CFG_DIR, id, { ...raw, apiKey: setupApiKey });
   temporaryAgentChoiceFile = path.join(CFG_DIR, `.setup-agent-choice-${process.pid}-${Date.now()}.json`);
   fs.writeFileSync(temporaryAgentChoiceFile,
-    `${JSON.stringify({ ...raw, authCompleted: true, readinessCompleted: true })}\n`, { mode: 0o600, flag: "wx" });
+    `${JSON.stringify({ ...raw, runtime: "pi", authCompleted: true, readinessCompleted: true })}\n`, { mode: 0o600, flag: "wx" });
   say(`[setup 2/5] ✓ 内置 Pi provider 已配置（${presetId}${setupBaseUrl ? " / custom" : ""}）`);
 } else if (piDistributionFlag === "external" && (setupProvider || setupApiKey || setupBaseUrl)) {
   throw new Error("external-pi 使用已有 pi 环境与登录，不接受 --provider/--api-key/--base-url");

--- a/test/unit/setup/bot-register-typescript.test.mjs
+++ b/test/unit/setup/bot-register-typescript.test.mjs
@@ -70,6 +70,8 @@ test("registration publishes the credential before binding, then verifies the bo
   assert.doesNotMatch(source, /config["', ]+init/);
   assert.match(source, /mode: 0o700/);
   assert.match(source, /mode: 0o600, flag: "wx"/);
+  assert.match(source, /JSON\.stringify\(\{ \.\.\.raw, runtime: "pi", authCompleted: true, readinessCompleted: true \}\)/,
+    "非交互 builtin-pi 的选择文件必须带 runtime:pi（否则 setup-bind 报 Agent 选择无效）");
   assert.match(source, /callbacks:\s*\{ items: \["card\.action\.trigger"\] \}/);
   assert.match(source, /systemSpawn\(command, args, \{ stdio: "ignore", shell: false \}\)/,
     "browser launch must be non-blocking and shell-free");


### PR DESCRIPTION
非交互 setup 写出的 .setup-agent-choice 缺 runtime 字段 → setup-bind 校验必报「Agent 选择无效」（Windows 实机复现，该路径所有平台都断）。补 runtime:"pi" + 源码断言测试。版本 0.2.81 → 0.2.82。typecheck/build ✓，bot-register + setup-agent-choice 单测 17/17 ✓。