### PR TITLE
fix(release): continue recovery after skipped builds

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -419,7 +419,10 @@ jobs:
       - resolve-release
       - prepare-release
       - assemble-release
-    if: needs.prepare-release.outputs.should_publish == 'true'
+    if: >-
+      always() &&
+      needs.prepare-release.outputs.should_publish == 'true' &&
+      needs.assemble-release.result == 'success'
     runs-on: windows-latest
     timeout-minutes: 20
     defaults:
@@ -482,7 +485,11 @@ jobs:
       - prepare-release
       - assemble-release
       - verify-windows-release
-    if: needs.prepare-release.outputs.should_publish == 'true'
+    if: >-
+      always() &&
+      needs.prepare-release.outputs.should_publish == 'true' &&
+      needs.assemble-release.result == 'success' &&
+      needs.verify-windows-release.result == 'success'
     runs-on: ubuntu-24.04
     permissions:
       contents: write

--- a/test/integration/build/release-platform-ci.test.mjs
+++ b/test/integration/build/release-platform-ci.test.mjs
@@ -132,9 +132,9 @@ test("package version and explicit tag publication share one immutable combined-
   assert.match(workflow, /repos\/\$\{GITHUB_REPOSITORY\}\/releases\/assets\/\$\{asset_ids\[0\]\}/);
   assert.match(workflow, /Expected exactly one uploaded draft asset named \$asset_name/);
   assert.match(workflow, /assemble-release:[\s\S]*bun scripts\/release\/assemble\.ts[\s\S]*actions\/upload-artifact@v4/);
-  assert.match(workflow, /verify-windows-release:[\s\S]*runs-on: windows-latest/);
+  assert.match(workflow, /verify-windows-release:[\s\S]*always\(\)[\s\S]*needs\.assemble-release\.result == 'success'[\s\S]*runs-on: windows-latest/);
   assert.match(workflow, /verify-windows-release:[\s\S]*ref: \$\{\{ github\.workflow_sha \}\}[\s\S]*path: release-tooling[\s\S]*actions\/download-artifact@v4[\s\S]*Get-FileHash[\s\S]*release-tooling\/scripts\/release\/smoke\.ts" --release-dir artifacts\/release/);
-  assert.match(workflow, /publish:[\s\S]*- verify-windows-release[\s\S]*Download Windows-verified assembled release[\s\S]*Finalize GitHub release/);
+  assert.match(workflow, /publish:[\s\S]*- verify-windows-release[\s\S]*always\(\)[\s\S]*needs\.verify-windows-release\.result == 'success'[\s\S]*Download Windows-verified assembled release[\s\S]*Finalize GitHub release/);
   assert.ok(workflow.indexOf("  verify-windows-release:") < workflow.indexOf("  publish:"));
   assert.match(workflow, /gh release edit[\s\S]*--draft=false/);
   assert.match(workflow, /bun scripts\/release\/assemble\.ts/);


### PR DESCRIPTION
## Summary
- explicitly run native Windows verification after a successful recovered assembly
- explicitly run publication after successful recovered assembly and Windows verification
- preserve fail-closed dependency result checks

## Validation
- `bun test --isolate --max-concurrency 1 ./test/integration/build/release-platform-ci.test.mjs`
- release workflow YAML syntax parse