### PR TITLE
docs(agent): keep Feishu links visibly clickable

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,10 @@ The rest of this document uses the short `larkin` form; it works as-is after `np
 
 Run `larkin --help` or `larkin config --help` for the available commands and configuration options. Local configuration is stored under `~/.larkin` by default; set `LARKIN_CONFIG_DIR` to use another directory.
 
+### Feishu message links
+
+Feishu clients do not reliably render Markdown links such as `[label](URL)` as clickable in text or Markdown messages. When a recipient must be able to open a link, keep the complete bare HTTPS URL visible, for example: Issue 115 — https://github.com/eddiearc/larkin/issues/115. A label may accompany it, but must not replace the bare URL. Larkin does not rewrite exact, verbatim, or user-authored message bodies to enforce this guidance.
+
 During setup, a new Agent is offered Pi first, followed by Codex and Claude Code. Pi can use an existing
 official `pi` installation or the official Pi runtime bundled in Larkin. The bundled option supports
 DeepSeek, Kimi/Moonshot, MiniMax, Zhipu/BigModel, and a custom OpenAI-compatible Base URL. Provider keys

--- a/evals/agent-experience-v6/scenarios.json
+++ b/evals/agent-experience-v6/scenarios.json
@@ -3,7 +3,7 @@
   "version": 6,
   "model": {
     "selection": "deterministic-trace",
-    "standing_prompt_version": "larkin-standing-v19"
+    "standing_prompt_version": "larkin-standing-v20"
   },
   "session": {
     "initial_turns": 0

--- a/evals/authoritative-freshness-gate/scenarios.json
+++ b/evals/authoritative-freshness-gate/scenarios.json
@@ -1,7 +1,7 @@
 {
   "dataset": "authoritative-freshness-gate",
   "version": 1,
-  "standing_prompt_version": "larkin-standing-v19",
+  "standing_prompt_version": "larkin-standing-v20",
   "runtime": { "adapter": "codex", "selection": "runtime-default" },
   "grader": {
     "name": "authoritative-freshness-trace-grader",

--- a/evals/clickable-link-delivery/scenarios.json
+++ b/evals/clickable-link-delivery/scenarios.json
@@ -1,0 +1,39 @@
+{
+  "dataset": "clickable-link-delivery",
+  "version": 1,
+  "standing_prompt_version": "larkin-standing-v20",
+  "runtime": { "adapter": "codex", "selection": "runtime-default" },
+  "threshold": 1,
+  "grader": {
+    "name": "clickable-link-delivery-trace-grader",
+    "version": 1,
+    "threshold": 1,
+    "rubric": [
+      "exactly one successful fake provider write reaches the scenario's fixed synthetic target",
+      "ordinary delivery keeps the complete HTTPS URL visible outside Markdown-link spans with URL boundaries",
+      "exact delivery uses --text and preserves the supplied body byte-for-byte",
+      "assistant output, prompt text, malformed traces, missing writes, and duplicate writes never count"
+    ]
+  },
+  "session": { "initial_turns": 0, "fresh_per_scenario": true },
+  "scenarios": [
+    {
+      "id": "ordinary-openable-link",
+      "operation": "send",
+      "target_flag": "--chat-id",
+      "target": "oc_eval_clickable",
+      "url": "https://github.com/eddiearc/larkin/issues/115",
+      "task": "Send a concise Issue 115 message to synthetic chat oc_eval_clickable. The recipient must be able to open https://github.com/eddiearc/larkin/issues/115.",
+      "prompt": "This is a controlled payload eval with a fake sink and synthetic target. Execute exactly one send using {larkin} im +messages-send --chat-id oc_eval_clickable. Send a concise Issue 115 message containing https://github.com/eddiearc/larkin/issues/115, and ensure the recipient can open the link. Use a regular textual body and --json. Do not merely describe the message; stop after the fake success result."
+    },
+    {
+      "id": "exact-markdown-link-body",
+      "operation": "reply",
+      "target_flag": "--message-id",
+      "target": "om_eval_clickable_exact",
+      "exact_body": "[Issue 115](https://github.com/eddiearc/larkin/issues/115)",
+      "task": "Reply to synthetic message om_eval_clickable_exact with this exact body: [Issue 115](https://github.com/eddiearc/larkin/issues/115)",
+      "prompt": "This is a controlled payload eval with a fake sink and synthetic target. Execute exactly one reply using {larkin} im +messages-reply --message-id om_eval_clickable_exact --text '[Issue 115](https://github.com/eddiearc/larkin/issues/115)' --json. The body is exact and verbatim: [Issue 115](https://github.com/eddiearc/larkin/issues/115). Do not add a visible URL, prefix, suffix, or any other text; stop after the fake success result."
+    }
+  ]
+}

--- a/evals/mention-construction/scenarios.json
+++ b/evals/mention-construction/scenarios.json
@@ -1,7 +1,7 @@
 {
   "dataset": "mention-construction",
   "version": 1,
-  "standing_prompt_version": "larkin-standing-v19",
+  "standing_prompt_version": "larkin-standing-v20",
   "runtime": { "adapter": "codex", "selection": "runtime-default" },
   "grader": {
     "name": "mention-construction-trace-grader",

--- a/evals/runtime-agent-interface-v2/scenarios.json
+++ b/evals/runtime-agent-interface-v2/scenarios.json
@@ -7,7 +7,7 @@
   },
   "model": {
     "selection": "gpt-5.6-sol",
-    "standing_prompt_version": "larkin-standing-v19"
+    "standing_prompt_version": "larkin-standing-v20"
   },
   "grader": {
     "name": "runtime-agent-interface-v2-trace-grader",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "larkin",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "private": false,
   "larkinPackageRole": "npm-published",
   "files": [
@@ -74,6 +74,8 @@
     "test:eval:authoritative-freshness-gate": "bun test --max-concurrency 1 test/unit/evals/authoritative-freshness-gate.test.mjs",
     "test:eval:agent-experience-v6": "bun test --max-concurrency 1 test/unit/evals/agent-experience-v6.test.mjs",
     "test:eval:mention-construction": "bun run build && LARKIN_RUN_MENTION_CONSTRUCTION_EVAL=1 bun test --max-concurrency 1 test/live/mention-construction-agent-eval.test.mjs",
+    "test:eval:clickable-link-delivery": "bun run build && bun test --max-concurrency 1 test/unit/evals/clickable-link-delivery.test.mjs",
+    "test:eval:clickable-link-delivery:native": "bun run build && LARKIN_RUN_CLICKABLE_LINK_DELIVERY_EVAL=1 bun test --max-concurrency 1 test/live/clickable-link-delivery-agent-eval.test.mjs",
     "test:eval:public-contribution-governance": "bun test --max-concurrency 1 test/unit/evals/public-contribution-governance.test.mjs",
     "test:live:public-contribution-governance": "bun test --max-concurrency 1 test/live/public-contribution-governance-live.test.mjs",
     "test:eval:authoritative-freshness-gate:native": "bun run build && LARKIN_RUN_AUTHORITATIVE_FRESHNESS_EVAL=1 bun test --max-concurrency 1 test/live/authoritative-freshness-gate-agent-eval.test.mjs",

--- a/src/agent/context-prompt.ts
+++ b/src/agent/context-prompt.ts
@@ -16,7 +16,7 @@ import type { AgentCliCapabilities, RuntimeId, RuntimeInput, StandingPrompt } fr
  * 6. 用 eval 验证：行为变化必须配套固定场景 + rubric（evals/*、test/support/*-grader.mjs、live 测试）。
  */
 
-export const LARKIN_STANDING_PROMPT_VERSION = "larkin-standing-v19";
+export const LARKIN_STANDING_PROMPT_VERSION = "larkin-standing-v20";
 
 /**
  * Agent 间协作唤醒引导（issue #75）：纯文本 @ 不会产生飞书 mention 事件，
@@ -145,7 +145,9 @@ export class ContextPromptBuilder {
       "Only a real Feishu `message_id` beginning with `om_` may be passed to `+messages-reply`; `rem_`, `redeliver_`, and every other synthetic ID must never be replied to. Send with a confirmed `chat_id` and never guess a chat id from a display name.",
       "Before every send/reply/card write, Larkin probes the exact chat or thread history with the current Bot identity. A nonzero `freshness_conflict` includes bounded unseen context and direct-acks that cursor; reconsider it, then retry the ordinary command. Larkin never saves the blocked message body as a draft.",
       "For regular textual message bodies, default to `--markdown`, including brief single-line replies, so Feishu renders Markdown structure instead of showing its markers literally.",
+      "When a URL must be visible, clickable, or openable by the recipient, include the complete bare `https://...` URL as visible text. Do not rely solely on `[label](URL)`, because Feishu client rendering is unreliable. A label may also be included, but the bare URL must remain present.",
       "Use native `--text` only when plain text or verbatim preservation is explicitly needed, such as logs, code, or exact whitespace. Both `--markdown` and `--text` remain supported in the Larkin Runtime.",
+      "Never rewrite or normalize an exact or verbatim user-supplied body to expose a URL; the existing exact-content paths remain authoritative and preserve the supplied body unchanged.",
       "For exact text supplied directly in the current instruction or Inbox event, pass the body unchanged as one literal `--text` argument. A direct literal must not use command substitution, backticks, `eval`, `echo`, or an unquoted variable; if it cannot be represented safely, stop and report the limitation instead of normalizing it.",
       "An explicit exact or verbatim direct literal uses `--text` and overrides the regular markdown default.",
       `For a common exact send with a confirmed chat id, use the complete schematic recipe \`${executable} im +messages-send --chat-id <confirmed_chat_id> --text '<exact_body_as_one_literal_argument>' --json\`; replace each placeholder with the corresponding confirmed or exact literal value.`,

--- a/test/live/clickable-link-delivery-agent-eval.test.mjs
+++ b/test/live/clickable-link-delivery-agent-eval.test.mjs
@@ -1,0 +1,161 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { execFileSync, spawn } from "node:child_process";
+import { PassThrough } from "node:stream";
+import { test } from "bun:test";
+import { ContextPromptBuilder } from "../../dist/agent/context-prompt.mjs";
+import { createNativeRuntimeAdapter } from "../../dist/runtime/runtime-adapters.mjs";
+import { gradeClickableLinkDeliveryTrace, loadClickableLinkDeliveryEval } from "../support/clickable-link-delivery-grader.mjs";
+import { gradeNativeCommandAudit, isolatedNativeEnv, v19Counterfactual } from "../support/clickable-link-delivery-native-support.mjs";
+
+const RUN = process.env.LARKIN_RUN_CLICKABLE_LINK_DELIVERY_EVAL === "1";
+const ROOT = path.resolve(import.meta.dirname, "../..");
+const FAKE = path.join(ROOT, "test/support/clickable-link-delivery-eval-cli.mjs");
+const DATASET = loadClickableLinkDeliveryEval(path.join(ROOT, "evals/clickable-link-delivery/scenarios.json"));
+const PROMPT_VERSION = process.env.LARKIN_CLICKABLE_EVAL_PROMPT_VERSION || "v20";
+const SCENARIO_ID = process.env.LARKIN_CLICKABLE_EVAL_SCENARIO || "ordinary-openable-link";
+const SCENARIO = DATASET.scenarios.find((scenario) => scenario.id === SCENARIO_ID);
+const MAX_RUN_MS = 52_000;
+
+function remaining(deadline) {
+  const value = deadline - Date.now();
+  if (value <= 0) throw new Error("native clickable-link eval timed out after 52s");
+  return value;
+}
+
+async function promptWhenReady(session, input, deadline) {
+  for (;;) {
+    const result = await session.prompt(input);
+    if (result.status !== "deferred" || !/not initialized/i.test(result.reason || "")) return result;
+    remaining(deadline);
+    await new Promise((resolve) => setTimeout(resolve, 25));
+  }
+}
+
+function waitForTurnEnd(events, after, deadline) {
+  return new Promise((resolve, reject) => {
+    const find = () => events.items.slice(after).find((event) => event.type === "turn-end");
+    if (find()) return resolve(find());
+    const timer = setTimeout(() => reject(new Error("native clickable-link eval timed out after 52s")), remaining(deadline));
+    events.waiters.push(() => { const found = find(); if (found) { clearTimeout(timer); resolve(found); } });
+  });
+}
+
+function writeShadow(file, surface) {
+  fs.writeFileSync(file,
+    `#!/bin/sh\nCLICKABLE_EVAL_SURFACE=${surface} exec ${JSON.stringify(process.execPath)} ${JSON.stringify(FAKE)} "$@"\n`,
+    { mode: 0o700 });
+}
+
+if (RUN) {
+  if (!SCENARIO) throw new Error(`unknown clickable-link eval scenario: ${SCENARIO_ID}`);
+  if (!["v19", "v20"].includes(PROMPT_VERSION)) throw new Error(`unknown clickable-link prompt version: ${PROMPT_VERSION}`);
+}
+
+test.skipIf(!RUN)(`native clickable-link payload eval (${PROMPT_VERSION}/${SCENARIO_ID})`, { timeout: 55_000 }, async () => {
+  const deadline = Date.now() + MAX_RUN_MS;
+  const temp = fs.mkdtempSync(path.join(os.tmpdir(), "larkin-clickable-native-eval-"));
+  const workspaceDir = path.join(temp, "workspace");
+  const stateDir = path.join(temp, "state");
+  const binDir = path.join(temp, "bin");
+  const traceFile = path.join(temp, "trace.ndjson");
+  const fakeLarkin = path.join(binDir, "larkin");
+  const fakeLarkCli = path.join(binDir, "lark-cli");
+  let session;
+  let model = null;
+  let evidenceWritten = false;
+  const commandAudit = [];
+  try {
+    for (const dir of [workspaceDir, stateDir, binDir]) fs.mkdirSync(dir, { recursive: true, mode: 0o700 });
+    fs.writeFileSync(traceFile, "", { mode: 0o600 });
+    fs.writeFileSync(path.join(workspaceDir, "AGENTS.md"), [
+      "# Controlled clickable-link payload evaluation",
+      `Use only the absolute fake larkin command supplied by the task. Both larkin and lark-cli on PATH are inert fake sinks.`,
+      "Never inspect files or environment, use network tools, or invoke any other command.",
+      "The targets beginning oc_eval_/om_eval_ are synthetic and no Feishu write is possible.",
+      "Stop immediately after the single fake write result.", "",
+    ].join("\n"), { mode: 0o600 });
+    writeShadow(fakeLarkin, "larkin");
+    writeShadow(fakeLarkCli, "lark-cli");
+    const codexCommand = execFileSync("sh", ["-c", "command -v codex"], { encoding: "utf8", timeout: 2_000 }).trim();
+    assert.ok(codexCommand, "native Codex executable is unavailable");
+    const nativeEnv = isolatedNativeEnv(process.env, { temp, binDir, codexCommand, traceFile });
+    assert.equal(Object.entries(nativeEnv).some(([key, value]) => /^(?:LARK|FEISHU)/i.test(key) && value !== undefined), false);
+    assert.equal(fs.existsSync(path.join(nativeEnv.HOME, ".larkin")), false);
+    const captureSpawn = (command, args, options) => {
+      const child = spawn(command, args, options);
+      const stdout = new PassThrough();
+      let pending = "";
+      child.stdout.setEncoding("utf8");
+      child.stdout.on("data", (chunk) => {
+        stdout.write(chunk); pending += chunk;
+        for (;;) {
+          const newline = pending.indexOf("\n");
+          if (newline < 0) break;
+          const line = pending.slice(0, newline); pending = pending.slice(newline + 1);
+          try {
+            const message = JSON.parse(line); const item = message.params?.item;
+            if (message.method === "item/completed" && item?.type === "commandExecution") {
+              commandAudit.push({ item_type: item.type, command: item.command, exit_code: item.exitCode });
+            } else if (message.method === "item/completed" && item?.type
+                && !["userMessage", "agentMessage", "reasoning"].includes(item.type)) {
+              commandAudit.push({ item_type: item.type, command: `[${item.type}]`, exit_code: null });
+            }
+          } catch { /* only app-server protocol frames contribute evidence */ }
+        }
+      });
+      child.stdout.on("end", () => stdout.end());
+      return { stdin: child.stdin, stdout, stderr: child.stderr, pid: child.pid,
+        once: child.once.bind(child), on: child.on.bind(child), kill: child.kill.bind(child) };
+    };
+    const v20Prompt = new ContextPromptBuilder().build({
+      agentId: `cli_clickableEval${SCENARIO.id === "ordinary-openable-link" ? "Ord" : "Exact"}`,
+      name: "Clickable Eval", runtime: "codex",
+    });
+    const standingPrompt = PROMPT_VERSION === "v19" ? v19Counterfactual(v20Prompt) : v20Prompt;
+    const adapter = createNativeRuntimeAdapter("codex", { codexCommand, spawn: captureSpawn, env: nativeEnv });
+    session = await adapter.createSession({
+      agentId: "cli_clickableEvalA1", workspaceDir, stateDir, standingPrompt, env: nativeEnv,
+    });
+    const events = { items: [], waiters: [] };
+    session.subscribe((event) => {
+      if (event.type === "session-init") model = event.model || null;
+      events.items.push(event); for (const waiter of events.waiters) waiter(event);
+    });
+    const after = events.items.length;
+    const accepted = await promptWhenReady(session, {
+      inputId: `${PROMPT_VERSION}-${SCENARIO.id}`, kind: "initial", attempt: 0,
+      text: SCENARIO.prompt.replaceAll("{larkin}", JSON.stringify(fakeLarkin)),
+    }, deadline);
+    assert.equal(accepted.status, "accepted", accepted.reason);
+    await waitForTurnEnd(events, after, deadline);
+    const runtimeError = events.items.slice(after).find((event) => ["error", "configuration-error", "input-error"].includes(event.type));
+    assert.equal(runtimeError, undefined, runtimeError?.message);
+    const trace = fs.readFileSync(traceFile, "utf8").split("\n").filter(Boolean).map(JSON.parse);
+    const payloadGrade = gradeClickableLinkDeliveryTrace(SCENARIO, trace);
+    const auditGrade = gradeNativeCommandAudit(commandAudit, fakeLarkin, fakeLarkCli);
+    const grade = { passed: payloadGrade.passed && auditGrade.passed,
+      failures: [...payloadGrade.failures, ...auditGrade.failures] };
+    process.stderr.write(`# clickable-link native eval: ${JSON.stringify({
+      dataset: DATASET.dataset, scenario: SCENARIO.id, runtime: "codex",
+      model: model || DATASET.runtime.selection, model_id_exposed: Boolean(model),
+      prompt: { version: standingPrompt.version, hash: standingPrompt.hash },
+      trace, grade, real_provider_write_possible: false,
+    })}\n`);
+    evidenceWritten = true;
+    assert.equal(grade.passed, true, JSON.stringify(grade.failures));
+  } catch (error) {
+    if (!evidenceWritten) process.stderr.write(`# clickable-link native eval blocker: ${JSON.stringify({
+      dataset: DATASET.dataset, scenario: SCENARIO?.id || SCENARIO_ID, runtime: "codex",
+      model: model || DATASET.runtime.selection, model_id_exposed: Boolean(model),
+      prompt_version: PROMPT_VERSION, blocker: error instanceof Error ? error.message : String(error),
+      real_provider_write_possible: false,
+    })}\n`);
+    throw error;
+  } finally {
+    await session?.close("clickable-link eval complete");
+    fs.rmSync(temp, { recursive: true, force: true });
+  }
+});

--- a/test/support/agent-experience-v6-grader.mjs
+++ b/test/support/agent-experience-v6-grader.mjs
@@ -41,7 +41,7 @@ function correctionBoundaryIssue(scenario) {
 export function loadAgentExperienceV6Eval(file) {
   const value = JSON.parse(fs.readFileSync(file, "utf8"));
   if (value.dataset !== "agent-experience-v6" || value.version !== 6) throw new Error("eval dataset/version mismatch");
-  if (value.model?.standing_prompt_version !== "larkin-standing-v19") throw new Error("standing prompt version mismatch");
+  if (value.model?.standing_prompt_version !== "larkin-standing-v20") throw new Error("standing prompt version mismatch");
   if (value.session?.initial_turns !== 0) throw new Error("eval scenarios must start from a fresh empty session");
   if (value.grader?.name !== "agent-experience-v6-trace-grader" || value.grader.version !== 6 || value.grader.threshold !== 1) {
     throw new Error("eval grader metadata mismatch");

--- a/test/support/authoritative-freshness-gate-grader.mjs
+++ b/test/support/authoritative-freshness-gate-grader.mjs
@@ -3,7 +3,7 @@ import fs from "node:fs";
 export function loadAuthoritativeFreshnessEval(file) {
   const value = JSON.parse(fs.readFileSync(file, "utf8"));
   if (value.dataset !== "authoritative-freshness-gate" || value.version !== 1) throw new Error("eval dataset/version mismatch");
-  if (value.standing_prompt_version !== "larkin-standing-v19") throw new Error("standing prompt version mismatch");
+  if (value.standing_prompt_version !== "larkin-standing-v20") throw new Error("standing prompt version mismatch");
   if (value.runtime?.adapter !== "codex" || !value.runtime.selection) throw new Error("native runtime metadata is required");
   if (value.grader?.name !== "authoritative-freshness-trace-grader" || value.grader.version !== 1) throw new Error("grader metadata mismatch");
   if (!(value.grader.threshold > 0 && value.grader.threshold <= 1)) throw new Error("grader threshold must be in (0,1]");

--- a/test/support/clickable-link-delivery-eval-cli.mjs
+++ b/test/support/clickable-link-delivery-eval-cli.mjs
@@ -1,0 +1,54 @@
+import fs from "node:fs";
+
+const traceFile = process.env.CLICKABLE_EVAL_TRACE_FILE;
+if (!traceFile) throw new Error("CLICKABLE_EVAL_TRACE_FILE is required");
+const argv = process.argv.slice(2);
+const surface = process.env.CLICKABLE_EVAL_SURFACE || "unknown";
+const append = (event) => fs.appendFileSync(traceFile, `${JSON.stringify(event)}\n`, { encoding: "utf8", mode: 0o600, flag: "a" });
+const indexes = (flag) => argv.reduce((all, value, index) => value === flag ? [...all, index] : all, []);
+const valueAt = (flag) => {
+  const found = indexes(flag);
+  return found.length === 1 ? argv[found[0] + 1] ?? "" : "";
+};
+
+const command = argv[1];
+const operation = command === "+messages-send" ? "send" : command === "+messages-reply" ? "reply" : null;
+if (argv[0] !== "im" || operation === null) {
+  append({ action: "eval_rejection", argv, error: "unsupported command" });
+  process.stderr.write("clickable-link eval exposes only synthetic send/reply commands\n");
+  process.exit(2);
+}
+
+const targetFlag = operation === "send" ? "--chat-id" : "--message-id";
+const bodyFlags = ["--text", "--markdown", "--content"];
+const presentBodyFlags = bodyFlags.flatMap((flag) => indexes(flag).map(() => flag));
+const bodyFlag = presentBodyFlags.length === 1 ? presentBodyFlags[0] : "";
+const target = valueAt(targetFlag);
+const body = bodyFlag ? valueAt(bodyFlag) : "";
+const expectedTarget = operation === "send" ? "oc_eval_clickable" : "om_eval_clickable_exact";
+const valid = surface === "larkin"
+  && indexes(targetFlag).length === 1
+  && target === expectedTarget
+  && presentBodyFlags.length === 1
+  && body.length > 0;
+const error = valid ? null : "fake sink rejected surface, target, or body flags";
+const messageId = valid ? (operation === "send" ? "om_eval_clickable_sent" : "om_eval_clickable_replied") : null;
+append({
+  schema_version: 1,
+  action: "provider_write",
+  surface,
+  operation,
+  target_flag: targetFlag,
+  target,
+  body_flag: bodyFlag,
+  body,
+  argv,
+  success: valid,
+  message_id: messageId,
+  error,
+});
+if (!valid) {
+  process.stderr.write(`${error}\n`);
+  process.exit(2);
+}
+process.stdout.write(`${JSON.stringify({ ok: true, data: { message_id: messageId, synthetic: true } })}\n`);

--- a/test/support/clickable-link-delivery-grader.mjs
+++ b/test/support/clickable-link-delivery-grader.mjs
@@ -1,0 +1,148 @@
+import fs from "node:fs";
+
+const EVENT_KEYS = [
+  "schema_version", "action", "surface", "operation", "target_flag", "target",
+  "body_flag", "body", "argv", "success", "message_id", "error",
+].sort();
+const BODY_FLAGS = new Set(["--text", "--markdown", "--content"]);
+
+function object(value) {
+  return value !== null && typeof value === "object" && !Array.isArray(value);
+}
+
+function nonempty(value, label) {
+  if (typeof value !== "string" || value.length === 0) throw new Error(`${label} must be a non-empty string`);
+  return value;
+}
+
+function exactKeys(value, expected, label) {
+  const actual = Object.keys(value).sort();
+  if (actual.length !== expected.length || actual.some((key, index) => key !== expected[index])) {
+    throw new Error(`${label} fields mismatch`);
+  }
+}
+
+function occurrences(argv, flag) {
+  return argv.reduce((indexes, value, index) => value === flag ? [...indexes, index] : indexes, []);
+}
+
+function validateProviderWrite(event) {
+  if (!object(event)) throw new Error("provider write must be an object");
+  exactKeys(event, EVENT_KEYS, "provider write");
+  if (event.schema_version !== 1 || event.action !== "provider_write") throw new Error("provider write identity mismatch");
+  if (!["larkin", "lark-cli"].includes(event.surface)) throw new Error("provider write surface mismatch");
+  if (!["send", "reply"].includes(event.operation)) throw new Error("provider write operation mismatch");
+  if (!["--chat-id", "--message-id"].includes(event.target_flag)) throw new Error("provider write target flag mismatch");
+  nonempty(event.target, "provider write target");
+  if (!BODY_FLAGS.has(event.body_flag)) throw new Error("provider write body flag mismatch");
+  if (typeof event.body !== "string") throw new Error("provider write body must be a string");
+  if (!Array.isArray(event.argv) || event.argv.some((part) => typeof part !== "string")) throw new Error("provider write argv mismatch");
+  if (typeof event.success !== "boolean") throw new Error("provider write success mismatch");
+  if (event.success ? !/^om_eval_[A-Za-z0-9_]+$/.test(event.message_id || "") : event.message_id !== null) {
+    throw new Error("provider write message_id mismatch");
+  }
+  if (event.success ? event.error !== null : typeof event.error !== "string" || !event.error) {
+    throw new Error("provider write error mismatch");
+  }
+  const expectedCommand = event.operation === "send" ? "+messages-send" : "+messages-reply";
+  const expectedTargetFlag = event.operation === "send" ? "--chat-id" : "--message-id";
+  if (event.target_flag !== expectedTargetFlag || event.argv[0] !== "im" || event.argv[1] !== expectedCommand) {
+    throw new Error("provider write argv command mismatch");
+  }
+  const targetIndexes = occurrences(event.argv, event.target_flag);
+  const bodyIndexes = [...BODY_FLAGS].flatMap((flag) => occurrences(event.argv, flag));
+  const jsonIndexes = occurrences(event.argv, "--json");
+  if (targetIndexes.length !== 1 || event.argv[targetIndexes[0] + 1] !== event.target) throw new Error("provider write argv target mismatch");
+  if (bodyIndexes.length !== 1 || event.argv[bodyIndexes[0]] !== event.body_flag || event.argv[bodyIndexes[0] + 1] !== event.body) {
+    throw new Error("provider write argv body mismatch");
+  }
+  const consumed = new Set([0, 1, targetIndexes[0], targetIndexes[0] + 1,
+    bodyIndexes[0], bodyIndexes[0] + 1, jsonIndexes[0]]);
+  if (jsonIndexes.length !== 1 || event.argv.length !== 7 || consumed.size !== 7) {
+    throw new Error("provider write argv contains missing, overlapping, or unexpected arguments");
+  }
+  return event;
+}
+
+function stripMarkdownLinkSpans(body) {
+  return body.replace(/!?\[[^\]\r\n]*\]\([^\s)]+(?:\s+['"][^'"\r\n]*['"])?\)/g, "");
+}
+
+function hasBoundedVisibleUrl(body, expectedUrl) {
+  const visible = stripMarkdownLinkSpans(body);
+  let from = 0;
+  for (;;) {
+    const index = visible.indexOf(expectedUrl, from);
+    if (index < 0) return false;
+    const before = index === 0 ? "" : visible[index - 1];
+    const afterIndex = index + expectedUrl.length;
+    const after = afterIndex === visible.length ? "" : visible[afterIndex];
+    const leftBoundary = !before || /[\s([{"'“‘<]/u.test(before);
+    const rightBoundary = !after || /[\s)\]}>,.!?;:"'”’]/u.test(after);
+    if (leftBoundary && rightBoundary) return true;
+    from = index + 1;
+  }
+}
+
+export function loadClickableLinkDeliveryEval(file) {
+  const value = JSON.parse(fs.readFileSync(file, "utf8"));
+  if (value.dataset !== "clickable-link-delivery" || value.version !== 1) throw new Error("eval dataset/version mismatch");
+  if (value.standing_prompt_version !== "larkin-standing-v20") throw new Error("standing prompt version mismatch");
+  if (value.threshold !== 1 || value.grader?.name !== "clickable-link-delivery-trace-grader"
+      || value.grader.version !== 1 || value.grader.threshold !== 1) throw new Error("eval grader metadata mismatch");
+  if (value.session?.initial_turns !== 0 || value.session?.fresh_per_scenario !== true) throw new Error("eval requires fresh sessions");
+  if (!Array.isArray(value.grader.rubric) || value.grader.rubric.length !== 4) throw new Error("eval rubric mismatch");
+  if (!Array.isArray(value.scenarios) || value.scenarios.length !== 2) throw new Error("eval requires exactly two scenarios");
+  const [ordinary, exact] = value.scenarios;
+  if (ordinary?.id !== "ordinary-openable-link" || ordinary.operation !== "send"
+      || ordinary.target_flag !== "--chat-id" || ordinary.target !== "oc_eval_clickable"
+      || ordinary.url !== "https://github.com/eddiearc/larkin/issues/115") throw new Error("ordinary scenario mismatch");
+  if (exact?.id !== "exact-markdown-link-body" || exact.operation !== "reply"
+      || exact.target_flag !== "--message-id" || exact.target !== "om_eval_clickable_exact"
+      || exact.exact_body !== "[Issue 115](https://github.com/eddiearc/larkin/issues/115)") throw new Error("exact scenario mismatch");
+  for (const scenario of value.scenarios) {
+    nonempty(scenario.task, `${scenario.id}.task`);
+    nonempty(scenario.prompt, `${scenario.id}.prompt`);
+  }
+  return value;
+}
+
+export function gradeClickableLinkDeliveryTrace(scenario, trace) {
+  const failures = [];
+  const fail = (rule, detail) => failures.push({ rule, detail });
+  const raw = Array.isArray(trace) ? trace : [];
+  const writes = raw.filter((event) => object(event) && event.action === "provider_write");
+  const validated = [];
+  for (const [index, write] of writes.entries()) {
+    try { validated.push(validateProviderWrite(write)); }
+    catch (error) { fail("trace_schema", `write ${index + 1}: ${error.message}`); }
+  }
+  if (writes.length !== 1) fail("write_count", `expected exactly one provider write, observed ${writes.length}`);
+  const successful = validated.filter((event) => event.success);
+  if (successful.length !== 1) fail("successful_write_count", `expected exactly one successful write, observed ${successful.length}`);
+  const write = successful.length === 1 ? successful[0] : null;
+  if (!write) return { passed: false, failures };
+  if (write.surface !== "larkin") fail("surface", "write must use the PATH-shadowed larkin surface");
+  if (write.operation !== scenario.operation || write.target_flag !== scenario.target_flag || write.target !== scenario.target) {
+    fail("target", "write did not reach the expected synthetic operation and target");
+  }
+  if (scenario.id === "ordinary-openable-link") {
+    if (!["--text", "--markdown"].includes(write.body_flag)) fail("ordinary_body_flag", "ordinary body must use --text or --markdown");
+    if (!hasBoundedVisibleUrl(write.body, scenario.url)) {
+      fail("visible_https_url", "complete HTTPS URL is not visible outside Markdown-link spans with URL boundaries");
+    }
+  } else if (scenario.id === "exact-markdown-link-body") {
+    if (write.body_flag !== "--text") fail("exact_body_flag", "exact direct literal must use --text");
+    if (write.body !== scenario.exact_body) fail("exact_body", "body is not byte-equal to the supplied exact body");
+  } else {
+    fail("scenario", "unsupported scenario");
+  }
+  return { passed: failures.length === 0, failures };
+}
+
+export function summarizeClickableLinkDeliveryEval(dataset, tracesById) {
+  const results = dataset.scenarios.map((scenario) => ({ id: scenario.id,
+    ...gradeClickableLinkDeliveryTrace(scenario, tracesById[scenario.id] || []) }));
+  const passRate = results.filter((result) => result.passed).length / results.length;
+  return { passed: passRate >= dataset.threshold, pass_rate: passRate, threshold: dataset.threshold, results };
+}

--- a/test/support/clickable-link-delivery-native-support.mjs
+++ b/test/support/clickable-link-delivery-native-support.mjs
@@ -1,0 +1,67 @@
+import { createHash } from "node:crypto";
+import fs from "node:fs";
+import path from "node:path";
+
+export const CLICKABLE_LINK_V20_GUIDANCE = [
+  "When a URL must be visible, clickable, or openable by the recipient, include the complete bare `https://...` URL as visible text. Do not rely solely on `[label](URL)`, because Feishu client rendering is unreliable. A label may also be included, but the bare URL must remain present.",
+  "Never rewrite or normalize an exact or verbatim user-supplied body to expose a URL; the existing exact-content paths remain authoritative and preserve the supplied body unchanged.",
+];
+
+export function v19Counterfactual(standingPrompt) {
+  if (standingPrompt?.version !== "larkin-standing-v20" || typeof standingPrompt.content !== "string") {
+    throw new Error("v19 counterfactual requires a v20 standing prompt");
+  }
+  let content = standingPrompt.content;
+  for (const line of CLICKABLE_LINK_V20_GUIDANCE) {
+    const count = content.split(line).length - 1;
+    if (count !== 1 || !content.includes(`${line}\n`)) throw new Error("v20 guidance line must occur exactly once");
+    content = content.replace(`${line}\n`, "");
+  }
+  if (CLICKABLE_LINK_V20_GUIDANCE.some((line) => content.includes(line))) throw new Error("v20 guidance survived counterfactual");
+  return {
+    version: "larkin-standing-v19",
+    content,
+    hash: createHash("sha256").update(content).digest("hex"),
+  };
+}
+
+export function isolatedNativeEnv(baseEnv, { temp, binDir, codexCommand, traceFile }) {
+  const env = {};
+  for (const [key, value] of Object.entries(baseEnv)) {
+    env[key] = /^(?:LARK|FEISHU)/i.test(key) ? undefined : value;
+  }
+  const home = path.join(temp, "home");
+  const nonexistentConfig = path.join(temp, "nonexistent-provider-config");
+  fs.mkdirSync(home, { recursive: true, mode: 0o700 });
+  fs.rmSync(nonexistentConfig, { recursive: true, force: true });
+  env.HOME = home;
+  env.XDG_CONFIG_HOME = nonexistentConfig;
+  const inheritedCodexHome = baseEnv.CODEX_HOME || (baseEnv.HOME ? path.join(baseEnv.HOME, ".codex") : "");
+  if (inheritedCodexHome && fs.existsSync(inheritedCodexHome)) env.CODEX_HOME = inheritedCodexHome;
+  env.PATH = [binDir, path.dirname(codexCommand), path.dirname(process.execPath), "/usr/bin", "/bin"].join(path.delimiter);
+  env.CLICKABLE_EVAL_TRACE_FILE = traceFile;
+  for (const [key, value] of Object.entries(env)) {
+    if (/^(?:LARK|FEISHU)/i.test(key) && value !== undefined) throw new Error(`unsafe inherited provider environment: ${key}`);
+  }
+  if (fs.existsSync(path.join(home, ".larkin")) || fs.existsSync(nonexistentConfig)) {
+    throw new Error("provider config isolation failed");
+  }
+  return env;
+}
+
+export function gradeNativeCommandAudit(commandAudit, fakeLarkin, fakeLarkCli) {
+  const failures = [];
+  if (!Array.isArray(commandAudit) || commandAudit.length !== 1) {
+    failures.push({ rule: "native_command_count", detail: `expected one command execution, observed ${commandAudit?.length ?? 0}` });
+  }
+  for (const event of Array.isArray(commandAudit) ? commandAudit : []) {
+    if (event.item_type !== "commandExecution" || typeof event.command !== "string" || event.exit_code !== 0) {
+      failures.push({ rule: "native_command_shape", detail: "command execution was malformed or unsuccessful" });
+      continue;
+    }
+    if (!event.command.includes(fakeLarkin) || event.command.includes(fakeLarkCli)) {
+      failures.push({ rule: "fake_sink_only", detail: "command did not exclusively select the controlled larkin sink" });
+    }
+  }
+  return { passed: failures.length === 0, failures };
+}

--- a/test/support/mention-construction-grader.mjs
+++ b/test/support/mention-construction-grader.mjs
@@ -8,7 +8,7 @@ function nonempty(value, label) {
 export function loadMentionConstructionEval(file) {
   const value = JSON.parse(fs.readFileSync(file, "utf8"));
   if (value.dataset !== "mention-construction" || value.version !== 1) throw new Error("eval dataset/version mismatch");
-  if (value.standing_prompt_version !== "larkin-standing-v19") throw new Error("standing prompt version mismatch");
+  if (value.standing_prompt_version !== "larkin-standing-v20") throw new Error("standing prompt version mismatch");
   if (value.session?.initial_turns !== 0) throw new Error("eval scenarios must start from a fresh empty session");
   if (value.grader?.name !== "mention-construction-trace-grader" || value.grader.version !== 1 || value.grader.threshold !== 1) {
     throw new Error("eval grader metadata mismatch");

--- a/test/support/runtime-agent-interface-v2-grader.mjs
+++ b/test/support/runtime-agent-interface-v2-grader.mjs
@@ -10,7 +10,7 @@ export function loadRuntimeAgentInterfaceEval(file) {
   if (value.dataset !== "runtime-agent-interface-v2" || value.version !== 1) throw new Error("eval dataset/version mismatch");
   if (value.runtime?.adapter !== "codex") throw new Error("eval runtime.adapter must be codex");
   nonempty(value.runtime.minimum_cli_version, "runtime.minimum_cli_version");
-  if (value.model?.standing_prompt_version !== "larkin-standing-v19") throw new Error("eval standing prompt version mismatch");
+  if (value.model?.standing_prompt_version !== "larkin-standing-v20") throw new Error("eval standing prompt version mismatch");
   nonempty(value.model.selection, "model.selection");
   if (value.grader?.name !== "runtime-agent-interface-v2-trace-grader" || value.grader.version !== 1) {
     throw new Error("eval grader metadata mismatch");

--- a/test/unit/evals/agent-experience-v6.test.mjs
+++ b/test/unit/evals/agent-experience-v6.test.mjs
@@ -16,7 +16,7 @@ const DATASET = loadAgentExperienceV6Eval(path.join(ROOT, "evals/agent-experienc
 
 test("fixed Agent Experience v6 eval starts every selected scenario from an empty session", () => {
   assert.equal(DATASET.session.initial_turns, 0);
-  assert.equal(DATASET.model.standing_prompt_version, "larkin-standing-v19");
+  assert.equal(DATASET.model.standing_prompt_version, "larkin-standing-v20");
   assert.deepEqual(DATASET.scenarios.map((scenario) => scenario.id), [
     "target-scoped-thread-read",
     "failed-thread-read-no-false-success",

--- a/test/unit/evals/agent-mention-prompt.test.mjs
+++ b/test/unit/evals/agent-mention-prompt.test.mjs
@@ -96,7 +96,7 @@ test("lark-cli launcher passes --mention argv through without injecting --conten
 });
 
 test("mention guidance ships under the current standing prompt version", () => {
-  assert.equal(LARKIN_STANDING_PROMPT_VERSION, "larkin-standing-v19");
+  assert.equal(LARKIN_STANDING_PROMPT_VERSION, "larkin-standing-v20");
   const prompt = buildPrompt("codex");
   assert.match(prompt, /## Collaboration and delivery/);
 });

--- a/test/unit/evals/authoritative-freshness-gate.test.mjs
+++ b/test/unit/evals/authoritative-freshness-gate.test.mjs
@@ -10,7 +10,7 @@ const dataset = loadAuthoritativeFreshnessEval(path.join(ROOT, "evals/authoritat
 test("authoritative freshness eval is versioned, reproducible, and covers the critical rubric", () => {
   assert.equal(dataset.dataset, "authoritative-freshness-gate");
   assert.equal(dataset.version, 1);
-  assert.equal(dataset.standing_prompt_version, "larkin-standing-v19");
+  assert.equal(dataset.standing_prompt_version, "larkin-standing-v20");
   assert.equal(dataset.threshold, 1);
   assert.deepEqual(dataset.scenarios.map((scenario) => scenario.id), [
     "missing-inbox-history", "direct-ack-retry", "same-ms-new-id", "edited-message",

--- a/test/unit/evals/clickable-link-delivery.test.mjs
+++ b/test/unit/evals/clickable-link-delivery.test.mjs
@@ -1,0 +1,179 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { spawnSync } from "node:child_process";
+import { test } from "bun:test";
+import { ContextPromptBuilder } from "../../../dist/agent/context-prompt.mjs";
+import {
+  gradeClickableLinkDeliveryTrace,
+  loadClickableLinkDeliveryEval,
+  summarizeClickableLinkDeliveryEval,
+} from "../../support/clickable-link-delivery-grader.mjs";
+import {
+  CLICKABLE_LINK_V20_GUIDANCE,
+  gradeNativeCommandAudit,
+  isolatedNativeEnv,
+  v19Counterfactual,
+} from "../../support/clickable-link-delivery-native-support.mjs";
+
+const ROOT = path.resolve(import.meta.dirname, "../../..");
+const DATASET = loadClickableLinkDeliveryEval(path.join(ROOT, "evals/clickable-link-delivery/scenarios.json"));
+const FAKE = path.join(ROOT, "test/support/clickable-link-delivery-eval-cli.mjs");
+const [ORDINARY, EXACT] = DATASET.scenarios;
+
+function writeEvent(scenario, bodyFlag, body, overrides = {}) {
+  const command = scenario.operation === "send" ? "+messages-send" : "+messages-reply";
+  const targetFlag = overrides.target_flag ?? scenario.target_flag;
+  const target = overrides.target ?? scenario.target;
+  const event = {
+    schema_version: 1,
+    action: "provider_write",
+    surface: "larkin",
+    operation: scenario.operation,
+    target_flag: targetFlag,
+    target,
+    body_flag: bodyFlag,
+    body,
+    argv: ["im", command, targetFlag, target, bodyFlag, body, "--json"],
+    success: true,
+    message_id: "om_eval_clickable_unit",
+    error: null,
+    ...overrides,
+  };
+  return event;
+}
+
+function runFake(args, surface = "larkin") {
+  const temp = fs.mkdtempSync(path.join(os.tmpdir(), "clickable-eval-cli-"));
+  const traceFile = path.join(temp, "trace.ndjson");
+  fs.writeFileSync(traceFile, "", { mode: 0o600 });
+  try {
+    const result = spawnSync(process.execPath, [FAKE, ...args], {
+      encoding: "utf8",
+      env: { PATH: process.env.PATH, CLICKABLE_EVAL_TRACE_FILE: traceFile, CLICKABLE_EVAL_SURFACE: surface },
+    });
+    const trace = fs.readFileSync(traceFile, "utf8").split("\n").filter(Boolean).map(JSON.parse);
+    return { result, trace };
+  } finally {
+    fs.rmSync(temp, { recursive: true, force: true });
+  }
+}
+
+test("clickable-link delivery dataset is fixed, fresh, versioned, and thresholded", () => {
+  assert.equal(DATASET.dataset, "clickable-link-delivery");
+  assert.equal(DATASET.version, 1);
+  assert.equal(DATASET.standing_prompt_version, "larkin-standing-v20");
+  assert.equal(DATASET.threshold, 1);
+  assert.equal(DATASET.session.initial_turns, 0);
+  assert.equal(DATASET.session.fresh_per_scenario, true);
+  assert.deepEqual(DATASET.scenarios.map(({ id }) => id), ["ordinary-openable-link", "exact-markdown-link-body"]);
+  assert.equal(DATASET.scenarios.length, 2);
+});
+
+test("golden structured provider writes pass both payload behaviors", () => {
+  const ordinary = writeEvent(ORDINARY, "--markdown", `Issue 115: ${ORDINARY.url}`);
+  const exact = writeEvent(EXACT, "--text", EXACT.exact_body);
+  assert.deepEqual(gradeClickableLinkDeliveryTrace(ORDINARY, [ordinary]), { passed: true, failures: [] });
+  assert.deepEqual(gradeClickableLinkDeliveryTrace(EXACT, [exact]), { passed: true, failures: [] });
+  assert.equal(summarizeClickableLinkDeliveryEval(DATASET, {
+    [ORDINARY.id]: [ordinary], [EXACT.id]: [exact],
+  }).passed, true);
+});
+
+test("26 adversarial payload/trace mutations fail closed", () => {
+  const ordinaryGolden = writeEvent(ORDINARY, "--markdown", `Issue 115: ${ORDINARY.url}`);
+  const exactGolden = writeEvent(EXACT, "--text", EXACT.exact_body);
+  const malformed = { ...ordinaryGolden, injected_prompt: ORDINARY.prompt };
+  const missingField = { ...ordinaryGolden }; delete missingField.error;
+  const extraArgv = { ...ordinaryGolden, argv: [...ordinaryGolden.argv, "--profile"] };
+  const argvMismatch = { ...ordinaryGolden, argv: [...ordinaryGolden.argv] };
+  argvMismatch.argv[argvMismatch.argv.indexOf("--markdown") + 1] = "different body";
+  const unsuccessful = { ...ordinaryGolden, success: false, message_id: null, error: "rejected" };
+  const wrongOperation = writeEvent(EXACT, "--text", EXACT.exact_body);
+  const adversarial = [
+    ["ordinary missing", ORDINARY, []],
+    ["ordinary assistant output only", ORDINARY, [{ action: "assistant_output", text: ORDINARY.url }]],
+    ["ordinary label only", ORDINARY, [writeEvent(ORDINARY, "--markdown", `[Issue 115](${ORDINARY.url})`)]],
+    ["ordinary truncated", ORDINARY, [writeEvent(ORDINARY, "--markdown", "https://github.com/eddiearc/larkin/issues/11")]],
+    ["ordinary http", ORDINARY, [writeEvent(ORDINARY, "--markdown", ORDINARY.url.replace("https://", "http://"))]],
+    ["ordinary left boundary", ORDINARY, [writeEvent(ORDINARY, "--markdown", `x${ORDINARY.url}`)]],
+    ["ordinary right boundary", ORDINARY, [writeEvent(ORDINARY, "--markdown", `${ORDINARY.url}x`)]],
+    ["ordinary Markdown span", ORDINARY, [writeEvent(ORDINARY, "--markdown", `See [link](${ORDINARY.url}) now`)]],
+    ["ordinary duplicate", ORDINARY, [ordinaryGolden, ordinaryGolden]],
+    ["ordinary wrong target", ORDINARY, [writeEvent(ORDINARY, "--markdown", ORDINARY.url, { target: "oc_eval_other",
+      argv: ["im", "+messages-send", "--chat-id", "oc_eval_other", "--markdown", ORDINARY.url, "--json"] })]],
+    ["ordinary wrong operation", ORDINARY, [wrongOperation]],
+    ["ordinary unsuccessful", ORDINARY, [unsuccessful]],
+    ["ordinary content flag", ORDINARY, [writeEvent(ORDINARY, "--content", JSON.stringify({ text: ORDINARY.url }))]],
+    ["ordinary extra trace field", ORDINARY, [malformed]],
+    ["ordinary missing trace field", ORDINARY, [missingField]],
+    ["ordinary unexpected argv", ORDINARY, [extraArgv]],
+    ["ordinary argv/body mismatch", ORDINARY, [argvMismatch]],
+    ["ordinary prompt text only", ORDINARY, [{ action: "tool", prompt: ORDINARY.prompt, body: ORDINARY.url }]],
+    ["exact markdown flag", EXACT, [writeEvent(EXACT, "--markdown", EXACT.exact_body)]],
+    ["exact prefix", EXACT, [writeEvent(EXACT, "--text", `See ${EXACT.exact_body}`)]],
+    ["exact suffix", EXACT, [writeEvent(EXACT, "--text", `${EXACT.exact_body}.`)]],
+    ["exact injected URL", EXACT, [writeEvent(EXACT, "--text", `${EXACT.exact_body} ${ORDINARY.url}`)]],
+    ["exact newline", EXACT, [writeEvent(EXACT, "--text", `${EXACT.exact_body}\n`)]],
+    ["exact wrong target", EXACT, [writeEvent(EXACT, "--text", EXACT.exact_body, { target: "om_eval_other",
+      argv: ["im", "+messages-reply", "--message-id", "om_eval_other", "--text", EXACT.exact_body, "--json"] })]],
+    ["exact duplicate", EXACT, [exactGolden, exactGolden]],
+    ["exact missing", EXACT, []],
+  ];
+  assert.equal(adversarial.length, 26);
+  for (const [label, scenario, trace] of adversarial) {
+    assert.equal(gradeClickableLinkDeliveryTrace(scenario, trace).passed, false, label);
+  }
+});
+
+test("fake sink accepts only the two synthetic writes and emits gradeable argv/body traces", () => {
+  const ordinaryArgs = ["im", "+messages-send", "--chat-id", ORDINARY.target, "--markdown", `Issue 115: ${ORDINARY.url}`, "--json"];
+  const ordinary = runFake(ordinaryArgs);
+  assert.equal(ordinary.result.status, 0, ordinary.result.stderr);
+  assert.equal(gradeClickableLinkDeliveryTrace(ORDINARY, ordinary.trace).passed, true);
+  const exactArgs = ["im", "+messages-reply", "--message-id", EXACT.target, "--text", EXACT.exact_body, "--json"];
+  const exact = runFake(exactArgs);
+  assert.equal(exact.result.status, 0, exact.result.stderr);
+  assert.equal(gradeClickableLinkDeliveryTrace(EXACT, exact.trace).passed, true);
+  assert.notEqual(runFake(ordinaryArgs.toSpliced(3, 1, "oc_real_or_other")).result.status, 0);
+  assert.notEqual(runFake(ordinaryArgs, "lark-cli").result.status, 0);
+  assert.notEqual(runFake(["im", "+chat-list", "--json"]).result.status, 0);
+});
+
+test("fake sink has no provider/runtime import or process invocation surface", () => {
+  const source = fs.readFileSync(FAKE, "utf8");
+  assert.doesNotMatch(source, /node:child_process|@larksuite|from ["'][^"']*(?:dist|src)\//);
+  assert.doesNotMatch(source, /\b(?:spawn|execFile|exec|fork)\s*\(/);
+  assert.match(source, /synthetic: true/);
+});
+
+test("v19 counterfactual removes exactly the two v20 lines and restores version/hash in memory", () => {
+  const v20 = new ContextPromptBuilder().build({ agentId: "cli_clickableEvalA1", name: "Clickable Eval", runtime: "codex" });
+  for (const line of CLICKABLE_LINK_V20_GUIDANCE) assert.equal(v20.content.split(line).length - 1, 1);
+  const v19 = v19Counterfactual(v20);
+  assert.equal(v19.version, "larkin-standing-v19");
+  assert.match(v19.hash, /^[a-f0-9]{64}$/);
+  assert.notEqual(v19.hash, v20.hash);
+  assert.equal(v20.content.split("\n").length - v19.content.split("\n").length, 2);
+  for (const line of CLICKABLE_LINK_V20_GUIDANCE) assert.equal(v19.content.includes(line), false);
+});
+
+test("native eval environment and command audit fail closed around the fake sink", () => {
+  const temp = fs.mkdtempSync(path.join(os.tmpdir(), "clickable-native-isolation-"));
+  try {
+    const binDir = path.join(temp, "bin");
+    const codexHome = path.join(temp, "codex-home");
+    fs.mkdirSync(binDir, { recursive: true }); fs.mkdirSync(codexHome);
+    const env = isolatedNativeEnv({ HOME: temp, CODEX_HOME: codexHome, LARK_TEST_VALUE: "fixture", FEISHU_TEST_VALUE: "fixture" }, {
+      temp, binDir, codexCommand: "/usr/bin/false", traceFile: path.join(temp, "trace.ndjson"),
+    });
+    assert.equal(Object.entries(env).some(([key, value]) => /^(?:LARK|FEISHU)/i.test(key) && value !== undefined), false);
+    assert.equal(fs.existsSync(path.join(env.HOME, ".larkin")), false);
+    const fakeLarkin = path.join(binDir, "larkin"); const fakeLarkCli = path.join(binDir, "lark-cli");
+    assert.equal(gradeNativeCommandAudit([{ item_type: "commandExecution", command: `/bin/zsh -lc '${fakeLarkin} im +messages-send'`, exit_code: 0 }],
+      fakeLarkin, fakeLarkCli).passed, true);
+    assert.equal(gradeNativeCommandAudit([{ item_type: "commandExecution", command: "lark-cli im +messages-send", exit_code: 0 }],
+      fakeLarkin, fakeLarkCli).passed, false);
+  } finally { fs.rmSync(temp, { recursive: true, force: true }); }
+});

--- a/test/unit/evals/runtime-agent-interface-v2.test.mjs
+++ b/test/unit/evals/runtime-agent-interface-v2.test.mjs
@@ -16,7 +16,7 @@ test("fixed runtime Agent interface eval registers dataset, rubric, grader, thre
   assert.equal(DATASET.version, 1);
   assert.equal(DATASET.runtime.adapter, "codex");
   assert.equal(DATASET.model.selection, "gpt-5.6-sol");
-  assert.equal(DATASET.model.standing_prompt_version, "larkin-standing-v19");
+  assert.equal(DATASET.model.standing_prompt_version, "larkin-standing-v20");
   assert.equal(DATASET.grader.version, 1);
   assert.equal(DATASET.grader.threshold, 1);
   assert.ok(DATASET.grader.rubric.length >= 5);

--- a/test/unit/runtime/runtime-adapters.test.mjs
+++ b/test/unit/runtime/runtime-adapters.test.mjs
@@ -92,7 +92,7 @@ test("context prompt is capability-driven, versioned and produces bounded notifi
 
 test("default context prompt consumes the Agent CLI manifest", () => {
   const prompt = new ContextPromptBuilder().build({ agentId: "cli_test", runtime: "pi" });
-  assert.equal(prompt.version, "larkin-standing-v19");
+  assert.equal(prompt.version, "larkin-standing-v20");
   assert.match(prompt.content, /larkin reminder schedule/);
   assert.match(prompt.content, /larkin reminder cancel/);
   assert.match(prompt.content, /larkin interaction resolve/);
@@ -194,10 +194,17 @@ test("default context prompt consumes the Agent CLI manifest", () => {
   assert.doesNotMatch(prompt.content, /oc_eval_exact|om_eval_anchor|原文：“修复 A\/B”|收到：“A\/B”|引用：“抢到”|消息原文：“保持”/);
 });
 
-test("Codex, Claude and Pi receive the markdown-default standing contract", async () => {
+test("Codex, Claude and Pi receive the clickable-link and exact-content standing contracts", async () => {
   const standingPrompt = (runtime) => new ContextPromptBuilder().build({ agentId: "cli_test", runtime });
   const assertContract = (content) => {
     assert.match(content, /regular textual message bodies.*`--markdown`/i);
+    assert.match(content, /URL must be visible, clickable, or openable.*complete bare `https:\/\/\.\.\.` URL.*visible text/i);
+    assert.match(content, /Do not rely solely on `\[label\]\(URL\)`.*Feishu client rendering is unreliable/i);
+    assert.match(content, /label may also be included.*bare URL must remain present/i);
+    assert.match(content, /Never rewrite or normalize.*exact or verbatim user-supplied body.*existing exact-content paths.*authoritative.*unchanged/i);
+    assert.match(content, /exact text supplied directly.*body unchanged as one literal `--text` argument/i);
+    assert.match(content, /explicit exact or verbatim direct literal uses `--text`.*overrides.*markdown default/i);
+    assert.match(content, /tool-sourced exact or verbatim text.*deterministic native `--jq`.*`--content`/i);
     assert.match(content, /native `--text`.*logs.*code.*exact whitespace/i);
     assert.doesNotMatch(content, /rejected|--literal-text/i);
     assert.doesNotMatch(content, /use `--text` for brief single-line replies/i);


### PR DESCRIPTION
## Root cause

Feishu text/Markdown messages do not reliably render `[label](https://...)` as clickable, while a visible bare HTTPS URL is auto-linked. Larkin's standing prompt defaults ordinary bodies to `--markdown`, so agents could send a label-only Markdown link that recipients could not open.

Closes #115.

## Scope

- bump the standing prompt from v19 to v20
- require a complete visible bare `https://...` URL whenever recipients must see/click/open it
- preserve exact/verbatim user bodies and existing exact-content paths
- add dedicated dataset v1 with the two fixed fresh-session scenarios
- add a strict structured provider-write grader and isolated fake CLI/sink
- add an opt-in native Codex v19/v20 counterfactual runner
- bump package version to 0.3.1 per contribution policy

No transport behavior, unrelated grader, card, URL-preview, or Markdown classification behavior changed.

## Dedicated deterministic evidence

`test/unit/evals/clickable-link-delivery.test.mjs`: **7 passed**, including both golden traces and **26 adversarial mutations** (label-only, truncated/http/boundary failures, assistant/prompt-only output, malformed/duplicate/missing/wrong-target writes, and exact-body mutations).

Also passed:

- `bun run typecheck`
- `bun run build`
- existing prompt evals: **47 passed**
- runtime adapter prompt coverage: **51 passed**

## Honest native effect evaluation

Runtime: native Codex; dataset model selection: `runtime-default` (the adapter did not expose a concrete model ID). Every cell used a fresh session and a separate command bounded to 52 seconds.

| Prompt | ordinary-openable-link | exact-markdown-link-body |
|---|---:|---:|
| v19 counterfactual | PASS | PASS |
| v20 current | PASS | PASS |

Observed effect on these two fixed cases: **no pass-rate change (2/2 to 2/2)**. We do not assume v19 fails. The v19 prompt was produced in memory by removing exactly the two v20 guidance lines, restoring version v19, and recomputing the prompt hash; source was not modified. Structured evidence recorded runtime/model selection, prompt version/hash, argv/body trace, and grade only.

## Isolation and claim boundary

The native runner scrubs all inherited `LARK*`/`FEISHU*` values, uses an isolated HOME with nonexistent provider config, PATH-shadows both `larkin` and `lark-cli`, permits only the two synthetic targets, audits the single command, and uses a sink that cannot import/invoke Feishu or real Larkin/lark-cli. **No Feishu write occurred.** Fake provider success validates agent payload construction only; it does **not** prove Feishu client clickability.

## CI

Checks for commit `a2fb389` are queued/running. Prior head `e50fc61` was green.