### PR TITLE
fix(setup): choice file carries the provider-qualified model for custom preset (#94)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "larkin",
-  "version": "0.2.90",
+  "version": "0.2.91",
   "private": false,
   "larkinPackageRole": "npm-published",
   "files": [

--- a/src/setup/bot-register.ts
+++ b/src/setup/bot-register.ts
@@ -15,7 +15,7 @@ import { managedLarkCliEnv } from "../app/agent-lark-cli-workspace.js";
 import { resolveOfficialLarkCli, type OfficialLarkCliCommand } from "../app/official-lark-cli.js";
 import { collectSetupAgentChoice, recoverUnavailableExternalPi, terminalSetupQuestioner } from "./setup-agent-choice.js";
 import { probeNativeRuntimeReadiness } from "../runtime/runtime-readiness.js";
-import { configureBuiltinPiProviderModel, stageBuiltinPiProvider, validatePiBaseUrl, listProviderModels, PI_PROVIDER_PRESETS,
+import { configureBuiltinPiProviderModel, stageBuiltinPiProvider, validatePiBaseUrl, validateBuiltinPiProviderSelection, listProviderModels, PI_PROVIDER_PRESETS,
   type BuiltinPiProviderSetupSelection, type PiProviderPresetId } from "../runtime/pi-provider-config.js";
 import {
   beginBuiltinPiCredentialTransaction,
@@ -650,9 +650,13 @@ if (piDistributionFlag === "builtin") {
     }
   }
   stageBuiltinPiProvider(CFG_DIR, id, { ...raw, apiKey: setupApiKey });
+  // 选择文件写入解析后的全称模型（custom 预设为 larkin-custom/<model>）：
+  // pi 运行时按 provider 前缀解析凭证，裸模型名会回落到默认 provider（deepseek）
+  // 导致「No API key found for deepseek」。
+  const validated = validateBuiltinPiProviderSelection({ ...raw, apiKey: setupApiKey });
   temporaryAgentChoiceFile = path.join(CFG_DIR, `.setup-agent-choice-${process.pid}-${Date.now()}.json`);
   fs.writeFileSync(temporaryAgentChoiceFile,
-    `${JSON.stringify({ ...raw, runtime: "pi", authCompleted: true, readinessCompleted: true })}\n`, { mode: 0o600, flag: "wx" });
+    `${JSON.stringify({ ...raw, runtime: "pi", model: validated.model, authCompleted: true, readinessCompleted: true })}\n`, { mode: 0o600, flag: "wx" });
   say(`[setup 2/5] ✓ 内置 Pi provider 已配置（${presetId}${setupBaseUrl ? " / custom" : ""}）`);
 } else if (piDistributionFlag === "external" && (setupProvider || setupApiKey || setupBaseUrl)) {
   throw new Error("external-pi 使用已有 pi 环境与登录，不接受 --provider/--api-key/--base-url");

--- a/test/unit/setup/bot-register-typescript.test.mjs
+++ b/test/unit/setup/bot-register-typescript.test.mjs
@@ -70,8 +70,8 @@ test("registration publishes the credential before binding, then verifies the bo
   assert.doesNotMatch(source, /config["', ]+init/);
   assert.match(source, /mode: 0o700/);
   assert.match(source, /mode: 0o600, flag: "wx"/);
-  assert.match(source, /JSON\.stringify\(\{ \.\.\.raw, runtime: "pi", authCompleted: true, readinessCompleted: true \}\)/,
-    "非交互 builtin-pi 的选择文件必须带 runtime:pi（否则 setup-bind 报 Agent 选择无效）");
+  assert.match(source, /JSON\.stringify\(\{ \.\.\.raw, runtime: "pi", model: validated\.model, authCompleted: true, readinessCompleted: true \}\)/,
+    "非交互 builtin-pi 的选择文件必须带 runtime:pi 与解析后的全称模型（否则 pi 回落到默认 provider）");
   assert.match(source, /callbacks:\s*\{ items: \["card\.action\.trigger"\] \}/);
   assert.match(source, /systemSpawn\(command, args, \{ stdio: "ignore", shell: false \}\)/,
     "browser launch must be non-blocking and shell-free");


### PR DESCRIPTION
Windows 实机：配置存裸模型名，pi 回落默认 provider deepseek → No API key found for deepseek。修正：选择文件写入解析后的全称模型（larkin-custom/deepseek-v4-pro），pi 正确命中 custom provider。版本 0.2.90 → 0.2.91。typecheck/build ✓，相关单测 14/14 ✓。