### PR TITLE
fix(setup): explicit --base-url overrides preset default (#94)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "larkin",
-  "version": "0.2.88",
+  "version": "0.2.89",
   "private": false,
   "larkinPackageRole": "npm-published",
   "files": [

--- a/src/runtime/pi-provider-config.ts
+++ b/src/runtime/pi-provider-config.ts
@@ -105,7 +105,7 @@ export async function listProviderModels(
     return payload.data.map((entry) => String(entry.id ?? "")).filter(Boolean);
   } catch (error) {
     if (error instanceof Error && (error.name === "TimeoutError" || error.name === "AbortError"
-        || /fetch failed|network|ETIMEDOUT|ECONNREFUSED/i.test(error.message))) {
+        || /fetch failed|network|ETIMEDOUT|ECONNREFUSED|ConnectionRefused|Unable to connect/i.test(error.message))) {
       return null;
     }
     throw error;

--- a/src/setup/bot-register.ts
+++ b/src/setup/bot-register.ts
@@ -629,7 +629,8 @@ if (piDistributionFlag === "builtin") {
     distribution: "builtin",
     preset: presetId as PiProviderPresetId,
     model: setupModel ?? presetDef?.defaultModel ?? "",
-    ...(presetDef ? { baseUrl: presetDef.baseUrl } : setupBaseUrl ? { baseUrl: validatePiBaseUrl(setupBaseUrl) } : {}),
+    // 显式 --base-url 优先于预设默认值（自定义网关场景，如 opencode）。
+    ...(setupBaseUrl ? { baseUrl: validatePiBaseUrl(setupBaseUrl) } : presetDef ? { baseUrl: presetDef.baseUrl } : {}),
   };
   if (setupModel && raw.baseUrl) {
     // Owner 决策：模型名必须来自 provider 的权威可用列表，输错即报错，不做运行时猜测。


### PR DESCRIPTION
Windows 实机暴露：预设存在时 --base-url 被忽略，opencode 网关场景 provider 配置被写成预设默认 api.openai.com。修正：显式 --base-url 优先；/models 容错补 ConnectionRefused/Unable to connect。版本 0.2.88 → 0.2.89。typecheck/build ✓，相关单测 14/14 ✓。