### PR TITLE
fix(setup): custom --base-url routes through the custom provider preset (#94)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "larkin",
-  "version": "0.2.89",
+  "version": "0.2.90",
   "private": false,
   "larkinPackageRole": "npm-published",
   "files": [

--- a/src/setup/bot-register.ts
+++ b/src/setup/bot-register.ts
@@ -622,7 +622,10 @@ if (piDistributionFlag === "builtin") {
     throw new Error("builtin-pi 需要 --provider <id>（deepseek|kimi|minimax|zhipu|openai|anthropic|gemini|groq|cerebras|xai|fireworks|together|mistral|openrouter|kimi-coding|qwen-cn|custom）或 --base-url；或改用 --runtime external-pi 使用已有 pi 环境");
   }
   if (!setupApiKey) throw new Error("builtin-pi 需要 --api-key；或改用 --runtime external-pi 使用已有 pi 登录");
-  const presetId = setupProvider ?? "custom";
+  // 自定义网关（--base-url）走 custom 预设：pi 会把 baseUrl 作为 provider 端点写入配置，
+  // 而不是用预设厂商目录（否则会打到预设默认地址，如 api.openai.com）。
+  const presetId = setupBaseUrl ? "custom" : (setupProvider ?? "custom");
+  if (presetId === "custom" && !setupModel) throw new Error("custom base-url 需要 --model <模型名>");
   const presetDef = PI_PROVIDER_PRESETS.find((p) => p.id === presetId);
   if (!presetDef && !setupBaseUrl) throw new Error(`未知 provider \`${presetId}\`；可选：${PI_PROVIDER_PRESETS.map((p) => p.id).join(" | ")} | custom`);
   const raw: BuiltinPiProviderSetupSelection = {


### PR DESCRIPTION
Windows 实机暴露：非交互 setup 传 --base-url 时仍按厂商预设（openai）写入 provider 配置，pi 打到预设默认 api.openai.com（可用模型全是 gpt-*，opencode 从未生效）。修正：--base-url 改用 custom 预设（larkin-custom provider + 显式 baseUrl 写入 models.json）。版本 0.2.89 → 0.2.90。typecheck/build ✓，相关单测 21/21 ✓。