### PR TITLE
fix(runtime): accept provider/model prefix for pi effective model match (#94)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "larkin",
-  "version": "0.2.85",
+  "version": "0.2.86",
   "private": false,
   "larkinPackageRole": "npm-published",
   "files": [

--- a/src/runtime/runtime-adapters.ts
+++ b/src/runtime/runtime-adapters.ts
@@ -877,7 +877,12 @@ async function createPiRpcBackend(input: RuntimeSessionCreate, dependencies: Nat
     ]);
     if (!available?.models?.length) throw new Error("Pi has no authenticated available models. Run the official `pi` login flow or configure provider credentials; Larkin will not create a fallback session.");
     const effectiveModel = state.model?.provider && state.model.id ? `${state.model.provider}/${state.model.id}` : null;
-    if (requestedModel && effectiveModel !== requestedModel) throw new Error(`Pi model fallback refused: requested ${requestedModel}, effective ${effectiveModel || "none"}`);
+    // pi 回报的是 provider/model 两段式；Larkin 配置允许只存 model 段（内置 Pi 单 provider）。
+    const effectiveMatches = (candidate: string): boolean => effectiveModel === candidate
+      || (effectiveModel ? effectiveModel.endsWith(`/${candidate}`) : false);
+    if (requestedModel && !effectiveMatches(requestedModel)) {
+      throw new Error(`Pi model fallback refused: requested ${requestedModel}, effective ${effectiveModel || "none"}`);
+    }
     if (requestedEffort && state.thinkingLevel !== requestedEffort) throw new Error(`Pi thinking level ${requestedEffort} was not accepted by effective model ${effectiveModel || "unknown"}`);
     return new PiRpcBackend(client, state);
   } catch (error) {


### PR DESCRIPTION
内置 Pi 单 provider 配置（model 无斜杠）时，pi 回报 effective model 为 provider/model 两段式，严格相等比较拒绝 → turn 被挡（Windows 实机复现：requested deepseek-v4-pro vs effective deepseek/deepseek-v4-pro）。匹配改为允许 effective 以 /requested 结尾。版本 0.2.85 → 0.2.86。typecheck/build ✓，runtime-adapters 单测 49/49 ✓。