### PR TITLE
feat(setup): align builtin pi presets with the full pi-native provider catalog (#101)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "larkin",
-  "version": "0.2.92",
+  "version": "0.2.93",
   "private": false,
   "larkinPackageRole": "npm-published",
   "files": [

--- a/src/runtime/pi-provider-config.ts
+++ b/src/runtime/pi-provider-config.ts
@@ -7,7 +7,10 @@ export type PiDistribution = "external" | "builtin";
 export const BUNDLED_PI_VERSION = "0.83.0";
 export type PiProviderPresetId = "deepseek" | "kimi" | "minimax" | "zhipu" | "openai" | "anthropic"
   | "gemini" | "groq" | "cerebras" | "xai" | "fireworks" | "together" | "mistral"
-  | "openrouter" | "kimi-coding" | "qwen-cn" | "opencode-go" | "custom";
+  | "openrouter" | "kimi-coding" | "qwen-cn" | "opencode-go" | "ant-ling" | "nvidia"
+  | "huggingface" | "minimax-global" | "moonshotai" | "opencode" | "qwen-token-plan"
+  | "vercel-ai-gateway" | "xiaomi" | "xiaomi-token-plan-cn" | "xiaomi-token-plan-ams"
+  | "xiaomi-token-plan-sgp" | "zai" | "custom";
 
 export interface PiProviderPreset {
   id: Exclude<PiProviderPresetId, "custom">;
@@ -38,6 +41,19 @@ export const PI_PROVIDER_PRESETS: readonly PiProviderPreset[] = Object.freeze([
   { id: "kimi-coding", name: "Kimi For Coding", provider: "kimi-coding", baseUrl: "https://api.kimi.com/coding", defaultModel: "kimi-for-coding", api: "openai-completions" },
   { id: "qwen-cn", name: "通义千问 Token Plan（中国）", provider: "qwen-token-plan-cn", baseUrl: "https://token-plan.cn-beijing.maas.aliyuncs.com/compatible-mode/v1", defaultModel: "qwen3.7-max", api: "openai-completions" },
   { id: "opencode-go", name: "OpenCode Go", provider: "opencode-go", baseUrl: "https://opencode.ai/zen/go/v1", defaultModel: "kimi-k2.6", api: "openai-completions" },
+  { id: "ant-ling", name: "Ant Ling", provider: "ant-ling", baseUrl: "https://api.ant-ling.com/v1", defaultModel: "Ring-2.6-1T", api: "openai-completions" },
+  { id: "nvidia", name: "NVIDIA NIM", provider: "nvidia", baseUrl: "https://integrate.api.nvidia.com/v1", defaultModel: "google/gemma-3-12b-it", api: "openai-completions" },
+  { id: "huggingface", name: "Hugging Face", provider: "huggingface", baseUrl: "https://router.huggingface.co/v1", defaultModel: "MiniMaxAI/MiniMax-M2", api: "openai-completions" },
+  { id: "minimax-global", name: "MiniMax（全球）", provider: "minimax", baseUrl: "https://api.minimax.io/anthropic", defaultModel: "MiniMax-M2.7", api: "anthropic-messages" },
+  { id: "moonshotai", name: "Moonshot（全球）", provider: "moonshotai", baseUrl: "https://api.moonshot.ai/v1", defaultModel: "kimi-k2-0711-preview", api: "openai-completions" },
+  { id: "opencode", name: "OpenCode Zen", provider: "opencode", baseUrl: "https://opencode.ai/zen", defaultModel: "claude-fable-5", api: "openai-completions" },
+  { id: "qwen-token-plan", name: "通义千问 Token Plan（全球）", provider: "qwen-token-plan", baseUrl: "https://token-plan.ap-southeast-1.maas.aliyuncs.com/compatible-mode/v1", defaultModel: "qwen3.7-max", api: "openai-completions" },
+  { id: "vercel-ai-gateway", name: "Vercel AI Gateway", provider: "vercel-ai-gateway", baseUrl: "https://ai-gateway.vercel.sh", defaultModel: "zai/glm-5.1", api: "anthropic-messages" },
+  { id: "xiaomi", name: "Xiaomi MiMo", provider: "xiaomi", baseUrl: "https://api.xiaomimimo.com/v1", defaultModel: "mimo-v2-flash", api: "openai-completions" },
+  { id: "xiaomi-token-plan-cn", name: "Xiaomi MiMo Token Plan（中国）", provider: "xiaomi-token-plan-cn", baseUrl: "https://token-plan-cn.xiaomimimo.com/v1", defaultModel: "mimo-v2.5-pro", api: "openai-completions" },
+  { id: "xiaomi-token-plan-ams", name: "Xiaomi MiMo Token Plan（阿姆斯特丹）", provider: "xiaomi-token-plan-ams", baseUrl: "https://token-plan-ams.xiaomimimo.com/v1", defaultModel: "mimo-v2.5-pro", api: "openai-completions" },
+  { id: "xiaomi-token-plan-sgp", name: "Xiaomi MiMo Token Plan（新加坡）", provider: "xiaomi-token-plan-sgp", baseUrl: "https://token-plan-sgp.xiaomimimo.com/v1", defaultModel: "mimo-v2.5-pro", api: "openai-completions" },
+  { id: "zai", name: "ZAI Coding Plan（全球）", provider: "zai", baseUrl: "https://api.z.ai/api/coding/paas/v4", defaultModel: "glm-4.5-air", api: "openai-completions" },
 ]);
 
 export interface BuiltinPiProviderSetupSelection {

--- a/src/setup/bot-register.ts
+++ b/src/setup/bot-register.ts
@@ -619,7 +619,7 @@ const setupBaseUrl = flag("--base-url");
 const setupModel = flag("--model");
 if (piDistributionFlag === "builtin") {
   if (!setupProvider && !setupBaseUrl) {
-    throw new Error("builtin-pi 需要 --provider <id>（deepseek|kimi|minimax|zhipu|openai|anthropic|gemini|groq|cerebras|xai|fireworks|together|mistral|openrouter|kimi-coding|qwen-cn|custom）或 --base-url；或改用 --runtime external-pi 使用已有 pi 环境");
+    throw new Error(`builtin-pi 需要 --provider <id>（${PI_PROVIDER_PRESETS.map((p) => p.id).join("|")}|custom）或 --base-url；或改用 --runtime external-pi 使用已有 pi 环境`);
   }
   if (!setupApiKey) throw new Error("builtin-pi 需要 --api-key；或改用 --runtime external-pi 使用已有 pi 登录");
   // 自定义网关（--base-url）走 custom 预设：pi 会把 baseUrl 作为 provider 端点写入配置，

--- a/test/unit/runtime/pi-provider-config.test.mjs
+++ b/test/unit/runtime/pi-provider-config.test.mjs
@@ -15,6 +15,8 @@ test("Pi provider presets keep the requested setup order and audited official en
   assert.deepEqual(PI_PROVIDER_PRESETS.map((item) => item.id), [
     "deepseek", "kimi", "minimax", "zhipu", "openai", "anthropic", "gemini", "groq",
     "cerebras", "xai", "fireworks", "together", "mistral", "openrouter", "kimi-coding", "qwen-cn", "opencode-go",
+    "ant-ling", "nvidia", "huggingface", "minimax-global", "moonshotai", "opencode", "qwen-token-plan",
+    "vercel-ai-gateway", "xiaomi", "xiaomi-token-plan-cn", "xiaomi-token-plan-ams", "xiaomi-token-plan-sgp", "zai",
   ]);
   assert.deepEqual(PI_PROVIDER_PRESETS.map((item) => item.baseUrl), [
     "https://api.deepseek.com",
@@ -34,6 +36,19 @@ test("Pi provider presets keep the requested setup order and audited official en
     "https://api.kimi.com/coding",
     "https://token-plan.cn-beijing.maas.aliyuncs.com/compatible-mode/v1",
     "https://opencode.ai/zen/go/v1",
+    "https://api.ant-ling.com/v1",
+    "https://integrate.api.nvidia.com/v1",
+    "https://router.huggingface.co/v1",
+    "https://api.minimax.io/anthropic",
+    "https://api.moonshot.ai/v1",
+    "https://opencode.ai/zen",
+    "https://token-plan.ap-southeast-1.maas.aliyuncs.com/compatible-mode/v1",
+    "https://ai-gateway.vercel.sh",
+    "https://api.xiaomimimo.com/v1",
+    "https://token-plan-cn.xiaomimimo.com/v1",
+    "https://token-plan-ams.xiaomimimo.com/v1",
+    "https://token-plan-sgp.xiaomimimo.com/v1",
+    "https://api.z.ai/api/coding/paas/v4",
   ]);
 });
 


### PR DESCRIPTION
从 pi 发行包的 providers/data/*.json 与 model-resolver 默认模型表提取官方 baseUrl/默认模型，一次性补齐 13 个纯 API-key 预设（ant-ling/nvidia/huggingface/minimax-global/moonshotai/opencode/qwen-token-plan/vercel-ai-gateway/xiaomi 系 4 个/zai），预设总数 30。OAuth 类与参数模板类另行追踪（issue #101）。版本 0.2.92 → 0.2.93。typecheck/build ✓，相关单测 21/21 ✓。