### PR TITLE
fix(windows): skip -e extension injection for builtin pi on win32 (#100)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "larkin",
-  "version": "0.2.84",
+  "version": "0.2.85",
   "private": false,
   "larkinPackageRole": "npm-published",
   "files": [

--- a/src/runtime/runtime-adapters.ts
+++ b/src/runtime/runtime-adapters.ts
@@ -21,6 +21,7 @@ import { internalCommandSpec } from "../app/internal-command.js";
 import { piAgentDirectory } from "./pi-provider-config.js";
 import { resolvePiSubagentExtensionArg } from "./pi-subagent-injection.js";
 import { resolvePiBashTimeoutExtensionArg } from "./pi-bash-timeout-injection.js";
+import { isWindows } from "../platform/secure-metadata.js";
 import {
   classifyRuntimePrerequisite,
   probeNativeRuntimeReadiness,
@@ -850,14 +851,14 @@ async function createPiRpcBackend(input: RuntimeSessionCreate, dependencies: Nat
     mergedEnv.PI_CODING_AGENT_DIR = piAgentDirectory(mergedEnv.LARKIN_CONFIG_DIR, input.agentId);
     mergedEnv.PI_TELEMETRY = "0";
   }
-  const subagentExtension = resolvePiSubagentExtensionArg({
+  const subagentExtension = builtin && isWindows ? null : resolvePiSubagentExtensionArg({
     distribution: builtin ? "builtin" : "external",
     piCommand: command,
     env: mergedEnv,
   });
   if (subagentExtension) commandArgs.push("-e", subagentExtension);
   // bash 60s 超时护栏（issue #55/#56）：与 pi-subagents 一起注入，两者工具名不冲突。
-  const bashTimeoutExtension = resolvePiBashTimeoutExtensionArg({
+  const bashTimeoutExtension = builtin && isWindows ? null : resolvePiBashTimeoutExtensionArg({
     distribution: builtin ? "builtin" : "external",
     piCommand: command,
     env: mergedEnv,


### PR DESCRIPTION
内置 Pi 在 Windows 上加载 -e 扩展时，pi 的 JIT 模块包装（data: URL）撞 bun/Windows 路径长度上限 → 启动即退（Windows 实机复现，消息已入 Inbox、pi 拉起即崩）。win32 暂缓注入 pi-subagents 与 pi-bash-timeout（跟进 issue #100），恢复 Windows 可用性。版本 0.2.84 → 0.2.85。typecheck/build ✓；相关单测通过（仅已知本机 ~/.pi 环境 flake）。