### PR TITLE
fix(setup+runtime): model must come from the provider's authoritative list (#94)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "larkin",
-  "version": "0.2.86",
+  "version": "0.2.87",
   "private": false,
   "larkinPackageRole": "npm-published",
   "files": [

--- a/src/runtime/pi-provider-config.ts
+++ b/src/runtime/pi-provider-config.ts
@@ -83,6 +83,26 @@ export function validatePiBaseUrl(raw: string): string {
   return url.toString().replace(/\/$/, "");
 }
 
+/**
+ * 查询 OpenAI 兼容 provider 的 /models 列表（setup 时校验 --model 是否真实可用）。
+ * 失败即抛错：setup 不应该接受一个没有依据的模型名。
+ */
+export async function listProviderModels(
+  baseUrl: string,
+  apiKey: string,
+  fetchImpl: typeof fetch = fetch,
+): Promise<string[]> {
+  const url = `${validatePiBaseUrl(baseUrl)}/models`;
+  const response = await fetchImpl(url, {
+    headers: { Authorization: `Bearer ${apiKey}` },
+    signal: AbortSignal.timeout(15_000),
+  });
+  if (!response.ok) throw new Error(`provider /models 查询失败：HTTP ${response.status}`);
+  const payload = await response.json() as { data?: Array<{ id?: unknown }> } | null;
+  if (!payload || !Array.isArray(payload.data)) throw new Error("provider /models 响应格式非法");
+  return payload.data.map((entry) => String(entry.id ?? "")).filter(Boolean);
+}
+
 export function resolveBuiltinPiProviderSetupSelection(input: BuiltinPiProviderSetupSelection): ResolvedBuiltinPiProviderSetupSelection {
   if (input.distribution !== "builtin") throw new Error("provider 凭证只能用于内置 Pi");
   const model = input.model.trim();

--- a/src/runtime/runtime-adapters.ts
+++ b/src/runtime/runtime-adapters.ts
@@ -877,11 +877,16 @@ async function createPiRpcBackend(input: RuntimeSessionCreate, dependencies: Nat
     ]);
     if (!available?.models?.length) throw new Error("Pi has no authenticated available models. Run the official `pi` login flow or configure provider credentials; Larkin will not create a fallback session.");
     const effectiveModel = state.model?.provider && state.model.id ? `${state.model.provider}/${state.model.id}` : null;
-    // pi 回报的是 provider/model 两段式；Larkin 配置允许只存 model 段（内置 Pi 单 provider）。
-    const effectiveMatches = (candidate: string): boolean => effectiveModel === candidate
-      || (effectiveModel ? effectiveModel.endsWith(`/${candidate}`) : false);
-    if (requestedModel && !effectiveMatches(requestedModel)) {
-      throw new Error(`Pi model fallback refused: requested ${requestedModel}, effective ${effectiveModel || "none"}`);
+    // 严格对账（Owner 决策）：模型必须来自 pi 的权威可用列表，不做后缀猜测——
+    // 配置的模型与 pi 可用列表不符即报错，并在错误里列出可用模型。
+    const availableEntries = (available.models ?? []).map((entry) => ({
+      provider: String(entry.provider ?? ""), id: String(entry.id ?? ""),
+    }));
+    const matchesAvailable = (candidate: string): boolean => availableEntries.some((entry) =>
+      entry.id === candidate || (entry.provider ? `${entry.provider}/${entry.id}` === candidate : false));
+    if (requestedModel && effectiveModel !== requestedModel && !matchesAvailable(requestedModel)) {
+      const availableText = availableEntries.slice(0, 10).map((entry) => entry.provider ? `${entry.provider}/${entry.id}` : entry.id).join(", ");
+      throw new Error(`Pi model fallback refused: requested ${requestedModel} is not in Pi's available models${availableText ? ` (${availableText})` : ""}`);
     }
     if (requestedEffort && state.thinkingLevel !== requestedEffort) throw new Error(`Pi thinking level ${requestedEffort} was not accepted by effective model ${effectiveModel || "unknown"}`);
     return new PiRpcBackend(client, state);

--- a/src/setup/bot-register.ts
+++ b/src/setup/bot-register.ts
@@ -15,7 +15,7 @@ import { managedLarkCliEnv } from "../app/agent-lark-cli-workspace.js";
 import { resolveOfficialLarkCli, type OfficialLarkCliCommand } from "../app/official-lark-cli.js";
 import { collectSetupAgentChoice, recoverUnavailableExternalPi, terminalSetupQuestioner } from "./setup-agent-choice.js";
 import { probeNativeRuntimeReadiness } from "../runtime/runtime-readiness.js";
-import { configureBuiltinPiProviderModel, stageBuiltinPiProvider, validatePiBaseUrl, PI_PROVIDER_PRESETS,
+import { configureBuiltinPiProviderModel, stageBuiltinPiProvider, validatePiBaseUrl, listProviderModels, PI_PROVIDER_PRESETS,
   type BuiltinPiProviderSetupSelection, type PiProviderPresetId } from "../runtime/pi-provider-config.js";
 import {
   beginBuiltinPiCredentialTransaction,
@@ -631,6 +631,15 @@ if (piDistributionFlag === "builtin") {
     model: setupModel ?? presetDef?.defaultModel ?? "",
     ...(presetDef ? { baseUrl: presetDef.baseUrl } : setupBaseUrl ? { baseUrl: validatePiBaseUrl(setupBaseUrl) } : {}),
   };
+  if (setupModel && raw.baseUrl) {
+    // Owner 决策：模型名必须来自 provider 的权威可用列表，输错即报错，不做运行时猜测。
+    const availableIds = await listProviderModels(raw.baseUrl, setupApiKey);
+    const matched = availableIds.some((id) => id === setupModel || id.endsWith(`/${setupModel}`));
+    if (!matched) {
+      const preview = availableIds.slice(0, 12).join(", ") + (availableIds.length > 12 ? ", …" : "");
+      throw new Error(`未知模型 ${setupModel}；provider 可用模型：[${preview || "无"}]`);
+    }
+  }
   stageBuiltinPiProvider(CFG_DIR, id, { ...raw, apiKey: setupApiKey });
   temporaryAgentChoiceFile = path.join(CFG_DIR, `.setup-agent-choice-${process.pid}-${Date.now()}.json`);
   fs.writeFileSync(temporaryAgentChoiceFile,


### PR DESCRIPTION
Owner 决策：模型名不做后缀猜测。运行时严格对账——配置模型必须与 pi 的 get_available_models 条目精确匹配（单段或 provider/model 两段），否则报错并列出可用模型；setup 端在 stage 前查询 provider /models 校验 --model，未知模型直接报错并展示可用列表。版本 0.2.86 → 0.2.87。typecheck/build ✓，runtime-adapters + pi-provider-config + bot-register 单测 63/63 ✓。