### PR TITLE
fix(setup): /models preflight tolerates network timeout, runtime stays strict (#94)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "larkin",
-  "version": "0.2.87",
+  "version": "0.2.88",
   "private": false,
   "larkinPackageRole": "npm-published",
   "files": [

--- a/src/runtime/pi-provider-config.ts
+++ b/src/runtime/pi-provider-config.ts
@@ -85,22 +85,31 @@ export function validatePiBaseUrl(raw: string): string {
 
 /**
  * 查询 OpenAI 兼容 provider 的 /models 列表（setup 时校验 --model 是否真实可用）。
- * 失败即抛错：setup 不应该接受一个没有依据的模型名。
+ * 网络超时/不可达返回 null（不阻塞 setup——运行时对账会严格兜底）；
+ * 列表拿到但模型不在其中时抛错。
  */
 export async function listProviderModels(
   baseUrl: string,
   apiKey: string,
   fetchImpl: typeof fetch = fetch,
-): Promise<string[]> {
-  const url = `${validatePiBaseUrl(baseUrl)}/models`;
-  const response = await fetchImpl(url, {
-    headers: { Authorization: `Bearer ${apiKey}` },
-    signal: AbortSignal.timeout(15_000),
-  });
-  if (!response.ok) throw new Error(`provider /models 查询失败：HTTP ${response.status}`);
-  const payload = await response.json() as { data?: Array<{ id?: unknown }> } | null;
-  if (!payload || !Array.isArray(payload.data)) throw new Error("provider /models 响应格式非法");
-  return payload.data.map((entry) => String(entry.id ?? "")).filter(Boolean);
+): Promise<string[] | null> {
+  try {
+    const url = `${validatePiBaseUrl(baseUrl)}/models`;
+    const response = await fetchImpl(url, {
+      headers: { Authorization: `Bearer ${apiKey}` },
+      signal: AbortSignal.timeout(30_000),
+    });
+    if (!response.ok) throw new Error(`provider /models 查询失败：HTTP ${response.status}`);
+    const payload = await response.json() as { data?: Array<{ id?: unknown }> } | null;
+    if (!payload || !Array.isArray(payload.data)) throw new Error("provider /models 响应格式非法");
+    return payload.data.map((entry) => String(entry.id ?? "")).filter(Boolean);
+  } catch (error) {
+    if (error instanceof Error && (error.name === "TimeoutError" || error.name === "AbortError"
+        || /fetch failed|network|ETIMEDOUT|ECONNREFUSED/i.test(error.message))) {
+      return null;
+    }
+    throw error;
+  }
 }
 
 export function resolveBuiltinPiProviderSetupSelection(input: BuiltinPiProviderSetupSelection): ResolvedBuiltinPiProviderSetupSelection {

--- a/src/setup/bot-register.ts
+++ b/src/setup/bot-register.ts
@@ -633,11 +633,16 @@ if (piDistributionFlag === "builtin") {
   };
   if (setupModel && raw.baseUrl) {
     // Owner 决策：模型名必须来自 provider 的权威可用列表，输错即报错，不做运行时猜测。
+    // 网络超时/不可达时不阻塞 setup（null），运行时对账会严格兜底。
     const availableIds = await listProviderModels(raw.baseUrl, setupApiKey);
-    const matched = availableIds.some((id) => id === setupModel || id.endsWith(`/${setupModel}`));
-    if (!matched) {
-      const preview = availableIds.slice(0, 12).join(", ") + (availableIds.length > 12 ? ", …" : "");
-      throw new Error(`未知模型 ${setupModel}；provider 可用模型：[${preview || "无"}]`);
+    if (availableIds !== null) {
+      const matched = availableIds.some((id) => id === setupModel || id.endsWith(`/${setupModel}`));
+      if (!matched) {
+        const preview = availableIds.slice(0, 12).join(", ") + (availableIds.length > 12 ? ", …" : "");
+        throw new Error(`未知模型 ${setupModel}；provider 可用模型：[${preview || "无"}]`);
+      }
+    } else {
+      say("[setup] 网络暂不可达，跳过 /models 预校验；运行时将对模型严格对账");
     }
   }
   stageBuiltinPiProvider(CFG_DIR, id, { ...raw, apiKey: setupApiKey });


### PR DESCRIPTION
Windows 实机：setup 3/5 阶段 /models 预校验 15s 超时（opencode 网关首次连接慢）→ TimeoutError 打挂 setup。修正：超时/网络不可达返回 null 并警告放行（setup 不被网络抖动阻塞），运行时对账保持严格；列表拿到但模型不在其中仍硬报错。超时 15s→30s。版本 0.2.87 → 0.2.88。typecheck/build ✓，相关单测 63/63 ✓。