### PR TITLE
feat(setup): add builtin opencode-go provider preset (#94)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "larkin",
-  "version": "0.2.91",
+  "version": "0.2.92",
   "private": false,
   "larkinPackageRole": "npm-published",
   "files": [

--- a/src/runtime/pi-provider-config.ts
+++ b/src/runtime/pi-provider-config.ts
@@ -7,7 +7,7 @@ export type PiDistribution = "external" | "builtin";
 export const BUNDLED_PI_VERSION = "0.83.0";
 export type PiProviderPresetId = "deepseek" | "kimi" | "minimax" | "zhipu" | "openai" | "anthropic"
   | "gemini" | "groq" | "cerebras" | "xai" | "fireworks" | "together" | "mistral"
-  | "openrouter" | "kimi-coding" | "qwen-cn" | "custom";
+  | "openrouter" | "kimi-coding" | "qwen-cn" | "opencode-go" | "custom";
 
 export interface PiProviderPreset {
   id: Exclude<PiProviderPresetId, "custom">;
@@ -37,6 +37,7 @@ export const PI_PROVIDER_PRESETS: readonly PiProviderPreset[] = Object.freeze([
   { id: "openrouter", name: "OpenRouter", provider: "openrouter", baseUrl: "https://openrouter.ai/api/v1", defaultModel: "moonshotai/kimi-k2.6", api: "openai-completions" },
   { id: "kimi-coding", name: "Kimi For Coding", provider: "kimi-coding", baseUrl: "https://api.kimi.com/coding", defaultModel: "kimi-for-coding", api: "openai-completions" },
   { id: "qwen-cn", name: "通义千问 Token Plan（中国）", provider: "qwen-token-plan-cn", baseUrl: "https://token-plan.cn-beijing.maas.aliyuncs.com/compatible-mode/v1", defaultModel: "qwen3.7-max", api: "openai-completions" },
+  { id: "opencode-go", name: "OpenCode Go", provider: "opencode-go", baseUrl: "https://opencode.ai/zen/go/v1", defaultModel: "kimi-k2.6", api: "openai-completions" },
 ]);
 
 export interface BuiltinPiProviderSetupSelection {

--- a/test/unit/runtime/pi-provider-config.test.mjs
+++ b/test/unit/runtime/pi-provider-config.test.mjs
@@ -14,7 +14,7 @@ import {
 test("Pi provider presets keep the requested setup order and audited official endpoints", () => {
   assert.deepEqual(PI_PROVIDER_PRESETS.map((item) => item.id), [
     "deepseek", "kimi", "minimax", "zhipu", "openai", "anthropic", "gemini", "groq",
-    "cerebras", "xai", "fireworks", "together", "mistral", "openrouter", "kimi-coding", "qwen-cn",
+    "cerebras", "xai", "fireworks", "together", "mistral", "openrouter", "kimi-coding", "qwen-cn", "opencode-go",
   ]);
   assert.deepEqual(PI_PROVIDER_PRESETS.map((item) => item.baseUrl), [
     "https://api.deepseek.com",
@@ -33,6 +33,7 @@ test("Pi provider presets keep the requested setup order and audited official en
     "https://openrouter.ai/api/v1",
     "https://api.kimi.com/coding",
     "https://token-plan.cn-beijing.maas.aliyuncs.com/compatible-mode/v1",
+    "https://opencode.ai/zen/go/v1",
   ]);
 });
 


### PR DESCRIPTION
Owner 指正：opencode-go 是 pi 内置 provider（OPENCODE_API_KEY），不该走 custom 预设。新增预设（provider=opencode-go、baseUrl=https://opencode.ai/zen/go/v1、默认 kimi-k2.6），setup 直接 --provider opencode-go，模型解析为 opencode-go/<model>，pi 原生识别 provider 与凭证。版本 0.2.91 → 0.2.92。typecheck/build ✓，相关单测 21/21 ✓。