### PR TITLE
fix(release): grant draft asset visibility

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -334,7 +334,8 @@ jobs:
       (github.event_name == 'workflow_dispatch' && needs.build.result == 'skipped'))
     runs-on: ubuntu-24.04
     permissions:
-      contents: read
+      # GitHub hides draft releases and their assets from read-only workflow tokens.
+      contents: write
     defaults:
       run:
         working-directory: release-source

--- a/test/integration/build/release-platform-ci.test.mjs
+++ b/test/integration/build/release-platform-ci.test.mjs
@@ -126,6 +126,7 @@ test("package version and explicit tag publication share one immutable combined-
   assert.doesNotMatch(workflow, /gh release download|--clobber/);
   assert.match(workflow, /build:[\s\S]*github\.event_name != 'workflow_dispatch'/);
   assert.match(workflow, /assemble-release:[\s\S]*always\(\)[\s\S]*needs\.build\.result == 'skipped'/);
+  assert.match(workflow, /assemble-release:[\s\S]*permissions:\n\s+# GitHub hides draft releases and their assets from read-only workflow tokens\.\n\s+contents: write/);
   assert.match(workflow, /repos\/\$\{GITHUB_REPOSITORY\}\/releases\?per_page=100/);
   assert.match(workflow, /repos\/\$\{GITHUB_REPOSITORY\}\/releases\/\$\{release_id\}\/assets\?per_page=100/);
   assert.match(workflow, /repos\/\$\{GITHUB_REPOSITORY\}\/releases\/assets\/\$\{asset_ids\[0\]\}/);


### PR DESCRIPTION
## Summary
- grant the assembly job the contents permission GitHub requires to discover and download draft release assets
- retain exact draft-asset validation and non-clobbering recovery behavior

## Validation
- `bun test --isolate --max-concurrency 1 ./test/integration/build/release-platform-ci.test.mjs`
- release workflow YAML syntax parse