### PR TITLE
Fix canonical targets for reminder Runtime delivery

### DIFF
--- a/.github/workflows/release-platform-smoke.yml
+++ b/.github/workflows/release-platform-smoke.yml
@@ -124,7 +124,7 @@ jobs:
         run: bun run build
 
       - name: Run focused Windows unit and integration tests
-        run: bun test --isolate --max-concurrency 1 test/unit/agent/host-reminder-orchestrator.test.mjs test/unit/agent/inbox-projection.test.mjs test/unit/feishu/host-business-state.test.mjs test/unit/platform/release-artifacts.test.mjs test/unit/runtime/pi-inline-extensions.test.mjs test/unit/runtime/runtime-adapters.test.mjs test/unit/runtime/runtime-host.test.mjs test/integration/build/runtime-clean-cutover.test.mjs test/integration/build/release-platform-ci.test.mjs
+        run: bun test --isolate --max-concurrency 1 test/unit/agent/host-reminder-orchestrator.test.mjs test/unit/feishu/host-business-state.test.mjs test/unit/platform/release-artifacts.test.mjs test/unit/runtime/pi-inline-extensions.test.mjs test/unit/runtime/runtime-adapters.test.mjs test/unit/runtime/runtime-inbox-target.test.mjs test/integration/build/runtime-clean-cutover.test.mjs test/integration/build/release-platform-ci.test.mjs
 
       - name: Download exact Windows standalone build
         uses: actions/download-artifact@v4

--- a/.github/workflows/release-platform-smoke.yml
+++ b/.github/workflows/release-platform-smoke.yml
@@ -124,7 +124,7 @@ jobs:
         run: bun run build
 
       - name: Run focused Windows unit and integration tests
-        run: bun test --isolate --max-concurrency 1 test/unit/platform/release-artifacts.test.mjs test/unit/runtime/pi-inline-extensions.test.mjs test/unit/runtime/runtime-adapters.test.mjs test/integration/build/runtime-clean-cutover.test.mjs test/integration/build/release-platform-ci.test.mjs
+        run: bun test --isolate --max-concurrency 1 test/unit/agent/host-reminder-orchestrator.test.mjs test/unit/agent/inbox-projection.test.mjs test/unit/feishu/host-business-state.test.mjs test/unit/platform/release-artifacts.test.mjs test/unit/runtime/pi-inline-extensions.test.mjs test/unit/runtime/runtime-adapters.test.mjs test/unit/runtime/runtime-host.test.mjs test/integration/build/runtime-clean-cutover.test.mjs test/integration/build/release-platform-ci.test.mjs
 
       - name: Download exact Windows standalone build
         uses: actions/download-artifact@v4

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "larkin",
-  "version": "0.3.4",
+  "version": "0.4.0",
   "private": false,
   "larkinPackageRole": "npm-published",
   "files": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "larkin",
-  "version": "0.3.3",
+  "version": "0.3.4",
   "private": false,
   "larkinPackageRole": "npm-published",
   "files": [

--- a/src/agent/agent-state-store.ts
+++ b/src/agent/agent-state-store.ts
@@ -120,7 +120,7 @@ interface InboxSendIntent {
 interface InboxStateFile {
   version: 2;
   targets: Record<string, InboxTargetState>;
-  messages: Record<string, { target: string; seq: number }>;
+  messages: Record<string, { target: string; seq: number; kind?: string }>;
   drafts: Record<string, InboxDraft>;
   intents: Record<string, InboxSendIntent>;
 }
@@ -153,8 +153,10 @@ function normalizeInboxState(value: unknown): InboxStateFile {
   if (raw.messages && typeof raw.messages === "object" && !Array.isArray(raw.messages)) {
     for (const [messageId, candidate] of Object.entries(raw.messages)) {
       if (!candidate || typeof candidate !== "object" || Array.isArray(candidate)) continue;
-      const row = candidate as { target?: unknown; seq?: unknown };
-      if (typeof row.target === "string" && row.target && validSequence(row.seq)) state.messages[messageId] = { target: row.target, seq: row.seq };
+      const row = candidate as { target?: unknown; seq?: unknown; kind?: unknown };
+      if (typeof row.target === "string" && row.target && validSequence(row.seq)) state.messages[messageId] = {
+        target: row.target, seq: row.seq, ...(typeof row.kind === "string" && row.kind ? { kind: row.kind } : {}),
+      };
     }
   }
   if (raw.drafts && typeof raw.drafts === "object" && !Array.isArray(raw.drafts)) {
@@ -475,7 +477,8 @@ export class AgentStateStore {
     const targetSeq = requested > current.latest_received_seq ? requested : current.latest_received_seq + 1;
     state.targets[target] = { ...current, latest_received_seq: targetSeq };
     if (typeof input.message_id === "string" && input.message_id) {
-      state.messages[input.message_id] = { target, seq: targetSeq };
+      state.messages[input.message_id] = { target, seq: targetSeq,
+        ...(typeof input.kind === "string" && input.kind ? { kind: input.kind } : {}) };
       const messageIds = Object.keys(state.messages);
       for (const stale of messageIds.slice(0, Math.max(0, messageIds.length - 2_048))) delete state.messages[stale];
     }
@@ -492,7 +495,8 @@ export class AgentStateStore {
         : existing?.target === target ? existing.seq : current.latest_received_seq + 1;
       current.latest_received_seq = Math.max(current.latest_received_seq, targetSeq);
       state.targets[target] = current;
-      if (typeof row.message_id === "string" && row.message_id) state.messages[row.message_id] = { target, seq: targetSeq };
+      if (typeof row.message_id === "string" && row.message_id) state.messages[row.message_id] = { target, seq: targetSeq,
+        ...(typeof row.kind === "string" && row.kind ? { kind: row.kind } : {}) };
       return { ...row, envelope_version: 2, target, target_seq: targetSeq };
     });
   }
@@ -732,8 +736,9 @@ export class AgentStateStore {
   resolveInboxMessageTarget(messageId: string): string | null {
     return this.withInboxLock(this.file("inbox"), () => {
       const state = this.inboxState();
-      const known = state.messages[messageId]?.target;
-      if (known) return targetKeyOfInboxEnvelope({ message_id: messageId, target: known });
+      const known = state.messages[messageId];
+      if (known) return targetKeyOfInboxEnvelope({ message_id: messageId, target: known.target,
+        ...(known.kind ? { kind: known.kind } : {}) });
       const row = this.readNdjson<InboxEnvelope>("inbox").find((candidate) => candidate.message_id === messageId);
       return row ? targetKeyOfInboxEnvelope(row) : null;
     });

--- a/src/agent/agent-state-store.ts
+++ b/src/agent/agent-state-store.ts
@@ -4,7 +4,7 @@ import * as path from "node:path";
 import { TargetRootLayout, type AgentStatePaths } from "../platform/root-layout.js";
 import { acquireProcessLock, inspectProcess } from "../platform/process-state.js";
 import { isWindows } from "../platform/secure-metadata.js";
-import { targetKeyOfInboxEnvelope, type InboxEnvelope } from "./inbox-projection.js";
+import { isCanonicalInboxTarget, targetKeyOfInboxEnvelope, type InboxEnvelope } from "./inbox-projection.js";
 
 export type JsonStateKey = "agentState" | "status" | "map" | "replyctx" | "botIdentity" |
   "senderProfiles" | "readReceipts" | "pendingReact" | "runtimeDeliveries" | "inboxState" | "freshnessState" | "documentComments" | "reminders" | "interactions";
@@ -469,7 +469,7 @@ export class AgentStateStore {
   private normalizeInboxEnvelope(value: unknown, state: InboxStateFile): InboxEnvelope {
     if (!value || typeof value !== "object" || Array.isArray(value)) throw new Error("Inbox envelope must be an object");
     const input = value as InboxEnvelope;
-    const target = typeof input.target === "string" && input.target ? input.target : targetKeyOfInboxEnvelope(input);
+    const target = targetKeyOfInboxEnvelope(input);
     const current = state.targets[target] ?? { latest_received_seq: 0, model_seen_seq: 0 };
     const requested = validSequence(input.target_seq) ? input.target_seq : 0;
     const targetSeq = requested > current.latest_received_seq ? requested : current.latest_received_seq + 1;
@@ -483,8 +483,9 @@ export class AgentStateStore {
   }
 
   private reconcileInboxRows(rows: InboxEnvelope[], state: InboxStateFile): InboxEnvelope[] {
-    return rows.map((row) => {
-      const target = typeof row.target === "string" && row.target ? row.target : targetKeyOfInboxEnvelope(row);
+    const targets = rows.map((row) => targetKeyOfInboxEnvelope(row));
+    return rows.map((row, index) => {
+      const target = targets[index]!;
       const existing = typeof row.message_id === "string" ? state.messages[row.message_id] : undefined;
       const current = state.targets[target] ?? { latest_received_seq: 0, model_seen_seq: 0 };
       const targetSeq = validSequence(row.target_seq) ? row.target_seq
@@ -602,6 +603,7 @@ export class AgentStateStore {
     if (!value || typeof value !== "object" || Array.isArray(value)) throw new Error("Inbox envelope must be an object");
     const messageId = (value as Record<string, unknown>).message_id;
     if (typeof messageId !== "string" || !messageId) throw new Error("Inbox envelope requires message_id");
+    targetKeyOfInboxEnvelope(value as InboxEnvelope);
     const file = this.file("inbox");
     return this.withInboxLock(file, () => {
       if (this.inboxState().messages[messageId]) return false;
@@ -620,6 +622,7 @@ export class AgentStateStore {
     if (!value || typeof value !== "object" || Array.isArray(value)) throw new Error("Inbox envelope must be an object");
     const messageId = (value as Record<string, unknown>).message_id;
     if (typeof messageId !== "string" || !messageId) throw new Error("Inbox envelope requires message_id");
+    targetKeyOfInboxEnvelope(value as InboxEnvelope);
     const file = this.file("inbox");
     return this.withInboxLock(file, () => {
       const ledger = this.readJson<RuntimeDeliveryStore>("runtimeDeliveries", { version: 1, records: [] });
@@ -657,6 +660,9 @@ export class AgentStateStore {
    * this transaction is active waits and becomes part of the next batch.
    */
   pollInbox<T extends InboxEnvelope = InboxEnvelope>(options: InboxPollOptions = {}): InboxPollResult<T> {
+    if (options.target && !isCanonicalInboxTarget(options.target)) {
+      throw new Error(`Invalid canonical Inbox poll target ${JSON.stringify(options.target)}`);
+    }
     const file = this.file("inbox");
     return this.withInboxLock(file, () => {
       let rawRows: T[];
@@ -670,13 +676,13 @@ export class AgentStateStore {
       const envelopes: T[] = [];
       const remaining: T[] = [];
       for (const row of rows) {
-        const selectedTarget = typeof row.target === "string" ? row.target : targetKeyOfInboxEnvelope(row);
+        const selectedTarget = targetKeyOfInboxEnvelope(row);
         if (envelopes.length < limit && (!options.target || options.target === selectedTarget)) envelopes.push(row);
         else remaining.push(row);
       }
       const pendingCount = remaining.reduce((count, row) => {
         if (!options.target) return count + 1;
-        const rowTarget = typeof row.target === "string" ? row.target : targetKeyOfInboxEnvelope(row);
+        const rowTarget = targetKeyOfInboxEnvelope(row);
         return count + (rowTarget === options.target ? 1 : 0);
       }, 0);
       if (!envelopes.length) return { envelopes, consumedDeliveryIds: [], seenThroughSeq: null, pendingCount };
@@ -703,7 +709,7 @@ export class AgentStateStore {
       }
       let seenThroughSeq: number | null = null;
       for (const envelope of envelopes) {
-        const target = String(envelope.target || targetKeyOfInboxEnvelope(envelope));
+        const target = targetKeyOfInboxEnvelope(envelope);
         const targetSeq = Number(envelope.target_seq);
         const targetState = state.targets[target] ?? { latest_received_seq: targetSeq, model_seen_seq: 0 };
         if (validSequence(targetSeq)) {
@@ -727,9 +733,9 @@ export class AgentStateStore {
     return this.withInboxLock(this.file("inbox"), () => {
       const state = this.inboxState();
       const known = state.messages[messageId]?.target;
-      if (known) return known;
+      if (known) return targetKeyOfInboxEnvelope({ message_id: messageId, target: known });
       const row = this.readNdjson<InboxEnvelope>("inbox").find((candidate) => candidate.message_id === messageId);
-      return row ? (typeof row.target === "string" ? row.target : targetKeyOfInboxEnvelope(row)) : null;
+      return row ? targetKeyOfInboxEnvelope(row) : null;
     });
   }
 

--- a/src/agent/agent-transport.ts
+++ b/src/agent/agent-transport.ts
@@ -121,11 +121,13 @@ export function createAgentTransport(env: Record<string, string | undefined> = p
     // —— legacy events/inbox characterization：从 host 写的 inbox 文件读入站正文（读后清空=已读）——
     //    必须严格对齐 agentApiEventsResponseSchema，否则 CLI 报 INVALID_JSON_RESPONSE，Claude 读不到消息。
     if (p.includes("/events") || p.includes("/inbox")) {
-      let envelopes: InboxEnvelope[] = [];
       try {
-        envelopes = stateStore.pollInbox<InboxEnvelope>().envelopes;
-      } catch { /* preserve legacy: malformed/unreadable inbox returns empty and is not cleared */ }
-      return { ok: true, status: 200, data: projectInboxEvents(envelopes) };
+        const envelopes = stateStore.pollInbox<InboxEnvelope>().envelopes;
+        return { ok: true, status: 200, data: projectInboxEvents(envelopes) };
+      } catch (error) {
+        return { ok: false, status: 409,
+          error: `Inbox consumption rejected; persisted rows were left unchanged: ${error instanceof Error ? error.message : String(error)}` };
+      }
     }
     // —— legacy history characterization：接飞书群历史 im +chat-messages-list ——
     //    需 bot 有 im:message:readonly；缺 scope 则优雅降级为空（不让 Claude 崩）。

--- a/src/agent/host-reminder-orchestrator.ts
+++ b/src/agent/host-reminder-orchestrator.ts
@@ -4,6 +4,7 @@ import type { HostAgent, HostEnvelopeProjector, ReminderEnvelope } from "../feis
 import { countWakeEnvelopes } from "../feishu/host-business-state.js";
 import * as defaultReminderStore from "./reminder-store.js";
 import type { ReminderRecord, ReminderStore } from "./reminder-store.js";
+import { targetKeyOfInboxEnvelope, type InboxEnvelope } from "./inbox-projection.js";
 
 interface ReminderAgent extends HostAgent { stateDir?: string | null }
 interface ReminderDeliveryTarget {
@@ -13,6 +14,12 @@ interface StateStore {
   paths: AgentStatePaths;
   appendNdjson(key: "inbox", value: unknown): void;
 }
+function withCanonicalTarget<T extends object>(envelope: T): T & { target: string } {
+  const input = envelope as InboxEnvelope;
+  if (typeof input.target === "string" && input.target) return envelope as T & { target: string };
+  return { ...envelope, target: targetKeyOfInboxEnvelope(input) };
+}
+
 interface ReminderStoreApi {
   load(file: string): ReminderStore;
   mutate<T>(file: string, fn: (store: ReminderStore) => T): T;
@@ -96,7 +103,7 @@ export class HostReminderOrchestrator {
 
   private deliver(agent: ReminderAgent, reminder: ReminderRecord, overdueMs: number): void {
     const recurrence = reminder.repeat ? this.store.parseRepeat(reminder.repeat, reminder.tz) : null;
-    const envelope = this.options.envelopeProjector.createReminderEnvelope(
+    const envelope = withCanonicalTarget(this.options.envelopeProjector.createReminderEnvelope(
       agent.agentId,
       {
         reminderId: reminder.reminderId,
@@ -108,7 +115,7 @@ export class HostReminderOrchestrator {
       },
       overdueMs,
       reminder.repeat && recurrence && !("error" in recurrence) ? (recurrence.description || null) : null,
-    );
+    ));
     try { this.options.stateStore(agent).appendNdjson("inbox", envelope); }
     catch (error) { this.log("reminder inbox 写失败", (error as Error).message); return; }
     if (this.options.deliveryTarget) void this.options.deliveryTarget.deliver(agent.agentId, envelope);
@@ -234,7 +241,7 @@ export class HostReminderOrchestrator {
       if (this.options.deliveryTarget) this.redelivered.add(agent.agentId);
       return;
     }
-    const envelope = existing ?? this.options.envelopeProjector.createRedeliveryEnvelope(agent.agentId, wakeCount);
+    const envelope = withCanonicalTarget(existing ?? this.options.envelopeProjector.createRedeliveryEnvelope(agent.agentId, wakeCount));
     if (!existing) {
       try { this.options.stateStore(agent).appendNdjson("inbox", envelope); }
       catch (error) { this.log("启动补投 inbox 写失败", (error as Error).message); return; }

--- a/src/agent/host-reminder-orchestrator.ts
+++ b/src/agent/host-reminder-orchestrator.ts
@@ -16,8 +16,8 @@ interface StateStore {
 }
 function withCanonicalTarget<T extends object>(envelope: T): T & { target: string } {
   const input = envelope as InboxEnvelope;
-  if (typeof input.target === "string" && input.target) return envelope as T & { target: string };
-  return { ...envelope, target: targetKeyOfInboxEnvelope(input) };
+  const target = targetKeyOfInboxEnvelope(input);
+  return input.target === target ? envelope as T & { target: string } : { ...envelope, target };
 }
 
 interface ReminderStoreApi {

--- a/src/agent/inbox-projection.ts
+++ b/src/agent/inbox-projection.ts
@@ -16,36 +16,54 @@ export interface InboxEnvelope {
 
 export const RUNTIME_REMINDER_TARGET = "runtime:reminder" as const;
 export const RUNTIME_REDELIVERY_TARGET = "runtime:redelivery" as const;
-export const DOCUMENT_COMMENT_TARGET_PATTERN = /^document-comment:(doc|docx|sheet|file):([A-Za-z0-9_-]+):([A-Za-z0-9_-]+):(in-thread|top-level)$/;
 
-const CHAT_ID_PATTERN = /^oc_[A-Za-z0-9_-]+$/;
-const THREAD_ID_PATTERN = /^omt_[A-Za-z0-9_-]+$/;
-const CHAT_TARGET_PATTERN = /^chat:(oc_[A-Za-z0-9_-]+)$/;
-const THREAD_TARGET_PATTERN = /^thread:(oc_[A-Za-z0-9_-]+):(omt_[A-Za-z0-9_-]+)$/;
+const CHAT_TARGET_PREFIX = "chat:";
+const THREAD_TARGET_PREFIX = "thread:";
+const DOCUMENT_COMMENT_TARGET_PREFIX = "document-comment:";
+const REMINDER_MESSAGE_PREFIX = "rem_";
+const REDELIVERY_MESSAGE_PREFIX = "redeliver_";
+
+function hasNonemptySuffix(value: string, prefix: string): boolean {
+  return value.startsWith(prefix) && value.length > prefix.length;
+}
 
 function internalTargetOfInboxEnvelope(envelope: InboxEnvelope): string | null {
   const messageId = typeof envelope.message_id === "string" ? envelope.message_id : "";
   const reminderKind = envelope.kind === "reminder";
   const redeliveryKind = envelope.kind === "redelivery";
-  const reminderId = /^rem_[A-Za-z0-9_-]+$/.test(messageId);
-  const redeliveryId = /^redeliver_[A-Za-z0-9_-]+$/.test(messageId);
-  const hasInternalMarker = reminderKind || redeliveryKind || reminderId || redeliveryId;
+  const reminderMarker = messageId.startsWith(REMINDER_MESSAGE_PREFIX);
+  const redeliveryMarker = messageId.startsWith(REDELIVERY_MESSAGE_PREFIX);
+  const reminderId = hasNonemptySuffix(messageId, REMINDER_MESSAGE_PREFIX);
+  const redeliveryId = hasNonemptySuffix(messageId, REDELIVERY_MESSAGE_PREFIX);
+  const hasInternalMarker = reminderKind || redeliveryKind || reminderMarker || redeliveryMarker;
   if (!hasInternalMarker) return null;
-  if (reminderKind && reminderId && !redeliveryKind && !redeliveryId) return RUNTIME_REMINDER_TARGET;
-  if (redeliveryKind && redeliveryId && !reminderKind && !reminderId) return RUNTIME_REDELIVERY_TARGET;
-  throw new Error(`Inbox internal source requires matching kind and message_id; received kind=${JSON.stringify(envelope.kind ?? null)} message_id=${JSON.stringify(envelope.message_id ?? null)}`);
+  if (reminderKind && reminderId && !redeliveryKind && !redeliveryMarker) return RUNTIME_REMINDER_TARGET;
+  if (redeliveryKind && redeliveryId && !reminderKind && !reminderMarker) return RUNTIME_REDELIVERY_TARGET;
+  throw new Error(`Inbox internal source requires matching kind and message_id prefix; received kind=${JSON.stringify(envelope.kind ?? null)} message_id=${JSON.stringify(envelope.message_id ?? null)}`);
+}
+
+function isChatTarget(target: string): boolean {
+  return hasNonemptySuffix(target, CHAT_TARGET_PREFIX);
+}
+
+function isThreadTarget(target: string): boolean {
+  return hasNonemptySuffix(target, THREAD_TARGET_PREFIX);
+}
+
+function isDocumentCommentTarget(target: string): boolean {
+  return hasNonemptySuffix(target, DOCUMENT_COMMENT_TARGET_PREFIX);
 }
 
 export function isCanonicalInboxTarget(target: string): boolean {
-  return CHAT_TARGET_PATTERN.test(target)
-    || THREAD_TARGET_PATTERN.test(target)
+  return isChatTarget(target)
+    || isThreadTarget(target)
     || target === RUNTIME_REMINDER_TARGET
     || target === RUNTIME_REDELIVERY_TARGET
-    || DOCUMENT_COMMENT_TARGET_PATTERN.test(target);
+    || isDocumentCommentTarget(target);
 }
 
 function invalidTarget(target: string): Error {
-  return new Error(`Invalid canonical Inbox target ${JSON.stringify(target)}; expected chat:<oc_...>, thread:<oc_...>:<omt_...>, runtime:reminder, runtime:redelivery, or a valid document-comment locator`);
+  return new Error(`Invalid canonical Inbox target ${JSON.stringify(target)}; expected chat:<nonempty>, thread:<nonempty>, runtime:reminder, runtime:redelivery, or document-comment:<nonempty>`);
 }
 
 function optionalLocator(envelope: InboxEnvelope, key: "chat_id" | "thread_id"): string {
@@ -60,47 +78,40 @@ export function targetKeyOfInboxEnvelope(envelope: InboxEnvelope | null | undefi
   const internalTarget = internalTargetOfInboxEnvelope(envelope);
   const chatId = optionalLocator(envelope, "chat_id");
   const threadId = optionalLocator(envelope, "thread_id");
+  if (threadId && !chatId) {
+    throw new Error(`Inbox thread locator requires nonempty chat_id and thread_id; received chat_id=${JSON.stringify(chatId)} thread_id=${JSON.stringify(threadId)}`);
+  }
+  const locatorTarget = chatId ? (threadId ? `thread:${chatId}:${threadId}` : `chat:${chatId}`) : null;
   const hasExplicitTarget = Object.prototype.hasOwnProperty.call(envelope, "target");
   if (hasExplicitTarget) {
     if (typeof envelope.target !== "string" || envelope.target.length === 0) throw invalidTarget(String(envelope.target));
     const target = envelope.target;
     if (!isCanonicalInboxTarget(target)) throw invalidTarget(target);
-    const chatMatch = CHAT_TARGET_PATTERN.exec(target);
-    if (chatMatch) {
-      if (internalTarget || envelope.kind === "document_comment") throw new Error(`Inbox chat target conflicts with source kind/message_id`);
-      if (chatId && chatId !== chatMatch[1]) throw new Error(`Inbox chat target conflicts with chat_id=${JSON.stringify(chatId)}`);
-      if (threadId) throw new Error(`Inbox chat target cannot carry thread_id=${JSON.stringify(threadId)}`);
-      return target;
-    }
-    const threadMatch = THREAD_TARGET_PATTERN.exec(target);
-    if (threadMatch) {
-      if (internalTarget || envelope.kind === "document_comment") throw new Error(`Inbox thread target conflicts with source kind/message_id`);
-      if (chatId && chatId !== threadMatch[1]) throw new Error(`Inbox thread target conflicts with chat_id=${JSON.stringify(chatId)}`);
-      if (threadId && threadId !== threadMatch[2]) throw new Error(`Inbox thread target conflicts with thread_id=${JSON.stringify(threadId)}`);
+    if (isChatTarget(target) || isThreadTarget(target)) {
+      if (internalTarget || envelope.kind === "document_comment") throw new Error(`Inbox chat/thread target conflicts with source kind/message_id`);
+      if (locatorTarget && locatorTarget !== target) {
+        throw new Error(`Inbox chat/thread target conflicts with locator target ${JSON.stringify(locatorTarget)}`);
+      }
       return target;
     }
     if (target === RUNTIME_REMINDER_TARGET || target === RUNTIME_REDELIVERY_TARGET) {
-      if (chatId || threadId) throw new Error(`Inbox runtime target cannot carry chat_id/thread_id locators`);
-      if (internalTarget !== target) throw new Error(`Inbox target ${target} requires exact matching kind and message_id`);
+      if (locatorTarget) throw new Error(`Inbox runtime target cannot carry chat_id/thread_id locators`);
+      if (internalTarget !== target) throw new Error(`Inbox target ${target} requires exact matching kind and message_id prefix`);
       return target;
     }
-    if (DOCUMENT_COMMENT_TARGET_PATTERN.test(target)) {
+    if (isDocumentCommentTarget(target)) {
       if (envelope.kind !== "document_comment" || internalTarget) throw new Error(`Inbox document-comment target requires kind=document_comment and no internal source`);
-      if (chatId || threadId) throw new Error(`Inbox document-comment target cannot carry chat_id/thread_id locators`);
+      if (locatorTarget) throw new Error(`Inbox document-comment target cannot carry chat_id/thread_id locators`);
       return target;
     }
     throw invalidTarget(target);
   }
   if (envelope.kind === "document_comment") {
-    throw new Error("Inbox document_comment requires an explicit valid document-comment locator");
+    throw new Error("Inbox document_comment requires an explicit document-comment:<nonempty> target");
   }
-  if (chatId || threadId) {
+  if (locatorTarget) {
     if (internalTarget) throw new Error(`Inbox internal source cannot be derived as a chat/thread target`);
-    if (threadId && (!THREAD_ID_PATTERN.test(threadId) || !CHAT_ID_PATTERN.test(chatId))) {
-      throw new Error(`Inbox thread locator requires full oc_ chat_id and omt_ thread_id; received chat_id=${JSON.stringify(chatId)} thread_id=${JSON.stringify(threadId)}`);
-    }
-    if (!CHAT_ID_PATTERN.test(chatId)) throw new Error(`Inbox chat locator requires a full oc_ chat_id; received ${JSON.stringify(chatId)}`);
-    return threadId ? `thread:${chatId}:${threadId}` : `chat:${chatId}`;
+    return locatorTarget;
   }
   if (internalTarget) throw new Error(`Inbox internal source requires an explicit ${internalTarget} target`);
   throw new Error(`Inbox envelope has no canonical target locator (message_id=${JSON.stringify(envelope.message_id ?? null)}, kind=${JSON.stringify(envelope.kind ?? null)})`);

--- a/src/agent/inbox-projection.ts
+++ b/src/agent/inbox-projection.ts
@@ -25,14 +25,15 @@ const THREAD_TARGET_PATTERN = /^thread:(oc_[A-Za-z0-9_-]+):(omt_[A-Za-z0-9_-]+)$
 
 function internalTargetOfInboxEnvelope(envelope: InboxEnvelope): string | null {
   const messageId = typeof envelope.message_id === "string" ? envelope.message_id : "";
-  const kindTarget = envelope.kind === "reminder" ? RUNTIME_REMINDER_TARGET
-    : envelope.kind === "redelivery" ? RUNTIME_REDELIVERY_TARGET : null;
-  const messageTarget = /^rem_[A-Za-z0-9_-]+$/.test(messageId) ? RUNTIME_REMINDER_TARGET
-    : /^redeliver_[A-Za-z0-9_-]+$/.test(messageId) ? RUNTIME_REDELIVERY_TARGET : null;
-  if (kindTarget && messageTarget && kindTarget !== messageTarget) {
-    throw new Error(`Inbox internal source mismatch: kind=${JSON.stringify(envelope.kind)} message_id=${JSON.stringify(messageId)}`);
-  }
-  return kindTarget ?? messageTarget;
+  const reminderKind = envelope.kind === "reminder";
+  const redeliveryKind = envelope.kind === "redelivery";
+  const reminderId = /^rem_[A-Za-z0-9_-]+$/.test(messageId);
+  const redeliveryId = /^redeliver_[A-Za-z0-9_-]+$/.test(messageId);
+  const hasInternalMarker = reminderKind || redeliveryKind || reminderId || redeliveryId;
+  if (!hasInternalMarker) return null;
+  if (reminderKind && reminderId && !redeliveryKind && !redeliveryId) return RUNTIME_REMINDER_TARGET;
+  if (redeliveryKind && redeliveryId && !reminderKind && !reminderId) return RUNTIME_REDELIVERY_TARGET;
+  throw new Error(`Inbox internal source requires matching kind and message_id; received kind=${JSON.stringify(envelope.kind ?? null)} message_id=${JSON.stringify(envelope.message_id ?? null)}`);
 }
 
 export function isCanonicalInboxTarget(target: string): boolean {
@@ -47,38 +48,61 @@ function invalidTarget(target: string): Error {
   return new Error(`Invalid canonical Inbox target ${JSON.stringify(target)}; expected chat:<oc_...>, thread:<oc_...>:<omt_...>, runtime:reminder, runtime:redelivery, or a valid document-comment locator`);
 }
 
+function optionalLocator(envelope: InboxEnvelope, key: "chat_id" | "thread_id"): string {
+  const value = envelope[key];
+  if (value === undefined || value === null || value === "") return "";
+  if (typeof value !== "string") throw new Error(`Inbox ${key} must be a string when present; received ${JSON.stringify(value)}`);
+  return value;
+}
+
 export function targetKeyOfInboxEnvelope(envelope: InboxEnvelope | null | undefined): string {
   if (!envelope) throw new Error("Inbox envelope is required to derive a canonical target");
   const internalTarget = internalTargetOfInboxEnvelope(envelope);
-  if (typeof envelope.target === "string" && envelope.target.length > 0) {
-    if (!isCanonicalInboxTarget(envelope.target)) throw invalidTarget(envelope.target);
-    if ((envelope.target === RUNTIME_REMINDER_TARGET || envelope.target === RUNTIME_REDELIVERY_TARGET) && !internalTarget) {
-      throw new Error(`Inbox target ${envelope.target} requires matching reminder/redelivery kind or message_id convention`);
+  const chatId = optionalLocator(envelope, "chat_id");
+  const threadId = optionalLocator(envelope, "thread_id");
+  const hasExplicitTarget = Object.prototype.hasOwnProperty.call(envelope, "target");
+  if (hasExplicitTarget) {
+    if (typeof envelope.target !== "string" || envelope.target.length === 0) throw invalidTarget(String(envelope.target));
+    const target = envelope.target;
+    if (!isCanonicalInboxTarget(target)) throw invalidTarget(target);
+    const chatMatch = CHAT_TARGET_PATTERN.exec(target);
+    if (chatMatch) {
+      if (internalTarget || envelope.kind === "document_comment") throw new Error(`Inbox chat target conflicts with source kind/message_id`);
+      if (chatId && chatId !== chatMatch[1]) throw new Error(`Inbox chat target conflicts with chat_id=${JSON.stringify(chatId)}`);
+      if (threadId) throw new Error(`Inbox chat target cannot carry thread_id=${JSON.stringify(threadId)}`);
+      return target;
     }
-    if (internalTarget && envelope.target !== internalTarget) {
-      throw new Error(`Inbox ${String(envelope.kind || envelope.message_id || "internal")} target must be ${internalTarget}, received ${JSON.stringify(envelope.target)}`);
+    const threadMatch = THREAD_TARGET_PATTERN.exec(target);
+    if (threadMatch) {
+      if (internalTarget || envelope.kind === "document_comment") throw new Error(`Inbox thread target conflicts with source kind/message_id`);
+      if (chatId && chatId !== threadMatch[1]) throw new Error(`Inbox thread target conflicts with chat_id=${JSON.stringify(chatId)}`);
+      if (threadId && threadId !== threadMatch[2]) throw new Error(`Inbox thread target conflicts with thread_id=${JSON.stringify(threadId)}`);
+      return target;
     }
-    if (envelope.kind === "document_comment" && !DOCUMENT_COMMENT_TARGET_PATTERN.test(envelope.target)) {
-      throw new Error(`Inbox document_comment requires a valid document-comment locator, received ${JSON.stringify(envelope.target)}`);
+    if (target === RUNTIME_REMINDER_TARGET || target === RUNTIME_REDELIVERY_TARGET) {
+      if (chatId || threadId) throw new Error(`Inbox runtime target cannot carry chat_id/thread_id locators`);
+      if (internalTarget !== target) throw new Error(`Inbox target ${target} requires exact matching kind and message_id`);
+      return target;
     }
-    return envelope.target;
-  }
-  if (envelope.target !== undefined && envelope.target !== null && envelope.target !== "") {
-    throw invalidTarget(String(envelope.target));
-  }
-  const chatId = typeof envelope.chat_id === "string" ? envelope.chat_id : "";
-  const threadId = typeof envelope.thread_id === "string" ? envelope.thread_id : "";
-  if (threadId && (!THREAD_ID_PATTERN.test(threadId) || !CHAT_ID_PATTERN.test(chatId))) {
-    throw new Error(`Inbox thread locator requires full oc_ chat_id and omt_ thread_id; received chat_id=${JSON.stringify(chatId)} thread_id=${JSON.stringify(threadId)}`);
-  }
-  if (chatId) {
-    if (!CHAT_ID_PATTERN.test(chatId)) throw new Error(`Inbox chat locator requires a full oc_ chat_id; received ${JSON.stringify(chatId)}`);
-    return threadId ? `thread:${chatId}:${threadId}` : `chat:${chatId}`;
+    if (DOCUMENT_COMMENT_TARGET_PATTERN.test(target)) {
+      if (envelope.kind !== "document_comment" || internalTarget) throw new Error(`Inbox document-comment target requires kind=document_comment and no internal source`);
+      if (chatId || threadId) throw new Error(`Inbox document-comment target cannot carry chat_id/thread_id locators`);
+      return target;
+    }
+    throw invalidTarget(target);
   }
   if (envelope.kind === "document_comment") {
     throw new Error("Inbox document_comment requires an explicit valid document-comment locator");
   }
-  if (internalTarget) return internalTarget;
+  if (chatId || threadId) {
+    if (internalTarget) throw new Error(`Inbox internal source cannot be derived as a chat/thread target`);
+    if (threadId && (!THREAD_ID_PATTERN.test(threadId) || !CHAT_ID_PATTERN.test(chatId))) {
+      throw new Error(`Inbox thread locator requires full oc_ chat_id and omt_ thread_id; received chat_id=${JSON.stringify(chatId)} thread_id=${JSON.stringify(threadId)}`);
+    }
+    if (!CHAT_ID_PATTERN.test(chatId)) throw new Error(`Inbox chat locator requires a full oc_ chat_id; received ${JSON.stringify(chatId)}`);
+    return threadId ? `thread:${chatId}:${threadId}` : `chat:${chatId}`;
+  }
+  if (internalTarget) throw new Error(`Inbox internal source requires an explicit ${internalTarget} target`);
   throw new Error(`Inbox envelope has no canonical target locator (message_id=${JSON.stringify(envelope.message_id ?? null)}, kind=${JSON.stringify(envelope.kind ?? null)})`);
 }
 

--- a/src/agent/inbox-projection.ts
+++ b/src/agent/inbox-projection.ts
@@ -4,6 +4,7 @@ export interface InboxEnvelope {
   seq?: unknown;
   target?: unknown;
   target_seq?: unknown;
+  kind?: unknown;
   chat_id?: unknown;
   thread_id?: unknown;
   channel_type?: unknown;
@@ -13,15 +14,72 @@ export interface InboxEnvelope {
   [key: string]: unknown;
 }
 
-export function targetKeyOfInboxEnvelope(envelope: InboxEnvelope | null | undefined): string {
-  if (!envelope) return "runtime:unknown";
-  if (typeof envelope.target === "string" && envelope.target) return envelope.target;
-  if (typeof envelope.chat_id === "string" && envelope.chat_id) {
-    return typeof envelope.thread_id === "string" && envelope.thread_id
-      ? `thread:${envelope.chat_id}:${envelope.thread_id}`
-      : `chat:${envelope.chat_id}`;
+export const RUNTIME_REMINDER_TARGET = "runtime:reminder" as const;
+export const RUNTIME_REDELIVERY_TARGET = "runtime:redelivery" as const;
+export const DOCUMENT_COMMENT_TARGET_PATTERN = /^document-comment:(doc|docx|sheet|file):([A-Za-z0-9_-]+):([A-Za-z0-9_-]+):(in-thread|top-level)$/;
+
+const CHAT_ID_PATTERN = /^oc_[A-Za-z0-9_-]+$/;
+const THREAD_ID_PATTERN = /^omt_[A-Za-z0-9_-]+$/;
+const CHAT_TARGET_PATTERN = /^chat:(oc_[A-Za-z0-9_-]+)$/;
+const THREAD_TARGET_PATTERN = /^thread:(oc_[A-Za-z0-9_-]+):(omt_[A-Za-z0-9_-]+)$/;
+
+function internalTargetOfInboxEnvelope(envelope: InboxEnvelope): string | null {
+  const messageId = typeof envelope.message_id === "string" ? envelope.message_id : "";
+  const kindTarget = envelope.kind === "reminder" ? RUNTIME_REMINDER_TARGET
+    : envelope.kind === "redelivery" ? RUNTIME_REDELIVERY_TARGET : null;
+  const messageTarget = /^rem_[A-Za-z0-9_-]+$/.test(messageId) ? RUNTIME_REMINDER_TARGET
+    : /^redeliver_[A-Za-z0-9_-]+$/.test(messageId) ? RUNTIME_REDELIVERY_TARGET : null;
+  if (kindTarget && messageTarget && kindTarget !== messageTarget) {
+    throw new Error(`Inbox internal source mismatch: kind=${JSON.stringify(envelope.kind)} message_id=${JSON.stringify(messageId)}`);
   }
-  return targetOfInboxEnvelope(envelope) || "runtime:system";
+  return kindTarget ?? messageTarget;
+}
+
+export function isCanonicalInboxTarget(target: string): boolean {
+  return CHAT_TARGET_PATTERN.test(target)
+    || THREAD_TARGET_PATTERN.test(target)
+    || target === RUNTIME_REMINDER_TARGET
+    || target === RUNTIME_REDELIVERY_TARGET
+    || DOCUMENT_COMMENT_TARGET_PATTERN.test(target);
+}
+
+function invalidTarget(target: string): Error {
+  return new Error(`Invalid canonical Inbox target ${JSON.stringify(target)}; expected chat:<oc_...>, thread:<oc_...>:<omt_...>, runtime:reminder, runtime:redelivery, or a valid document-comment locator`);
+}
+
+export function targetKeyOfInboxEnvelope(envelope: InboxEnvelope | null | undefined): string {
+  if (!envelope) throw new Error("Inbox envelope is required to derive a canonical target");
+  const internalTarget = internalTargetOfInboxEnvelope(envelope);
+  if (typeof envelope.target === "string" && envelope.target.length > 0) {
+    if (!isCanonicalInboxTarget(envelope.target)) throw invalidTarget(envelope.target);
+    if ((envelope.target === RUNTIME_REMINDER_TARGET || envelope.target === RUNTIME_REDELIVERY_TARGET) && !internalTarget) {
+      throw new Error(`Inbox target ${envelope.target} requires matching reminder/redelivery kind or message_id convention`);
+    }
+    if (internalTarget && envelope.target !== internalTarget) {
+      throw new Error(`Inbox ${String(envelope.kind || envelope.message_id || "internal")} target must be ${internalTarget}, received ${JSON.stringify(envelope.target)}`);
+    }
+    if (envelope.kind === "document_comment" && !DOCUMENT_COMMENT_TARGET_PATTERN.test(envelope.target)) {
+      throw new Error(`Inbox document_comment requires a valid document-comment locator, received ${JSON.stringify(envelope.target)}`);
+    }
+    return envelope.target;
+  }
+  if (envelope.target !== undefined && envelope.target !== null && envelope.target !== "") {
+    throw invalidTarget(String(envelope.target));
+  }
+  const chatId = typeof envelope.chat_id === "string" ? envelope.chat_id : "";
+  const threadId = typeof envelope.thread_id === "string" ? envelope.thread_id : "";
+  if (threadId && (!THREAD_ID_PATTERN.test(threadId) || !CHAT_ID_PATTERN.test(chatId))) {
+    throw new Error(`Inbox thread locator requires full oc_ chat_id and omt_ thread_id; received chat_id=${JSON.stringify(chatId)} thread_id=${JSON.stringify(threadId)}`);
+  }
+  if (chatId) {
+    if (!CHAT_ID_PATTERN.test(chatId)) throw new Error(`Inbox chat locator requires a full oc_ chat_id; received ${JSON.stringify(chatId)}`);
+    return threadId ? `thread:${chatId}:${threadId}` : `chat:${chatId}`;
+  }
+  if (envelope.kind === "document_comment") {
+    throw new Error("Inbox document_comment requires an explicit valid document-comment locator");
+  }
+  if (internalTarget) return internalTarget;
+  throw new Error(`Inbox envelope has no canonical target locator (message_id=${JSON.stringify(envelope.message_id ?? null)}, kind=${JSON.stringify(envelope.kind ?? null)})`);
 }
 
 export interface AgentEventsProjection {
@@ -69,22 +127,10 @@ export function projectInboxEnvelope(
   };
 }
 
-/** Preserve the target/thread format consumed by the existing Agent CLI. */
+/** Return an allowlisted canonical target when the envelope is locatable. */
 export function targetOfInboxEnvelope(envelope: InboxEnvelope | null | undefined): string | null {
-  if (!envelope) return null;
-  if (envelope.kind === "document_comment") {
-    return typeof envelope.target === "string" && envelope.target ? envelope.target : null;
-  }
-  if (envelope.channel_type === "thread" && envelope.parent_channel_name && envelope.channel_name) {
-    const base = envelope.parent_channel_type === "dm"
-      ? `dm:@${String(envelope.parent_channel_name)}`
-      : `#${String(envelope.parent_channel_name)}`;
-    return `${base}:${String(envelope.channel_name).slice(0, 8)}`;
-  }
-  if (typeof envelope.channel_name !== "string" || !envelope.channel_name) return null;
-  return envelope.channel_type === "dm"
-    ? `dm:@${envelope.channel_name}`
-    : `#${envelope.channel_name}`;
+  try { return targetKeyOfInboxEnvelope(envelope); }
+  catch { return null; }
 }
 
 /** Project persisted inbox envelopes into the exact agentApi events response data shape. */
@@ -94,7 +140,7 @@ export function projectInboxEvents(envelopes: InboxEnvelope[]): AgentEventsProje
     events: envelopes,
     last_seen_msgId: last ? (last.message_id || null) : null,
     last_seen_seq: last ? (last.seq ?? null) : null,
-    reply_target: targetOfInboxEnvelope(last),
+    reply_target: last ? targetKeyOfInboxEnvelope(last) : null,
     pending_notice_ids: [],
     wake_reason: null,
     has_more: false,
@@ -108,9 +154,12 @@ export function projectInboxCheck(envelopes: InboxEnvelope[], onlyTarget?: strin
   pending_total: number;
   has_more: boolean;
 } {
+  if (onlyTarget && !isCanonicalInboxTarget(onlyTarget)) {
+    throw new Error(`Invalid canonical Inbox check target ${JSON.stringify(onlyTarget)}`);
+  }
   const byTarget = new Map<string, InboxEnvelope[]>();
   for (const envelope of envelopes) {
-    const target = typeof envelope.target === "string" && envelope.target ? envelope.target : targetKeyOfInboxEnvelope(envelope);
+    const target = targetKeyOfInboxEnvelope(envelope);
     if (onlyTarget && onlyTarget !== target) continue;
     const rows = byTarget.get(target) ?? [];
     rows.push(envelope);

--- a/src/agent/inbox-projection.ts
+++ b/src/agent/inbox-projection.ts
@@ -15,9 +15,7 @@ export interface InboxEnvelope {
 
 export function targetKeyOfInboxEnvelope(envelope: InboxEnvelope | null | undefined): string {
   if (!envelope) return "runtime:unknown";
-  if (envelope.kind === "document_comment" && typeof envelope.target === "string" && envelope.target) {
-    return envelope.target;
-  }
+  if (typeof envelope.target === "string" && envelope.target) return envelope.target;
   if (typeof envelope.chat_id === "string" && envelope.chat_id) {
     return typeof envelope.thread_id === "string" && envelope.thread_id
       ? `thread:${envelope.chat_id}:${envelope.thread_id}`
@@ -77,15 +75,16 @@ export function targetOfInboxEnvelope(envelope: InboxEnvelope | null | undefined
   if (envelope.kind === "document_comment") {
     return typeof envelope.target === "string" && envelope.target ? envelope.target : null;
   }
-  if (envelope.channel_type === "thread" && envelope.parent_channel_name) {
+  if (envelope.channel_type === "thread" && envelope.parent_channel_name && envelope.channel_name) {
     const base = envelope.parent_channel_type === "dm"
       ? `dm:@${String(envelope.parent_channel_name)}`
       : `#${String(envelope.parent_channel_name)}`;
-    return `${base}:${String(envelope.channel_name || "").slice(0, 8)}`;
+    return `${base}:${String(envelope.channel_name).slice(0, 8)}`;
   }
+  if (typeof envelope.channel_name !== "string" || !envelope.channel_name) return null;
   return envelope.channel_type === "dm"
-    ? `dm:@${String(envelope.channel_name)}`
-    : `#${String(envelope.channel_name)}`;
+    ? `dm:@${envelope.channel_name}`
+    : `#${envelope.channel_name}`;
 }
 
 /** Project persisted inbox envelopes into the exact agentApi events response data shape. */

--- a/src/feishu/document-comment.ts
+++ b/src/feishu/document-comment.ts
@@ -1,5 +1,6 @@
 import { createHash } from "node:crypto";
 import type { CommentEvent, CommentTarget, FetchedComment } from "@larksuite/channel";
+import { DOCUMENT_COMMENT_TARGET_PATTERN } from "../agent/inbox-projection.js";
 
 export const DOCUMENT_COMMENT_EVENT = "drive.notice.comment_add_v1";
 
@@ -59,7 +60,7 @@ export function documentCommentTarget(target: CommentTarget, commentId: string, 
 }
 
 export function parseDocumentCommentTarget(value: string): (CommentTarget & { commentId: string; topLevel: boolean }) | null {
-  const match = /^document-comment:(doc|docx|sheet|file):([A-Za-z0-9_-]+):([A-Za-z0-9_-]+):(in-thread|top-level)$/.exec(value);
+  const match = DOCUMENT_COMMENT_TARGET_PATTERN.exec(value);
   return match ? {
     fileType: match[1] as CommentTarget["fileType"], fileToken: match[2], commentId: match[3], topLevel: match[4] === "top-level",
   } : null;

--- a/src/feishu/document-comment.ts
+++ b/src/feishu/document-comment.ts
@@ -1,8 +1,8 @@
 import { createHash } from "node:crypto";
 import type { CommentEvent, CommentTarget, FetchedComment } from "@larksuite/channel";
-import { DOCUMENT_COMMENT_TARGET_PATTERN } from "../agent/inbox-projection.js";
 
 export const DOCUMENT_COMMENT_EVENT = "drive.notice.comment_add_v1";
+const DOCUMENT_COMMENT_TARGET_PATTERN = /^document-comment:(doc|docx|sheet|file):([A-Za-z0-9_-]+):([A-Za-z0-9_-]+):(in-thread|top-level)$/;
 
 export interface DocumentCommentSurface {
   resolveTarget(fileToken: string, fileType: string): Promise<CommentTarget | null>;

--- a/src/feishu/host-business-state.ts
+++ b/src/feishu/host-business-state.ts
@@ -1,4 +1,5 @@
 import type { AgentStatePaths } from "../platform/root-layout.js";
+import { targetKeyOfInboxEnvelope } from "../agent/inbox-projection.js";
 import crypto from "node:crypto";
 import {
   createMessageEnvelope,
@@ -319,6 +320,7 @@ export interface InboundEnvelopeOptions {
 
 export interface ReminderEnvelope {
   message_id: string;
+  target: string;
   seq: number;
   sender_name: "定时提醒";
   sender_type: "system";
@@ -332,6 +334,7 @@ export interface ReminderEnvelope {
 
 export interface RedeliveryEnvelope {
   message_id: string;
+  target: string;
   seq: number;
   sender_name: "系统";
   sender_type: "system";
@@ -428,33 +431,35 @@ export class HostEnvelopeProjector {
             : `本条存量提醒缺少可用的飞书 message_id/chat_id，无法安全推断原会话；请先用 ${this.larkCommand("im +chat-search")} 确认目标，禁止猜测发送`,
       `这是你之前用 ${this.agentCommand("reminder schedule")} 设置的提醒，请按标题执行相应动作。管理: ${this.agentCommand("reminder list")} / ${this.agentCommand("reminder snooze")} / ${this.agentCommand("reminder cancel")}`,
     ].filter((line): line is string => Boolean(line));
-    return {
+    const envelope = {
       message_id: `rem_${reminder.reminderId.slice(0, 16)}_${seq}`,
       seq,
-      sender_name: "定时提醒",
-      sender_type: "system",
-      channel_type: "dm",
-      channel_name: "system",
+      sender_name: "定时提醒" as const,
+      sender_type: "system" as const,
+      channel_type: "dm" as const,
+      channel_name: "system" as const,
       content: lines.join("\n"),
       timestamp: this.now().toISOString(),
       thread_id: null,
-      wake: true,
+      wake: true as const,
     };
+    return { ...envelope, target: targetKeyOfInboxEnvelope(envelope) };
   }
 
   createRedeliveryEnvelope(agentId: string, wakeCount: number): RedeliveryEnvelope {
     const seq = this.nextSequence(agentId);
-    return {
+    const envelope = {
       message_id: `redeliver_${this.randomHex(6)}`,
       seq,
-      sender_name: "系统",
-      sender_type: "system",
-      channel_type: "dm",
-      channel_name: "system",
+      sender_name: "系统" as const,
+      sender_type: "system" as const,
+      channel_type: "dm" as const,
+      channel_name: "system" as const,
       content: `[启动补投] 服务重启期间有 ${wakeCount} 条本应唤醒你的消息未被读取（可能包含用户消息、@提及或定时提醒）。请先用 ${this.agentCommand("inbox check")} 看目标摘要，再用 ${this.agentCommand("inbox poll")} 领取完整消息；仅当 message_id 以 om_ 开头时才用 ${this.larkCommand("im +messages-reply")}，系统 rem_/redeliver_ ID 不可回复；有 chat_id 时可用 ${this.larkCommand("im +messages-send")}，否则先查询确认目标，禁止猜测。`,
       timestamp: this.now().toISOString(),
       thread_id: null,
     };
+    return { ...envelope, target: targetKeyOfInboxEnvelope(envelope) };
   }
 }
 

--- a/src/feishu/host-business-state.ts
+++ b/src/feishu/host-business-state.ts
@@ -1,5 +1,5 @@
 import type { AgentStatePaths } from "../platform/root-layout.js";
-import { targetKeyOfInboxEnvelope } from "../agent/inbox-projection.js";
+import { RUNTIME_REDELIVERY_TARGET, RUNTIME_REMINDER_TARGET } from "../agent/inbox-projection.js";
 import crypto from "node:crypto";
 import {
   createMessageEnvelope,
@@ -319,8 +319,9 @@ export interface InboundEnvelopeOptions {
 }
 
 export interface ReminderEnvelope {
+  kind: "reminder";
   message_id: string;
-  target: string;
+  target: typeof RUNTIME_REMINDER_TARGET;
   seq: number;
   sender_name: "定时提醒";
   sender_type: "system";
@@ -333,8 +334,9 @@ export interface ReminderEnvelope {
 }
 
 export interface RedeliveryEnvelope {
+  kind: "redelivery";
   message_id: string;
-  target: string;
+  target: typeof RUNTIME_REDELIVERY_TARGET;
   seq: number;
   sender_name: "系统";
   sender_type: "system";
@@ -432,6 +434,7 @@ export class HostEnvelopeProjector {
       `这是你之前用 ${this.agentCommand("reminder schedule")} 设置的提醒，请按标题执行相应动作。管理: ${this.agentCommand("reminder list")} / ${this.agentCommand("reminder snooze")} / ${this.agentCommand("reminder cancel")}`,
     ].filter((line): line is string => Boolean(line));
     const envelope = {
+      kind: "reminder" as const,
       message_id: `rem_${reminder.reminderId.slice(0, 16)}_${seq}`,
       seq,
       sender_name: "定时提醒" as const,
@@ -443,12 +446,13 @@ export class HostEnvelopeProjector {
       thread_id: null,
       wake: true as const,
     };
-    return { ...envelope, target: targetKeyOfInboxEnvelope(envelope) };
+    return { ...envelope, target: RUNTIME_REMINDER_TARGET };
   }
 
   createRedeliveryEnvelope(agentId: string, wakeCount: number): RedeliveryEnvelope {
     const seq = this.nextSequence(agentId);
     const envelope = {
+      kind: "redelivery" as const,
       message_id: `redeliver_${this.randomHex(6)}`,
       seq,
       sender_name: "系统" as const,
@@ -459,7 +463,7 @@ export class HostEnvelopeProjector {
       timestamp: this.now().toISOString(),
       thread_id: null,
     };
-    return { ...envelope, target: targetKeyOfInboxEnvelope(envelope) };
+    return { ...envelope, target: RUNTIME_REDELIVERY_TARGET };
   }
 }
 

--- a/src/runtime/runtime-host.ts
+++ b/src/runtime/runtime-host.ts
@@ -846,6 +846,16 @@ export function createRuntimeHost(options: {
       const messageId = String(envelope.message_id || envelope.seq || crypto.randomUUID());
       const agent = managed.get(agentId);
       if (!agent) { telemetry?.delivery(agentId, messageId, "error"); throw new Error(`unknown runtime Agent: ${agentId}`); }
+      let target: string;
+      try {
+        target = targetKeyOfInboxEnvelope(envelope);
+      } catch (error) {
+        const reason = `Inbox target derivation failed: ${error instanceof Error ? error.message : String(error)}`;
+        const deliveryId = `invalid-target-${crypto.createHash("sha256").update(`${agentId}\0${messageId}`).digest("hex").slice(0, 24)}`;
+        telemetry?.delivery(agentId, messageId, "error");
+        emit({ type: "delivery", agentId, deliveryId, messageId, status: "error", reason });
+        return { status: "error", deliveryId, reason, retryable: false };
+      }
       reconcileExternalConsumption(agent);
       const existingId = agent.byMessage.get(messageId);
       if (existingId) {
@@ -872,9 +882,6 @@ export function createRuntimeHost(options: {
       }
       const deliveryId = crypto.randomUUID();
       const busy = agent.busy || agent.submitting;
-      const target = typeof envelope.target === "string" && envelope.target
-        ? envelope.target
-        : targetKeyOfInboxEnvelope(envelope);
       const input: RuntimeInput = { inputId: deliveryId, deliveryId, kind: busy ? "inbox_update" : "wake",
         text: options.promptBuilder.buildInboxNotice({ busy, count: 1, deliveryId, target,
           ...(typeof envelope.wake_reason === "string" ? { wakeReason: envelope.wake_reason } : {}) }), attempt: 0 };

--- a/src/runtime/runtime-host.ts
+++ b/src/runtime/runtime-host.ts
@@ -2,6 +2,7 @@ import crypto from "node:crypto";
 import fs from "node:fs";
 import path from "node:path";
 import { agentCliPromptCapabilities } from "../agent/agent-cli-capabilities.js";
+import { targetKeyOfInboxEnvelope } from "../agent/inbox-projection.js";
 import { SpanKind } from "@opentelemetry/api";
 import type { ContextPromptBuilder } from "../agent/context-prompt.js";
 import type {
@@ -871,9 +872,11 @@ export function createRuntimeHost(options: {
       }
       const deliveryId = crypto.randomUUID();
       const busy = agent.busy || agent.submitting;
+      const target = typeof envelope.target === "string" && envelope.target
+        ? envelope.target
+        : targetKeyOfInboxEnvelope(envelope);
       const input: RuntimeInput = { inputId: deliveryId, deliveryId, kind: busy ? "inbox_update" : "wake",
-        text: options.promptBuilder.buildInboxNotice({ busy, count: 1, deliveryId,
-          ...(typeof envelope.target === "string" ? { target: envelope.target } : {}),
+        text: options.promptBuilder.buildInboxNotice({ busy, count: 1, deliveryId, target,
           ...(typeof envelope.wake_reason === "string" ? { wakeReason: envelope.wake_reason } : {}) }), attempt: 0 };
       const record: DeliveryRecord = { deliveryId, messageId, status: "pending", input, updatedAt: now() };
       agent.records.set(deliveryId, record); agent.byMessage.set(messageId, deliveryId); persist(agent);

--- a/test/e2e/pi-prompt-preflight-recovery-mock-e2e.test.mjs
+++ b/test/e2e/pi-prompt-preflight-recovery-mock-e2e.test.mjs
@@ -71,7 +71,7 @@ test("production-order Pi preflight progress preserves one durable Inbox deliver
   const host = createRuntimeHost({ adapterFor: () => adapter, promptBuilder: new ContextPromptBuilder(),
     stateStoreFor: () => store, telemetry, retryPolicy: { baseDelayMs: 2, maxDelayMs: 2, maxAttempts: 2 },
     assertOfficialCliReady: () => {} });
-  const target = "chat:PRIVATE_TARGET";
+  const target = "chat:oc_private_target";
   const envelope = { message_id: messageId, target, content: "PRIVATE_PROMPT_BODY", wake: true };
   try {
     fs.mkdirSync(workspaceDir, { recursive: true });
@@ -130,7 +130,7 @@ test("external Pi production-order preflight timeout stays bounded, pending, obs
   const host = createRuntimeHost({ adapterFor: () => adapter, promptBuilder: new ContextPromptBuilder(),
     stateStoreFor: () => store, telemetry, retryPolicy: { baseDelayMs: 2, maxDelayMs: 2, maxAttempts: 0 },
     assertOfficialCliReady: () => {} });
-  const target = "chat:PRIVATE_TIMEOUT_TARGET";
+  const target = "chat:oc_private_timeout_target";
   const envelope = { message_id: messageId, target, content: "PRIVATE_TIMEOUT_BODY", wake: true };
   try {
     fs.mkdirSync(workspaceDir, { recursive: true });

--- a/test/e2e/runtime-production-mock-e2e.test.mjs
+++ b/test/e2e/runtime-production-mock-e2e.test.mjs
@@ -712,7 +712,7 @@ else process.stdout.write(JSON.stringify({ok:true,data:{users:[],bots:[],message
         assert.doesNotMatch(JSON.stringify(failedStatus.runtimeReadiness) + JSON.stringify(failedStatus.recentErrors),
           /Users\/example|cc-switch-token|fixture-secret|unsafe raw action/);
 
-        const authRetry = await runtimeHost.deliver(agentId, { message_id: "om_pi_auth" });
+        const authRetry = await runtimeHost.deliver(agentId, { message_id: "om_pi_auth", chat_id: "oc_pi" });
         assert.equal(authRetry.status, "accepted");
         session.emit({ type: "turn-start", turnId: "pi-auth-aborted" });
         session.emit({ type: "activity", activity: "text" });

--- a/test/integration/build/production-boundary.test.mjs
+++ b/test/integration/build/production-boundary.test.mjs
@@ -147,7 +147,7 @@ test("transport derives identity and state only from strict hydrated v3 selectio
 
     const otherInbox = path.join(root, "state", "agents", other, "feishu-inbox.ndjson");
     fs.mkdirSync(path.dirname(otherInbox), { recursive: true });
-    fs.writeFileSync(otherInbox, JSON.stringify({ message_id: "other-event", seq: 1, sender_name: "user", sender_type: "human", channel_type: "dm", channel_name: "user", content: "hello", timestamp: "2026-07-15T00:00:00.000Z", thread_id: null }) + "\n");
+    fs.writeFileSync(otherInbox, JSON.stringify({ message_id: "other-event", target: "chat:c123", seq: 1, sender_name: "user", sender_type: "human", channel_type: "dm", channel_name: "user", content: "hello", timestamp: "2026-07-15T00:00:00.000Z", thread_id: null }) + "\n");
     const otherScript = `const cp=require("node:child_process"),original=cp.spawnSync;cp.spawnSync=function(command){return command==="lark-cli"?{status:1,stdout:"",stderr:"mocked"}:original.apply(this,arguments)}; const {transport}=require(${JSON.stringify(path.join(ROOT, "dist/agent/agent-transport.cjs"))}); (async()=>{const p=await transport.request({method:"GET",path:"/profile"}); const e=await transport.request({method:"GET",path:"/events"}); process.stdout.write(JSON.stringify({profile:p.data,events:e.data.events}));})().catch(e=>{console.error(e);process.exit(1)});`;
     const selectedOther = spawnSync(process.execPath, ["--eval", otherScript], { cwd: ROOT, encoding: "utf8", env: {
       ...process.env, HOME: path.join(temp, "home"), LARKIN_CONFIG_DIR: root, LARKIN_AGENT_ID: other,

--- a/test/integration/build/release-platform-ci.test.mjs
+++ b/test/integration/build/release-platform-ci.test.mjs
@@ -44,6 +44,14 @@ test("PR and main CI retain Linux source checks and add a blocking native Window
   assert.match(workflow, /windows-native:\n\s+name: Windows 11 x64 core and standalone gate\n\s+needs: windows-release-artifact\n\s+runs-on: windows-latest/);
   assert.match(windowsJob, /bun run build/);
   assert.match(windowsJob, /bun test --isolate --max-concurrency 1/);
+  for (const issue122Test of [
+    "test/unit/agent/host-reminder-orchestrator.test.mjs",
+    "test/unit/agent/inbox-projection.test.mjs",
+    "test/unit/feishu/host-business-state.test.mjs",
+    "test/unit/runtime/runtime-host.test.mjs",
+  ]) {
+    assert.match(windowsJob, new RegExp(issue122Test.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")), `${issue122Test} remains in the native Windows gate`);
+  }
   assert.match(windowsJob, /test\/unit\/runtime\/pi-inline-extensions\.test\.mjs/);
   assert.match(windowsJob, /test\/unit\/runtime\/runtime-adapters\.test\.mjs/);
   assert.match(windowsJob, /test\/integration\/build\/release-platform-ci\.test\.mjs/);

--- a/test/integration/build/release-platform-ci.test.mjs
+++ b/test/integration/build/release-platform-ci.test.mjs
@@ -43,18 +43,31 @@ test("PR and main CI retain Linux source checks and add a blocking native Window
   assert.match(workflow, /windows-release-artifact:[\s\S]*bun scripts\/release\/build\.ts --target windows-x64 --out-dir artifacts\/release[\s\S]*actions\/upload-artifact@v4/);
   assert.match(workflow, /windows-native:\n\s+name: Windows 11 x64 core and standalone gate\n\s+needs: windows-release-artifact\n\s+runs-on: windows-latest/);
   assert.match(windowsJob, /bun run build/);
-  assert.match(windowsJob, /bun test --isolate --max-concurrency 1/);
+  const expectedWindowsTestInputs = [
+    "test/unit/agent/host-reminder-orchestrator.test.mjs",
+    "test/unit/feishu/host-business-state.test.mjs",
+    "test/unit/platform/release-artifacts.test.mjs",
+    "test/unit/runtime/pi-inline-extensions.test.mjs",
+    "test/unit/runtime/runtime-adapters.test.mjs",
+    "test/unit/runtime/runtime-inbox-target.test.mjs",
+    "test/integration/build/runtime-clean-cutover.test.mjs",
+    "test/integration/build/release-platform-ci.test.mjs",
+  ];
+  const focusedWindowsCommand = windowsJob.split("\n").map((line) => line.trim())
+    .find((line) => line.startsWith("run: bun test --isolate --max-concurrency 1 "));
+  assert.equal(focusedWindowsCommand,
+    `run: bun test --isolate --max-concurrency 1 ${expectedWindowsTestInputs.join(" ")}`,
+    "the native Windows gate keeps the exact focused coverage contract");
   for (const issue122Test of [
     "test/unit/agent/host-reminder-orchestrator.test.mjs",
-    "test/unit/agent/inbox-projection.test.mjs",
     "test/unit/feishu/host-business-state.test.mjs",
+    "test/unit/runtime/runtime-inbox-target.test.mjs",
+  ]) assert.ok(expectedWindowsTestInputs.includes(issue122Test), `${issue122Test} covers issue 122 natively`);
+  for (const broadProblematicTest of [
+    "test/unit/agent/inbox-projection.test.mjs",
     "test/unit/runtime/runtime-host.test.mjs",
-  ]) {
-    assert.match(windowsJob, new RegExp(issue122Test.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")), `${issue122Test} remains in the native Windows gate`);
-  }
-  assert.match(windowsJob, /test\/unit\/runtime\/pi-inline-extensions\.test\.mjs/);
-  assert.match(windowsJob, /test\/unit\/runtime\/runtime-adapters\.test\.mjs/);
-  assert.match(windowsJob, /test\/integration\/build\/release-platform-ci\.test\.mjs/);
+  ]) assert.equal(expectedWindowsTestInputs.includes(broadProblematicTest), false,
+    `${broadProblematicTest} is not a standalone native Windows input`);
   assert.match(windowsJob, /actions\/download-artifact@v4[\s\S]*bun run release:smoke -- --release-dir artifacts\/release/);
   assert.doesNotMatch(windowsJob, /secrets\.|LARKIN_RUN_OFFICIAL_LARK_CHANNEL_BIND|test\/live|continue-on-error/);
   assert.match(workflow, /fetch-depth: 0\n\s+persist-credentials: false/);

--- a/test/unit/agent/agent-state-store.test.mjs
+++ b/test/unit/agent/agent-state-store.test.mjs
@@ -138,7 +138,7 @@ test("Inbox delivery preparation treats consumed Runtime ownership as final acro
   try {
     const { createAgentStateStore } = await import(moduleUrl);
     const store = createAgentStateStore(root, "cli_stateDeliveryA1");
-    const envelope = { message_id: "interaction_run_1", wake: true };
+    const envelope = { message_id: "interaction_run_1", kind: "interaction", chat_id: "oc_interaction", wake: true };
     assert.equal(store.prepareInboxDelivery(envelope), "appended");
     assert.equal(store.prepareInboxDelivery(envelope), "present");
     store.writeJson("runtimeDeliveries", { version: 1, records: [{ deliveryId: "d1", messageId: envelope.message_id, status: "accepted" }] });

--- a/test/unit/agent/agent-state-store.test.mjs
+++ b/test/unit/agent/agent-state-store.test.mjs
@@ -156,7 +156,8 @@ test("appendInboxOnce remembers a stable provider id after the Inbox row is cons
   try {
     const { createAgentStateStore } = await import(moduleUrl);
     const store = createAgentStateStore(root, "cli_stateStableInboxA1");
-    const envelope = { message_id: "doc_comment_stable", target: "document-comment:docx:file:comment:in-thread" };
+    const envelope = { kind: "document_comment", message_id: "doc_comment_stable",
+      target: "document-comment:docx:file:comment:in-thread" };
     assert.equal(store.appendInboxOnce(envelope), true);
     store.pollInbox({ target: envelope.target, limit: 1 });
     assert.equal(store.readNdjson("inbox").length, 0);

--- a/test/unit/agent/host-reminder-orchestrator.test.mjs
+++ b/test/unit/agent/host-reminder-orchestrator.test.mjs
@@ -35,8 +35,8 @@ function fixture(reminders) {
     appendEvent() {},
   };
   const projector = {
-    createReminderEnvelope(_agentId, reminder) { return { message_id: `rem_${reminder.reminderId}`, seq: 1, wake: true, target: "runtime:reminder" }; },
-    createRedeliveryEnvelope(_agentId, count) { return { message_id: `redeliver_${count}`, seq: 2, target: "runtime:redelivery" }; },
+    createReminderEnvelope(_agentId, reminder) { return { kind: "reminder", message_id: `rem_${reminder.reminderId}`, seq: 1, wake: true, target: "runtime:reminder" }; },
+    createRedeliveryEnvelope(_agentId, count) { return { kind: "redelivery", message_id: `redeliver_${count}`, seq: 2, target: "runtime:redelivery" }; },
   };
   return { deliveries, inbox, state, api, projector };
 }
@@ -63,7 +63,8 @@ test("due fire persists before delivery, updates record, then forces snapshot", 
   const reminder = { reminderId: "123456789", version: 1, ownerAgentId: "cli_rem", fireAt: "2026-07-16T02:00:00Z", createdAt: "2026-07-15T00:00:00Z", title: "due", status: "scheduled" };
   const f = fixture([reminder]);
   f.projector.createReminderEnvelope = (_agentId, value) => ({
-    message_id: `rem_${value.reminderId}`, seq: 1, wake: true, channel_type: "dm", channel_name: "system",
+    kind: "reminder", message_id: `rem_${value.reminderId}`, seq: 1, wake: true, target: "runtime:reminder",
+    channel_type: "dm", channel_name: "system",
   });
   const order = [];
   f.state.appendNdjson = (_key, value) => { order.push("persist"); f.inbox.push(value); };
@@ -102,10 +103,10 @@ test("due reminder and startup redelivery reach final Runtime input with source-
     promptBuilder: new ContextPromptBuilder(), stateStoreFor: () => store });
   const delivered = [];
   const projector = {
-    createReminderEnvelope(_id, value) { return { message_id: `rem_${value.reminderId}`, seq: 1, wake: true,
-      channel_type: "dm", channel_name: "system" }; },
-    createRedeliveryEnvelope() { return { message_id: "redeliver_target", seq: 2,
-      channel_type: "dm", channel_name: "system" }; },
+    createReminderEnvelope(_id, value) { return { kind: "reminder", message_id: `rem_${value.reminderId}`, seq: 1, wake: true,
+      target: "runtime:reminder", channel_type: "dm", channel_name: "system" }; },
+    createRedeliveryEnvelope() { return { kind: "redelivery", message_id: "redeliver_target", seq: 2,
+      target: "runtime:redelivery", channel_type: "dm", channel_name: "system" }; },
   };
   const orchestrator = new HostReminderOrchestrator({ agents: [realAgent], stateStore: () => store,
     envelopeProjector: projector, deliveryTarget: { deliver(id, envelope) { delivered.push(envelope); return host.deliver(id, envelope); } },
@@ -143,12 +144,14 @@ test("due reminder and startup redelivery reach final Runtime input with source-
 test("restart redelivery counts only wake=true and delivers once", async () => {
   const f = fixture([]);
   f.projector.createRedeliveryEnvelope = (_agentId, count) => ({
-    message_id: `redeliver_${count}`, seq: 2, channel_type: "dm", channel_name: "system",
+    kind: "redelivery", message_id: `redeliver_${count}`, seq: 2, target: "runtime:redelivery",
+    channel_type: "dm", channel_name: "system",
   });
   const orchestrator = new HostReminderOrchestrator({ agents: [agent], stateStore: () => f.state, envelopeProjector: f.projector, deliveryTarget: { deliver(_id, envelope) { f.deliveries.push(envelope); } }, reminderStore: f.api, readFile: () => '{"wake":true}\n{"wake":false}\n{"wake":true}\n' });
   await orchestrator.redeliverUnread(agent);
   await orchestrator.redeliverUnread(agent);
-  assert.deepEqual(f.deliveries, [{ message_id: "redeliver_2", seq: 2, channel_type: "dm", channel_name: "system", target: "runtime:redelivery" }]);
+  assert.deepEqual(f.deliveries, [{ kind: "redelivery", message_id: "redeliver_2", seq: 2,
+    target: "runtime:redelivery", channel_type: "dm", channel_name: "system" }]);
   assert.deepEqual(f.inbox, f.deliveries);
   assert.strictEqual(f.inbox[0], f.deliveries[0], "new startup redelivery persists and delivers one target-complete object");
 });
@@ -197,7 +200,7 @@ test("transient startup Inbox read failure does not burn redelivery", async () =
   await orchestrator.redeliverUnread(agent);
   await orchestrator.redeliverUnread(agent);
   assert.equal(reads, 2);
-  assert.deepEqual(f.inbox, [{ message_id: "redeliver_1", seq: 2, target: "runtime:redelivery" }]);
+  assert.deepEqual(f.inbox, [{ kind: "redelivery", message_id: "redeliver_1", seq: 2, target: "runtime:redelivery" }]);
   assert.deepEqual(f.deliveries, f.inbox);
 });
 
@@ -211,7 +214,7 @@ test("malformed startup Inbox does not burn redelivery after the file is repaire
   inbox = `${JSON.stringify({ message_id: "om_after_repair", wake: true })}\n`;
   await orchestrator.redeliverUnread(agent);
   await orchestrator.redeliverUnread(agent);
-  assert.deepEqual(f.inbox, [{ message_id: "redeliver_1", seq: 2, target: "runtime:redelivery" }]);
+  assert.deepEqual(f.inbox, [{ kind: "redelivery", message_id: "redeliver_1", seq: 2, target: "runtime:redelivery" }]);
   assert.deepEqual(f.deliveries, f.inbox);
 });
 
@@ -223,13 +226,14 @@ test("zero unread without a Runtime delivery target does not burn redelivery", a
   await orchestrator.redeliverUnread(agent);
   inbox = `${JSON.stringify({ message_id: "om_after_targetless_startup", wake: true })}\n`;
   await orchestrator.redeliverUnread(agent);
-  assert.deepEqual(f.inbox, [{ message_id: "redeliver_1", seq: 2, target: "runtime:redelivery" }]);
+  assert.deepEqual(f.inbox, [{ kind: "redelivery", message_id: "redeliver_1", seq: 2, target: "runtime:redelivery" }]);
 });
 
 test("restart redelivery reuses an existing canonical synthetic envelope instead of appending a duplicate", async () => {
   const f = fixture([]);
   const logs = [];
-  const existing = { message_id: "redeliver_existing", seq: 7, wake: true, content: "already durable", target: "runtime:redelivery" };
+  const existing = { kind: "redelivery", message_id: "redeliver_existing", seq: 7, wake: true,
+    content: "already durable", target: "runtime:redelivery" };
   const orchestrator = new HostReminderOrchestrator({ agents: [agent], stateStore: () => f.state,
     envelopeProjector: f.projector, deliveryTarget: { deliver(_agentId, envelope) { f.deliveries.push(envelope); } },
     reminderStore: f.api, log: (...parts) => logs.push(parts.join(" ")),
@@ -241,16 +245,17 @@ test("restart redelivery reuses an existing canonical synthetic envelope instead
   assert.match(logs.join("\n"), /滞留 wake 消息 1 条/, "existing redeliver_ rows are excluded from wakeCount");
 });
 
-test("restart redelivery recognizes a targetless redelivery row by its authoritative message id", async () => {
+test("restart redelivery rejects a targetless old redelivery row without append or delivery", async () => {
   const f = fixture([]);
-  const legacy = { message_id: "redeliver_legacy", seq: 8, channel_type: "dm", channel_name: "system", content: "legacy" };
+  const oldRow = { message_id: "redeliver_old", seq: 8, channel_type: "dm", channel_name: "system", content: "old" };
+  const bytes = `${JSON.stringify(oldRow)}\n`;
   const orchestrator = new HostReminderOrchestrator({ agents: [agent], stateStore: () => f.state,
     envelopeProjector: f.projector, deliveryTarget: { deliver(_agentId, envelope) { f.deliveries.push(envelope); } },
-    reminderStore: f.api, readFile: () => `${JSON.stringify(legacy)}\n` });
-  await orchestrator.redeliverUnread(agent);
-  assert.deepEqual(f.inbox, [], "an existing durable row is not appended again");
-  assert.deepEqual(f.deliveries, [{ ...legacy, target: "runtime:redelivery" }]);
-  assert.equal("target" in legacy, false, "legacy disk value remains an immutable counterfactual fixture");
+    reminderStore: f.api, readFile: () => bytes });
+  await assert.rejects(orchestrator.redeliverUnread(agent), /matching kind and message_id/);
+  assert.deepEqual(f.inbox, [], "invalid existing row causes no append");
+  assert.deepEqual(f.deliveries, [], "invalid existing row causes no Runtime delivery");
+  assert.equal(bytes, `${JSON.stringify(oldRow)}\n`, "the persisted fixture remains byte-for-byte unchanged");
 });
 
 test("transient append failure does not burn the once-per-host redelivery opportunity", async () => {
@@ -346,7 +351,8 @@ test("orphan startup Inbox appends a durable redelivery envelope and one drain c
     const orchestrator = new HostReminderOrchestrator({ agents: [realAgent], stateStore: () => store,
       envelopeProjector: {
         createReminderEnvelope() { throw new Error("unused"); },
-        createRedeliveryEnvelope() { return { message_id: "redeliver_orphan", seq: 9, wake: true, content: "drain" }; },
+        createRedeliveryEnvelope() { return { kind: "redelivery", message_id: "redeliver_orphan", seq: 9,
+          target: "runtime:redelivery", wake: true, content: "drain" }; },
       }, deliveryTarget: host, reminderStore: fixture([]).api });
     await orchestrator.redeliverUnread(realAgent);
     assert.deepEqual(store.readNdjson("inbox").map((row) => row.message_id), ["om_orphan", "redeliver_orphan"]);
@@ -387,7 +393,8 @@ test("an existing pending Runtime delivery and its durable startup redelivery ar
     const orchestrator = new HostReminderOrchestrator({ agents: [realAgent], stateStore: () => store,
       envelopeProjector: {
         createReminderEnvelope() { throw new Error("unused"); },
-        createRedeliveryEnvelope() { return { message_id: "redeliver_existing_pending", seq: 10, wake: true, content: "drain" }; },
+        createRedeliveryEnvelope() { return { kind: "redelivery", message_id: "redeliver_existing_pending", seq: 10,
+          target: "runtime:redelivery", wake: true, content: "drain" }; },
       }, deliveryTarget: host, reminderStore: fixture([]).api });
     await orchestrator.redeliverUnread(realAgent);
     assert.equal(session.prompts.length, 1);
@@ -420,7 +427,7 @@ const agent={agentId:process.env.TEST_AGENT,name:process.env.TEST_AGENT,stateDir
 const wrapped={paths:store.paths,appendNdjson(key,value){fs.writeFileSync(process.env.TEST_READY,"ready");store.appendNdjson(key,value)}};
 const orchestrator=new HostReminderOrchestrator({agents:[agent],stateStore:()=>wrapped,envelopeProjector:{
  createReminderEnvelope(){throw new Error("unused")},
- createRedeliveryEnvelope(){return {message_id:"redeliver_lock",seq:11,wake:true}}
+ createRedeliveryEnvelope(){return {kind:"redelivery",message_id:"redeliver_lock",target:"runtime:redelivery",seq:11,wake:true}}
 },deliveryTarget:{deliver(_id,envelope){fs.writeFileSync(process.env.TEST_DELIVERED,JSON.stringify(envelope))}}});
 await orchestrator.redeliverUnread(agent);
 `;

--- a/test/unit/agent/host-reminder-orchestrator.test.mjs
+++ b/test/unit/agent/host-reminder-orchestrator.test.mjs
@@ -65,7 +65,10 @@ test("due fire persists before delivery, updates record, then forces snapshot", 
   assert.strictEqual(f.inbox[0], f.deliveries[0], "the same target-complete envelope is persisted and delivered");
 });
 
-test("due reminder and startup redelivery reach final Runtime input with the same durable dm target", async () => {
+// Hosted Windows needed 7.3s under the serialized native gate; only the runner envelope is widened.
+test("due reminder and startup redelivery reach final Runtime input with the same durable dm target", {
+  timeout: 20_000,
+}, async () => {
   const root = fs.mkdtempSync(path.join(os.tmpdir(), "larkin-reminder-target-runtime-"));
   const agentId = "cli_reminderTargetA1";
   const realAgent = { agentId, name: agentId, stateDir: path.join(root, "state", "agents", agentId) };

--- a/test/unit/agent/host-reminder-orchestrator.test.mjs
+++ b/test/unit/agent/host-reminder-orchestrator.test.mjs
@@ -10,6 +10,19 @@ import { HostReminderOrchestrator } from "../../../dist/agent/host-reminder-orch
 import { createRuntimeHost } from "../../../dist/runtime/runtime-host.mjs";
 
 const agent = { agentId: "cli_rem", name: "cli_rem", stateDir: "/state/cli_rem" };
+const deterministicProcessInspect = (pid) => ({ ok: true, dead: false, startToken: `test-process-${pid}` });
+const deterministicStateStore = (root, agentId) => createAgentStateStore(root, agentId, {
+  inspectProcess: deterministicProcessInspect,
+});
+
+async function waitFor(condition, label, timeoutMs = 10_000) {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    if (condition()) return;
+    await new Promise((resolve) => setTimeout(resolve, 10));
+  }
+  throw new Error(`${label} did not settle within ${timeoutMs}ms`);
+}
 
 function fixture(reminders) {
   const deliveries = [], inbox = [];
@@ -65,9 +78,10 @@ test("due fire persists before delivery, updates record, then forces snapshot", 
   assert.strictEqual(f.inbox[0], f.deliveries[0], "the same target-complete envelope is persisted and delivered");
 });
 
-// Hosted Windows needed 7.3s under the serialized native gate; only the runner envelope is widened.
+// Native Windows exposed both slow process inspection and async ledger races. This test is not
+// about CIM/lock ownership, so it injects stable process identity and waits on durable states.
 test("due reminder and startup redelivery reach final Runtime input with the same durable dm target", {
-  timeout: 20_000,
+  timeout: 30_000,
 }, async () => {
   const root = fs.mkdtempSync(path.join(os.tmpdir(), "larkin-reminder-target-runtime-"));
   const agentId = "cli_reminderTargetA1";
@@ -75,7 +89,7 @@ test("due reminder and startup redelivery reach final Runtime input with the sam
   const reminder = { reminderId: "target-reminder", version: 1, ownerAgentId: agentId,
     fireAt: "2026-07-16T02:00:00Z", createdAt: "2026-07-15T00:00:00Z", title: "target", status: "scheduled" };
   const f = fixture([reminder]);
-  const store = createAgentStateStore(root, agentId);
+  const store = deterministicStateStore(root, agentId);
   const session = {
     sessionId: "reminder-target-session", listeners: new Set(), prompts: [], steers: [],
     subscribe(listener) { this.listeners.add(listener); return () => this.listeners.delete(listener); },
@@ -99,7 +113,10 @@ test("due reminder and startup redelivery reach final Runtime input with the sam
   try {
     await host.start([{ agentId, name: agentId, runtime: "codex", model: "g", workspaceDir: path.join(root, "agents", agentId), stateDir: store.paths.root }]);
     orchestrator.handleFire({ agentId, reminderId: reminder.reminderId });
-    await new Promise((resolve) => setImmediate(resolve));
+    await waitFor(() => session.prompts.length === 1
+      && store.readJson("runtimeDeliveries", { records: [] }).records
+        .some((record) => record.messageId === `rem_${reminder.reminderId}` && record.status === "accepted"),
+    "reminder Runtime acceptance");
     const persistedReminder = store.readNdjson("inbox")[0];
     assert.equal(persistedReminder.target, "dm:@system");
     assert.equal(delivered[0].target, persistedReminder.target);
@@ -107,7 +124,9 @@ test("due reminder and startup redelivery reach final Runtime input with the sam
     store.pollInbox({ target: "dm:@system", limit: 1 });
     session.emit({ type: "turn-start", turnId: "reminder-turn" });
     session.emit({ type: "turn-end", turnId: "reminder-turn" });
-    await new Promise((resolve) => setImmediate(resolve));
+    await waitFor(() => store.readJson("runtimeDeliveries", { records: [] }).records
+      .some((record) => record.messageId === `rem_${reminder.reminderId}` && record.status === "consumed"),
+    "reminder Runtime consumption");
 
     store.appendNdjson("inbox", { message_id: "om_startup_orphan", target: "chat:oc_orphan", wake: true });
     await orchestrator.redeliverUnread(realAgent);
@@ -305,11 +324,13 @@ test("Inbox append failure prevents reminder and restart delivery", async () => 
   assert.deepEqual(f.deliveries, []);
 });
 
-test("orphan startup Inbox appends a durable redelivery envelope and one drain consumes its Runtime ledger", async () => {
+test("orphan startup Inbox appends a durable redelivery envelope and one drain consumes its Runtime ledger", {
+  timeout: 15_000,
+}, async () => {
   const root = fs.mkdtempSync(path.join(os.tmpdir(), "larkin-redelivery-orphan-"));
   const agentId = "cli_orphanA1";
   const realAgent = { agentId, name: agentId, stateDir: path.join(root, "state", "agents", agentId) };
-  const store = createAgentStateStore(root, agentId);
+  const store = deterministicStateStore(root, agentId);
   const session = {
     sessionId: "orphan-session", listeners: new Set(), prompts: [], steers: [],
     subscribe(listener) { this.listeners.add(listener); return () => this.listeners.delete(listener); },
@@ -340,11 +361,13 @@ test("orphan startup Inbox appends a durable redelivery envelope and one drain c
   }
 });
 
-test("an existing pending Runtime delivery and its durable startup redelivery are both consumed by one drain", async () => {
+test("an existing pending Runtime delivery and its durable startup redelivery are both consumed by one drain", {
+  timeout: 15_000,
+}, async () => {
   const root = fs.mkdtempSync(path.join(os.tmpdir(), "larkin-redelivery-pending-"));
   const agentId = "cli_pendingRedeliveryA1";
   const realAgent = { agentId, name: agentId, stateDir: path.join(root, "state", "agents", agentId) };
-  const store = createAgentStateStore(root, agentId);
+  const store = deterministicStateStore(root, agentId);
   const session = {
     sessionId: "pending-session", listeners: new Set(), prompts: [], steers: [],
     subscribe(listener) { this.listeners.add(listener); return () => this.listeners.delete(listener); },

--- a/test/unit/agent/host-reminder-orchestrator.test.mjs
+++ b/test/unit/agent/host-reminder-orchestrator.test.mjs
@@ -22,8 +22,8 @@ function fixture(reminders) {
     appendEvent() {},
   };
   const projector = {
-    createReminderEnvelope(_agentId, reminder) { return { message_id: `rem_${reminder.reminderId}`, seq: 1, wake: true }; },
-    createRedeliveryEnvelope(_agentId, count) { return { message_id: `redeliver_${count}`, seq: 2 }; },
+    createReminderEnvelope(_agentId, reminder) { return { message_id: `rem_${reminder.reminderId}`, seq: 1, wake: true, target: "dm:@system" }; },
+    createRedeliveryEnvelope(_agentId, count) { return { message_id: `redeliver_${count}`, seq: 2, target: "dm:@system" }; },
   };
   return { deliveries, inbox, state, api, projector };
 }
@@ -49,6 +49,9 @@ test("reminder schedules deduplicate unless forced", () => {
 test("due fire persists before delivery, updates record, then forces snapshot", () => {
   const reminder = { reminderId: "123456789", version: 1, ownerAgentId: "cli_rem", fireAt: "2026-07-16T02:00:00Z", createdAt: "2026-07-15T00:00:00Z", title: "due", status: "scheduled" };
   const f = fixture([reminder]);
+  f.projector.createReminderEnvelope = (_agentId, value) => ({
+    message_id: `rem_${value.reminderId}`, seq: 1, wake: true, channel_type: "dm", channel_name: "system",
+  });
   const order = [];
   f.state.appendNdjson = (_key, value) => { order.push("persist"); f.inbox.push(value); };
   const target = { deliver(_agentId, envelope) { order.push("deliver"); f.deliveries.push(envelope); } };
@@ -57,15 +60,75 @@ test("due fire persists before delivery, updates record, then forces snapshot", 
   assert.deepEqual(order, ["persist", "deliver"]);
   assert.equal(reminder.status, "fired");
   assert.equal(reminder.version, 2);
+  assert.equal(f.inbox[0].target, "dm:@system");
+  assert.equal(f.deliveries[0].target, "dm:@system");
+  assert.strictEqual(f.inbox[0], f.deliveries[0], "the same target-complete envelope is persisted and delivered");
+});
+
+test("due reminder and startup redelivery reach final Runtime input with the same durable dm target", async () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "larkin-reminder-target-runtime-"));
+  const agentId = "cli_reminderTargetA1";
+  const realAgent = { agentId, name: agentId, stateDir: path.join(root, "state", "agents", agentId) };
+  const reminder = { reminderId: "target-reminder", version: 1, ownerAgentId: agentId,
+    fireAt: "2026-07-16T02:00:00Z", createdAt: "2026-07-15T00:00:00Z", title: "target", status: "scheduled" };
+  const f = fixture([reminder]);
+  const store = createAgentStateStore(root, agentId);
+  const session = {
+    sessionId: "reminder-target-session", listeners: new Set(), prompts: [], steers: [],
+    subscribe(listener) { this.listeners.add(listener); return () => this.listeners.delete(listener); },
+    emit(event) { for (const listener of this.listeners) listener(event); },
+    async prompt(input) { this.prompts.push(input); return { status: "accepted", inputId: input.inputId }; },
+    async busyInput(input) { this.steers.push(input); return { status: "accepted", inputId: input.inputId }; },
+    async cancel() {}, async close() {},
+  };
+  const host = createRuntimeHost({ adapterFor: () => ({ id: "codex", capabilities: {}, async createSession() { return session; } }),
+    promptBuilder: new ContextPromptBuilder(), stateStoreFor: () => store });
+  const delivered = [];
+  const projector = {
+    createReminderEnvelope(_id, value) { return { message_id: `rem_${value.reminderId}`, seq: 1, wake: true,
+      channel_type: "dm", channel_name: "system" }; },
+    createRedeliveryEnvelope() { return { message_id: "redeliver_target", seq: 2,
+      channel_type: "dm", channel_name: "system" }; },
+  };
+  const orchestrator = new HostReminderOrchestrator({ agents: [realAgent], stateStore: () => store,
+    envelopeProjector: projector, deliveryTarget: { deliver(id, envelope) { delivered.push(envelope); return host.deliver(id, envelope); } },
+    reminderStore: f.api, now: () => Date.parse("2026-07-16T03:00:00Z") });
+  try {
+    await host.start([{ agentId, name: agentId, runtime: "codex", model: "g", workspaceDir: path.join(root, "agents", agentId), stateDir: store.paths.root }]);
+    orchestrator.handleFire({ agentId, reminderId: reminder.reminderId });
+    await new Promise((resolve) => setImmediate(resolve));
+    const persistedReminder = store.readNdjson("inbox")[0];
+    assert.equal(persistedReminder.target, "dm:@system");
+    assert.equal(delivered[0].target, persistedReminder.target);
+    assert.match(session.prompts[0].text, /Inbox changed for dm:@system/);
+    store.pollInbox({ target: "dm:@system", limit: 1 });
+    session.emit({ type: "turn-start", turnId: "reminder-turn" });
+    session.emit({ type: "turn-end", turnId: "reminder-turn" });
+    await new Promise((resolve) => setImmediate(resolve));
+
+    store.appendNdjson("inbox", { message_id: "om_startup_orphan", target: "chat:oc_orphan", wake: true });
+    await orchestrator.redeliverUnread(realAgent);
+    const persistedRedelivery = store.readNdjson("inbox").find((row) => row.message_id === "redeliver_target");
+    assert.equal(persistedRedelivery.target, "dm:@system");
+    assert.equal(delivered[1].target, persistedRedelivery.target);
+    assert.match(session.prompts[1].text, /Inbox changed for dm:@system/);
+  } finally {
+    await host.shutdown("reminder target test complete");
+    fs.rmSync(root, { recursive: true, force: true });
+  }
 });
 
 test("restart redelivery counts only wake=true and delivers once", async () => {
   const f = fixture([]);
+  f.projector.createRedeliveryEnvelope = (_agentId, count) => ({
+    message_id: `redeliver_${count}`, seq: 2, channel_type: "dm", channel_name: "system",
+  });
   const orchestrator = new HostReminderOrchestrator({ agents: [agent], stateStore: () => f.state, envelopeProjector: f.projector, deliveryTarget: { deliver(_id, envelope) { f.deliveries.push(envelope); } }, reminderStore: f.api, readFile: () => '{"wake":true}\n{"wake":false}\n{"wake":true}\n' });
   await orchestrator.redeliverUnread(agent);
   await orchestrator.redeliverUnread(agent);
-  assert.deepEqual(f.deliveries, [{ message_id: "redeliver_2", seq: 2 }]);
-  assert.deepEqual(f.inbox, [{ message_id: "redeliver_2", seq: 2 }]);
+  assert.deepEqual(f.deliveries, [{ message_id: "redeliver_2", seq: 2, channel_type: "dm", channel_name: "system", target: "dm:@system" }]);
+  assert.deepEqual(f.inbox, f.deliveries);
+  assert.strictEqual(f.inbox[0], f.deliveries[0], "new startup redelivery persists and delivers one target-complete object");
 });
 
 test("authoritative empty startup Inbox consumes redelivery without capturing a later inbound message", async () => {
@@ -112,8 +175,8 @@ test("transient startup Inbox read failure does not burn redelivery", async () =
   await orchestrator.redeliverUnread(agent);
   await orchestrator.redeliverUnread(agent);
   assert.equal(reads, 2);
-  assert.deepEqual(f.inbox, [{ message_id: "redeliver_1", seq: 2 }]);
-  assert.deepEqual(f.deliveries, [{ message_id: "redeliver_1", seq: 2 }]);
+  assert.deepEqual(f.inbox, [{ message_id: "redeliver_1", seq: 2, target: "dm:@system" }]);
+  assert.deepEqual(f.deliveries, f.inbox);
 });
 
 test("malformed startup Inbox does not burn redelivery after the file is repaired", async () => {
@@ -126,8 +189,8 @@ test("malformed startup Inbox does not burn redelivery after the file is repaire
   inbox = `${JSON.stringify({ message_id: "om_after_repair", wake: true })}\n`;
   await orchestrator.redeliverUnread(agent);
   await orchestrator.redeliverUnread(agent);
-  assert.deepEqual(f.inbox, [{ message_id: "redeliver_1", seq: 2 }]);
-  assert.deepEqual(f.deliveries, [{ message_id: "redeliver_1", seq: 2 }]);
+  assert.deepEqual(f.inbox, [{ message_id: "redeliver_1", seq: 2, target: "dm:@system" }]);
+  assert.deepEqual(f.deliveries, f.inbox);
 });
 
 test("zero unread without a Runtime delivery target does not burn redelivery", async () => {
@@ -138,13 +201,13 @@ test("zero unread without a Runtime delivery target does not burn redelivery", a
   await orchestrator.redeliverUnread(agent);
   inbox = `${JSON.stringify({ message_id: "om_after_targetless_startup", wake: true })}\n`;
   await orchestrator.redeliverUnread(agent);
-  assert.deepEqual(f.inbox, [{ message_id: "redeliver_1", seq: 2 }]);
+  assert.deepEqual(f.inbox, [{ message_id: "redeliver_1", seq: 2, target: "dm:@system" }]);
 });
 
 test("restart redelivery reuses an existing canonical synthetic envelope instead of appending a duplicate", async () => {
   const f = fixture([]);
   const logs = [];
-  const existing = { message_id: "redeliver_existing", seq: 7, wake: true, content: "already durable" };
+  const existing = { message_id: "redeliver_existing", seq: 7, wake: true, content: "already durable", target: "chat:oc_canonical" };
   const orchestrator = new HostReminderOrchestrator({ agents: [agent], stateStore: () => f.state,
     envelopeProjector: f.projector, deliveryTarget: { deliver(_agentId, envelope) { f.deliveries.push(envelope); } },
     reminderStore: f.api, log: (...parts) => logs.push(parts.join(" ")),
@@ -152,7 +215,20 @@ test("restart redelivery reuses an existing canonical synthetic envelope instead
   await orchestrator.redeliverUnread(agent);
   assert.deepEqual(f.inbox, []);
   assert.deepEqual(f.deliveries, [existing]);
+  assert.equal(f.deliveries[0].target, "chat:oc_canonical", "an existing canonical target is preserved without normalization");
   assert.match(logs.join("\n"), /滞留 wake 消息 1 条/, "existing redeliver_ rows are excluded from wakeCount");
+});
+
+test("restart redelivery normalizes only a legacy existing targetless row", async () => {
+  const f = fixture([]);
+  const legacy = { message_id: "redeliver_legacy", seq: 8, channel_type: "dm", channel_name: "system", content: "legacy" };
+  const orchestrator = new HostReminderOrchestrator({ agents: [agent], stateStore: () => f.state,
+    envelopeProjector: f.projector, deliveryTarget: { deliver(_agentId, envelope) { f.deliveries.push(envelope); } },
+    reminderStore: f.api, readFile: () => `${JSON.stringify(legacy)}\n` });
+  await orchestrator.redeliverUnread(agent);
+  assert.deepEqual(f.inbox, [], "an existing durable row is not appended again");
+  assert.deepEqual(f.deliveries, [{ ...legacy, target: "dm:@system" }]);
+  assert.equal("target" in legacy, false, "legacy disk value remains an immutable counterfactual fixture");
 });
 
 test("transient append failure does not burn the once-per-host redelivery opportunity", async () => {

--- a/test/unit/agent/host-reminder-orchestrator.test.mjs
+++ b/test/unit/agent/host-reminder-orchestrator.test.mjs
@@ -35,8 +35,8 @@ function fixture(reminders) {
     appendEvent() {},
   };
   const projector = {
-    createReminderEnvelope(_agentId, reminder) { return { message_id: `rem_${reminder.reminderId}`, seq: 1, wake: true, target: "dm:@system" }; },
-    createRedeliveryEnvelope(_agentId, count) { return { message_id: `redeliver_${count}`, seq: 2, target: "dm:@system" }; },
+    createReminderEnvelope(_agentId, reminder) { return { message_id: `rem_${reminder.reminderId}`, seq: 1, wake: true, target: "runtime:reminder" }; },
+    createRedeliveryEnvelope(_agentId, count) { return { message_id: `redeliver_${count}`, seq: 2, target: "runtime:redelivery" }; },
   };
   return { deliveries, inbox, state, api, projector };
 }
@@ -73,14 +73,14 @@ test("due fire persists before delivery, updates record, then forces snapshot", 
   assert.deepEqual(order, ["persist", "deliver"]);
   assert.equal(reminder.status, "fired");
   assert.equal(reminder.version, 2);
-  assert.equal(f.inbox[0].target, "dm:@system");
-  assert.equal(f.deliveries[0].target, "dm:@system");
+  assert.equal(f.inbox[0].target, "runtime:reminder");
+  assert.equal(f.deliveries[0].target, "runtime:reminder");
   assert.strictEqual(f.inbox[0], f.deliveries[0], "the same target-complete envelope is persisted and delivered");
 });
 
 // Native Windows exposed both slow process inspection and async ledger races. This test is not
 // about CIM/lock ownership, so it injects stable process identity and waits on durable states.
-test("due reminder and startup redelivery reach final Runtime input with the same durable dm target", {
+test("due reminder and startup redelivery reach final Runtime input with source-specific runtime targets", {
   timeout: 30_000,
 }, async () => {
   const root = fs.mkdtempSync(path.join(os.tmpdir(), "larkin-reminder-target-runtime-"));
@@ -118,10 +118,10 @@ test("due reminder and startup redelivery reach final Runtime input with the sam
         .some((record) => record.messageId === `rem_${reminder.reminderId}` && record.status === "accepted"),
     "reminder Runtime acceptance");
     const persistedReminder = store.readNdjson("inbox")[0];
-    assert.equal(persistedReminder.target, "dm:@system");
+    assert.equal(persistedReminder.target, "runtime:reminder");
     assert.equal(delivered[0].target, persistedReminder.target);
-    assert.match(session.prompts[0].text, /Inbox changed for dm:@system/);
-    store.pollInbox({ target: "dm:@system", limit: 1 });
+    assert.match(session.prompts[0].text, /Inbox changed for runtime:reminder/);
+    store.pollInbox({ target: "runtime:reminder", limit: 1 });
     session.emit({ type: "turn-start", turnId: "reminder-turn" });
     session.emit({ type: "turn-end", turnId: "reminder-turn" });
     await waitFor(() => store.readJson("runtimeDeliveries", { records: [] }).records
@@ -131,9 +131,9 @@ test("due reminder and startup redelivery reach final Runtime input with the sam
     store.appendNdjson("inbox", { message_id: "om_startup_orphan", target: "chat:oc_orphan", wake: true });
     await orchestrator.redeliverUnread(realAgent);
     const persistedRedelivery = store.readNdjson("inbox").find((row) => row.message_id === "redeliver_target");
-    assert.equal(persistedRedelivery.target, "dm:@system");
+    assert.equal(persistedRedelivery.target, "runtime:redelivery");
     assert.equal(delivered[1].target, persistedRedelivery.target);
-    assert.match(session.prompts[1].text, /Inbox changed for dm:@system/);
+    assert.match(session.prompts[1].text, /Inbox changed for runtime:redelivery/);
   } finally {
     await host.shutdown("reminder target test complete");
     fs.rmSync(root, { recursive: true, force: true });
@@ -148,7 +148,7 @@ test("restart redelivery counts only wake=true and delivers once", async () => {
   const orchestrator = new HostReminderOrchestrator({ agents: [agent], stateStore: () => f.state, envelopeProjector: f.projector, deliveryTarget: { deliver(_id, envelope) { f.deliveries.push(envelope); } }, reminderStore: f.api, readFile: () => '{"wake":true}\n{"wake":false}\n{"wake":true}\n' });
   await orchestrator.redeliverUnread(agent);
   await orchestrator.redeliverUnread(agent);
-  assert.deepEqual(f.deliveries, [{ message_id: "redeliver_2", seq: 2, channel_type: "dm", channel_name: "system", target: "dm:@system" }]);
+  assert.deepEqual(f.deliveries, [{ message_id: "redeliver_2", seq: 2, channel_type: "dm", channel_name: "system", target: "runtime:redelivery" }]);
   assert.deepEqual(f.inbox, f.deliveries);
   assert.strictEqual(f.inbox[0], f.deliveries[0], "new startup redelivery persists and delivers one target-complete object");
 });
@@ -197,7 +197,7 @@ test("transient startup Inbox read failure does not burn redelivery", async () =
   await orchestrator.redeliverUnread(agent);
   await orchestrator.redeliverUnread(agent);
   assert.equal(reads, 2);
-  assert.deepEqual(f.inbox, [{ message_id: "redeliver_1", seq: 2, target: "dm:@system" }]);
+  assert.deepEqual(f.inbox, [{ message_id: "redeliver_1", seq: 2, target: "runtime:redelivery" }]);
   assert.deepEqual(f.deliveries, f.inbox);
 });
 
@@ -211,7 +211,7 @@ test("malformed startup Inbox does not burn redelivery after the file is repaire
   inbox = `${JSON.stringify({ message_id: "om_after_repair", wake: true })}\n`;
   await orchestrator.redeliverUnread(agent);
   await orchestrator.redeliverUnread(agent);
-  assert.deepEqual(f.inbox, [{ message_id: "redeliver_1", seq: 2, target: "dm:@system" }]);
+  assert.deepEqual(f.inbox, [{ message_id: "redeliver_1", seq: 2, target: "runtime:redelivery" }]);
   assert.deepEqual(f.deliveries, f.inbox);
 });
 
@@ -223,13 +223,13 @@ test("zero unread without a Runtime delivery target does not burn redelivery", a
   await orchestrator.redeliverUnread(agent);
   inbox = `${JSON.stringify({ message_id: "om_after_targetless_startup", wake: true })}\n`;
   await orchestrator.redeliverUnread(agent);
-  assert.deepEqual(f.inbox, [{ message_id: "redeliver_1", seq: 2, target: "dm:@system" }]);
+  assert.deepEqual(f.inbox, [{ message_id: "redeliver_1", seq: 2, target: "runtime:redelivery" }]);
 });
 
 test("restart redelivery reuses an existing canonical synthetic envelope instead of appending a duplicate", async () => {
   const f = fixture([]);
   const logs = [];
-  const existing = { message_id: "redeliver_existing", seq: 7, wake: true, content: "already durable", target: "chat:oc_canonical" };
+  const existing = { message_id: "redeliver_existing", seq: 7, wake: true, content: "already durable", target: "runtime:redelivery" };
   const orchestrator = new HostReminderOrchestrator({ agents: [agent], stateStore: () => f.state,
     envelopeProjector: f.projector, deliveryTarget: { deliver(_agentId, envelope) { f.deliveries.push(envelope); } },
     reminderStore: f.api, log: (...parts) => logs.push(parts.join(" ")),
@@ -237,11 +237,11 @@ test("restart redelivery reuses an existing canonical synthetic envelope instead
   await orchestrator.redeliverUnread(agent);
   assert.deepEqual(f.inbox, []);
   assert.deepEqual(f.deliveries, [existing]);
-  assert.equal(f.deliveries[0].target, "chat:oc_canonical", "an existing canonical target is preserved without normalization");
+  assert.equal(f.deliveries[0].target, "runtime:redelivery", "an existing source-specific target is preserved without normalization");
   assert.match(logs.join("\n"), /滞留 wake 消息 1 条/, "existing redeliver_ rows are excluded from wakeCount");
 });
 
-test("restart redelivery normalizes only a legacy existing targetless row", async () => {
+test("restart redelivery recognizes a targetless redelivery row by its authoritative message id", async () => {
   const f = fixture([]);
   const legacy = { message_id: "redeliver_legacy", seq: 8, channel_type: "dm", channel_name: "system", content: "legacy" };
   const orchestrator = new HostReminderOrchestrator({ agents: [agent], stateStore: () => f.state,
@@ -249,7 +249,7 @@ test("restart redelivery normalizes only a legacy existing targetless row", asyn
     reminderStore: f.api, readFile: () => `${JSON.stringify(legacy)}\n` });
   await orchestrator.redeliverUnread(agent);
   assert.deepEqual(f.inbox, [], "an existing durable row is not appended again");
-  assert.deepEqual(f.deliveries, [{ ...legacy, target: "dm:@system" }]);
+  assert.deepEqual(f.deliveries, [{ ...legacy, target: "runtime:redelivery" }]);
   assert.equal("target" in legacy, false, "legacy disk value remains an immutable counterfactual fixture");
 });
 
@@ -341,7 +341,7 @@ test("orphan startup Inbox appends a durable redelivery envelope and one drain c
   const host = createRuntimeHost({ adapterFor: () => ({ id: "codex", capabilities: {}, async createSession() { return session; } }),
     promptBuilder: new ContextPromptBuilder(), stateStoreFor: () => store });
   try {
-    store.appendNdjson("inbox", { message_id: "om_orphan", wake: true, content: "orphan" });
+    store.appendNdjson("inbox", { message_id: "om_orphan", target: "chat:oc_orphan", wake: true, content: "orphan" });
     await host.start([{ agentId, name: agentId, runtime: "codex", model: "g", workspaceDir: path.join(root, "agents", agentId), stateDir: store.paths.root }]);
     const orchestrator = new HostReminderOrchestrator({ agents: [realAgent], stateStore: () => store,
       envelopeProjector: {
@@ -378,7 +378,7 @@ test("an existing pending Runtime delivery and its durable startup redelivery ar
   const host = createRuntimeHost({ adapterFor: () => ({ id: "codex", capabilities: {}, async createSession() { return session; } }),
     promptBuilder: new ContextPromptBuilder(), stateStoreFor: () => store });
   try {
-    store.appendNdjson("inbox", { message_id: "om_existing", wake: true, content: "existing" });
+    store.appendNdjson("inbox", { message_id: "om_existing", target: "chat:oc_existing", wake: true, content: "existing" });
     store.writeJson("runtimeDeliveries", { version: 1, records: [{
       deliveryId: "delivery-existing", messageId: "om_existing", status: "accepted", updatedAt: "2026-07-19T00:00:00.000Z",
       input: { inputId: "delivery-existing", deliveryId: "delivery-existing", kind: "wake", text: "check", attempt: 0 },
@@ -410,7 +410,7 @@ test("startup redelivery append shares the Inbox lock and cannot be erased by a 
   const delivered = path.join(root, "delivered.json");
   let child;
   try {
-    store.appendNdjson("inbox", { message_id: "om_lock", wake: true });
+    store.appendNdjson("inbox", { message_id: "om_lock", target: "chat:oc_lock", wake: true });
     const script = `
 import fs from "node:fs";
 import { createAgentStateStore } from ${JSON.stringify(new URL("../../../dist/agent/agent-state-store.mjs", import.meta.url).href)};

--- a/test/unit/agent/host-reminder-orchestrator.test.mjs
+++ b/test/unit/agent/host-reminder-orchestrator.test.mjs
@@ -409,7 +409,10 @@ test("an existing pending Runtime delivery and its durable startup redelivery ar
   }
 });
 
-test("startup redelivery append shares the Inbox lock and cannot be erased by a concurrent drain", async () => {
+// Native Windows process startup can exceed Bun's default 5s test envelope; this is only a runner bound.
+test("startup redelivery append shares the Inbox lock and cannot be erased by a concurrent drain", {
+  timeout: 20_000,
+}, async () => {
   const root = fs.mkdtempSync(path.join(os.tmpdir(), "larkin-redelivery-lock-"));
   const agentId = "cli_redeliveryLockA1";
   const store = createAgentStateStore(root, agentId);
@@ -434,7 +437,7 @@ await orchestrator.redeliverUnread(agent);
     const drained = store.drainInbox({ afterRead() {
       child = spawn(process.execPath, ["--input-type=module", "--eval", script], { env: { ...process.env,
         TEST_ROOT: root, TEST_AGENT: agentId, TEST_READY: ready, TEST_DELIVERED: delivered } });
-      const deadline = Date.now() + 5_000;
+      const deadline = Date.now() + 10_000;
       while (!fs.existsSync(ready) && Date.now() < deadline) Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, 10);
       assert.equal(fs.existsSync(ready), true, "child reached the locked append before drain released it");
     } });

--- a/test/unit/agent/inbox-projection.test.mjs
+++ b/test/unit/agent/inbox-projection.test.mjs
@@ -8,7 +8,7 @@ import { fileURLToPath } from "node:url";
 
 const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..", "..", "..");
 const require = createRequire(import.meta.url);
-const { projectInboxEnvelope, projectInboxEvents, targetOfInboxEnvelope } = require(path.join(ROOT, "dist/agent/inbox-projection.cjs"));
+const { projectInboxEnvelope, projectInboxEvents, targetKeyOfInboxEnvelope, targetOfInboxEnvelope } = require(path.join(ROOT, "dist/agent/inbox-projection.cjs"));
 const { createAgentStateStore } = require(path.join(ROOT, "dist/agent/agent-state-store.cjs"));
 
 test("local Inbox projection adds Feishu locators without mutating the canonical envelope", () => {
@@ -27,6 +27,14 @@ test("inbox projection preserves DM, channel, and thread reply target formats", 
   assert.equal(targetOfInboxEnvelope({
     channel_type: "thread", channel_name: "topic987654", parent_channel_type: "dm", parent_channel_name: "cpeer",
   }), "dm:@cpeer:topic987");
+});
+
+test("canonical target keys cover target, dm, chat, thread, and unlocatable envelopes", () => {
+  assert.equal(targetKeyOfInboxEnvelope({ target: "chat:oc_preserved" }), "chat:oc_preserved");
+  assert.equal(targetKeyOfInboxEnvelope({ channel_type: "dm", channel_name: "system" }), "dm:@system");
+  assert.equal(targetKeyOfInboxEnvelope({ chat_id: "oc_chat" }), "chat:oc_chat");
+  assert.equal(targetKeyOfInboxEnvelope({ chat_id: "oc_chat", thread_id: "omt_thread" }), "thread:oc_chat:omt_thread");
+  assert.equal(targetKeyOfInboxEnvelope({ message_id: "unlocatable" }), "runtime:system");
 });
 
 test("events projection retains the exact check response data shape", () => {

--- a/test/unit/agent/inbox-projection.test.mjs
+++ b/test/unit/agent/inbox-projection.test.mjs
@@ -8,7 +8,7 @@ import { fileURLToPath } from "node:url";
 
 const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..", "..", "..");
 const require = createRequire(import.meta.url);
-const { projectInboxEnvelope, projectInboxEvents, targetKeyOfInboxEnvelope, targetOfInboxEnvelope } = require(path.join(ROOT, "dist/agent/inbox-projection.cjs"));
+const { projectInboxEnvelope, projectInboxEvents, targetOfInboxEnvelope } = require(path.join(ROOT, "dist/agent/inbox-projection.cjs"));
 const { createAgentStateStore } = require(path.join(ROOT, "dist/agent/agent-state-store.cjs"));
 
 test("local Inbox projection adds Feishu locators without mutating the canonical envelope", () => {
@@ -27,14 +27,6 @@ test("inbox projection preserves DM, channel, and thread reply target formats", 
   assert.equal(targetOfInboxEnvelope({
     channel_type: "thread", channel_name: "topic987654", parent_channel_type: "dm", parent_channel_name: "cpeer",
   }), "dm:@cpeer:topic987");
-});
-
-test("canonical target keys cover target, dm, chat, thread, and unlocatable envelopes", () => {
-  assert.equal(targetKeyOfInboxEnvelope({ target: "chat:oc_preserved" }), "chat:oc_preserved");
-  assert.equal(targetKeyOfInboxEnvelope({ channel_type: "dm", channel_name: "system" }), "dm:@system");
-  assert.equal(targetKeyOfInboxEnvelope({ chat_id: "oc_chat" }), "chat:oc_chat");
-  assert.equal(targetKeyOfInboxEnvelope({ chat_id: "oc_chat", thread_id: "omt_thread" }), "thread:oc_chat:omt_thread");
-  assert.equal(targetKeyOfInboxEnvelope({ message_id: "unlocatable" }), "runtime:system");
 });
 
 test("events projection retains the exact check response data shape", () => {

--- a/test/unit/agent/inbox-projection.test.mjs
+++ b/test/unit/agent/inbox-projection.test.mjs
@@ -18,27 +18,24 @@ test("local Inbox projection adds Feishu locators without mutating the canonical
   assert.equal("chat_id" in canonical, false);
 });
 
-test("inbox projection preserves DM, channel, and thread reply target formats", () => {
-  assert.equal(targetOfInboxEnvelope({ channel_type: "dm", channel_name: "cpeer" }), "dm:@cpeer");
-  assert.equal(targetOfInboxEnvelope({ channel_type: "channel", channel_name: "cgroup" }), "#cgroup");
-  assert.equal(targetOfInboxEnvelope({
-    channel_type: "thread", channel_name: "thread123456", parent_channel_type: "channel", parent_channel_name: "cgroup",
-  }), "#cgroup:thread12");
-  assert.equal(targetOfInboxEnvelope({
-    channel_type: "thread", channel_name: "topic987654", parent_channel_type: "dm", parent_channel_name: "cpeer",
-  }), "dm:@cpeer:topic987");
+test("inbox projection exposes only allowlisted canonical reply targets", () => {
+  assert.equal(targetOfInboxEnvelope({ chat_id: "oc_peer" }), "chat:oc_peer");
+  assert.equal(targetOfInboxEnvelope({ chat_id: "oc_group", thread_id: "omt_topic" }), "thread:oc_group:omt_topic");
+  assert.equal(targetOfInboxEnvelope({ target: "dm:@cpeer" }), null);
+  assert.equal(targetOfInboxEnvelope({ target: "#cgroup" }), null);
+  assert.equal(targetOfInboxEnvelope({ target: "runtime:system" }), null);
 });
 
 test("events projection retains the exact check response data shape", () => {
   const events = [
-    { message_id: "m1", seq: 4, channel_type: "channel", channel_name: "cold" },
-    { message_id: "m2", seq: 5, channel_type: "thread", channel_name: "abcdefghijk", parent_channel_type: "channel", parent_channel_name: "croom" },
+    { message_id: "m1", seq: 4, target: "chat:oc_old" },
+    { message_id: "m2", seq: 5, target: "thread:oc_room:omt_abcdefghijk" },
   ];
   assert.deepEqual(projectInboxEvents(events), {
     events,
     last_seen_msgId: "m2",
     last_seen_seq: 5,
-    reply_target: "#croom:abcdefgh",
+    reply_target: "thread:oc_room:omt_abcdefghijk",
     pending_notice_ids: [],
     wake_reason: null,
     has_more: false,
@@ -56,8 +53,8 @@ test("state store preserves read-then-clear semantics without following inbox sy
     const store = createAgentStateStore(root, "cli_inboxA1");
     store.clearNdjson("inbox");
     assert.equal(fs.existsSync(store.paths.inbox), false, "clearing a missing inbox must not create it");
-    store.appendNdjson("inbox", { message_id: "m1" });
-    store.appendNdjson("inbox", { message_id: "m2" });
+    store.appendNdjson("inbox", { message_id: "m1", chat_id: "oc_1" });
+    store.appendNdjson("inbox", { message_id: "m2", chat_id: "oc_1" });
     assert.deepEqual(store.readNdjson("inbox").map((event) => event.message_id), ["m1", "m2"]);
     store.clearNdjson("inbox");
     assert.deepEqual(store.readNdjson("inbox"), []);
@@ -75,6 +72,8 @@ test("production events route uses typed storage and projection without moving i
   const source = fs.readFileSync(path.join(ROOT, "src/agent/agent-transport.ts"), "utf8");
   assert.match(source, /stateStore\.pollInbox<InboxEnvelope>\(\)/);
   assert.match(source, /data: projectInboxEvents\(envelopes\)/);
+  assert.match(source, /Inbox consumption rejected; persisted rows were left unchanged/);
+  assert.doesNotMatch(source, /malformed\/unreadable inbox returns empty/);
   assert.match(source, /request: \(input: AgentTransportInput\) => handle\(input\)/);
   assert.match(source, /globalThis\.__LARKIN_AGENT_TRANSPORT/);
 });

--- a/test/unit/app/agent-cli.test.mjs
+++ b/test/unit/app/agent-cli.test.mjs
@@ -385,7 +385,7 @@ test("an artificially old but live Inbox lock cannot be reclaimed by a cross-pro
   const moduleFile = path.join(ROOT, "dist/agent/agent-state-store.cjs");
   let child;
   try {
-    f.store.appendNdjson("inbox", { message_id: "om_old" });
+    f.store.appendNdjson("inbox", { message_id: "om_old", chat_id: "oc_old" });
     const drained = f.store.pollInbox({
       afterRead() {
         const old = new Date(Date.now() - 60_000);
@@ -394,7 +394,7 @@ test("an artificially old but live Inbox lock cannot be reclaimed by a cross-pro
 const fs = require("node:fs");
 const { createAgentStateStore } = require(process.argv[1]);
 fs.writeFileSync(process.argv[4], "started");
-createAgentStateStore(process.argv[2], process.argv[3]).appendNdjson("inbox", { message_id: "om_new" });
+createAgentStateStore(process.argv[2], process.argv[3]).appendNdjson("inbox", { message_id: "om_new", chat_id: "oc_new" });
 fs.writeFileSync(process.argv[5], "complete");
 `, moduleFile, f.root, f.agentId, marker, appended], { stdio: "ignore" });
         const deadline = Date.now() + 2_000;

--- a/test/unit/app/local-control.test.mjs
+++ b/test/unit/app/local-control.test.mjs
@@ -184,7 +184,7 @@ test("local control keeps upsert ID idempotency and coalesces only concurrent re
     const publicStore = createAgentStateStore(root, "cli_newA1");
     const status = publicStore.readJson("status", {});
     publicStore.writeJson("status", { ...status, reconnectingAt: new Date(Date.now() + 1_000).toISOString() });
-    publicStore.appendNdjson("inbox", { message_id: "om_reconnect_refusal", content: "pending during reconnect" });
+    publicStore.appendNdjson("inbox", { message_id: "om_reconnect_refusal", chat_id: "oc_reconnect_refusal", content: "pending during reconnect" });
     const refused = await requestSessionReset({ larkinHome: root, agentId: "cli_newA1", waitReadyMs: 0 });
     assert.deepEqual(refused, {
       ok: false, agentId: "cli_newA1", code: "channel_reconnecting",

--- a/test/unit/feishu/host-business-state.test.mjs
+++ b/test/unit/feishu/host-business-state.test.mjs
@@ -138,7 +138,7 @@ test("inbound, reminder, and restart envelopes retain exact persistence and sequ
     msgRef: "om_anchor", channel: "#team",
   }, 180_000, "每天 09:00");
   assert.deepEqual(reminder, {
-    message_id: "rem_1234567890abcdef_2", seq: 2, sender_name: "定时提醒", sender_type: "system",
+    message_id: "rem_1234567890abcdef_2", target: "dm:@system", seq: 2, sender_name: "定时提醒", sender_type: "system",
     channel_type: "dm", channel_name: "system",
     content: "[定时提醒触发] Send report\n提醒ID: #12345678　重复: 每天 09:00（下次已自动排在 2026-07-17T01:00:00.000Z）\n注意: 原定时间已过 3 分钟（Runtime Host 离线期间错过，现补触发）\n锚定消息: om_anchor\n回复原会话: larkin im +messages-reply --message-id om_anchor ...\n历史目标 #team 不是 chat_id；若不回复锚定消息，先用 larkin im +chat-search 查询并确认 oc_ chat_id，禁止按名称猜测发送目标\n这是你之前用 larkin reminder schedule 设置的提醒，请按标题执行相应动作。管理: larkin reminder list / larkin reminder snooze / larkin reminder cancel",
     timestamp: "2026-07-16T02:00:00.000Z", thread_id: null, wake: true,
@@ -146,6 +146,7 @@ test("inbound, reminder, and restart envelopes retain exact persistence and sequ
   const redelivery = projector.createRedeliveryEnvelope(agent.agentId, 2);
   assert.equal(redelivery.seq, 3);
   assert.equal(redelivery.message_id, "redeliver_abcdef123456");
+  assert.equal(redelivery.target, "dm:@system");
   assert.match(redelivery.content, /有 2 条/);
   assert.match(redelivery.content, /larkin inbox check/);
   assert.match(redelivery.content, /larkin im \+messages-reply/);

--- a/test/unit/feishu/host-business-state.test.mjs
+++ b/test/unit/feishu/host-business-state.test.mjs
@@ -138,15 +138,16 @@ test("inbound, reminder, and restart envelopes retain exact persistence and sequ
     msgRef: "om_anchor", channel: "#team",
   }, 180_000, "每天 09:00");
   assert.deepEqual(reminder, {
-    message_id: "rem_1234567890abcdef_2", target: "dm:@system", seq: 2, sender_name: "定时提醒", sender_type: "system",
+    kind: "reminder", message_id: "rem_1234567890abcdef_2", target: "runtime:reminder", seq: 2, sender_name: "定时提醒", sender_type: "system",
     channel_type: "dm", channel_name: "system",
     content: "[定时提醒触发] Send report\n提醒ID: #12345678　重复: 每天 09:00（下次已自动排在 2026-07-17T01:00:00.000Z）\n注意: 原定时间已过 3 分钟（Runtime Host 离线期间错过，现补触发）\n锚定消息: om_anchor\n回复原会话: larkin im +messages-reply --message-id om_anchor ...\n历史目标 #team 不是 chat_id；若不回复锚定消息，先用 larkin im +chat-search 查询并确认 oc_ chat_id，禁止按名称猜测发送目标\n这是你之前用 larkin reminder schedule 设置的提醒，请按标题执行相应动作。管理: larkin reminder list / larkin reminder snooze / larkin reminder cancel",
     timestamp: "2026-07-16T02:00:00.000Z", thread_id: null, wake: true,
   });
   const redelivery = projector.createRedeliveryEnvelope(agent.agentId, 2);
   assert.equal(redelivery.seq, 3);
+  assert.equal(redelivery.kind, "redelivery");
   assert.equal(redelivery.message_id, "redeliver_abcdef123456");
-  assert.equal(redelivery.target, "dm:@system");
+  assert.equal(redelivery.target, "runtime:redelivery");
   assert.match(redelivery.content, /有 2 条/);
   assert.match(redelivery.content, /larkin inbox check/);
   assert.match(redelivery.content, /larkin im \+messages-reply/);

--- a/test/unit/runtime/runtime-host.test.mjs
+++ b/test/unit/runtime/runtime-host.test.mjs
@@ -275,6 +275,78 @@ test("Runtime Host owns duplicate suppression, busy delivery and turn-boundary r
   await host.shutdown("test complete");
 });
 
+test("targetless Runtime delivery derives canonical dm, chat, thread, and unlocatable targets in final input", async () => {
+  const session = new FakeSession();
+  const host = createRuntimeHost({
+    adapterFor: () => ({ id: "codex", capabilities: {}, async createSession() { return session; } }),
+    promptBuilder: new ContextPromptBuilder(),
+  });
+  try {
+    const agentId = "cli_targetDefenseA1";
+    await host.start([{ agentId, name: agentId, runtime: "codex", model: "g", workspaceDir: "/tmp" }]);
+    await host.deliver(agentId, { message_id: "rem_dm", channel_type: "dm", channel_name: "system" });
+    await host.deliver(agentId, { message_id: "om_chat", chat_id: "oc_chat" });
+    await host.deliver(agentId, { message_id: "om_thread", chat_id: "oc_chat", thread_id: "omt_thread" });
+    await host.deliver(agentId, { message_id: "runtime_unlocatable" });
+    const inputs = [...session.prompts, ...session.steers].map((input) => input.text);
+    assert.equal(inputs.length, 4);
+    for (const target of ["dm:@system", "chat:oc_chat", "thread:oc_chat:omt_thread", "runtime:system"]) {
+      assert.ok(inputs.some((text) => text.includes(`Inbox changed for ${target}`)), `final Runtime input names ${target}`);
+    }
+    assert.equal(inputs.some((text) => /Inbox changed \(/.test(text)), false, "no final notice is targetless");
+  } finally {
+    await host.shutdown("target derivation test complete");
+  }
+});
+
+test("issue 122 old/base counterfactual retries a targetless notice while canonical poll makes the new path terminal", async () => {
+  const run = async (oldProjection) => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), oldProjection ? "larkin-issue122-old-" : "larkin-issue122-new-"));
+    const agentId = oldProjection ? "cli_issue122OldA1" : "cli_issue122NewA1";
+    const store = createAgentStateStore(root, agentId);
+    const session = new FakeSession();
+    const canonicalBuilder = new ContextPromptBuilder();
+    const promptBuilder = oldProjection ? {
+      build(input) { return canonicalBuilder.build(input); },
+      buildInboxNotice(input) { return canonicalBuilder.buildInboxNotice({ ...input, target: undefined }); },
+    } : canonicalBuilder;
+    const host = createRuntimeHost({
+      adapterFor: () => ({ id: "codex", capabilities: {}, async createSession() { return session; } }),
+      promptBuilder, stateStoreFor: () => store,
+    });
+    try {
+      await host.start([{ agentId, name: agentId, runtime: "codex", model: "g", workspaceDir: path.join(root, "agents", agentId), stateDir: store.paths.root }]);
+      const source = { message_id: oldProjection ? "rem_issue122_old" : "rem_issue122_new", channel_type: "dm", channel_name: "system", wake: true };
+      store.appendNdjson("inbox", source);
+      assert.equal(store.readNdjson("inbox")[0].target, "dm:@system");
+      await host.deliver(agentId, source);
+      if (oldProjection) {
+        assert.doesNotMatch(session.prompts[0].text, /Inbox changed for /, "base call shape produces a targetless final payload");
+      } else {
+        assert.match(session.prompts[0].text, /Inbox changed for dm:@system/, "new final payload names the exact poll target");
+        const polled = store.pollInbox({ target: "dm:@system", limit: 1 });
+        assert.deepEqual(polled.envelopes.map((row) => row.message_id), [source.message_id]);
+      }
+      session.emit({ type: "turn-start", turnId: oldProjection ? "old-turn" : "new-turn" });
+      session.emit({ type: "turn-end", turnId: oldProjection ? "old-turn" : "new-turn" });
+      await new Promise((resolve) => setImmediate(resolve));
+      return { prompts: session.prompts.length, inbox: store.readNdjson("inbox"),
+        statuses: store.readJson("runtimeDeliveries", { records: [] }).records.map((record) => record.status) };
+    } finally {
+      await host.shutdown("issue 122 counterfactual complete");
+      fs.rmSync(root, { recursive: true, force: true });
+    }
+  };
+  const oldResult = await run(true);
+  const newResult = await run(false);
+  assert.equal(oldResult.prompts, 2, "old/base targetless notice leaves the durable row and retries at turn end");
+  assert.equal(oldResult.inbox.length, 1);
+  assert.deepEqual(oldResult.statuses, ["accepted"]);
+  assert.equal(newResult.prompts, 1, "exact-target durable poll prevents turn-end retry");
+  assert.deepEqual(newResult.inbox, []);
+  assert.deepEqual(newResult.statuses, ["consumed"]);
+});
+
 test("Codex compatibility recovery closes, updates once, recreates, and retries the owned delivery", async () => {
   const sessions = [];
   let recoveries = 0;

--- a/test/unit/runtime/runtime-host.test.mjs
+++ b/test/unit/runtime/runtime-host.test.mjs
@@ -4,10 +4,24 @@ import os from "node:os";
 import path from "node:path";
 import { test } from "bun:test";
 import { ContextPromptBuilder } from "../../../dist/agent/context-prompt.mjs";
-import { createRuntimeHost } from "../../../dist/runtime/runtime-host.mjs";
+import { createRuntimeHost as createProductionRuntimeHost } from "../../../dist/runtime/runtime-host.mjs";
 import { RuntimePrerequisiteError } from "../../../dist/runtime/runtime-readiness.mjs";
 import { createAgentStateStore } from "../../../dist/agent/agent-state-store.mjs";
 import { ProcessingEyeOrchestrator } from "../../../dist/feishu/host-processing-eye.mjs";
+
+// Unrelated RuntimeHost scenarios use a producer-valid canonical chat locator. The dedicated
+// runtime-inbox-target contract invokes the unwrapped production host for rejection coverage.
+function createRuntimeHost(options) {
+  const host = createProductionRuntimeHost(options);
+  const deliver = host.deliver.bind(host);
+  host.deliver = (agentId, envelope) => {
+    const messageId = typeof envelope?.message_id === "string" ? envelope.message_id : "";
+    const alreadyLocatable = typeof envelope?.target === "string" || typeof envelope?.chat_id === "string"
+      || /^rem_[A-Za-z0-9_-]+$/.test(messageId) || /^redeliver_[A-Za-z0-9_-]+$/.test(messageId);
+    return deliver(agentId, alreadyLocatable ? envelope : { ...envelope, chat_id: "oc_runtime_host_fixture" });
+  };
+  return host;
+}
 
 class FakeSession {
   sessionId = "session-1";
@@ -275,7 +289,7 @@ test("Runtime Host owns duplicate suppression, busy delivery and turn-boundary r
   await host.shutdown("test complete");
 });
 
-test("issue 122 old/base counterfactual retries a targetless notice while canonical poll makes the new path terminal", async () => {
+test("issue 122 injected former call shape retries a targetless notice while the corrected exact-target path is terminal", async () => {
   const run = async (oldProjection) => {
     const root = fs.mkdtempSync(path.join(os.tmpdir(), oldProjection ? "larkin-issue122-old-" : "larkin-issue122-new-"));
     const agentId = oldProjection ? "cli_issue122OldA1" : "cli_issue122NewA1";
@@ -294,13 +308,13 @@ test("issue 122 old/base counterfactual retries a targetless notice while canoni
       await host.start([{ agentId, name: agentId, runtime: "codex", model: "g", workspaceDir: path.join(root, "agents", agentId), stateDir: store.paths.root }]);
       const source = { message_id: oldProjection ? "rem_issue122_old" : "rem_issue122_new", channel_type: "dm", channel_name: "system", wake: true };
       store.appendNdjson("inbox", source);
-      assert.equal(store.readNdjson("inbox")[0].target, "dm:@system");
+      assert.equal(store.readNdjson("inbox")[0].target, "runtime:reminder");
       await host.deliver(agentId, source);
       if (oldProjection) {
-        assert.doesNotMatch(session.prompts[0].text, /Inbox changed for /, "base call shape produces a targetless final payload");
+        assert.doesNotMatch(session.prompts[0].text, /Inbox changed for /, "injected former call shape produces a targetless final payload");
       } else {
-        assert.match(session.prompts[0].text, /Inbox changed for dm:@system/, "new final payload names the exact poll target");
-        const polled = store.pollInbox({ target: "dm:@system", limit: 1 });
+        assert.match(session.prompts[0].text, /Inbox changed for runtime:reminder/, "new final payload names the exact poll target");
+        const polled = store.pollInbox({ target: "runtime:reminder", limit: 1 });
         assert.deepEqual(polled.envelopes.map((row) => row.message_id), [source.message_id]);
       }
       session.emit({ type: "turn-start", turnId: oldProjection ? "old-turn" : "new-turn" });
@@ -315,7 +329,7 @@ test("issue 122 old/base counterfactual retries a targetless notice while canoni
   };
   const oldResult = await run(true);
   const newResult = await run(false);
-  assert.equal(oldResult.prompts, 2, "old/base targetless notice leaves the durable row and retries at turn end");
+  assert.equal(oldResult.prompts, 2, "the injected former targetless call shape leaves the durable row and retries at turn end");
   assert.equal(oldResult.inbox.length, 1);
   assert.deepEqual(oldResult.statuses, ["accepted"]);
   assert.equal(newResult.prompts, 1, "exact-target durable poll prevents turn-end retry");
@@ -390,7 +404,7 @@ test("delivery ownership, dedupe and correlation survive recreation and reach co
   const adapter = { id: "codex", capabilities: {}, async createSession() { const session = new FakeSession(); session.sessionId = `session-${sessions.length + 1}`; sessions.push(session); return session; } };
   const config = { agentId, name: agentId, runtime: "codex", model: "gpt", workspaceDir: path.join(root, "agents", agentId), stateDir: store.paths.root };
   try {
-    store.appendNdjson("inbox", { message_id: "om_persist", content: "canonical" });
+    store.appendNdjson("inbox", { message_id: "om_persist", target: "chat:oc_persist", content: "canonical" });
     const host1 = createRuntimeHost({ adapterFor: () => adapter, promptBuilder: new ContextPromptBuilder(), stateStoreFor: () => store });
     await host1.start([config]);
     const accepted = await host1.deliver(agentId, { message_id: "om_persist" });
@@ -545,7 +559,7 @@ test("a canonical drain that wins before the current deliver call atomically clo
   const host = createRuntimeHost({ adapterFor: () => ({ id: "codex", capabilities: {}, async createSession() { return session; } }),
     promptBuilder: new ContextPromptBuilder(), stateStoreFor: () => store });
   try {
-    store.appendNdjson("inbox", { message_id: "om_drain_won", wake: true });
+    store.appendNdjson("inbox", { message_id: "om_drain_won", target: "chat:oc_drain_won", wake: true });
     store.drainInbox();
     await host.start([{ agentId, name: agentId, runtime: "codex", model: "g", workspaceDir: path.join(root, "agents", agentId), stateDir: store.paths.root }]);
     const receipt = await host.deliver(agentId, { message_id: "om_drain_won", wake: true });

--- a/test/unit/runtime/runtime-host.test.mjs
+++ b/test/unit/runtime/runtime-host.test.mjs
@@ -275,30 +275,6 @@ test("Runtime Host owns duplicate suppression, busy delivery and turn-boundary r
   await host.shutdown("test complete");
 });
 
-test("targetless Runtime delivery derives canonical dm, chat, thread, and unlocatable targets in final input", async () => {
-  const session = new FakeSession();
-  const host = createRuntimeHost({
-    adapterFor: () => ({ id: "codex", capabilities: {}, async createSession() { return session; } }),
-    promptBuilder: new ContextPromptBuilder(),
-  });
-  try {
-    const agentId = "cli_targetDefenseA1";
-    await host.start([{ agentId, name: agentId, runtime: "codex", model: "g", workspaceDir: "/tmp" }]);
-    await host.deliver(agentId, { message_id: "rem_dm", channel_type: "dm", channel_name: "system" });
-    await host.deliver(agentId, { message_id: "om_chat", chat_id: "oc_chat" });
-    await host.deliver(agentId, { message_id: "om_thread", chat_id: "oc_chat", thread_id: "omt_thread" });
-    await host.deliver(agentId, { message_id: "runtime_unlocatable" });
-    const inputs = [...session.prompts, ...session.steers].map((input) => input.text);
-    assert.equal(inputs.length, 4);
-    for (const target of ["dm:@system", "chat:oc_chat", "thread:oc_chat:omt_thread", "runtime:system"]) {
-      assert.ok(inputs.some((text) => text.includes(`Inbox changed for ${target}`)), `final Runtime input names ${target}`);
-    }
-    assert.equal(inputs.some((text) => /Inbox changed \(/.test(text)), false, "no final notice is targetless");
-  } finally {
-    await host.shutdown("target derivation test complete");
-  }
-});
-
 test("issue 122 old/base counterfactual retries a targetless notice while canonical poll makes the new path terminal", async () => {
   const run = async (oldProjection) => {
     const root = fs.mkdtempSync(path.join(os.tmpdir(), oldProjection ? "larkin-issue122-old-" : "larkin-issue122-new-"));

--- a/test/unit/runtime/runtime-host.test.mjs
+++ b/test/unit/runtime/runtime-host.test.mjs
@@ -17,7 +17,8 @@ function createRuntimeHost(options) {
   host.deliver = (agentId, envelope) => {
     const messageId = typeof envelope?.message_id === "string" ? envelope.message_id : "";
     const alreadyLocatable = typeof envelope?.target === "string" || typeof envelope?.chat_id === "string"
-      || /^rem_[A-Za-z0-9_-]+$/.test(messageId) || /^redeliver_[A-Za-z0-9_-]+$/.test(messageId);
+      || (envelope?.kind === "reminder" && /^rem_[A-Za-z0-9_-]+$/.test(messageId))
+      || (envelope?.kind === "redelivery" && /^redeliver_[A-Za-z0-9_-]+$/.test(messageId));
     return deliver(agentId, alreadyLocatable ? envelope : { ...envelope, chat_id: "oc_runtime_host_fixture" });
   };
   return host;
@@ -289,14 +290,14 @@ test("Runtime Host owns duplicate suppression, busy delivery and turn-boundary r
   await host.shutdown("test complete");
 });
 
-test("issue 122 injected former call shape retries a targetless notice while the corrected exact-target path is terminal", async () => {
-  const run = async (oldProjection) => {
-    const root = fs.mkdtempSync(path.join(os.tmpdir(), oldProjection ? "larkin-issue122-old-" : "larkin-issue122-new-"));
-    const agentId = oldProjection ? "cli_issue122OldA1" : "cli_issue122NewA1";
+test("issue 122 injected former prompt-builder target omission retries while the corrected exact-target path is terminal", async () => {
+  const run = async (formerPromptOmission) => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), formerPromptOmission ? "larkin-issue122-former-prompt-" : "larkin-issue122-current-"));
+    const agentId = formerPromptOmission ? "cli_issue122FormerA1" : "cli_issue122CurrentA1";
     const store = createAgentStateStore(root, agentId);
     const session = new FakeSession();
     const canonicalBuilder = new ContextPromptBuilder();
-    const promptBuilder = oldProjection ? {
+    const promptBuilder = formerPromptOmission ? {
       build(input) { return canonicalBuilder.build(input); },
       buildInboxNotice(input) { return canonicalBuilder.buildInboxNotice({ ...input, target: undefined }); },
     } : canonicalBuilder;
@@ -306,19 +307,20 @@ test("issue 122 injected former call shape retries a targetless notice while the
     });
     try {
       await host.start([{ agentId, name: agentId, runtime: "codex", model: "g", workspaceDir: path.join(root, "agents", agentId), stateDir: store.paths.root }]);
-      const source = { message_id: oldProjection ? "rem_issue122_old" : "rem_issue122_new", channel_type: "dm", channel_name: "system", wake: true };
+      const source = { kind: "reminder", message_id: formerPromptOmission ? "rem_issue122_former" : "rem_issue122_current",
+        target: "runtime:reminder", channel_type: "dm", channel_name: "system", wake: true };
       store.appendNdjson("inbox", source);
       assert.equal(store.readNdjson("inbox")[0].target, "runtime:reminder");
       await host.deliver(agentId, source);
-      if (oldProjection) {
-        assert.doesNotMatch(session.prompts[0].text, /Inbox changed for /, "injected former call shape produces a targetless final payload");
+      if (formerPromptOmission) {
+        assert.doesNotMatch(session.prompts[0].text, /Inbox changed for /, "injected former prompt-builder omission produces a targetless final payload");
       } else {
         assert.match(session.prompts[0].text, /Inbox changed for runtime:reminder/, "new final payload names the exact poll target");
         const polled = store.pollInbox({ target: "runtime:reminder", limit: 1 });
         assert.deepEqual(polled.envelopes.map((row) => row.message_id), [source.message_id]);
       }
-      session.emit({ type: "turn-start", turnId: oldProjection ? "old-turn" : "new-turn" });
-      session.emit({ type: "turn-end", turnId: oldProjection ? "old-turn" : "new-turn" });
+      session.emit({ type: "turn-start", turnId: formerPromptOmission ? "former-turn" : "current-turn" });
+      session.emit({ type: "turn-end", turnId: formerPromptOmission ? "former-turn" : "current-turn" });
       await new Promise((resolve) => setImmediate(resolve));
       return { prompts: session.prompts.length, inbox: store.readNdjson("inbox"),
         statuses: store.readJson("runtimeDeliveries", { records: [] }).records.map((record) => record.status) };
@@ -329,7 +331,7 @@ test("issue 122 injected former call shape retries a targetless notice while the
   };
   const oldResult = await run(true);
   const newResult = await run(false);
-  assert.equal(oldResult.prompts, 2, "the injected former targetless call shape leaves the durable row and retries at turn end");
+  assert.equal(oldResult.prompts, 2, "the injected former prompt-builder target omission leaves the valid durable row and retries at turn end");
   assert.equal(oldResult.inbox.length, 1);
   assert.deepEqual(oldResult.statuses, ["accepted"]);
   assert.equal(newResult.prompts, 1, "exact-target durable poll prevents turn-end retry");

--- a/test/unit/runtime/runtime-inbox-target.test.mjs
+++ b/test/unit/runtime/runtime-inbox-target.test.mjs
@@ -33,14 +33,14 @@ const canonicalDocumentTarget = "document-comment:docx:doxcnFile_1:comment_1:in-
 test("canonical Inbox target derivation accepts only authoritative namespace partitions", () => {
   const valid = [
     [{ target: "chat:oc_preserved_1" }, "chat:oc_preserved_1"],
+    [{ target: "chat:oc_preserved_1", chat_id: "oc_preserved_1", kind: "interaction" }, "chat:oc_preserved_1"],
     [{ target: "thread:oc_chat_1:omt_thread_1" }, "thread:oc_chat_1:omt_thread_1"],
+    [{ target: "thread:oc_chat_1:omt_thread_1", chat_id: "oc_chat_1", thread_id: "omt_thread_1" }, "thread:oc_chat_1:omt_thread_1"],
     [{ target: canonicalDocumentTarget, kind: "document_comment" }, canonicalDocumentTarget],
-    [{ chat_id: "oc_chat_1" }, "chat:oc_chat_1"],
+    [{ chat_id: "oc_chat_1", kind: "interaction" }, "chat:oc_chat_1"],
     [{ chat_id: "oc_chat_1", thread_id: "omt_thread_1" }, "thread:oc_chat_1:omt_thread_1"],
-    [{ message_id: "rem_legacy_shape" }, RUNTIME_REMINDER_TARGET],
-    [{ kind: "reminder", message_id: "internal_1" }, RUNTIME_REMINDER_TARGET],
-    [{ message_id: "redeliver_legacy_shape" }, RUNTIME_REDELIVERY_TARGET],
-    [{ kind: "redelivery", message_id: "internal_2" }, RUNTIME_REDELIVERY_TARGET],
+    [{ target: RUNTIME_REMINDER_TARGET, kind: "reminder", message_id: "rem_current_1" }, RUNTIME_REMINDER_TARGET],
+    [{ target: RUNTIME_REDELIVERY_TARGET, kind: "redelivery", message_id: "redeliver_current_1" }, RUNTIME_REDELIVERY_TARGET],
   ];
   for (const [envelope, expected] of valid) {
     assert.equal(targetKeyOfInboxEnvelope(envelope), expected);
@@ -51,8 +51,11 @@ test("canonical Inbox target derivation accepts only authoritative namespace par
     null,
     undefined,
     { message_id: "unlocatable" },
+    { target: "" },
+    { target: undefined },
+    { target: null },
+    { target: 7 },
     { target: "dm:@system", message_id: "legacy_dm" },
-    { target: "dm:@c123", message_id: "legacy_dm_chat" },
     { target: "#c123", message_id: "legacy_alias" },
     { target: "runtime:system", message_id: "legacy_runtime" },
     { target: "runtime:unknown", message_id: "legacy_unknown" },
@@ -60,15 +63,33 @@ test("canonical Inbox target derivation accepts only authoritative namespace par
     { target: "chat:c123", message_id: "short_chat" },
     { target: "thread:oc_chat_1:thread_1", message_id: "short_thread" },
     { target: "document-comment:docx:file:comment:anywhere", kind: "document_comment" },
+    { message_id: "rem_prefix_only" },
+    { kind: "reminder", message_id: "om_kind_only" },
+    { target: RUNTIME_REMINDER_TARGET, message_id: "om_target_only" },
+    { kind: "reminder", message_id: "rem_targetless_both" },
+    { kind: "redelivery", message_id: "redeliver_targetless_both" },
+    { target: RUNTIME_REDELIVERY_TARGET, kind: "redelivery", message_id: "redeliver_with_chat", chat_id: "oc_conflict" },
+    { target: RUNTIME_REMINDER_TARGET, kind: "reminder", message_id: "rem_with_thread", thread_id: "omt_conflict" },
+    { target: "chat:oc_expected", chat_id: "oc_different" },
+    { target: "chat:oc_expected", thread_id: "omt_forbidden" },
+    { target: "chat:oc_expected", kind: "document_comment" },
+    { target: "chat:oc_expected", kind: "reminder", message_id: "rem_internal_chat_target" },
+    { target: "thread:oc_expected:omt_expected", chat_id: "oc_different" },
+    { target: "thread:oc_expected:omt_expected", thread_id: "omt_different" },
+    { target: "thread:oc_expected:omt_expected", kind: "reminder", message_id: "rem_internal" },
+    { target: canonicalDocumentTarget, message_id: "doc_without_kind" },
+    { target: canonicalDocumentTarget, kind: "document_comment", chat_id: "oc_forbidden" },
+    { target: canonicalDocumentTarget, kind: "document_comment", message_id: "redeliver_internal" },
+    { kind: "document_comment", message_id: "doc_without_locator" },
+    { kind: "document_comment", message_id: "doc_with_chat", chat_id: "oc_forbidden" },
+    { message_id: "rem_prefix_chat", chat_id: "oc_conflict" },
+    { kind: "reminder", message_id: "om_kind_chat", chat_id: "oc_conflict" },
+    { kind: "reminder", message_id: "rem_internal_chat", chat_id: "oc_conflict" },
+    { kind: "redelivery", message_id: "redeliver_internal_thread", chat_id: "oc_conflict", thread_id: "omt_conflict" },
     { chat_id: "c123", message_id: "display_alias" },
     { chat_id: "oc_chat_1", thread_id: "thread_1", message_id: "bad_thread_locator" },
-    { kind: "document_comment", message_id: "doc_without_locator" },
-    { target: "runtime:reminder", message_id: "om_unproven_internal" },
-    { target: "runtime:redelivery", kind: "interaction", message_id: "interaction_unproven_internal" },
-    { kind: "reminder", message_id: "redeliver_source_conflict" },
-    { kind: "reminder", message_id: "rem_wrong", target: "chat:oc_wrong" },
-    { message_id: "redeliver_wrong", target: "runtime:reminder" },
-  ]) assert.throws(() => targetKeyOfInboxEnvelope(envelope), /Inbox|canonical|target|locator/);
+    { kind: "reminder", message_id: "redeliver_source_conflict", target: RUNTIME_REMINDER_TARGET },
+  ]) assert.throws(() => targetKeyOfInboxEnvelope(envelope), /Inbox|canonical|target|locator|source/);
   assert.throws(() => projectInboxCheck([], "dm:@system"), /Invalid canonical Inbox check target/);
 });
 
@@ -110,6 +131,12 @@ test("persistence rejects legacy and malformed targets and leaves durable old ro
       { message_id: "legacy_runtime", target: "runtime:system" },
       { message_id: "legacy_unknown", target: "runtime:unknown" },
       { message_id: "unlocatable" },
+      { message_id: "rem_prefix_only" },
+      { kind: "reminder", message_id: "om_kind_only" },
+      { target: "runtime:reminder", message_id: "om_target_only" },
+      { kind: "redelivery", message_id: "redeliver_targetless" },
+      { target: "chat:oc_expected", chat_id: "oc_conflict" },
+      { target: canonicalDocumentTarget, message_id: "doc_without_kind" },
     ]) assert.throws(() => store.appendNdjson("inbox", envelope), /Inbox|canonical|target|locator/);
     assert.throws(() => store.appendInboxOnce({ message_id: "om_valid_before_rejection", target: "dm:@system" }), /Invalid canonical Inbox target/,
       "dedup must not bypass validation");
@@ -130,6 +157,7 @@ test("persistence rejects legacy and malformed targets and leaves durable old ro
     const oldRows = [
       { message_id: "legacy_dm_disk", target: "dm:@system" },
       { message_id: "legacy_runtime_disk", target: "runtime:system" },
+      { message_id: "redeliver_targetless_disk", kind: "redelivery" },
     ];
     const bytes = `${oldRows.map((row) => JSON.stringify(row)).join("\n")}\n`;
     fs.writeFileSync(store.paths.inbox, bytes, { mode: 0o600 });
@@ -160,8 +188,8 @@ test("Runtime final inputs use exact targets and malformed deliveries fail close
   host.subscribe((event) => events.push(event));
   const agentId = "cli_targetDefenseA1";
   const cases = [
-    [{ message_id: "rem_final", kind: "reminder" }, RUNTIME_REMINDER_TARGET],
-    [{ message_id: "redeliver_final", kind: "redelivery" }, RUNTIME_REDELIVERY_TARGET],
+    [{ target: RUNTIME_REMINDER_TARGET, message_id: "rem_final", kind: "reminder" }, RUNTIME_REMINDER_TARGET],
+    [{ target: RUNTIME_REDELIVERY_TARGET, message_id: "redeliver_final", kind: "redelivery" }, RUNTIME_REDELIVERY_TARGET],
     [{ message_id: "om_chat", chat_id: "oc_chat" }, "chat:oc_chat"],
     [{ message_id: "om_thread", chat_id: "oc_chat", thread_id: "omt_thread" }, "thread:oc_chat:omt_thread"],
     [{ message_id: "interaction_run", kind: "interaction", chat_id: "oc_interaction" }, "chat:oc_interaction"],
@@ -183,6 +211,14 @@ test("Runtime final inputs use exact targets and malformed deliveries fail close
       { message_id: "legacy_dm_runtime", target: "dm:@system" },
       { message_id: "generic_runtime", target: "runtime:system" },
       { message_id: "malformed_chat_runtime", target: "chat:c_alias" },
+      { message_id: "rem_runtime_prefix_only" },
+      { message_id: "om_runtime_kind_only", kind: "reminder" },
+      { message_id: "om_runtime_target_only", target: RUNTIME_REMINDER_TARGET },
+      { message_id: "redeliver_runtime_targetless", kind: "redelivery" },
+      { message_id: "om_runtime_chat_conflict", target: "chat:oc_expected", chat_id: "oc_different" },
+      { message_id: "rem_runtime_externalized", kind: "reminder", chat_id: "oc_conflict" },
+      { message_id: "doc_runtime_no_kind", target: canonicalDocumentTarget },
+      { message_id: "doc_runtime_with_chat", kind: "document_comment", target: canonicalDocumentTarget, chat_id: "oc_conflict" },
     ];
     const ledgerBeforeRejection = fs.readFileSync(store.paths.runtimeDeliveries);
     for (const invalid of invalidCases) {

--- a/test/unit/runtime/runtime-inbox-target.test.mjs
+++ b/test/unit/runtime/runtime-inbox-target.test.mjs
@@ -30,23 +30,27 @@ class FakeSession {
 
 const canonicalDocumentTarget = "document-comment:docx:doxcnFile_1:comment_1:in-thread";
 
-test("canonical Inbox target derivation accepts only authoritative namespace partitions", () => {
+test("canonical Inbox target derivation validates namespace and source coherence, not platform ID grammar", () => {
   const valid = [
-    [{ target: "chat:oc_preserved_1" }, "chat:oc_preserved_1"],
-    [{ target: "chat:oc_preserved_1", chat_id: "oc_preserved_1", kind: "interaction" }, "chat:oc_preserved_1"],
-    [{ target: "thread:oc_chat_1:omt_thread_1" }, "thread:oc_chat_1:omt_thread_1"],
-    [{ target: "thread:oc_chat_1:omt_thread_1", chat_id: "oc_chat_1", thread_id: "omt_thread_1" }, "thread:oc_chat_1:omt_thread_1"],
+    [{ target: "chat:c123" }, "chat:c123"],
+    [{ target: "chat:房间/?!", chat_id: "房间/?!", kind: "interaction" }, "chat:房间/?!"],
+    [{ target: "thread:nonstandard suffix / 标点:✨" }, "thread:nonstandard suffix / 标点:✨"],
+    [{ target: "thread:房间:/?:主题/✨", chat_id: "房间:/?", thread_id: "主题/✨" }, "thread:房间:/?:主题/✨"],
     [{ target: canonicalDocumentTarget, kind: "document_comment" }, canonicalDocumentTarget],
-    [{ chat_id: "oc_chat_1", kind: "interaction" }, "chat:oc_chat_1"],
-    [{ chat_id: "oc_chat_1", thread_id: "omt_thread_1" }, "thread:oc_chat_1:omt_thread_1"],
-    [{ target: RUNTIME_REMINDER_TARGET, kind: "reminder", message_id: "rem_current_1" }, RUNTIME_REMINDER_TARGET],
-    [{ target: RUNTIME_REDELIVERY_TARGET, kind: "redelivery", message_id: "redeliver_current_1" }, RUNTIME_REDELIVERY_TARGET],
+    [{ target: "document-comment:任意/?!::详细格式不在这里校验", kind: "document_comment" }, "document-comment:任意/?!::详细格式不在这里校验"],
+    [{ chat_id: "c123", kind: "interaction" }, "chat:c123"],
+    [{ chat_id: "群/聊:✨", thread_id: "话题?! / ü" }, "thread:群/聊:✨:话题?! / ü"],
+    [{ target: RUNTIME_REMINDER_TARGET, kind: "reminder", message_id: "rem_标点 !?/✨" }, RUNTIME_REMINDER_TARGET],
+    [{ target: RUNTIME_REDELIVERY_TARGET, kind: "redelivery", message_id: "redeliver_标点 !?/✨" }, RUNTIME_REDELIVERY_TARGET],
   ];
   for (const [envelope, expected] of valid) {
     assert.equal(targetKeyOfInboxEnvelope(envelope), expected);
     assert.equal(isCanonicalInboxTarget(expected), true);
   }
 
+  for (const target of ["chat:", "thread:", "document-comment:", "dm:@system", "#c123", "runtime:system", "runtime:unknown", "runtime:other", "unknown:value"]) {
+    assert.equal(isCanonicalInboxTarget(target), false);
+  }
   for (const envelope of [
     null,
     undefined,
@@ -55,39 +59,41 @@ test("canonical Inbox target derivation accepts only authoritative namespace par
     { target: undefined },
     { target: null },
     { target: 7 },
+    { target: "chat:" },
+    { target: "thread:" },
+    { target: "document-comment:", kind: "document_comment" },
     { target: "dm:@system", message_id: "legacy_dm" },
     { target: "#c123", message_id: "legacy_alias" },
     { target: "runtime:system", message_id: "legacy_runtime" },
     { target: "runtime:unknown", message_id: "legacy_unknown" },
-    { target: "runtime:other", message_id: "malformed_runtime" },
-    { target: "chat:c123", message_id: "short_chat" },
-    { target: "thread:oc_chat_1:thread_1", message_id: "short_thread" },
-    { target: "document-comment:docx:file:comment:anywhere", kind: "document_comment" },
+    { target: "runtime:other", message_id: "unknown_runtime" },
     { message_id: "rem_prefix_only" },
+    { message_id: "rem_" },
     { kind: "reminder", message_id: "om_kind_only" },
     { target: RUNTIME_REMINDER_TARGET, message_id: "om_target_only" },
     { kind: "reminder", message_id: "rem_targetless_both" },
     { kind: "redelivery", message_id: "redeliver_targetless_both" },
-    { target: RUNTIME_REDELIVERY_TARGET, kind: "redelivery", message_id: "redeliver_with_chat", chat_id: "oc_conflict" },
-    { target: RUNTIME_REMINDER_TARGET, kind: "reminder", message_id: "rem_with_thread", thread_id: "omt_conflict" },
-    { target: "chat:oc_expected", chat_id: "oc_different" },
-    { target: "chat:oc_expected", thread_id: "omt_forbidden" },
-    { target: "chat:oc_expected", kind: "document_comment" },
-    { target: "chat:oc_expected", kind: "reminder", message_id: "rem_internal_chat_target" },
-    { target: "thread:oc_expected:omt_expected", chat_id: "oc_different" },
-    { target: "thread:oc_expected:omt_expected", thread_id: "omt_different" },
-    { target: "thread:oc_expected:omt_expected", kind: "reminder", message_id: "rem_internal" },
+    { target: RUNTIME_REMINDER_TARGET, kind: "reminder", message_id: "rem_" },
+    { target: RUNTIME_REDELIVERY_TARGET, kind: "redelivery", message_id: "redeliver_" },
+    { target: RUNTIME_REDELIVERY_TARGET, kind: "redelivery", message_id: "redeliver_with_chat", chat_id: "任意" },
+    { target: RUNTIME_REMINDER_TARGET, kind: "reminder", message_id: "rem_with_thread", thread_id: "孤立线程" },
+    { target: "chat:expected", chat_id: "different" },
+    { target: "chat:expected", chat_id: "expected", thread_id: "forbidden" },
+    { target: "chat:expected", kind: "document_comment" },
+    { target: "chat:expected", kind: "reminder", message_id: "rem_internal_chat_target" },
+    { target: "thread:expected:pair", chat_id: "expected" },
+    { target: "thread:expected:pair", chat_id: "expected", thread_id: "different" },
+    { target: "thread:expected:pair", kind: "reminder", message_id: "rem_internal" },
     { target: canonicalDocumentTarget, message_id: "doc_without_kind" },
-    { target: canonicalDocumentTarget, kind: "document_comment", chat_id: "oc_forbidden" },
+    { target: canonicalDocumentTarget, kind: "document_comment", chat_id: "forbidden" },
     { target: canonicalDocumentTarget, kind: "document_comment", message_id: "redeliver_internal" },
     { kind: "document_comment", message_id: "doc_without_locator" },
-    { kind: "document_comment", message_id: "doc_with_chat", chat_id: "oc_forbidden" },
-    { message_id: "rem_prefix_chat", chat_id: "oc_conflict" },
-    { kind: "reminder", message_id: "om_kind_chat", chat_id: "oc_conflict" },
-    { kind: "reminder", message_id: "rem_internal_chat", chat_id: "oc_conflict" },
-    { kind: "redelivery", message_id: "redeliver_internal_thread", chat_id: "oc_conflict", thread_id: "omt_conflict" },
-    { chat_id: "c123", message_id: "display_alias" },
-    { chat_id: "oc_chat_1", thread_id: "thread_1", message_id: "bad_thread_locator" },
+    { kind: "document_comment", message_id: "doc_with_chat", chat_id: "forbidden" },
+    { message_id: "rem_prefix_chat", chat_id: "conflict" },
+    { kind: "reminder", message_id: "om_kind_chat", chat_id: "conflict" },
+    { kind: "reminder", message_id: "rem_internal_chat", chat_id: "conflict" },
+    { kind: "redelivery", message_id: "redeliver_internal_thread", chat_id: "conflict", thread_id: "thread" },
+    { thread_id: "thread-without-chat", message_id: "missing_pair" },
     { kind: "reminder", message_id: "redeliver_source_conflict", target: RUNTIME_REMINDER_TARGET },
   ]) assert.throws(() => targetKeyOfInboxEnvelope(envelope), /Inbox|canonical|target|locator|source/);
   assert.throws(() => projectInboxCheck([], "dm:@system"), /Invalid canonical Inbox check target/);
@@ -123,7 +129,7 @@ test("persistence rejects legacy and malformed targets and leaves durable old ro
     const store = createAgentStateStore(root, "cli_targetStoreA1", {
       inspectProcess: (pid) => ({ ok: true, dead: false, startToken: `test-${pid}` }),
     });
-    store.appendNdjson("inbox", { message_id: "om_valid_before_rejection", target: "chat:oc_valid" });
+    store.appendNdjson("inbox", { message_id: "om_valid_before_rejection", target: "chat:c123" });
     const inboxBeforeAppendRejection = fs.readFileSync(store.paths.inbox);
     const stateBeforeAppendRejection = fs.readFileSync(store.paths.inboxState);
     for (const envelope of [
@@ -188,12 +194,12 @@ test("Runtime final inputs use exact targets and malformed deliveries fail close
   host.subscribe((event) => events.push(event));
   const agentId = "cli_targetDefenseA1";
   const cases = [
-    [{ target: RUNTIME_REMINDER_TARGET, message_id: "rem_final", kind: "reminder" }, RUNTIME_REMINDER_TARGET],
-    [{ target: RUNTIME_REDELIVERY_TARGET, message_id: "redeliver_final", kind: "redelivery" }, RUNTIME_REDELIVERY_TARGET],
-    [{ message_id: "om_chat", chat_id: "oc_chat" }, "chat:oc_chat"],
-    [{ message_id: "om_thread", chat_id: "oc_chat", thread_id: "omt_thread" }, "thread:oc_chat:omt_thread"],
-    [{ message_id: "interaction_run", kind: "interaction", chat_id: "oc_interaction" }, "chat:oc_interaction"],
-    [{ message_id: "doc_comment_final", kind: "document_comment", target: canonicalDocumentTarget }, canonicalDocumentTarget],
+    [{ target: RUNTIME_REMINDER_TARGET, message_id: "rem_final!?✨", kind: "reminder" }, RUNTIME_REMINDER_TARGET],
+    [{ target: RUNTIME_REDELIVERY_TARGET, message_id: "redeliver_final!?✨", kind: "redelivery" }, RUNTIME_REDELIVERY_TARGET],
+    [{ message_id: "om_chat", chat_id: "c123" }, "chat:c123"],
+    [{ message_id: "om_thread", chat_id: "群/聊", thread_id: "主题:✨" }, "thread:群/聊:主题:✨"],
+    [{ message_id: "interaction_run", kind: "interaction", chat_id: "interaction?!" }, "chat:interaction?!"],
+    [{ message_id: "doc_comment_final", kind: "document_comment", target: "document-comment:unusual/✨!?" }, "document-comment:unusual/✨!?"],
   ];
   try {
     await host.start([{ agentId, name: agentId, runtime: "codex", model: "g", workspaceDir: ".", stateDir: store.paths.root }]);
@@ -210,7 +216,8 @@ test("Runtime final inputs use exact targets and malformed deliveries fail close
       { message_id: "unlocatable_runtime" },
       { message_id: "legacy_dm_runtime", target: "dm:@system" },
       { message_id: "generic_runtime", target: "runtime:system" },
-      { message_id: "malformed_chat_runtime", target: "chat:c_alias" },
+      { message_id: "empty_chat_runtime", target: "chat:" },
+      { message_id: "empty_thread_runtime", target: "thread:" },
       { message_id: "rem_runtime_prefix_only" },
       { message_id: "om_runtime_kind_only", kind: "reminder" },
       { message_id: "om_runtime_target_only", target: RUNTIME_REMINDER_TARGET },

--- a/test/unit/runtime/runtime-inbox-target.test.mjs
+++ b/test/unit/runtime/runtime-inbox-target.test.mjs
@@ -1,0 +1,73 @@
+import assert from "node:assert/strict";
+import { test } from "bun:test";
+import { ContextPromptBuilder } from "../../../dist/agent/context-prompt.mjs";
+import { targetKeyOfInboxEnvelope } from "../../../dist/agent/inbox-projection.mjs";
+import { HostEnvelopeProjector } from "../../../dist/feishu/host-business-state.mjs";
+import { createRuntimeHost } from "../../../dist/runtime/runtime-host.mjs";
+
+class FakeSession {
+  sessionId = "runtime-inbox-target-session";
+  listeners = new Set();
+  prompts = [];
+  steers = [];
+
+  subscribe(listener) { this.listeners.add(listener); return () => this.listeners.delete(listener); }
+  async prompt(input) { this.prompts.push(input); return { status: "accepted", inputId: input.inputId }; }
+  async busyInput(input) { this.steers.push(input); return { status: "accepted", inputId: input.inputId }; }
+  async cancel() {}
+  async close() {}
+}
+
+test("canonical Inbox target keys cover preserved, dm, chat, thread, and unlocatable envelopes", () => {
+  assert.equal(targetKeyOfInboxEnvelope({ target: "chat:oc_preserved" }), "chat:oc_preserved");
+  assert.equal(targetKeyOfInboxEnvelope({ channel_type: "dm", channel_name: "system" }), "dm:@system");
+  assert.equal(targetKeyOfInboxEnvelope({ chat_id: "oc_chat" }), "chat:oc_chat");
+  assert.equal(targetKeyOfInboxEnvelope({ chat_id: "oc_chat", thread_id: "omt_thread" }), "thread:oc_chat:omt_thread");
+  assert.equal(targetKeyOfInboxEnvelope({ message_id: "unlocatable" }), "runtime:system");
+});
+
+test("production HostEnvelopeProjector assigns the canonical dm target to reminder and redelivery outputs", () => {
+  const projector = new HostEnvelopeProjector(
+    {},
+    () => {},
+    () => "abcdef123456",
+    () => new Date("2026-07-16T02:00:00.000Z"),
+  );
+  const reminder = projector.createReminderEnvelope("cli_targetContractA1", {
+    reminderId: "1234567890abcdef", title: "Target contract", fireAt: "2026-07-17T01:00:00.000Z",
+  }, 0, null);
+  const redelivery = projector.createRedeliveryEnvelope("cli_targetContractA1", 2);
+
+  assert.equal(reminder.target, "dm:@system");
+  assert.equal(targetKeyOfInboxEnvelope(reminder), "dm:@system");
+  assert.equal(redelivery.target, "dm:@system");
+  assert.equal(targetKeyOfInboxEnvelope(redelivery), "dm:@system");
+});
+
+test("targetless Runtime delivery derives dm, chat, thread, and unlocatable targets in final Runtime input", async () => {
+  const session = new FakeSession();
+  const host = createRuntimeHost({
+    adapterFor: () => ({ id: "codex", capabilities: {}, async createSession() { return session; } }),
+    promptBuilder: new ContextPromptBuilder(),
+  });
+  const agentId = "cli_targetDefenseA1";
+  const cases = [
+    [{ message_id: "rem_dm", channel_type: "dm", channel_name: "system" }, "dm:@system"],
+    [{ message_id: "om_chat", chat_id: "oc_chat" }, "chat:oc_chat"],
+    [{ message_id: "om_thread", chat_id: "oc_chat", thread_id: "omt_thread" }, "thread:oc_chat:omt_thread"],
+    [{ message_id: "runtime_unlocatable" }, "runtime:system"],
+  ];
+  try {
+    await host.start([{ agentId, name: agentId, runtime: "codex", model: "g", workspaceDir: "." }]);
+    for (const [envelope] of cases) assert.equal((await host.deliver(agentId, envelope)).status, "accepted");
+
+    const finalInputs = [...session.prompts, ...session.steers];
+    assert.equal(finalInputs.length, cases.length);
+    cases.forEach(([, target], index) => {
+      assert.ok(finalInputs[index].text.includes(`Inbox changed for ${target}`), `final Runtime input names ${target}`);
+      assert.doesNotMatch(finalInputs[index].text, /Inbox changed \(/, "final Runtime notice is never targetless");
+    });
+  } finally {
+    await host.shutdown("target derivation contract complete");
+  }
+});

--- a/test/unit/runtime/runtime-inbox-target.test.mjs
+++ b/test/unit/runtime/runtime-inbox-target.test.mjs
@@ -1,7 +1,17 @@
 import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
 import { test } from "bun:test";
+import { createAgentStateStore } from "../../../dist/agent/agent-state-store.mjs";
 import { ContextPromptBuilder } from "../../../dist/agent/context-prompt.mjs";
-import { targetKeyOfInboxEnvelope } from "../../../dist/agent/inbox-projection.mjs";
+import {
+  RUNTIME_REDELIVERY_TARGET,
+  RUNTIME_REMINDER_TARGET,
+  isCanonicalInboxTarget,
+  projectInboxCheck,
+  targetKeyOfInboxEnvelope,
+} from "../../../dist/agent/inbox-projection.mjs";
 import { HostEnvelopeProjector } from "../../../dist/feishu/host-business-state.mjs";
 import { createRuntimeHost } from "../../../dist/runtime/runtime-host.mjs";
 
@@ -18,15 +28,51 @@ class FakeSession {
   async close() {}
 }
 
-test("canonical Inbox target keys cover preserved, dm, chat, thread, and unlocatable envelopes", () => {
-  assert.equal(targetKeyOfInboxEnvelope({ target: "chat:oc_preserved" }), "chat:oc_preserved");
-  assert.equal(targetKeyOfInboxEnvelope({ channel_type: "dm", channel_name: "system" }), "dm:@system");
-  assert.equal(targetKeyOfInboxEnvelope({ chat_id: "oc_chat" }), "chat:oc_chat");
-  assert.equal(targetKeyOfInboxEnvelope({ chat_id: "oc_chat", thread_id: "omt_thread" }), "thread:oc_chat:omt_thread");
-  assert.equal(targetKeyOfInboxEnvelope({ message_id: "unlocatable" }), "runtime:system");
+const canonicalDocumentTarget = "document-comment:docx:doxcnFile_1:comment_1:in-thread";
+
+test("canonical Inbox target derivation accepts only authoritative namespace partitions", () => {
+  const valid = [
+    [{ target: "chat:oc_preserved_1" }, "chat:oc_preserved_1"],
+    [{ target: "thread:oc_chat_1:omt_thread_1" }, "thread:oc_chat_1:omt_thread_1"],
+    [{ target: canonicalDocumentTarget, kind: "document_comment" }, canonicalDocumentTarget],
+    [{ chat_id: "oc_chat_1" }, "chat:oc_chat_1"],
+    [{ chat_id: "oc_chat_1", thread_id: "omt_thread_1" }, "thread:oc_chat_1:omt_thread_1"],
+    [{ message_id: "rem_legacy_shape" }, RUNTIME_REMINDER_TARGET],
+    [{ kind: "reminder", message_id: "internal_1" }, RUNTIME_REMINDER_TARGET],
+    [{ message_id: "redeliver_legacy_shape" }, RUNTIME_REDELIVERY_TARGET],
+    [{ kind: "redelivery", message_id: "internal_2" }, RUNTIME_REDELIVERY_TARGET],
+  ];
+  for (const [envelope, expected] of valid) {
+    assert.equal(targetKeyOfInboxEnvelope(envelope), expected);
+    assert.equal(isCanonicalInboxTarget(expected), true);
+  }
+
+  for (const envelope of [
+    null,
+    undefined,
+    { message_id: "unlocatable" },
+    { target: "dm:@system", message_id: "legacy_dm" },
+    { target: "dm:@c123", message_id: "legacy_dm_chat" },
+    { target: "#c123", message_id: "legacy_alias" },
+    { target: "runtime:system", message_id: "legacy_runtime" },
+    { target: "runtime:unknown", message_id: "legacy_unknown" },
+    { target: "runtime:other", message_id: "malformed_runtime" },
+    { target: "chat:c123", message_id: "short_chat" },
+    { target: "thread:oc_chat_1:thread_1", message_id: "short_thread" },
+    { target: "document-comment:docx:file:comment:anywhere", kind: "document_comment" },
+    { chat_id: "c123", message_id: "display_alias" },
+    { chat_id: "oc_chat_1", thread_id: "thread_1", message_id: "bad_thread_locator" },
+    { kind: "document_comment", message_id: "doc_without_locator" },
+    { target: "runtime:reminder", message_id: "om_unproven_internal" },
+    { target: "runtime:redelivery", kind: "interaction", message_id: "interaction_unproven_internal" },
+    { kind: "reminder", message_id: "redeliver_source_conflict" },
+    { kind: "reminder", message_id: "rem_wrong", target: "chat:oc_wrong" },
+    { message_id: "redeliver_wrong", target: "runtime:reminder" },
+  ]) assert.throws(() => targetKeyOfInboxEnvelope(envelope), /Inbox|canonical|target|locator/);
+  assert.throws(() => projectInboxCheck([], "dm:@system"), /Invalid canonical Inbox check target/);
 });
 
-test("production HostEnvelopeProjector assigns the canonical dm target to reminder and redelivery outputs", () => {
+test("production HostEnvelopeProjector emits source-specific reminder and redelivery targets", () => {
   const projector = new HostEnvelopeProjector(
     {},
     () => {},
@@ -38,27 +84,91 @@ test("production HostEnvelopeProjector assigns the canonical dm target to remind
   }, 0, null);
   const redelivery = projector.createRedeliveryEnvelope("cli_targetContractA1", 2);
 
-  assert.equal(reminder.target, "dm:@system");
-  assert.equal(targetKeyOfInboxEnvelope(reminder), "dm:@system");
-  assert.equal(redelivery.target, "dm:@system");
-  assert.equal(targetKeyOfInboxEnvelope(redelivery), "dm:@system");
+  assert.equal(reminder.kind, "reminder");
+  assert.equal(reminder.target, RUNTIME_REMINDER_TARGET);
+  assert.equal(targetKeyOfInboxEnvelope(reminder), RUNTIME_REMINDER_TARGET);
+  assert.equal(redelivery.kind, "redelivery");
+  assert.equal(redelivery.target, RUNTIME_REDELIVERY_TARGET);
+  assert.equal(targetKeyOfInboxEnvelope(redelivery), RUNTIME_REDELIVERY_TARGET);
+  for (const envelope of [reminder, redelivery]) {
+    const output = JSON.stringify(envelope);
+    assert.doesNotMatch(output, /dm:|runtime:(?:system|unknown)/);
+  }
 });
 
-test("targetless Runtime delivery derives dm, chat, thread, and unlocatable targets in final Runtime input", async () => {
+test("persistence rejects legacy and malformed targets and leaves durable old rows untouched", () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "larkin-inbox-target-rejection-"));
+  try {
+    const store = createAgentStateStore(root, "cli_targetStoreA1", {
+      inspectProcess: (pid) => ({ ok: true, dead: false, startToken: `test-${pid}` }),
+    });
+    store.appendNdjson("inbox", { message_id: "om_valid_before_rejection", target: "chat:oc_valid" });
+    const inboxBeforeAppendRejection = fs.readFileSync(store.paths.inbox);
+    const stateBeforeAppendRejection = fs.readFileSync(store.paths.inboxState);
+    for (const envelope of [
+      { message_id: "legacy_dm", target: "dm:@system" },
+      { message_id: "legacy_runtime", target: "runtime:system" },
+      { message_id: "legacy_unknown", target: "runtime:unknown" },
+      { message_id: "unlocatable" },
+    ]) assert.throws(() => store.appendNdjson("inbox", envelope), /Inbox|canonical|target|locator/);
+    assert.throws(() => store.appendInboxOnce({ message_id: "om_valid_before_rejection", target: "dm:@system" }), /Invalid canonical Inbox target/,
+      "dedup must not bypass validation");
+    assert.throws(() => store.prepareInboxDelivery({ message_id: "interaction_unlocatable", kind: "interaction" }), /no canonical target/,
+      "delivery preparation validates before considering append state");
+    assert.deepEqual(fs.readFileSync(store.paths.inbox), inboxBeforeAppendRejection, "invalid append leaves Inbox bytes unchanged");
+    assert.deepEqual(fs.readFileSync(store.paths.inboxState), stateBeforeAppendRejection, "invalid append leaves target cursors unchanged");
+
+    store.writeJson("status", { fixture: true });
+    store.writeJson("runtimeDeliveries", { version: 1, records: [{
+      deliveryId: "existing-delivery", messageId: "legacy_prepare", status: "accepted", updatedAt: "2026-08-15T00:00:00.000Z",
+      input: { inputId: "existing-delivery", deliveryId: "existing-delivery", kind: "wake", text: "existing", attempt: 0 },
+    }] });
+    const ledgerBeforePreparationRejection = fs.readFileSync(store.paths.runtimeDeliveries);
+    assert.throws(() => store.prepareInboxDelivery({ message_id: "legacy_prepare", target: "dm:@system" }), /Invalid canonical Inbox target/,
+      "active ledger ownership must not bypass validation");
+    assert.deepEqual(fs.readFileSync(store.paths.runtimeDeliveries), ledgerBeforePreparationRejection);
+    const oldRows = [
+      { message_id: "legacy_dm_disk", target: "dm:@system" },
+      { message_id: "legacy_runtime_disk", target: "runtime:system" },
+    ];
+    const bytes = `${oldRows.map((row) => JSON.stringify(row)).join("\n")}\n`;
+    fs.writeFileSync(store.paths.inbox, bytes, { mode: 0o600 });
+    const stateBeforePollRejection = fs.readFileSync(store.paths.inboxState);
+    const ledgerBeforePollRejection = fs.readFileSync(store.paths.runtimeDeliveries);
+    assert.throws(() => store.pollInbox({ limit: 1 }), /Invalid canonical Inbox target/);
+    assert.throws(() => store.pollInbox({ target: "dm:@system", limit: 1 }), /Invalid canonical Inbox poll target/);
+    assert.equal(fs.readFileSync(store.paths.inbox, "utf8"), bytes, "rejected legacy rows are neither migrated nor consumed");
+    assert.deepEqual(fs.readFileSync(store.paths.inboxState), stateBeforePollRejection, "invalid existing rows leave target cursors unchanged");
+    assert.deepEqual(fs.readFileSync(store.paths.runtimeDeliveries), ledgerBeforePollRejection, "invalid existing rows leave Runtime acceptance unchanged");
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("Runtime final inputs use exact targets and malformed deliveries fail closed before prompt or ledger acceptance", async () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "larkin-runtime-target-defense-"));
+  const store = createAgentStateStore(root, "cli_targetDefenseA1", {
+    inspectProcess: (pid) => ({ ok: true, dead: false, startToken: `test-${pid}` }),
+  });
   const session = new FakeSession();
+  const events = [];
   const host = createRuntimeHost({
     adapterFor: () => ({ id: "codex", capabilities: {}, async createSession() { return session; } }),
     promptBuilder: new ContextPromptBuilder(),
+    stateStoreFor: () => store,
   });
+  host.subscribe((event) => events.push(event));
   const agentId = "cli_targetDefenseA1";
   const cases = [
-    [{ message_id: "rem_dm", channel_type: "dm", channel_name: "system" }, "dm:@system"],
+    [{ message_id: "rem_final", kind: "reminder" }, RUNTIME_REMINDER_TARGET],
+    [{ message_id: "redeliver_final", kind: "redelivery" }, RUNTIME_REDELIVERY_TARGET],
     [{ message_id: "om_chat", chat_id: "oc_chat" }, "chat:oc_chat"],
     [{ message_id: "om_thread", chat_id: "oc_chat", thread_id: "omt_thread" }, "thread:oc_chat:omt_thread"],
-    [{ message_id: "runtime_unlocatable" }, "runtime:system"],
+    [{ message_id: "interaction_run", kind: "interaction", chat_id: "oc_interaction" }, "chat:oc_interaction"],
+    [{ message_id: "doc_comment_final", kind: "document_comment", target: canonicalDocumentTarget }, canonicalDocumentTarget],
   ];
   try {
-    await host.start([{ agentId, name: agentId, runtime: "codex", model: "g", workspaceDir: "." }]);
+    await host.start([{ agentId, name: agentId, runtime: "codex", model: "g", workspaceDir: ".", stateDir: store.paths.root }]);
     for (const [envelope] of cases) assert.equal((await host.deliver(agentId, envelope)).status, "accepted");
 
     const finalInputs = [...session.prompts, ...session.steers];
@@ -67,7 +177,31 @@ test("targetless Runtime delivery derives dm, chat, thread, and unlocatable targ
       assert.ok(finalInputs[index].text.includes(`Inbox changed for ${target}`), `final Runtime input names ${target}`);
       assert.doesNotMatch(finalInputs[index].text, /Inbox changed \(/, "final Runtime notice is never targetless");
     });
+
+    const invalidCases = [
+      { message_id: "unlocatable_runtime" },
+      { message_id: "legacy_dm_runtime", target: "dm:@system" },
+      { message_id: "generic_runtime", target: "runtime:system" },
+      { message_id: "malformed_chat_runtime", target: "chat:c_alias" },
+    ];
+    const ledgerBeforeRejection = fs.readFileSync(store.paths.runtimeDeliveries);
+    for (const invalid of invalidCases) {
+      const first = await host.deliver(agentId, invalid);
+      const second = await host.deliver(agentId, invalid);
+      assert.deepEqual(second, first, "fail-closed receipt is deterministic");
+      assert.equal(first.status, "error");
+      assert.equal(first.retryable, false);
+      assert.match(first.reason, /Inbox target derivation failed/);
+      assert.equal(events.filter((event) => event.type === "delivery" && event.messageId === invalid.message_id
+        && event.status === "error").length, 2, "each rejection emits deterministic error telemetry");
+    }
+    assert.equal([...session.prompts, ...session.steers].length, cases.length, "invalid delivery creates no Runtime prompt");
+    const ledger = store.readJson("runtimeDeliveries", { records: [] }).records;
+    assert.equal(invalidCases.some((invalid) => ledger.some((record) => record.messageId === invalid.message_id)), false,
+      "invalid delivery creates no ledger acceptance");
+    assert.deepEqual(fs.readFileSync(store.paths.runtimeDeliveries), ledgerBeforeRejection, "invalid delivery leaves the accepted ledger byte-for-byte unchanged");
   } finally {
     await host.shutdown("target derivation contract complete");
+    fs.rmSync(root, { recursive: true, force: true });
   }
 });


### PR DESCRIPTION
https://github.com/eddiearc/larkin/issues/122

Closes #122

## Root cause and architecture correction

The former call chain target-completed a persisted copy of a reminder while Runtime received the original targetless object. The final Runtime notice therefore lacked the exact partition required by the first canonical Inbox poll, and turn-end reconciliation could retry indefinitely.

This amendment applies Eddie's corrected prefix-only namespace design. `targetKeyOfInboxEnvelope()` now owns source classification and coherence:

- `chat:` plus any nonempty suffix;
- `thread:` plus any nonempty suffix;
- `document-comment:` plus any nonempty suffix and `kind=document_comment`;
- exact `runtime:reminder` plus `kind=reminder` and a `rem_` message ID with a nonempty suffix;
- exact `runtime:redelivery` plus `kind=redelivery` and a `redeliver_` message ID with a nonempty suffix.

A nonempty `chat_id` derives `chat:${chat_id}`; a nonempty chat/thread pair derives `thread:${chat_id}:${thread_id}`. The classifier deliberately does not inspect `oc_`/`omt_` prefixes, detailed document locator grammar, charset, segment count, or length. Explicit targets must exactly match any locator metadata. Internal/document sources cannot externalize to chat/thread, and runtime/document targets reject external locators.

Display aliases (`dm:*`, `#...`), generic or arbitrary runtime partitions, empty suffixes, missing thread pairs, incomplete internal proofs, source/locator conflicts, targetless internal envelopes, and unlocatable envelopes fail closed. This is intentionally not legacy-compatible: invalid old rows are neither rewritten nor consumed.

`HostEnvelopeProjector` emits explicit source-specific targets and kinds. `HostReminderOrchestrator` persists and delivers the same target-complete object. RuntimeHost independently validates before dedupe/backlog/prompt construction; derivation failures return deterministic non-retryable `status:error`, emit error delivery telemetry, and create no prompt or ledger acceptance.

## Verification

Tests cover exact reminder/redelivery Runtime inputs and polls, chat/topic/interaction/document partitions, punctuation/Unicode and nonstandard nonempty suffixes, prefix-only internal proof, namespace emptiness, unknown prefixes, missing thread pairs, source mismatch, and byte-for-byte no-mutation rejection. The Linux production-boundary fixture now supplies `chat:c123`; 409 behavior remains strict.

Local validation passed: focused target/reminder/state/runtime/document contracts 83/83; failed Linux integration 15/15; exact Windows-focused selection 92/92; typecheck; build; publication tree; version 0.4.0; diff checks.

## Scope / compatibility boundary

No reminder scheduling/recurrence change, polling-policy relaxation, Feishu destination guessing, detailed platform ID validation in Inbox classification, legacy-row migration/deletion, unrelated CIM/O_NOFOLLOW work, production config/process change, merge, release, comment, or manual issue closure.

This intentional compatibility break keeps package version `0.4.0`.
