### PR TITLE
test: harden nested CI timeout boundaries

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "larkin",
-  "version": "0.3.2",
+  "version": "0.3.3",
   "private": false,
   "larkinPackageRole": "npm-published",
   "files": [

--- a/test/integration/app/strict-production-cutover.test.mjs
+++ b/test/integration/app/strict-production-cutover.test.mjs
@@ -8,6 +8,8 @@ import { fileURLToPath } from "node:url";
 
 const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..", "..", "..");
 const APP = "cli_strictA1";
+const TRANSIENT_VERIFY_CHILD_TIMEOUT_MS = 10_000;
+const TRANSIENT_VERIFY_TEST_TIMEOUT_MS = 15_000;
 
 function storedConfig() {
   return { version: 3, serverId: "server-strict", activeAgent: APP, agents: { [APP]: { runtime: "codex", model: "gpt-5.5" } } };
@@ -219,7 +221,7 @@ module.exports={registerApp:async()=>({client_id:${JSON.stringify(returnedId)},c
   return { preload, loader };
 }
 
-test("bot-register binds once, then retries transient new-App Bot verification without exposing the secret", () => {
+test("bot-register binds once, then retries transient new-App Bot verification without exposing the secret", { timeout: TRANSIENT_VERIFY_TEST_TIMEOUT_MS }, () => {
   const temp = fs.mkdtempSync(path.join(os.tmpdir(), "larkin-strict-register-transient-sync-"));
   try {
     const root = path.join(temp, "root");
@@ -231,7 +233,7 @@ test("bot-register binds once, then retries transient new-App Bot verification w
     const result = spawnSync(process.execPath, ["--preload", loader, path.join(ROOT, "dist/setup/bot-register.mjs"), "--auto", "--result-file", resultFile], {
       cwd: ROOT,
       encoding: "utf8",
-      timeout: 5_000,
+      timeout: TRANSIENT_VERIFY_CHILD_TIMEOUT_MS,
       env: {
         ...process.env,
         HOME: path.join(temp, "home"),
@@ -263,7 +265,7 @@ test("bot-register binds once, then retries transient new-App Bot verification w
 });
 
 for (const [mode, expectedCalls, expectedStatus] of [["sync-network", 2, 0], ["sync-agent-context", 1, 1]]) {
-  test(`bot-register classifies ${mode} Bot verification with the intended retry policy`, () => {
+  test(`bot-register classifies ${mode} Bot verification with the intended retry policy`, { timeout: 15_000 }, () => {
     const temp = fs.mkdtempSync(path.join(os.tmpdir(), `larkin-strict-register-${mode}-`));
     try {
       const root = path.join(temp, "root");
@@ -287,7 +289,7 @@ for (const [mode, expectedCalls, expectedStatus] of [["sync-network", 2, 0], ["s
   });
 }
 
-test("bot-register bounds transient Bot verification retries and preserves authoritative binding state", () => {
+test("bot-register bounds transient Bot verification retries and preserves authoritative binding state", { timeout: 10_000 }, () => {
   const temp = fs.mkdtempSync(path.join(os.tmpdir(), "larkin-strict-register-transient-exhaust-"));
   try {
     const root = path.join(temp, "root");
@@ -518,7 +520,7 @@ for (const mode of ["sync-fail", "verify-fail"]) {
   });
 }
 
-test("host exits nonzero and records status when channel authentication fails; no consume fallback is spawned", () => {
+test("host exits nonzero and records status when channel authentication fails; no consume fallback is spawned", { timeout: 10_000 }, () => {
   const temp = fs.mkdtempSync(path.join(os.tmpdir(), "larkin-strict-host-channel-"));
   try {
     const root = path.join(temp, "root");
@@ -620,7 +622,7 @@ test("dry-run EVENT_FILE injection takes precedence over profile channel startup
 });
 
 for (const scenario of ["keepalive", "missing-identity"]) {
-  test(`host routes ${scenario} failure through status recording and bounded fatal shutdown`, () => {
+  test(`host routes ${scenario} failure through status recording and bounded fatal shutdown`, { timeout: 10_000 }, () => {
     const temp = fs.mkdtempSync(path.join(os.tmpdir(), `larkin-strict-channel-${scenario}-`));
     try {
       const root = path.join(temp, "root");
@@ -686,7 +688,7 @@ for (const disconnectMode of ["pending", "reject"]) {
   });
 }
 
-test("synchronous channel creation failure stops multi-agent startup and closes earlier channels", () => {
+test("synchronous channel creation failure stops multi-agent startup and closes earlier channels", { timeout: 10_000 }, () => {
   const temp = fs.mkdtempSync(path.join(os.tmpdir(), "larkin-strict-channel-multi-create-"));
   try {
     const root = path.join(temp, "root");

--- a/test/integration/build/runtime-clean-cutover.test.mjs
+++ b/test/integration/build/runtime-clean-cutover.test.mjs
@@ -8,6 +8,8 @@ import { fileURLToPath } from "node:url";
 
 const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..", "..", "..");
 const source = (relative) => fs.readFileSync(path.join(ROOT, relative), "utf8");
+const CLEAN_BUILD_CHILD_TIMEOUT_MS = 60_000;
+const CLEAN_BUILD_TEST_TIMEOUT_MS = 70_000;
 
 test("authored source and generated runtime use the seven-domain mirrored layout", () => {
   const domains = ["agent", "app", "dashboard", "feishu", "platform", "runtime", "setup"];
@@ -63,14 +65,14 @@ test("production build, start, and Agent CLI graph contain only current entries"
   assert.match(source("scripts/release/install.ts"), /--rollback/);
 });
 
-test("a clean standalone shell build contains the complete new production entry graph", () => {
+test("a clean standalone shell build contains the complete new production entry graph", { timeout: CLEAN_BUILD_TEST_TIMEOUT_MS }, () => {
   const temp = fs.mkdtempSync(path.join(os.tmpdir(), "larkin-runtime-clean-build-"));
   try {
     const outDir = path.join(temp, "dist");
     const result = spawnSync(process.execPath, [path.join(ROOT, "scripts/build.mjs"), "--out-dir", outDir], {
       cwd: ROOT,
       encoding: "utf8",
-      timeout: 60_000,
+      timeout: CLEAN_BUILD_CHILD_TIMEOUT_MS,
     });
     assert.equal(result.status, 0, result.stderr || result.stdout);
     for (const entry of ["app/runtime-process.mjs", "runtime/runtime-host.mjs", "runtime/runtime-adapters.mjs", "agent/context-prompt.mjs", "app/agent-cli.mjs"]) {


### PR DESCRIPTION
## Summary

- harden nested Bun-test/child-process timeout ordering for CI-sensitive integration cases
- preserve all product retry behavior and existing meaningful child bounds
- bump the package version from 0.3.2 to 0.3.3

## Failure evidence and root cause

https://github.com/eddiearc/larkin/actions/runs/31881795485

These were two independent E2 test-harness timing failures, not product assertion failures:

- Windows job `95005363046`: the runtime clean-build child was still rewriting module specifiers under its existing 60,000 ms bound when Bun's implicit 5,000 ms outer test expired at **5088.53 ms** (`status: null`). The same test had passed on the PR in **3973.60 ms**.
- Linux job `95005318683`: the transient bot-register success case had a 5,000 ms child bound and Bun's implicit 5,000 ms outer bound. It expired at **5057.82 ms** with child exit **143**, after expected retry logs. The other 171 integration tests passed.

The root cause is inverted/equal nested timeout ownership: the outer harness could terminate before the child process could return its intended result.

## Timeout hierarchy

- runtime clean build: child remains **60s**; explicit outer is **70s**
- transient bot-register success: child is **10s**; explicit outer is **15s**; retry count/assertions remain unchanged
- related transient-exhaust case: child remains **5s**; explicit outer is **10s**
- same-file audit fixes only cases with child >= implicit outer: classification cases **10s child / 15s outer**, and three bounded host cases **6s child / 10s outer**

No source-grep contract was added; repeated runtime execution covers the hierarchy without coupling tests to source formatting.

## Verification

- `bun run typecheck`: pass
- `bun run build`: pass
- runtime clean-cutover file: **3/3 pass**
- repeated clean-build case: **5/5 pass**, 3329.41–4598.96 ms
- repeated transient-success case: **5/5 pass**, 4170.35–4666.60 ms
- repeated transient-exhaust case: **5/5 pass**, 4065.36–4823.04 ms
- other modified same-file host cases: **4/4 pass**
- release-platform CI test: **2/2 pass**
- v0.3.3 version check, publication tree check, and `git diff --check`: pass

The whole strict-production-cutover file exceeded the required 60s foreground-command cap after its target cases passed; it was not retried. Its first unrelated assertion also observed the inherited local Runtime Agent identity.

## Non-goals

No production code or wait/retry duration changes; no merge/release; no changes to the v0.3.2 tag or assets; no old-workflow rerun. The exact v0.3.2 release SHA fully passed and published; this PR does not claim that publication was invalid.
