### PR TITLE
fix(windows): Inbox lock owner mode check guarded for win32 (#94)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "larkin",
-  "version": "0.2.83",
+  "version": "0.2.84",
   "private": false,
   "larkinPackageRole": "npm-published",
   "files": [

--- a/src/agent/agent-state-store.ts
+++ b/src/agent/agent-state-store.ts
@@ -3,6 +3,7 @@ import * as crypto from "node:crypto";
 import * as path from "node:path";
 import { TargetRootLayout, type AgentStatePaths } from "../platform/root-layout.js";
 import { acquireProcessLock, inspectProcess } from "../platform/process-state.js";
+import { isWindows } from "../platform/secure-metadata.js";
 import { targetKeyOfInboxEnvelope, type InboxEnvelope } from "./inbox-projection.js";
 
 export type JsonStateKey = "agentState" | "status" | "map" | "replyctx" | "botIdentity" |
@@ -264,7 +265,8 @@ export class AgentStateStore {
     try {
       fd = fs.openSync(ownerFile, fs.constants.O_RDONLY | fs.constants.O_NOFOLLOW);
       const stat = fs.fstatSync(fd);
-      if (!stat.isFile() || (typeof process.getuid === "function" && stat.uid !== process.getuid()) || (stat.mode & 0o077) !== 0) {
+      if (!stat.isFile() || (typeof process.getuid === "function" && stat.uid !== process.getuid())
+          || (!isWindows && (stat.mode & 0o077) !== 0)) {
         throw new Error(`Inbox lock owner 文件不安全：${ownerFile}`);
       }
       const value = JSON.parse(fs.readFileSync(fd, "utf8")) as unknown;


### PR DESCRIPTION
daemon 启动时 Inbox lock owner.json 的 (stat.mode & 0o077) !== 0 检查在 Windows 恒失败（mode 0o666）→ Runtime Host 启动即退（Windows 实机复现，setup 已完整跑通后撞上）。win32 跳过 mode 位（目录 ACL 承担），uid 守卫保留。版本 0.2.83 → 0.2.84。typecheck/build ✓，agent-state-store 单测 12/12 ✓。