### PR TITLE
fix(runtime): preserve canonical Inbox identity across upgrades

### DIFF
--- a/.github/workflows/release-platform-smoke.yml
+++ b/.github/workflows/release-platform-smoke.yml
@@ -124,7 +124,7 @@ jobs:
         run: bun run build
 
       - name: Run focused Windows unit and integration tests
-        run: bun test --isolate --max-concurrency 1 test/unit/agent/host-reminder-orchestrator.test.mjs test/unit/feishu/host-business-state.test.mjs test/unit/platform/release-artifacts.test.mjs test/unit/runtime/pi-inline-extensions.test.mjs test/unit/runtime/runtime-adapters.test.mjs test/unit/runtime/runtime-inbox-target.test.mjs test/integration/build/runtime-clean-cutover.test.mjs test/integration/build/release-platform-ci.test.mjs
+        run: bun test --isolate --max-concurrency 1 test/unit/agent/host-reminder-orchestrator.test.mjs test/unit/feishu/host-business-state.test.mjs test/unit/feishu/host-runtime-delivery-health.test.mjs test/unit/platform/release-artifacts.test.mjs test/unit/runtime/pi-inline-extensions.test.mjs test/unit/runtime/runtime-adapters.test.mjs test/unit/runtime/runtime-inbox-target.test.mjs test/integration/build/runtime-clean-cutover.test.mjs test/integration/build/runtime-upgrade-in-place.test.mjs test/e2e/issue124-thread-runtime-envelope-e2e.test.mjs test/integration/build/release-platform-ci.test.mjs
 
       - name: Download exact Windows standalone build
         uses: actions/download-artifact@v4

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "larkin",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "private": false,
   "larkinPackageRole": "npm-published",
   "files": [

--- a/scripts/release/smoke.ts
+++ b/scripts/release/smoke.ts
@@ -15,6 +15,15 @@ import {
   smokeArtifactEnvironment,
   smokeTerminationPlan,
 } from "./smoke-support.js";
+// Release smoke runs only after `bun run build`; exercising dist keeps the
+// same compiled module graph used to construct the standalone.
+// @ts-expect-error dist is generated and intentionally has no declaration file.
+import { createAgentStateStore } from "../../dist/agent/agent-state-store.mjs";
+// @ts-expect-error dist is generated and intentionally has no declaration file.
+import { ContextPromptBuilder } from "../../dist/agent/context-prompt.mjs";
+// @ts-expect-error dist is generated and intentionally has no declaration file.
+import { createRuntimeHost } from "../../dist/runtime/runtime-host.mjs";
+import type { RuntimeInput, RuntimeSession } from "../../src/runtime/runtime-contracts.js";
 
 async function freePort(): Promise<number> {
   const server = net.createServer();
@@ -101,6 +110,78 @@ export async function main(argv: string[] = process.argv.slice(2)): Promise<void
     const help = checkedArtifact(artifact, ["--help"], artifactEnv, "artifact help");
     if (!help.includes("Usage: larkin <command>")) throw new Error("artifact help is missing the public usage contract");
 
+    // Release smoke must cross a real upgrade boundary, not only boot a clean
+    // temporary home. This source-tag API capture is explicitly provenance-
+    // bounded in the fixture; the candidate Runtime must migrate and replay its
+    // same-home active targetless ledger, then the standalone must read that
+    // upgraded Inbox/ledger state without an extra mutation.
+    const upgradeFixtureFile = path.resolve(import.meta.dirname, "../../test/fixtures/runtime-upgrade/v0.3.3-active-thread.json");
+    const upgradeFixture = JSON.parse(fs.readFileSync(upgradeFixtureFile, "utf8")) as {
+      provenance: { release_tag: string; claim_boundary: string };
+      agent_id: string;
+      files: Record<string, unknown>;
+    };
+    if (upgradeFixture.provenance.release_tag !== "v0.3.3" || !/not a customer home/i.test(upgradeFixture.provenance.claim_boundary)) {
+      throw new Error("runtime upgrade smoke fixture provenance is missing or overstated");
+    }
+    const upgradeStateDir = path.join(larkinHome, "state", "agents", upgradeFixture.agent_id);
+    fs.mkdirSync(upgradeStateDir, { recursive: true, mode: 0o700 });
+    const inboxRows = upgradeFixture.files["feishu-inbox.ndjson"] as unknown[];
+    const inboxBytes = `${inboxRows.map((row) => JSON.stringify(row)).join("\n")}\n`;
+    const inboxFile = path.join(upgradeStateDir, "feishu-inbox.ndjson");
+    const inboxStateFile = path.join(upgradeStateDir, "inbox-state.json");
+    const deliveryFile = path.join(upgradeStateDir, "runtime-deliveries.json");
+    fs.writeFileSync(inboxFile, inboxBytes, { mode: 0o600 });
+    fs.writeFileSync(inboxStateFile, `${JSON.stringify(upgradeFixture.files["inbox-state.json"], null, 2)}\n`, { mode: 0o600 });
+    const deliveryBytes = `${JSON.stringify(upgradeFixture.files["runtime-deliveries.json"], null, 2)}\n`;
+    fs.writeFileSync(deliveryFile, deliveryBytes, { mode: 0o600 });
+    fs.writeFileSync(path.join(larkinHome, "config.json"), `${JSON.stringify({
+      version: 4, serverId: "release-smoke-upgrade", mentionPolicy: "require", activeAgent: upgradeFixture.agent_id,
+      agents: { [upgradeFixture.agent_id]: { runtime: "codex", model: "captured" } },
+    })}\n`, { mode: 0o600 });
+    const submittedInputs: RuntimeInput[] = [];
+    const runtimeSession: RuntimeSession = {
+      sessionId: "release-smoke-upgrade-session",
+      async prompt(input) { submittedInputs.push(structuredClone(input)); return { status: "accepted", inputId: input.inputId }; },
+      async busyInput(input) { submittedInputs.push(structuredClone(input)); return { status: "accepted", inputId: input.inputId }; },
+      async cancel() {}, async close() {}, subscribe() { return () => {}; },
+    };
+    const upgradeStore = createAgentStateStore(larkinHome, upgradeFixture.agent_id);
+    const runtimeHost = createRuntimeHost({
+      adapterFor: () => ({ id: "codex", capabilities: {}, async createSession() { return runtimeSession; } }),
+      promptBuilder: new ContextPromptBuilder(), stateStoreFor: () => upgradeStore, assertOfficialCliReady: () => {},
+    });
+    fs.mkdirSync(path.join(larkinHome, "agents", upgradeFixture.agent_id), { recursive: true });
+    try {
+      await runtimeHost.start([{ agentId: upgradeFixture.agent_id, name: upgradeFixture.agent_id,
+        runtime: "codex", model: "captured", workspaceDir: path.join(larkinHome, "agents", upgradeFixture.agent_id),
+        stateDir: upgradeStateDir }]);
+    } finally {
+      await runtimeHost.shutdown("release smoke upgrade replay complete");
+    }
+    const expectedTarget = "thread:oc_issue124_upgrade:omt_issue124_upgrade";
+    const expectedNotice = `The Larkin Inbox changed for ${expectedTarget} (1 pending message). Poll that target at the next safe boundary before any target-local side effect.`;
+    if (submittedInputs.length !== 1 || submittedInputs[0]?.text !== expectedNotice) {
+      throw new Error(`candidate Runtime failed to rebuild the exact canonical v0.3.3 thread notice (inputs=${submittedInputs.length}, actual=${JSON.stringify(submittedInputs[0]?.text || null)})`);
+    }
+    const upgradedDelivery = JSON.parse(fs.readFileSync(deliveryFile, "utf8"));
+    if (upgradedDelivery.records?.[0]?.status !== "accepted" || upgradedDelivery.records?.[0]?.target !== expectedTarget
+      || upgradedDelivery.records?.[0]?.input?.text !== expectedNotice) {
+      throw new Error("candidate Runtime failed to persist the rebuilt v0.3.3 active delivery");
+    }
+    const upgradedDeliveryBytes = fs.readFileSync(deliveryFile, "utf8");
+    if (upgradedDeliveryBytes === deliveryBytes) throw new Error("candidate Runtime did not migrate the active targetless v0.3.3 ledger");
+
+    const upgradeCheck = JSON.parse(checkedArtifact(artifact,
+      ["__internal", "agent-cli", "inbox", "check", "--target", expectedTarget, "--json"],
+      { ...artifactEnv, LARKIN_AGENT_ID: upgradeFixture.agent_id }, "artifact v0.3.3 same-home upgrade state"));
+    if (upgradeCheck.pending_total !== 1 || upgradeCheck.targets?.[0]?.target !== expectedTarget) {
+      throw new Error("artifact failed to resolve the captured v0.3.3 canonical thread target");
+    }
+    if (fs.readFileSync(inboxFile, "utf8") !== inboxBytes || fs.readFileSync(deliveryFile, "utf8") !== upgradedDeliveryBytes) {
+      throw new Error("read-only artifact upgrade check mutated candidate Runtime state");
+    }
+
     const port = await freePort();
     dashboard = spawn(artifact, ["__internal", "dashboard", "--port", String(port)], {
       env: artifactEnv,
@@ -129,7 +210,8 @@ export async function main(argv: string[] = process.argv.slice(2)): Promise<void
       throw new Error("embedded Dashboard client asset failed its HTTP smoke check");
     }
 
-    process.stdout.write(`${JSON.stringify({ ok: true, platform, arch, artifact: record.file, version: manifest.version, dashboard: "HTTP 200" })}\n`);
+    process.stdout.write(`${JSON.stringify({ ok: true, platform, arch, artifact: record.file, version: manifest.version,
+      legacyUpgradeState: "v0.3.3 active Runtime ledger replayed", dashboard: "HTTP 200" })}\n`);
   } finally {
     try {
       if (dashboard) await stop(dashboard, platform);

--- a/scripts/release/smoke.ts
+++ b/scripts/release/smoke.ts
@@ -146,7 +146,9 @@ export async function main(argv: string[] = process.argv.slice(2)): Promise<void
       async busyInput(input) { submittedInputs.push(structuredClone(input)); return { status: "accepted", inputId: input.inputId }; },
       async cancel() {}, async close() {}, subscribe() { return () => {}; },
     };
-    const upgradeStore = createAgentStateStore(larkinHome, upgradeFixture.agent_id);
+    const upgradeStore = createAgentStateStore(larkinHome, upgradeFixture.agent_id, {
+      inspectProcess: (pid: number) => ({ ok: true, dead: false, startToken: `release-upgrade-${pid}` }),
+    });
     const runtimeHost = createRuntimeHost({
       adapterFor: () => ({ id: "codex", capabilities: {}, async createSession() { return runtimeSession; } }),
       promptBuilder: new ContextPromptBuilder(), stateStoreFor: () => upgradeStore, assertOfficialCliReady: () => {},

--- a/src/agent/agent-state-store.ts
+++ b/src/agent/agent-state-store.ts
@@ -634,8 +634,20 @@ export class AgentStateStore {
         if (targetKeyOfInboxEnvelope(existing) !== incomingTarget) {
           throw new Error("Inbox duplicate message_id conflicts with its canonical target");
         }
+        if (existing.target_seq !== undefined && !validSequence(existing.target_seq)) {
+          throw new Error("Inbox duplicate message_id has a malformed canonical sequence");
+        }
         const known = state.messages[messageId];
-        if (known && known.target !== incomingTarget) throw new Error("Inbox message state conflicts with its canonical target");
+        if (known) {
+          if (known.target !== incomingTarget) throw new Error("Inbox message state conflicts with its canonical target");
+          if (validSequence(existing.target_seq) && existing.target_seq !== known.seq) {
+            throw new Error("Inbox message state conflicts with its canonical sequence");
+          }
+          const targetState = state.targets[known.target];
+          if (targetState && targetState.model_seen_seq >= known.seq) {
+            throw new Error("Inbox pending row conflicts with consumed model-seen state");
+          }
+        }
         return { status: "duplicate_pending", envelope: existing };
       }
       const known = state.messages[messageId];
@@ -676,8 +688,16 @@ export class AgentStateStore {
         let target: string;
         try { target = targetKeyOfInboxEnvelope(envelope); }
         catch { return { status: "invalid", code: "canonical_inbox_malformed" }; }
-        if (known && (known.target !== target || !validSequence(known.seq))) {
-          return { status: "invalid", code: "inbox_state_conflict" };
+        if (envelope.target_seq !== undefined && !validSequence(envelope.target_seq)) {
+          return { status: "invalid", code: "canonical_inbox_malformed" };
+        }
+        if (known) {
+          const targetState = state.targets[known.target];
+          if (known.target !== target || !validSequence(known.seq)
+            || (validSequence(envelope.target_seq) && envelope.target_seq !== known.seq)
+            || Boolean(targetState && targetState.model_seen_seq >= known.seq)) {
+            return { status: "invalid", code: "inbox_state_conflict" };
+          }
         }
         return { status: "pending", target, envelope };
       }

--- a/src/agent/agent-state-store.ts
+++ b/src/agent/agent-state-store.ts
@@ -237,6 +237,16 @@ function validInboxLockOwner(value: unknown): value is InboxLockOwner {
 
 export type InboxDeliveryPreparation = "appended" | "present" | "active" | "terminal_error" | "consumed";
 
+export type CanonicalInboxAppendResult =
+  | { status: "appended" | "duplicate_pending"; envelope: InboxEnvelope }
+  | { status: "duplicate_consumed"; envelope: null };
+
+export type InboxDeliverySourceResolution =
+  | { status: "pending"; target: string; envelope: InboxEnvelope }
+  | { status: "consumed"; target: string }
+  | { status: "missing"; code: "canonical_inbox_row_missing" }
+  | { status: "invalid"; code: "canonical_inbox_malformed" | "duplicate_message_id" | "inbox_state_conflict" };
+
 export class AgentStateStore {
   readonly paths: AgentStatePaths;
   private readonly boundary: string;
@@ -602,18 +612,82 @@ export class AgentStateStore {
     else append();
   }
 
-  /** Append a canonical Inbox envelope once by stable message_id under the shared cross-process lock. */
-  appendInboxOnce(value: unknown): boolean {
+  /**
+   * Append one canonical Inbox envelope and return the exact normalized object
+   * serialized to disk. Stable message_id dedupe and locator coherence share the
+   * same lock as poll, so HostShell can deliver that very object without a
+   * persistence/delivery split.
+   */
+  appendCanonicalInboxOnce(value: unknown): CanonicalInboxAppendResult {
     if (!value || typeof value !== "object" || Array.isArray(value)) throw new Error("Inbox envelope must be an object");
-    const messageId = (value as Record<string, unknown>).message_id;
+    const input = value as InboxEnvelope;
+    const messageId = input.message_id;
     if (typeof messageId !== "string" || !messageId) throw new Error("Inbox envelope requires message_id");
-    targetKeyOfInboxEnvelope(value as InboxEnvelope);
+    const incomingTarget = targetKeyOfInboxEnvelope(input);
     const file = this.file("inbox");
     return this.withInboxLock(file, () => {
-      if (this.inboxState().messages[messageId]) return false;
-      if (this.readNdjson<Record<string, unknown>>("inbox").some((row) => row.message_id === messageId)) return false;
-      this.appendInboxUnlocked(value);
-      return true;
+      const state = this.inboxState();
+      const matching = this.readNdjson<InboxEnvelope>("inbox").filter((row) => row.message_id === messageId);
+      if (matching.length > 1) throw new Error("Inbox duplicate message_id has multiple pending canonical rows");
+      if (matching.length === 1) {
+        const existing = matching[0]!;
+        if (targetKeyOfInboxEnvelope(existing) !== incomingTarget) {
+          throw new Error("Inbox duplicate message_id conflicts with its canonical target");
+        }
+        const known = state.messages[messageId];
+        if (known && known.target !== incomingTarget) throw new Error("Inbox message state conflicts with its canonical target");
+        return { status: "duplicate_pending", envelope: existing };
+      }
+      const known = state.messages[messageId];
+      if (known) {
+        if (known.target !== incomingTarget) throw new Error("Inbox duplicate message_id conflicts with consumed canonical target");
+        const targetState = state.targets[known.target];
+        if (!targetState || targetState.model_seen_seq < known.seq) {
+          throw new Error("Inbox state references a missing unconsumed canonical row");
+        }
+        return { status: "duplicate_consumed", envelope: null };
+      }
+      return { status: "appended", envelope: this.appendInboxUnlocked(input) };
+    });
+  }
+
+  /** Append a canonical Inbox envelope once by stable message_id under the shared cross-process lock. */
+  appendInboxOnce(value: unknown): boolean {
+    return this.appendCanonicalInboxOnce(value).status === "appended";
+  }
+
+  /**
+   * Resolve one Runtime delivery solely from canonical Inbox row/state. This is
+   * the single replay resolver used for startup migration and every retry; it
+   * never derives a DM/generic fallback from stale RuntimeInput text.
+   */
+  resolveInboxDeliverySource(messageId: string): InboxDeliverySourceResolution {
+    if (!messageId) return { status: "missing", code: "canonical_inbox_row_missing" };
+    return this.withInboxLock(this.file("inbox"), () => {
+      let rows: InboxEnvelope[];
+      try { rows = this.readNdjson<InboxEnvelope>("inbox"); }
+      catch { return { status: "invalid", code: "canonical_inbox_malformed" }; }
+      const matching = rows.filter((row) => row?.message_id === messageId);
+      if (matching.length > 1) return { status: "invalid", code: "duplicate_message_id" };
+      const state = this.inboxState();
+      const known = state.messages[messageId];
+      if (matching.length === 1) {
+        const envelope = matching[0]!;
+        let target: string;
+        try { target = targetKeyOfInboxEnvelope(envelope); }
+        catch { return { status: "invalid", code: "canonical_inbox_malformed" }; }
+        if (known && (known.target !== target || !validSequence(known.seq))) {
+          return { status: "invalid", code: "inbox_state_conflict" };
+        }
+        return { status: "pending", target, envelope };
+      }
+      if (!known) return { status: "missing", code: "canonical_inbox_row_missing" };
+      if (!isCanonicalInboxTarget(known.target) || !validSequence(known.seq)) {
+        return { status: "invalid", code: "inbox_state_conflict" };
+      }
+      const targetState = state.targets[known.target];
+      if (targetState && targetState.model_seen_seq >= known.seq) return { status: "consumed", target: known.target };
+      return { status: "missing", code: "canonical_inbox_row_missing" };
     });
   }
 

--- a/src/feishu/host-shell.ts
+++ b/src/feishu/host-shell.ts
@@ -279,6 +279,19 @@ export function createHostShell({
     return store;
   };
   const hostState = new HostStateProjection(stateStore, log);
+  const recordInboundDeliveryFailure = (
+    agent: ConfiguredAgent,
+    code: "non_retryable_receipt" | "runtime_delivery_exception" | "runtime_delivery_event",
+  ): void => {
+    const at = new Date().toISOString();
+    const reason = "Inbound Runtime delivery failed non-retryably; durable Inbox/ledger state is retained for recovery.";
+    const nextAction = "Inspect the delivery/status error, correct the Runtime or canonical Inbox state, then restart to replay safely.";
+    hostState.updateStatus(agent, {
+      inboundDeliveryHealth: { state: "error", code, at, reason, nextAction },
+      runtimeReadiness: { runtime: agent.runtime, state: "incompatible", reason, nextAction },
+    });
+    hostState.recordStatusError(agent, `${reason} ${nextAction} code=${code}`);
+  };
   const agentStates = new Map<string, AgentStateRecord>();
   const saveAgentState = (record: AgentStateRecord): void => {
     try { record.store.writeJson("agentState", record.state); }
@@ -396,55 +409,71 @@ export function createHostShell({
     if (event.event_id && (seenEventIds.has(eventKey) || inFlightEventIds.has(eventKey))) return;
     if (agent.botOpenId && event.sender_id === agent.botOpenId) { log(`agent=${agent.name} 跳过自己发的消息`); return; }
     const telemetryMessageId = String(event.message_id || event.event_id || eventKey);
+    let canonicalInboxDurable = false;
     if (wake) telemetry?.beginMessage(agent.agentId, telemetryMessageId);
     if (event.event_id) inFlightEventIds.add(eventKey);
     try {
-      const receive = async (): Promise<Record<string, unknown>> => {
+      const receive = async (): Promise<Record<string, unknown> | null> => {
         const [names, signature] = await Promise.all([
           senderIdentity.ensureChatNames(agent, event.chat_id, 3_000),
           event._sender_is_bot ? Promise.resolve(null) : senderIdentity.ensureSenderSignature(agent, event.sender_id, 3_000),
         ]);
-        const envelope = envelopeProjector.projectInbound(agent, event, { anchorReply: wake, names, signature }) as unknown as Record<string, unknown>;
-        envelope.target = targetKeyOfInboxEnvelope({ ...envelope, chat_id: event.chat_id, thread_id: event.thread_id });
-        if (wake) envelope.wake = true;
-        const inboxEnvelope = projectInboxEnvelope(envelope, {
+        const projected = envelopeProjector.projectInbound(agent, event, { anchorReply: wake, names, signature }) as unknown as Record<string, unknown>;
+        projected.target = targetKeyOfInboxEnvelope({ ...projected, chat_id: event.chat_id, thread_id: event.thread_id });
+        if (wake) projected.wake = true;
+        const candidate = projectInboxEnvelope(projected, {
           chat_id: event.chat_id,
           thread_id: event.thread_id,
           ...(event.create_time !== undefined ? { create_time: String(event.create_time) } : {}),
           sender_id: event.sender_id,
-          content: String(envelope.content ?? event.content ?? ""),
+          content: String(projected.content ?? event.content ?? ""),
         });
-        try { stateStore(agent).appendNdjson("inbox", inboxEnvelope); }
+        let append: ReturnType<AgentStateStore["appendCanonicalInboxOnce"]>;
+        try { append = stateStore(agent).appendCanonicalInboxOnce(candidate); }
         catch (error) { throw new Error(`inbox 写失败: ${errorMessage(error)}`); }
-        // An event becomes permanently seen only after its canonical Inbox append
-        // is durable. Failures remain eligible for same-process redelivery.
+        canonicalInboxDurable = true;
+        // An event becomes permanently transport-seen only after the canonical
+        // append/dedupe decision is durable. Agent model-seen state is untouched.
         if (event.event_id) seenEventIds.add(eventKey);
-        hostState.appendConversation(agent, {
-          direction: "in", from: envelope.sender_name, senderType: envelope.sender_type,
-          target: targetFor(event).target, wake, text: event.content, messageId: envelope.message_id,
-          at: envelope.timestamp || new Date().toISOString(),
+        if (append.status === "duplicate_consumed") return null;
+        const inboxEnvelope = append.envelope;
+        if (append.status === "appended") hostState.appendConversation(agent, {
+          direction: "in", from: inboxEnvelope.sender_name, senderType: inboxEnvelope.sender_type,
+          target: String(inboxEnvelope.target || targetFor(event).target), wake, text: event.content, messageId: inboxEnvelope.message_id,
+          at: inboxEnvelope.timestamp || new Date().toISOString(),
         });
-        return envelope;
+        return inboxEnvelope as Record<string, unknown>;
       };
-      const envelope = wake && telemetry
+      const inboxEnvelope = wake && telemetry
         ? await telemetry.phase(telemetryMessageId, "feishu.receive", SpanKind.CONSUMER, receive)
         : await receive();
-      if (!wake) return;
-      const receipt = await runtimeHost.deliver(agent.agentId, envelope);
-      if (receipt.status === "accepted" || receipt.status === "duplicate" || receipt.status === "deferred") {
+      if (!wake || !inboxEnvelope) return;
+      const receipt = await runtimeHost.deliver(agent.agentId, inboxEnvelope);
+      if (receipt.status === "error") {
+        recordInboundDeliveryFailure(agent, "non_retryable_receipt");
         hostState.appendStatusLog(agent, "deliverLog", {
-          from: envelope.sender_name,
-          target: targetFor(event).target,
-          excerpt: safeConversationExcerpt(event.content, 180),
-          at: new Date().toISOString(),
-        }, 30);
-        if (envelope.sender_type === "human" || envelope.sender_type === "agent") processingEyes.add(agent, String(envelope.message_id || ""));
-        if (receipt.status === "deferred") log(`Runtime 暂缓投递，消息保留在 inbox seq=${envelope.seq}: ${receipt.reason}`);
+          at: new Date().toISOString(), status: "error",
+          reason: "non-retryable Runtime delivery error; durable recovery state retained",
+        }, 80);
+        return;
       }
+      hostState.appendStatusLog(agent, "deliverLog", {
+        from: inboxEnvelope.sender_name,
+        target: String(inboxEnvelope.target || targetFor(event).target),
+        excerpt: safeConversationExcerpt(event.content, 180),
+        at: new Date().toISOString(),
+      }, 30);
+      if (inboxEnvelope.sender_type === "human" || inboxEnvelope.sender_type === "agent") processingEyes.add(agent, String(inboxEnvelope.message_id || ""));
+      if (receipt.status === "deferred") log(`Runtime 暂缓投递，消息保留在 inbox seq=${inboxEnvelope.seq}: ${receipt.reason}`);
     } catch (error) {
       if (wake) telemetry?.delivery(agent.agentId, telemetryMessageId, "error");
-      log(`onFeishuMessage 异常 agent=${agent.name}: ${error instanceof Error ? error.stack || error.message : String(error)}`);
-      hostState.recordStatusError(agent, `onFeishuMessage: ${errorMessage(error)}`);
+      if (canonicalInboxDurable) {
+        log(`onFeishuMessage Runtime delivery failed agent=${agent.name}; canonical Inbox retained`);
+        recordInboundDeliveryFailure(agent, "runtime_delivery_exception");
+      } else {
+        log(`onFeishuMessage 异常 agent=${agent.name}: ${error instanceof Error ? error.stack || error.message : String(error)}`);
+        hostState.recordStatusError(agent, `onFeishuMessage: ${errorMessage(error)}`);
+      }
     } finally {
       if (event.event_id) inFlightEventIds.delete(eventKey);
     }
@@ -1212,9 +1241,13 @@ export function createHostShell({
       return;
     }
     if (message.type === "delivery") {
+      if (message.status === "error") recordInboundDeliveryFailure(agent, "runtime_delivery_event");
       hostState.appendStatusLog(agent, "deliverLog", {
         at: new Date().toISOString(), deliveryId: message.deliveryId, messageId: message.messageId,
-        status: message.status, ...(message.reason ? { reason: safeConversationExcerpt(message.reason, 120) } : {}),
+        status: message.status,
+        ...(message.status === "error"
+          ? { reason: "non-retryable Runtime delivery error; durable recovery state retained" }
+          : (message.reason ? { reason: safeConversationExcerpt(message.reason, 120) } : {})),
       }, 80);
       return;
     }
@@ -1236,7 +1269,8 @@ export function createHostShell({
         const readiness = providerAuthenticationFailureReadiness(agent.runtime as "codex" | "claude" | "pi", message.event.upstream?.provider);
         hostState.recordStatusError(agent, `auth: ${readiness.reason}; ${readiness.nextAction}`);
       } else {
-        hostState.recordStatusError(agent, `${message.event.errorCategory || "provider"}: ${message.event.message}${message.event.nextAction ? `; ${message.event.nextAction}` : ""}`);
+        const category = message.event.errorCategory || "provider";
+        hostState.recordStatusError(agent, `${category}: Runtime input failed ${message.event.retryable ? "retryably" : "non-retryably"}; inspect delivery health and Runtime/provider configuration`);
       }
     }
   };

--- a/src/runtime/runtime-host.ts
+++ b/src/runtime/runtime-host.ts
@@ -2,7 +2,8 @@ import crypto from "node:crypto";
 import fs from "node:fs";
 import path from "node:path";
 import { agentCliPromptCapabilities } from "../agent/agent-cli-capabilities.js";
-import { targetKeyOfInboxEnvelope } from "../agent/inbox-projection.js";
+import { isCanonicalInboxTarget, targetKeyOfInboxEnvelope } from "../agent/inbox-projection.js";
+import type { InboxDeliverySourceResolution } from "../agent/agent-state-store.js";
 import { SpanKind } from "@opentelemetry/api";
 import type { ContextPromptBuilder } from "../agent/context-prompt.js";
 import type {
@@ -30,6 +31,9 @@ export interface AgentRuntimeConfig {
 export type DeliveryStatus = "pending" | "submitting" | "accepted" | "consumed" | "error";
 export interface DeliveryRecord {
   deliveryId: string; messageId: string; status: DeliveryStatus; input: RuntimeInput; updatedAt: string;
+  /** Structured canonical target is authoritative; RuntimeInput.text is always rebuilt before submission. */
+  target?: string;
+  wakeReason?: string;
   reason?: string; retryable?: boolean;
 }
 interface DeliveryFile { version: 1; records: DeliveryRecord[] }
@@ -38,6 +42,7 @@ interface DeliveryStateStore {
   readNdjson?<T>(key: "inbox"): T[];
   writeJson(key: "runtimeDeliveries", value: unknown): void;
   withInboxTransaction<T>(operation: () => T): T;
+  resolveInboxDeliverySource?(messageId: string): InboxDeliverySourceResolution;
 }
 
 export type RuntimeHostEvent =
@@ -103,6 +108,21 @@ export interface StagedRuntimeCandidate {
 const MAX_DELIVERIES = 2048;
 const now = (): string => new Date().toISOString();
 const isActiveDelivery = (status: DeliveryStatus): boolean => ["pending", "submitting", "accepted"].includes(status);
+type ReplayFailureCode = "canonical_inbox_row_missing" | "canonical_inbox_malformed" | "duplicate_message_id" | "inbox_state_conflict" | "delivery_target_conflict" | "structured_target_missing";
+const REPLAY_FAILURE_CODES: ReadonlySet<string> = new Set<ReplayFailureCode>([
+  "canonical_inbox_row_missing", "canonical_inbox_malformed", "duplicate_message_id",
+  "inbox_state_conflict", "delivery_target_conflict", "structured_target_missing",
+]);
+
+function replayFailureReason(code: ReplayFailureCode): string {
+  return `Runtime delivery quarantined (${code}): no safe canonical Inbox target is available; the Inbox/ledger remain durable for operator recovery`;
+}
+
+function replayFailureCodeOf(record: DeliveryRecord): ReplayFailureCode | null {
+  if (record.status !== "error" || typeof record.reason !== "string") return null;
+  const code = /^Runtime delivery quarantined \(([^)]+)\):/.exec(record.reason)?.[1];
+  return code && REPLAY_FAILURE_CODES.has(code) ? code as ReplayFailureCode : null;
+}
 
 function deliveryFile(agent: ManagedAgent): string | null {
   return agent.config.stateDir ? path.join(agent.config.stateDir, "runtime-deliveries.json") : null;
@@ -228,6 +248,66 @@ export function createRuntimeHost(options: {
     agent.byMessage.set(record.messageId, record.deliveryId);
     emitConsumed(agent, persist(agent));
     return agent.records.get(record.deliveryId) ?? record;
+  };
+
+  type RecordInputPreparation =
+    | { status: "ready"; target: string }
+    | { status: "consumed" }
+    | { status: "error"; code: ReplayFailureCode; reason: string };
+
+  const scrubQuarantinedInput = (record: DeliveryRecord, reason: string): void => {
+    const staleInput = record.input && typeof record.input === "object" ? record.input : null;
+    record.input = {
+      inputId: typeof staleInput?.inputId === "string" && staleInput.inputId ? staleInput.inputId : record.deliveryId,
+      deliveryId: record.deliveryId,
+      kind: "wake",
+      text: reason,
+      attempt: Number.isSafeInteger(staleInput?.attempt) && Number(staleInput?.attempt) >= 0 ? Number(staleInput!.attempt) : 0,
+    };
+  };
+
+  /** Rebuild every submitted notice from canonical structured state, never persisted text. */
+  const prepareRecordInput = (agent: ManagedAgent, record: DeliveryRecord, busy: boolean): RecordInputPreparation => {
+    let target = typeof record.target === "string" && isCanonicalInboxTarget(record.target) ? record.target : null;
+    if (agent.stateStore?.resolveInboxDeliverySource) {
+      let source: InboxDeliverySourceResolution;
+      try { source = agent.stateStore.resolveInboxDeliverySource(record.messageId); }
+      catch { source = { status: "invalid", code: "canonical_inbox_malformed" }; }
+      if (source.status === "consumed") return { status: "consumed" };
+      if (source.status === "missing" || source.status === "invalid") {
+        return { status: "error", code: source.code, reason: replayFailureReason(source.code) };
+      }
+      if (target && target !== source.target) {
+        return { status: "error", code: "delivery_target_conflict", reason: replayFailureReason("delivery_target_conflict") };
+      }
+      target = source.target;
+    }
+    if (!target) return { status: "error", code: "structured_target_missing", reason: replayFailureReason("structured_target_missing") };
+    const staleInput = record.input && typeof record.input === "object" ? record.input : null;
+    const attempt = Number.isSafeInteger(staleInput?.attempt) && Number(staleInput?.attempt) >= 0 ? Number(staleInput!.attempt) : 0;
+    const inputId = typeof staleInput?.inputId === "string" && staleInput.inputId ? staleInput.inputId : record.deliveryId;
+    record.target = target;
+    record.input = {
+      inputId,
+      deliveryId: record.deliveryId,
+      kind: busy ? "inbox_update" : "wake",
+      text: options.promptBuilder.buildInboxNotice({ busy, count: 1, deliveryId: record.deliveryId, target,
+        ...(record.wakeReason ? { wakeReason: record.wakeReason } : {}) }),
+      attempt,
+    };
+    return { status: "ready", target };
+  };
+
+  const quarantineRecord = (agent: ManagedAgent, record: DeliveryRecord, code: ReplayFailureCode): DeliveryReceipt => {
+    const reason = replayFailureReason(code);
+    scrubQuarantinedInput(record, reason);
+    record.reason = reason;
+    record.retryable = false;
+    const finalRecord = setRecord(agent, record, "error");
+    if (finalRecord.status === "consumed") return { status: "accepted", deliveryId: record.deliveryId };
+    emit({ type: "delivery", agentId: agent.config.agentId, deliveryId: record.deliveryId,
+      messageId: record.messageId, status: "error", reason });
+    return { status: "error", deliveryId: record.deliveryId, reason, retryable: false };
   };
 
   const reconcileExternalConsumption = (agent: ManagedAgent): void => {
@@ -375,6 +455,18 @@ export function createRuntimeHost(options: {
     agent.submitting = true;
     if (!busy) agent.busy = true; // Reserve the turn before prompt() can yield.
     try {
+      const prepared = prepareRecordInput(agent, record, busy);
+      if (prepared.status === "consumed") {
+        if (!busy) agent.busy = false;
+        const consumedRecord = setRecord(agent, record, "consumed");
+        emit({ type: "delivery", agentId: agent.config.agentId, deliveryId: consumedRecord.deliveryId,
+          messageId: consumedRecord.messageId, status: "consumed" });
+        return { status: "accepted", deliveryId: record.deliveryId };
+      }
+      if (prepared.status === "error") {
+        if (!busy) agent.busy = false;
+        return quarantineRecord(agent, record, prepared.code);
+      }
       const session = await ensureSession(agent);
       const submittingRecord = setRecord(agent, record, "submitting");
       if (submittingRecord.status === "consumed") {
@@ -798,7 +890,10 @@ export function createRuntimeHost(options: {
           ? stateStore.withInboxTransaction(() => {
             const deliveryFile = stateStore.readJson<DeliveryFile>("runtimeDeliveries", { version: 1, records: [] });
             if (!stateStore.readNdjson) return deliveryFile;
-            const inboxIds = new Set(stateStore.readNdjson<Record<string, unknown>>("inbox").flatMap((row) =>
+            let inboxRows: Record<string, unknown>[];
+            try { inboxRows = stateStore.readNdjson<Record<string, unknown>>("inbox"); }
+            catch { return deliveryFile; }
+            const inboxIds = new Set(inboxRows.flatMap((row) =>
               typeof row?.message_id === "string" ? [row.message_id] : []));
             let changed = false;
             const records = deliveryFile.records.map((record) => {
@@ -820,8 +915,32 @@ export function createRuntimeHost(options: {
           stabilityTimer: null, recreateReason: null, stopped: false, disabledReason: null,
           configurationRecovery: null, stateStore, readiness: null,
           turnInProgress: false, turnHadFailure: false, turnHadAuthenticatedOutput: false, authFailureActive: false };
-        for (const record of agent.records.values()) if (isActiveDelivery(record.status)) record.status = "pending";
-        emitConsumed(agent, persist(agent)); managed.set(config.agentId, agent);
+        const startupConsumed: DeliveryRecord[] = [];
+        const startupQuarantined: Array<{ record: DeliveryRecord; code: ReplayFailureCode }> = [];
+        for (const record of agent.records.values()) {
+          const existingQuarantine = replayFailureCodeOf(record);
+          if (existingQuarantine) {
+            startupQuarantined.push({ record, code: existingQuarantine });
+            continue;
+          }
+          if (!isActiveDelivery(record.status)) continue;
+          record.status = "pending";
+          const prepared = prepareRecordInput(agent, record, false);
+          if (prepared.status === "consumed") {
+            record.status = "consumed";
+            record.updatedAt = now();
+            startupConsumed.push(record);
+          } else if (prepared.status === "error") {
+            record.status = "error";
+            record.updatedAt = now();
+            scrubQuarantinedInput(record, prepared.reason);
+            record.reason = prepared.reason;
+            record.retryable = false;
+            startupQuarantined.push({ record, code: prepared.code });
+          }
+        }
+        managed.set(config.agentId, agent);
+        emitConsumed(agent, [...startupConsumed, ...persist(agent)]);
         try {
           await ensureSession(agent);
           activeCount += 1;
@@ -835,6 +954,11 @@ export function createRuntimeHost(options: {
           emit({ type: "agent-status", agentId: config.agentId, status: "error", error: reason,
             ...(error instanceof RuntimePrerequisiteError ? { readiness: error.readiness } : {}) });
         }
+        const visibleQuarantines = startupQuarantined.filter(({ record }) => agent.records.get(record.deliveryId)?.status === "error");
+        for (const { record, code } of visibleQuarantines) emit({ type: "delivery", agentId: config.agentId,
+          deliveryId: record.deliveryId, messageId: record.messageId, status: "error", reason: replayFailureReason(code) });
+        if (visibleQuarantines.length) emit({ type: "agent-status", agentId: config.agentId, status: "error",
+          error: `${visibleQuarantines.length} Runtime delivery record(s) quarantined; canonical Inbox recovery is required` });
         agent.poller = setInterval(() => reconcileExternalConsumption(agent), 250); agent.poller.unref?.();
       });
       await Promise.all(startups);
@@ -861,7 +985,13 @@ export function createRuntimeHost(options: {
       if (existingId) {
         const existing = agent.records.get(existingId);
         if (existing?.status === "error") {
-          existing.input.attempt += 1;
+          if (existing.target && existing.target !== target) return quarantineRecord(agent, existing, "delivery_target_conflict");
+          existing.target = target;
+          if (typeof envelope.wake_reason === "string") existing.wakeReason = envelope.wake_reason;
+          const priorAttempt = existing.input && Number.isSafeInteger(existing.input.attempt) ? existing.input.attempt : 0;
+          existing.input = existing.input && typeof existing.input === "object"
+            ? { ...existing.input, attempt: priorAttempt + 1 }
+            : { inputId: existing.deliveryId, deliveryId: existing.deliveryId, kind: "wake", text: "", attempt: priorAttempt + 1 };
           delete existing.reason;
           delete existing.retryable;
           setRecord(agent, existing, "pending");
@@ -882,10 +1012,12 @@ export function createRuntimeHost(options: {
       }
       const deliveryId = crypto.randomUUID();
       const busy = agent.busy || agent.submitting;
+      const wakeReason = typeof envelope.wake_reason === "string" ? envelope.wake_reason : undefined;
       const input: RuntimeInput = { inputId: deliveryId, deliveryId, kind: busy ? "inbox_update" : "wake",
         text: options.promptBuilder.buildInboxNotice({ busy, count: 1, deliveryId, target,
-          ...(typeof envelope.wake_reason === "string" ? { wakeReason: envelope.wake_reason } : {}) }), attempt: 0 };
-      const record: DeliveryRecord = { deliveryId, messageId, status: "pending", input, updatedAt: now() };
+          ...(wakeReason ? { wakeReason } : {}) }), attempt: 0 };
+      const record: DeliveryRecord = { deliveryId, messageId, status: "pending", input, target,
+        ...(wakeReason ? { wakeReason } : {}), updatedAt: now() };
       agent.records.set(deliveryId, record); agent.byMessage.set(messageId, deliveryId); persist(agent);
       if (agent.disabledReason) {
         reconcileAbsentCanonical(agent, record);

--- a/src/runtime/runtime-host.ts
+++ b/src/runtime/runtime-host.ts
@@ -108,10 +108,13 @@ export interface StagedRuntimeCandidate {
 const MAX_DELIVERIES = 2048;
 const now = (): string => new Date().toISOString();
 const isActiveDelivery = (status: DeliveryStatus): boolean => ["pending", "submitting", "accepted"].includes(status);
-type ReplayFailureCode = "canonical_inbox_row_missing" | "canonical_inbox_malformed" | "duplicate_message_id" | "inbox_state_conflict" | "delivery_target_conflict" | "structured_target_missing";
+type ReplayFailureCode = "canonical_inbox_row_missing" | "canonical_inbox_malformed" | "duplicate_message_id"
+  | "inbox_state_conflict" | "delivery_target_conflict" | "structured_target_invalid"
+  | "structured_target_missing" | "wake_reason_conflict";
 const REPLAY_FAILURE_CODES: ReadonlySet<string> = new Set<ReplayFailureCode>([
   "canonical_inbox_row_missing", "canonical_inbox_malformed", "duplicate_message_id",
-  "inbox_state_conflict", "delivery_target_conflict", "structured_target_missing",
+  "inbox_state_conflict", "delivery_target_conflict", "structured_target_invalid",
+  "structured_target_missing", "wake_reason_conflict",
 ]);
 
 function replayFailureReason(code: ReplayFailureCode): string {
@@ -268,7 +271,14 @@ export function createRuntimeHost(options: {
 
   /** Rebuild every submitted notice from canonical structured state, never persisted text. */
   const prepareRecordInput = (agent: ManagedAgent, record: DeliveryRecord, busy: boolean): RecordInputPreparation => {
-    let target = typeof record.target === "string" && isCanonicalInboxTarget(record.target) ? record.target : null;
+    if (record.target !== undefined && (typeof record.target !== "string" || !isCanonicalInboxTarget(record.target))) {
+      return { status: "error", code: "structured_target_invalid", reason: replayFailureReason("structured_target_invalid") };
+    }
+    if (record.wakeReason !== undefined && typeof record.wakeReason !== "string") {
+      return { status: "error", code: "wake_reason_conflict", reason: replayFailureReason("wake_reason_conflict") };
+    }
+    let target = typeof record.target === "string" ? record.target : null;
+    let wakeReason = typeof record.wakeReason === "string" ? record.wakeReason : undefined;
     if (agent.stateStore?.resolveInboxDeliverySource) {
       let source: InboxDeliverySourceResolution;
       try { source = agent.stateStore.resolveInboxDeliverySource(record.messageId); }
@@ -280,19 +290,26 @@ export function createRuntimeHost(options: {
       if (target && target !== source.target) {
         return { status: "error", code: "delivery_target_conflict", reason: replayFailureReason("delivery_target_conflict") };
       }
+      const canonicalWakeReason = typeof source.envelope.wake_reason === "string" ? source.envelope.wake_reason : undefined;
+      if (record.wakeReason !== undefined && wakeReason !== canonicalWakeReason) {
+        return { status: "error", code: "wake_reason_conflict", reason: replayFailureReason("wake_reason_conflict") };
+      }
       target = source.target;
+      wakeReason = canonicalWakeReason;
     }
     if (!target) return { status: "error", code: "structured_target_missing", reason: replayFailureReason("structured_target_missing") };
     const staleInput = record.input && typeof record.input === "object" ? record.input : null;
     const attempt = Number.isSafeInteger(staleInput?.attempt) && Number(staleInput?.attempt) >= 0 ? Number(staleInput!.attempt) : 0;
     const inputId = typeof staleInput?.inputId === "string" && staleInput.inputId ? staleInput.inputId : record.deliveryId;
     record.target = target;
+    if (wakeReason) record.wakeReason = wakeReason;
+    else delete record.wakeReason;
     record.input = {
       inputId,
       deliveryId: record.deliveryId,
       kind: busy ? "inbox_update" : "wake",
       text: options.promptBuilder.buildInboxNotice({ busy, count: 1, deliveryId: record.deliveryId, target,
-        ...(record.wakeReason ? { wakeReason: record.wakeReason } : {}) }),
+        ...(wakeReason ? { wakeReason } : {}) }),
       attempt,
     };
     return { status: "ready", target };
@@ -987,7 +1004,8 @@ export function createRuntimeHost(options: {
         if (existing?.status === "error") {
           if (existing.target && existing.target !== target) return quarantineRecord(agent, existing, "delivery_target_conflict");
           existing.target = target;
-          if (typeof envelope.wake_reason === "string") existing.wakeReason = envelope.wake_reason;
+          if (typeof envelope.wake_reason === "string" && envelope.wake_reason) existing.wakeReason = envelope.wake_reason;
+          else delete existing.wakeReason;
           const priorAttempt = existing.input && Number.isSafeInteger(existing.input.attempt) ? existing.input.attempt : 0;
           existing.input = existing.input && typeof existing.input === "object"
             ? { ...existing.input, attempt: priorAttempt + 1 }

--- a/test/e2e/issue124-thread-runtime-envelope-e2e.test.mjs
+++ b/test/e2e/issue124-thread-runtime-envelope-e2e.test.mjs
@@ -1,0 +1,230 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { test } from "bun:test";
+import { createAgentStateStore } from "../../dist/agent/agent-state-store.mjs";
+import { runAgentCli } from "../../dist/app/agent-cli.mjs";
+import { runLarkCli } from "../../dist/app/lark-cli.mjs";
+import { ContextPromptBuilder } from "../../dist/agent/context-prompt.mjs";
+import { createHostShell } from "../../dist/feishu/host-shell.mjs";
+import { createRuntimeHost } from "../../dist/runtime/runtime-host.mjs";
+
+const testManagedCli = () => ({ command: { command: "/test/official-lark-cli", argsPrefix: [], version: "1.0.80" }, env: {} });
+
+class FakeRuntimeSession {
+  sessionId = "issue124-runtime-session";
+  listeners = new Set();
+  prompts = [];
+  steers = [];
+  subscribe(listener) { this.listeners.add(listener); return () => this.listeners.delete(listener); }
+  emit(event) { for (const listener of this.listeners) listener(event); }
+  async prompt(input) { this.prompts.push(structuredClone(input)); return { status: "accepted", inputId: input.inputId }; }
+  async busyInput(input) { this.steers.push(structuredClone(input)); return { status: "accepted", inputId: input.inputId }; }
+  async cancel() {}
+  async close() {}
+}
+
+function fixture() {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "larkin-issue124-boundary-"));
+  const agentId = "cli_issue124BoundaryA1";
+  const store = createAgentStateStore(root, agentId);
+  const agent = {
+    agentId, name: agentId, runtime: "codex", model: "fixture", feishuAppId: agentId, feishuProfile: agentId,
+    larkConfigDir: path.join(store.paths.root, "lark-cli-config"), workspaceDir: path.join(root, "agents", agentId), stateDir: store.paths.root,
+  };
+  fs.writeFileSync(path.join(root, "config.json"), `${JSON.stringify({
+    version: 4, serverId: "server-issue124-boundary", mentionPolicy: "require", activeAgent: agentId,
+    agents: { [agentId]: { runtime: "codex", model: "fixture" } },
+  })}\n`, { mode: 0o600 });
+  const session = new FakeRuntimeSession();
+  const runtimeEvents = [];
+  const runtimeHost = createRuntimeHost({
+    adapterFor: () => ({ id: "codex", capabilities: {}, async createSession() { return session; } }),
+    promptBuilder: new ContextPromptBuilder(), stateStoreFor: () => store, assertOfficialCliReady: () => {},
+  });
+  runtimeHost.subscribe((event) => runtimeEvents.push(event));
+  const persistedObjects = [];
+  const deliveredObjects = [];
+  const append = store.appendCanonicalInboxOnce.bind(store);
+  store.appendCanonicalInboxOnce = (value) => {
+    const result = append(value);
+    if (result.envelope) persistedObjects.push(result.envelope);
+    return result;
+  };
+  const deliver = runtimeHost.deliver.bind(runtimeHost);
+  runtimeHost.deliver = (id, envelope) => {
+    deliveredObjects.push(envelope);
+    return deliver(id, envelope);
+  };
+  const host = createHostShell({
+    env: {
+      LARKIN_HOME: root, LARKIN_CONFIG_DIR: root, LARKIN_SERVER_ID: "server-issue124-boundary",
+      LARKIN_AGENTS_CONFIG: JSON.stringify([agent]), LARKIN_FEISHU_DRYRUN: "1",
+      LARKIN_FEISHU_EVENT_FILE: path.join(root, "events.ndjson"), LARKIN_INBOUND_DROUGHT_SEC: "0",
+    },
+    runtimeHost, stateStoreForImpl: () => store, managedCliForAgent: testManagedCli,
+    eventSourceStartDelayMs: 60_000,
+    execFileImpl(_command, args, _options, callback) {
+      const data = args.includes("bots") ? { items: [] } : { items: [{ member_id: "ou_issue124_sender", name: "Sender" }] };
+      callback(null, JSON.stringify({ ok: true, data }), "");
+      return {};
+    },
+    logImpl() {},
+  });
+  return { root, agentId, store, session, runtimeHost, runtimeEvents, host, persistedObjects, deliveredObjects };
+}
+
+function inbound({ chatId, messageId, eventId, threadId, content, createTime }) {
+  return {
+    chat_id: chatId, chat_type: "group", sender_id: "ou_issue124_sender", message_id: messageId,
+    event_id: eventId, content, create_time: createTime, thread_id: threadId,
+    _mentioned_bot: true, _mention_all: false, _sender_is_bot: true,
+  };
+}
+
+async function pollNative(root, agentId, store, target) {
+  let stdout = "", stderr = "";
+  const code = await runAgentCli(["inbox", "poll", "--target", target, "--limit", "1"], {
+    LARKIN_CONFIG_DIR: root, LARKIN_AGENT_ID: agentId,
+  }, { stateStore: store, io: { stdout: (text) => { stdout += text; }, stderr: (text) => { stderr += text; } } });
+  assert.equal(code, 0, stderr);
+  return JSON.parse(stdout);
+}
+
+function nativeReply(root, agentId, store, source, replyInThread) {
+  const providerCalls = [];
+  let stdout = "", stderr = "";
+  const argv = ["im", "+messages-reply", "--message-id", source.message_id, "--text", `reply-${source.message_id}`,
+    ...(replyInThread ? ["--reply-in-thread"] : []), "--json"];
+  const code = runLarkCli(argv, { LARKIN_CONFIG_DIR: root, LARKIN_AGENT_ID: agentId }, {
+    stateStore: store,
+    nativeCommand: { command: "/fixture/@larksuite/cli/scripts/run.js", argsPrefix: [], version: "1.0.80" },
+    spawn(command, args, options) {
+      if (args[0] === "api" && args[1] === "GET") return {
+        status: 0, stdout: JSON.stringify({ ok: true, identity: "bot", data: { messages: [source] } }), stderr: "", error: undefined,
+      };
+      providerCalls.push({ command, args, options });
+      return { status: 0, stdout: JSON.stringify({ ok: true, identity: "bot", data: {
+        message_id: `om_reply_${source.message_id}`, chat_id: source.chat_id,
+      } }), stderr: "", error: undefined };
+    },
+    io: { stdout: (text) => { stdout += text; }, stderr: (text) => { stderr += text; } },
+  });
+  assert.equal(code, 0, stderr);
+  assert.equal(providerCalls.length, 1);
+  return { argv, provider: providerCalls[0], output: JSON.parse(stdout) };
+}
+
+test("issue #124 production boundary keeps one canonical envelope through thread/chat poll and reply payloads", { timeout: 20_000 }, async () => {
+  const fx = fixture();
+  const chatId = "oc_issue124_exact";
+  const threadId = "omt_issue124_exact";
+  const threadTarget = `thread:${chatId}:${threadId}`;
+  const chatTarget = `chat:${chatId}`;
+  const threadEvent = inbound({ chatId, threadId, messageId: "om_issue124_thread_anchor", eventId: "evt_issue124_thread",
+    content: "thread request", createTime: "1786819560000" });
+  const chatEvent = inbound({ chatId, threadId: null, messageId: "om_issue124_chat_anchor", eventId: "evt_issue124_chat",
+    content: "chat request", createTime: "1786819561000" });
+  try {
+    await fx.host.start();
+    await fx.host.ingest(fx.agentId, threadEvent);
+    assert.equal(fx.persistedObjects.length, 1);
+    assert.equal(fx.deliveredObjects.length, 1);
+    assert.equal(fx.deliveredObjects[0], fx.persistedObjects[0], "HostShell must deliver the exact object returned by canonical persistence");
+    const threadDisk = fx.store.readNdjson("inbox")[0];
+    assert.deepEqual(threadDisk, fx.deliveredObjects[0]);
+    assert.deepEqual({ target: threadDisk.target, chat_id: threadDisk.chat_id, thread_id: threadDisk.thread_id }, {
+      target: threadTarget, chat_id: chatId, thread_id: threadId,
+    });
+    assert.equal(fx.session.prompts.length, 1);
+    assert.match(fx.session.prompts[0].text, new RegExp(`Inbox changed for ${threadTarget}`));
+    assert.equal(fx.runtimeEvents.some((event) => event.type === "delivery" && /invalid-target|target derivation failed/i.test(event.reason || "")), false);
+
+    const threadPoll = await pollNative(fx.root, fx.agentId, fx.store, threadTarget);
+    assert.equal(threadPoll.delivery, "direct_ack");
+    assert.equal(threadPoll.at_most_once, true);
+    assert.deepEqual(threadPoll.events.map((row) => row.message_id), [threadEvent.message_id]);
+    assert.equal(threadPoll.reply_target, threadTarget);
+    const threadReply = nativeReply(fx.root, fx.agentId, fx.store, {
+      message_id: threadEvent.message_id, chat_id: chatId, thread_id: threadId,
+      create_time: threadEvent.create_time, content: threadEvent.content,
+    }, true);
+    assert.ok(threadReply.provider.args.includes("--message-id"));
+    assert.equal(threadReply.provider.args[threadReply.provider.args.indexOf("--message-id") + 1], threadEvent.message_id);
+    assert.ok(threadReply.provider.args.includes("--reply-in-thread"));
+
+    fx.session.emit({ type: "turn-start", turnId: "issue124-thread-turn" });
+    fx.session.emit({ type: "turn-end", turnId: "issue124-thread-turn" });
+    await new Promise((resolve) => setImmediate(resolve));
+    assert.equal(fx.session.prompts.length, 1, "consumed thread delivery must not retry at turn end");
+    let records = fx.store.readJson("runtimeDeliveries", { records: [] }).records;
+    assert.equal(records.filter((record) => record.messageId === threadEvent.message_id).length, 1);
+    assert.equal(records.find((record) => record.messageId === threadEvent.message_id).status, "consumed");
+
+    await fx.host.ingest(fx.agentId, threadEvent);
+    assert.equal(fx.persistedObjects.length, 1, "duplicate event_id must not append a second canonical row");
+    assert.equal(fx.deliveredObjects.length, 1, "duplicate event_id must not redeliver");
+
+    await fx.host.ingest(fx.agentId, chatEvent);
+    assert.equal(fx.deliveredObjects[1], fx.persistedObjects[1]);
+    const chatDisk = fx.store.readNdjson("inbox")[0];
+    assert.deepEqual(chatDisk, fx.deliveredObjects[1]);
+    assert.deepEqual({ target: chatDisk.target, chat_id: chatDisk.chat_id, thread_id: chatDisk.thread_id }, {
+      target: chatTarget, chat_id: chatId, thread_id: null,
+    });
+    assert.equal(fx.session.prompts.length, 2);
+    assert.match(fx.session.prompts[1].text, new RegExp(`Inbox changed for ${chatTarget}`));
+
+    const chatPoll = await pollNative(fx.root, fx.agentId, fx.store, chatTarget);
+    assert.deepEqual(chatPoll.events.map((row) => row.message_id), [chatEvent.message_id]);
+    assert.equal(chatPoll.reply_target, chatTarget);
+    const chatReply = nativeReply(fx.root, fx.agentId, fx.store, {
+      message_id: chatEvent.message_id, chat_id: chatId, thread_id: null,
+      create_time: chatEvent.create_time, content: chatEvent.content,
+    }, false);
+    assert.equal(chatReply.provider.args.includes("--reply-in-thread"), false, "chat-level opposite case must not invent a thread reply");
+    assert.equal(chatReply.provider.args[chatReply.provider.args.indexOf("--message-id") + 1], chatEvent.message_id);
+
+    fx.session.emit({ type: "turn-start", turnId: "issue124-chat-turn" });
+    fx.session.emit({ type: "turn-end", turnId: "issue124-chat-turn" });
+    await new Promise((resolve) => setImmediate(resolve));
+    assert.equal(fx.session.prompts.length, 2);
+    records = fx.store.readJson("runtimeDeliveries", { records: [] }).records;
+    assert.equal(records.length, 2);
+    assert.equal(records.every((record) => record.status === "consumed"), true);
+    assert.equal(fx.runtimeEvents.filter((event) => event.type === "delivery" && event.status === "consumed").length, 2);
+  } finally {
+    await fx.host.shutdown("issue124 boundary complete");
+    fs.rmSync(fx.root, { recursive: true, force: true });
+  }
+});
+
+test("issue #124 poll racing between HostShell persistence and Runtime delivery closes ownership without a stale turn", { timeout: 10_000 }, async () => {
+  const fx = fixture();
+  const chatId = "oc_issue124_race";
+  const target = `thread:${chatId}:omt_issue124_race`;
+  const event = inbound({ chatId, threadId: "omt_issue124_race", messageId: "om_issue124_race", eventId: "evt_issue124_race",
+    content: "race", createTime: "1786819562000" });
+  const productionDeliver = fx.runtimeHost.deliver.bind(fx.runtimeHost);
+  let poll;
+  fx.runtimeHost.deliver = async (agentId, envelope) => {
+    poll = await pollNative(fx.root, fx.agentId, fx.store, target);
+    return productionDeliver(agentId, envelope);
+  };
+  try {
+    await fx.host.start();
+    await fx.host.ingest(fx.agentId, event);
+    assert.deepEqual(poll.events.map((row) => row.message_id), [event.message_id]);
+    assert.deepEqual(poll.consumed_delivery_ids, [], "the poll can win before Runtime ledger creation");
+    assert.equal(fx.session.prompts.length, 0, "post-poll delivery must reconcile consumed canonical state before prompt");
+    assert.deepEqual(fx.store.readNdjson("inbox"), []);
+    const records = fx.store.readJson("runtimeDeliveries", { records: [] }).records;
+    assert.equal(records.length, 1);
+    assert.equal(records[0].status, "consumed");
+    assert.equal(fx.runtimeEvents.filter((runtimeEvent) => runtimeEvent.type === "delivery" && runtimeEvent.status === "consumed").length, 1);
+  } finally {
+    await fx.host.shutdown("issue124 poll race complete");
+    fs.rmSync(fx.root, { recursive: true, force: true });
+  }
+});

--- a/test/e2e/issue124-thread-runtime-envelope-e2e.test.mjs
+++ b/test/e2e/issue124-thread-runtime-envelope-e2e.test.mjs
@@ -28,7 +28,9 @@ class FakeRuntimeSession {
 function fixture() {
   const root = fs.mkdtempSync(path.join(os.tmpdir(), "larkin-issue124-boundary-"));
   const agentId = "cli_issue124BoundaryA1";
-  const store = createAgentStateStore(root, agentId);
+  const store = createAgentStateStore(root, agentId, {
+    inspectProcess: (pid) => ({ ok: true, dead: false, startToken: `issue124-e2e-${pid}` }),
+  });
   const agent = {
     agentId, name: agentId, runtime: "codex", model: "fixture", feishuAppId: agentId, feishuProfile: agentId,
     larkConfigDir: path.join(store.paths.root, "lark-cli-config"), workspaceDir: path.join(root, "agents", agentId), stateDir: store.paths.root,

--- a/test/fixtures/runtime-upgrade/v0.2.79-active-thread.json
+++ b/test/fixtures/runtime-upgrade/v0.2.79-active-thread.json
@@ -1,0 +1,63 @@
+{
+  "fixture_version": 1,
+  "provenance": {
+    "release_tag": "v0.2.79",
+    "source_commit": "7d08182d3e6f0b4a0bbfe3dce34834f14af14abb",
+    "captured_at": "2026-08-15T19:47:31.667Z",
+    "capture_method": "Built the exact tagged source and invoked its exported createAgentStateStore/createRuntimeHost APIs with a canonical thread Inbox row plus a targetless Runtime deliver call.",
+    "claim_boundary": "Source-tag API capture with volatile UUID/time retained; not a customer home, npm install, standalone binary capture, or full historical environment checkout."
+  },
+  "agent_id": "cli_upgrade0279A1",
+  "files": {
+    "feishu-inbox.ndjson": [
+      {
+        "message_id": "om_upgrade_0279",
+        "chat_id": "oc_issue124_upgrade",
+        "thread_id": "omt_issue124_upgrade",
+        "channel_type": "thread",
+        "channel_name": "issue124upgrade",
+        "parent_channel_type": "channel",
+        "parent_channel_name": "cissue124upgrade",
+        "content": "captured upgrade fixture body",
+        "envelope_version": 2,
+        "target": "thread:oc_issue124_upgrade:omt_issue124_upgrade",
+        "target_seq": 1
+      }
+    ],
+    "inbox-state.json": {
+      "version": 2,
+      "targets": {
+        "thread:oc_issue124_upgrade:omt_issue124_upgrade": {
+          "latest_received_seq": 1,
+          "model_seen_seq": 0
+        }
+      },
+      "messages": {
+        "om_upgrade_0279": {
+          "target": "thread:oc_issue124_upgrade:omt_issue124_upgrade",
+          "seq": 1
+        }
+      },
+      "drafts": {},
+      "intents": {}
+    },
+    "runtime-deliveries.json": {
+      "version": 1,
+      "records": [
+        {
+          "deliveryId": "f24f5cb8-7c7c-407c-ac14-a92f1a0638f4",
+          "messageId": "om_upgrade_0279",
+          "status": "accepted",
+          "input": {
+            "inputId": "f24f5cb8-7c7c-407c-ac14-a92f1a0638f4",
+            "deliveryId": "f24f5cb8-7c7c-407c-ac14-a92f1a0638f4",
+            "kind": "wake",
+            "text": "The Larkin Inbox changed (1 pending message). Poll that target at the next safe boundary before any target-local side effect.",
+            "attempt": 0
+          },
+          "updatedAt": "2026-08-15T19:47:31.667Z"
+        }
+      ]
+    }
+  }
+}

--- a/test/fixtures/runtime-upgrade/v0.3.3-active-thread.json
+++ b/test/fixtures/runtime-upgrade/v0.3.3-active-thread.json
@@ -1,0 +1,63 @@
+{
+  "fixture_version": 1,
+  "provenance": {
+    "release_tag": "v0.3.3",
+    "source_commit": "107992631980480ab9cfcf2ecf91e0d0f0ac0e02",
+    "captured_at": "2026-08-15T19:47:31.667Z",
+    "capture_method": "Built the exact tagged source and invoked its exported createAgentStateStore/createRuntimeHost APIs with a canonical thread Inbox row plus a targetless Runtime deliver call.",
+    "claim_boundary": "Source-tag API capture with volatile UUID/time retained; not a customer home, npm install, standalone binary capture, or full historical environment checkout."
+  },
+  "agent_id": "cli_upgrade033A1",
+  "files": {
+    "feishu-inbox.ndjson": [
+      {
+        "message_id": "om_upgrade_033",
+        "chat_id": "oc_issue124_upgrade",
+        "thread_id": "omt_issue124_upgrade",
+        "channel_type": "thread",
+        "channel_name": "issue124upgrade",
+        "parent_channel_type": "channel",
+        "parent_channel_name": "cissue124upgrade",
+        "content": "captured upgrade fixture body",
+        "envelope_version": 2,
+        "target": "thread:oc_issue124_upgrade:omt_issue124_upgrade",
+        "target_seq": 1
+      }
+    ],
+    "inbox-state.json": {
+      "version": 2,
+      "targets": {
+        "thread:oc_issue124_upgrade:omt_issue124_upgrade": {
+          "latest_received_seq": 1,
+          "model_seen_seq": 0
+        }
+      },
+      "messages": {
+        "om_upgrade_033": {
+          "target": "thread:oc_issue124_upgrade:omt_issue124_upgrade",
+          "seq": 1
+        }
+      },
+      "drafts": {},
+      "intents": {}
+    },
+    "runtime-deliveries.json": {
+      "version": 1,
+      "records": [
+        {
+          "deliveryId": "6e157f81-569c-4127-8bfd-4932376896dc",
+          "messageId": "om_upgrade_033",
+          "status": "accepted",
+          "input": {
+            "inputId": "6e157f81-569c-4127-8bfd-4932376896dc",
+            "deliveryId": "6e157f81-569c-4127-8bfd-4932376896dc",
+            "kind": "wake",
+            "text": "The Larkin Inbox changed (1 pending message). Poll that target at the next safe boundary before any target-local side effect.",
+            "attempt": 0
+          },
+          "updatedAt": "2026-08-15T19:47:31.667Z"
+        }
+      ]
+    }
+  }
+}

--- a/test/integration/build/release-platform-ci.test.mjs
+++ b/test/integration/build/release-platform-ci.test.mjs
@@ -13,6 +13,7 @@ const GITLEAKS_BASELINE = [
 test("PR and main CI retain Linux source checks and add a blocking native Windows x64 gate", () => {
   const workflow = read(".github/workflows/release-platform-smoke.yml");
   const windowsJob = workflow.slice(workflow.indexOf("  windows-native:"));
+  const releaseSmoke = read("scripts/release/smoke.ts");
   assert.equal(read(".gitleaksignore"), `${GITLEAKS_BASELINE.join("\n")}\n`, "only the two verified synthetic history fingerprints may be ignored");
   assert.equal(fs.existsSync(path.join(ROOT, "THIRD_PARTY_NOTICES.md")), false, "complete lock-graph notices must not be tracked at the repository root");
   assert.match(workflow, /pull_request:/);
@@ -46,11 +47,14 @@ test("PR and main CI retain Linux source checks and add a blocking native Window
   const expectedWindowsTestInputs = [
     "test/unit/agent/host-reminder-orchestrator.test.mjs",
     "test/unit/feishu/host-business-state.test.mjs",
+    "test/unit/feishu/host-runtime-delivery-health.test.mjs",
     "test/unit/platform/release-artifacts.test.mjs",
     "test/unit/runtime/pi-inline-extensions.test.mjs",
     "test/unit/runtime/runtime-adapters.test.mjs",
     "test/unit/runtime/runtime-inbox-target.test.mjs",
     "test/integration/build/runtime-clean-cutover.test.mjs",
+    "test/integration/build/runtime-upgrade-in-place.test.mjs",
+    "test/e2e/issue124-thread-runtime-envelope-e2e.test.mjs",
     "test/integration/build/release-platform-ci.test.mjs",
   ];
   const focusedWindowsCommand = windowsJob.split("\n").map((line) => line.trim())
@@ -63,6 +67,16 @@ test("PR and main CI retain Linux source checks and add a blocking native Window
     "test/unit/feishu/host-business-state.test.mjs",
     "test/unit/runtime/runtime-inbox-target.test.mjs",
   ]) assert.ok(expectedWindowsTestInputs.includes(issue122Test), `${issue122Test} covers issue 122 natively`);
+  for (const issue124Test of [
+    "test/unit/feishu/host-runtime-delivery-health.test.mjs",
+    "test/integration/build/runtime-upgrade-in-place.test.mjs",
+    "test/e2e/issue124-thread-runtime-envelope-e2e.test.mjs",
+  ]) assert.ok(expectedWindowsTestInputs.includes(issue124Test), `${issue124Test} covers issue 124 natively`);
+  assert.match(releaseSmoke, /v0\.3\.3-active-thread\.json/);
+  assert.match(releaseSmoke, /createRuntimeHost/);
+  assert.match(releaseSmoke, /candidate Runtime did not migrate the active targetless v0\.3\.3 ledger/);
+  assert.match(releaseSmoke, /artifact v0\.3\.3 same-home upgrade state/);
+  assert.match(releaseSmoke, /read-only artifact upgrade check mutated candidate Runtime state/);
   for (const broadProblematicTest of [
     "test/unit/agent/inbox-projection.test.mjs",
     "test/unit/runtime/runtime-host.test.mjs",

--- a/test/integration/build/runtime-upgrade-in-place.test.mjs
+++ b/test/integration/build/runtime-upgrade-in-place.test.mjs
@@ -1,0 +1,270 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { test } from "bun:test";
+import { createAgentStateStore } from "../../../dist/agent/agent-state-store.mjs";
+import { runAgentCli } from "../../../dist/app/agent-cli.mjs";
+import { ContextPromptBuilder } from "../../../dist/agent/context-prompt.mjs";
+import { createRuntimeHost } from "../../../dist/runtime/runtime-host.mjs";
+
+const ROOT = path.resolve(import.meta.dirname, "../../..");
+const FIXTURES = ["v0.2.79-active-thread.json", "v0.3.3-active-thread.json"];
+const TARGET = "thread:oc_issue124_upgrade:omt_issue124_upgrade";
+const STALE_NOTICE = "The Larkin Inbox changed (1 pending message). Poll that target at the next safe boundary before any target-local side effect.";
+const EXACT_NOTICE = `The Larkin Inbox changed for ${TARGET} (1 pending message). Poll that target at the next safe boundary before any target-local side effect.`;
+
+class CapturingSession {
+  sessionId = "candidate-0.4.1-session";
+  listeners = new Set();
+  prompts = [];
+  subscribe(listener) { this.listeners.add(listener); return () => this.listeners.delete(listener); }
+  emit(event) { for (const listener of this.listeners) listener(event); }
+  async prompt(input) { this.prompts.push(structuredClone(input)); return { status: "accepted", inputId: input.inputId }; }
+  async busyInput(input) { throw new Error(`unexpected busy input ${input.inputId}`); }
+  async cancel() {}
+  async close() {}
+}
+
+function loadFixture(name) {
+  return JSON.parse(fs.readFileSync(path.join(ROOT, "test", "fixtures", "runtime-upgrade", name), "utf8"));
+}
+
+function materialize(name, mutate = () => {}) {
+  const fixture = loadFixture(name);
+  assert.match(fixture.provenance.capture_method, /exact tagged source/);
+  assert.match(fixture.provenance.claim_boundary, /not a customer home.*full historical environment checkout/i);
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "larkin-runtime-upgrade-in-place-"));
+  const store = createAgentStateStore(root, fixture.agent_id);
+  fs.mkdirSync(store.paths.root, { recursive: true, mode: 0o700 });
+  const files = structuredClone(fixture.files);
+  mutate(files);
+  if (files["feishu-inbox.ndjson"] !== null) {
+    const rows = files["feishu-inbox.ndjson"];
+    const bytes = rows === "syntactically-malformed" ? "{not-json\n"
+      : rows.length ? `${rows.map((row) => JSON.stringify(row)).join("\n")}\n` : "";
+    fs.writeFileSync(store.paths.inbox, bytes, { mode: 0o600 });
+  }
+  fs.writeFileSync(store.paths.inboxState, `${JSON.stringify(files["inbox-state.json"], null, 2)}\n`, { mode: 0o600 });
+  fs.writeFileSync(store.paths.runtimeDeliveries, `${JSON.stringify(files["runtime-deliveries.json"], null, 2)}\n`, { mode: 0o600 });
+  fs.writeFileSync(path.join(root, "config.json"), `${JSON.stringify({
+    version: 4,
+    serverId: "server-upgrade-fixture",
+    mentionPolicy: "require",
+    activeAgent: fixture.agent_id,
+    agents: { [fixture.agent_id]: { runtime: "codex", model: "captured" } },
+  })}\n`, { mode: 0o600 });
+  return { fixture, root, store };
+}
+
+function candidate(store, session, events) {
+  const host = createRuntimeHost({
+    adapterFor: () => ({ id: "codex", capabilities: {}, async createSession() { return session; } }),
+    promptBuilder: new ContextPromptBuilder(),
+    stateStoreFor: () => store,
+  });
+  host.subscribe((event) => events.push(event));
+  return host;
+}
+
+for (const fixtureName of FIXTURES) {
+  for (const persistedStatus of ["pending", "submitting", "accepted"]) {
+    test(`${fixtureName} ${persistedStatus} upgrades in place by rebuilding the exact canonical target`, { timeout: 10_000 }, async () => {
+      const { fixture, root, store } = materialize(fixtureName, (files) => {
+        files["runtime-deliveries.json"].records[0].status = persistedStatus;
+      });
+      const session = new CapturingSession();
+      const events = [];
+      const host = candidate(store, session, events);
+      try {
+        await host.start([{ agentId: fixture.agent_id, name: fixture.agent_id, runtime: "codex", model: "captured",
+          workspaceDir: path.join(root, "agents", fixture.agent_id), stateDir: store.paths.root }]);
+        assert.equal(session.prompts.length, 1);
+        assert.equal(session.prompts[0].text, EXACT_NOTICE);
+        assert.notEqual(session.prompts[0].text, STALE_NOTICE);
+        assert.equal(session.prompts[0].inputId, fixture.files["runtime-deliveries.json"].records[0].deliveryId);
+
+        const active = store.readJson("runtimeDeliveries", { records: [] }).records[0];
+        assert.equal(active.target, TARGET);
+        assert.equal(active.input.text, EXACT_NOTICE);
+        assert.equal(active.status, "accepted");
+
+        let stdout = "", stderr = "";
+        const code = await runAgentCli(["inbox", "poll", "--target", TARGET, "--limit", "1"], {
+          LARKIN_CONFIG_DIR: root, LARKIN_AGENT_ID: fixture.agent_id,
+        }, { stateStore: store, io: { stdout: (text) => { stdout += text; }, stderr: (text) => { stderr += text; } } });
+        assert.equal(code, 0, stderr);
+        const poll = JSON.parse(stdout);
+        assert.deepEqual(poll.events.map((row) => row.message_id), [active.messageId]);
+        assert.deepEqual(poll.consumed_delivery_ids, [active.deliveryId]);
+        assert.equal(poll.reply_target, TARGET);
+
+        session.emit({ type: "turn-start", turnId: `upgrade-${persistedStatus}` });
+        session.emit({ type: "turn-end", turnId: `upgrade-${persistedStatus}` });
+        await new Promise((resolve) => setImmediate(resolve));
+        assert.equal(session.prompts.length, 1, "direct-acked upgrade delivery must not retry at turn end");
+        const ledger = store.readJson("runtimeDeliveries", { records: [] }).records;
+        assert.equal(ledger.length, 1);
+        assert.equal(ledger[0].status, "consumed");
+        assert.equal(events.filter((event) => event.type === "delivery" && event.status === "consumed").length, 1);
+      } finally {
+        await host.shutdown("upgrade fixture complete");
+        fs.rmSync(root, { recursive: true, force: true });
+      }
+    });
+  }
+}
+
+test("invalid or missing legacy canonical rows are quarantined visibly without target guessing", { timeout: 10_000 }, async () => {
+  const cases = [
+    ["missing", (files) => { files["feishu-inbox.ndjson"] = null; }],
+    ["orphan-thread", (files) => { delete files["feishu-inbox.ndjson"][0].chat_id; }],
+    ["conflicting-target", (files) => { files["feishu-inbox.ndjson"][0].target = "chat:oc_wrong"; }],
+    ["duplicate-message-id", (files) => { files["feishu-inbox.ndjson"].push(structuredClone(files["feishu-inbox.ndjson"][0])); }],
+    ["syntactically-malformed", (files) => { files["feishu-inbox.ndjson"] = "syntactically-malformed"; }],
+  ];
+  for (const [label, mutate] of cases) {
+    const { fixture, root, store } = materialize("v0.3.3-active-thread.json", mutate);
+    const inboxBytes = fs.existsSync(store.paths.inbox) ? fs.readFileSync(store.paths.inbox) : null;
+    const session = new CapturingSession();
+    const events = [];
+    const host = candidate(store, session, events);
+    try {
+      await host.start([{ agentId: fixture.agent_id, name: fixture.agent_id, runtime: "codex", model: "captured",
+        workspaceDir: path.join(root, "agents", fixture.agent_id), stateDir: store.paths.root }]);
+      assert.equal(session.prompts.length, 0, `${label}: stale RuntimeInput must not be submitted`);
+      const record = store.readJson("runtimeDeliveries", { records: [] }).records[0];
+      assert.equal(record.status, "error", label);
+      assert.equal(record.retryable, false, label);
+      assert.match(record.reason, /Runtime delivery quarantined/);
+      assert.notEqual(record.input.text, STALE_NOTICE, `${label}: terminal state must scrub the stale targetless notice`);
+      assert.ok(events.some((event) => event.type === "delivery" && event.status === "error"), label);
+      assert.ok(events.some((event) => event.type === "agent-status" && event.status === "error" && /quarantined/.test(event.error)), label);
+      assert.deepEqual(fs.existsSync(store.paths.inbox) ? fs.readFileSync(store.paths.inbox) : null, inboxBytes,
+        `${label}: malformed/missing Inbox evidence must not be rewritten or consumed`);
+    } finally {
+      await host.shutdown(`invalid upgrade case ${label}`);
+      fs.rmSync(root, { recursive: true, force: true });
+    }
+  }
+});
+
+test("a terminal upgrade quarantine remains visibly degraded on later startups", { timeout: 10_000 }, async () => {
+  const { fixture, root, store } = materialize("v0.3.3-active-thread.json", (files) => {
+    files["feishu-inbox.ndjson"] = null;
+  });
+  const startOnce = async () => {
+    const session = new CapturingSession();
+    const events = [];
+    const host = candidate(store, session, events);
+    await host.start([{ agentId: fixture.agent_id, name: fixture.agent_id, runtime: "codex", model: "captured",
+      workspaceDir: path.join(root, "agents", fixture.agent_id), stateDir: store.paths.root }]);
+    return { host, session, events };
+  };
+  let first, second;
+  try {
+    first = await startOnce();
+    assert.equal(first.session.prompts.length, 0);
+    assert.ok(first.events.some((event) => event.type === "agent-status" && event.status === "error" && /quarantined/.test(event.error)));
+    await first.host.shutdown("first quarantined startup");
+    first = null;
+
+    second = await startOnce();
+    assert.equal(second.session.prompts.length, 0);
+    assert.ok(second.events.some((event) => event.type === "delivery" && event.status === "error"));
+    assert.ok(second.events.some((event) => event.type === "agent-status" && event.status === "error" && /quarantined/.test(event.error)),
+      "a later Runtime-ready event must not hide unresolved terminal recovery state");
+    assert.equal(store.readJson("runtimeDeliveries", { records: [] }).records[0].status, "error");
+  } finally {
+    if (first) await first.host.shutdown("cleanup first quarantine");
+    if (second) await second.host.shutdown("cleanup second quarantine");
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("a partial poll winning candidate startup consumes only its row and rebuilds the remaining exact target", { timeout: 10_000 }, async () => {
+  const secondMessageId = "om_upgrade_033_second";
+  const secondDeliveryId = "6e157f81-569c-4127-8bfd-4932376896dd";
+  const { fixture, root, store } = materialize("v0.3.3-active-thread.json", (files) => {
+    const secondRow = { ...structuredClone(files["feishu-inbox.ndjson"][0]),
+      message_id: secondMessageId, target_seq: 2, content: "second captured-shape row" };
+    files["feishu-inbox.ndjson"].push(secondRow);
+    files["inbox-state.json"].targets[TARGET].latest_received_seq = 2;
+    files["inbox-state.json"].messages[secondMessageId] = { target: TARGET, seq: 2 };
+    const secondRecord = structuredClone(files["runtime-deliveries.json"].records[0]);
+    secondRecord.deliveryId = secondDeliveryId;
+    secondRecord.messageId = secondMessageId;
+    secondRecord.status = "submitting";
+    secondRecord.input.inputId = secondDeliveryId;
+    secondRecord.input.deliveryId = secondDeliveryId;
+    files["runtime-deliveries.json"].records.push(secondRecord);
+  });
+  const firstMessageId = fixture.files["runtime-deliveries.json"].records[0].messageId;
+  const originalResolve = store.resolveInboxDeliverySource.bind(store);
+  let partialPoll;
+  store.resolveInboxDeliverySource = (messageId) => {
+    const resolution = originalResolve(messageId);
+    if (!partialPoll && messageId === firstMessageId && resolution.status === "pending") {
+      partialPoll = store.pollInbox({ target: resolution.target, limit: 1 });
+    }
+    return resolution;
+  };
+  const session = new CapturingSession();
+  const events = [];
+  const host = candidate(store, session, events);
+  try {
+    await host.start([{ agentId: fixture.agent_id, name: fixture.agent_id, runtime: "codex", model: "captured",
+      workspaceDir: path.join(root, "agents", fixture.agent_id), stateDir: store.paths.root }]);
+    assert.deepEqual(partialPoll.envelopes.map((row) => row.message_id), [firstMessageId]);
+    assert.equal(session.prompts.length, 1);
+    assert.equal(session.prompts[0].inputId, secondDeliveryId);
+    assert.equal(session.prompts[0].text, EXACT_NOTICE);
+    assert.deepEqual(store.readNdjson("inbox").map((row) => row.message_id), [secondMessageId]);
+    const statuses = Object.fromEntries(store.readJson("runtimeDeliveries", { records: [] }).records
+      .map((record) => [record.messageId, record.status]));
+    assert.deepEqual(statuses, { [firstMessageId]: "consumed", [secondMessageId]: "accepted" });
+    assert.equal(events.filter((event) => event.type === "delivery" && event.status === "consumed").length, 1);
+
+    const finalPoll = store.pollInbox({ target: TARGET, limit: 1 });
+    assert.deepEqual(finalPoll.envelopes.map((row) => row.message_id), [secondMessageId]);
+    session.emit({ type: "turn-start", turnId: "partial-upgrade-race" });
+    session.emit({ type: "turn-end", turnId: "partial-upgrade-race" });
+    await new Promise((resolve) => setImmediate(resolve));
+    assert.equal(session.prompts.length, 1);
+    assert.equal(store.readJson("runtimeDeliveries", { records: [] }).records.every((record) => record.status === "consumed"), true);
+  } finally {
+    await host.shutdown("partial startup poll race complete");
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("an Agent CLI poll winning the candidate startup race consumes once and prevents rebuilt replay", { timeout: 10_000 }, async () => {
+  const { fixture, root, store } = materialize("v0.3.3-active-thread.json");
+  const originalResolve = store.resolveInboxDeliverySource.bind(store);
+  let raced = false;
+  store.resolveInboxDeliverySource = (messageId) => {
+    const resolution = originalResolve(messageId);
+    if (!raced && resolution.status === "pending") {
+      raced = true;
+      const poll = store.pollInbox({ target: resolution.target, limit: 1 });
+      assert.deepEqual(poll.envelopes.map((row) => row.message_id), [messageId]);
+      assert.equal(poll.consumedDeliveryIds.length, 1);
+    }
+    return resolution;
+  };
+  const session = new CapturingSession();
+  const events = [];
+  const host = candidate(store, session, events);
+  try {
+    await host.start([{ agentId: fixture.agent_id, name: fixture.agent_id, runtime: "codex", model: "captured",
+      workspaceDir: path.join(root, "agents", fixture.agent_id), stateDir: store.paths.root }]);
+    assert.equal(raced, true);
+    assert.equal(session.prompts.length, 0);
+    assert.deepEqual(store.readNdjson("inbox"), []);
+    assert.equal(store.readJson("runtimeDeliveries", { records: [] }).records[0].status, "consumed");
+    assert.equal(events.filter((event) => event.type === "delivery" && event.status === "consumed").length, 1);
+  } finally {
+    await host.shutdown("startup poll race complete");
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});

--- a/test/integration/build/runtime-upgrade-in-place.test.mjs
+++ b/test/integration/build/runtime-upgrade-in-place.test.mjs
@@ -115,6 +115,29 @@ for (const fixtureName of FIXTURES) {
   }
 }
 
+test("startup rebuilds wake reason from the canonical Inbox row rather than stale Runtime text", { timeout: 10_000 }, async () => {
+  const canonicalReason = "canonical-upgrade-reason";
+  const { fixture, root, store } = materialize("v0.3.3-active-thread.json", (files) => {
+    files["feishu-inbox.ndjson"][0].wake_reason = canonicalReason;
+    files["runtime-deliveries.json"].records[0].input.text = `${STALE_NOTICE}; reason=stale-runtime-only-reason`;
+  });
+  const session = new CapturingSession();
+  const host = candidate(store, session, []);
+  try {
+    await host.start([{ agentId: fixture.agent_id, name: fixture.agent_id, runtime: "codex", model: "captured",
+      workspaceDir: path.join(root, "agents", fixture.agent_id), stateDir: store.paths.root }]);
+    assert.equal(session.prompts.length, 1);
+    assert.match(session.prompts[0].text, new RegExp(`reason=${canonicalReason}`));
+    assert.doesNotMatch(session.prompts[0].text, /stale-runtime-only-reason/);
+    const record = store.readJson("runtimeDeliveries", { records: [] }).records[0];
+    assert.equal(record.wakeReason, canonicalReason);
+    assert.equal(record.input.text, session.prompts[0].text);
+  } finally {
+    await host.shutdown("canonical wake reason upgrade complete");
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});
+
 test("invalid or missing legacy canonical rows are quarantined visibly without target guessing", { timeout: 10_000 }, async () => {
   const cases = [
     ["missing", (files) => { files["feishu-inbox.ndjson"] = null; }],
@@ -123,6 +146,8 @@ test("invalid or missing legacy canonical rows are quarantined visibly without t
     ["conflicting-sequence", (files) => { files["inbox-state.json"].messages.om_upgrade_033.seq = 2; }],
     ["malformed-row-sequence", (files) => { files["feishu-inbox.ndjson"][0].target_seq = "one"; }],
     ["pending-row-marked-consumed", (files) => { files["inbox-state.json"].targets[TARGET].model_seen_seq = 1; }],
+    ["malformed-structured-target", (files) => { files["runtime-deliveries.json"].records[0].target = "dm:oc_unsafe_fallback"; }],
+    ["conflicting-wake-reason", (files) => { files["runtime-deliveries.json"].records[0].wakeReason = "stale runtime-only reason"; }],
     ["duplicate-message-id", (files) => { files["feishu-inbox.ndjson"].push(structuredClone(files["feishu-inbox.ndjson"][0])); }],
     ["syntactically-malformed", (files) => { files["feishu-inbox.ndjson"] = "syntactically-malformed"; }],
   ];

--- a/test/integration/build/runtime-upgrade-in-place.test.mjs
+++ b/test/integration/build/runtime-upgrade-in-place.test.mjs
@@ -35,7 +35,9 @@ function materialize(name, mutate = () => {}) {
   assert.match(fixture.provenance.capture_method, /exact tagged source/);
   assert.match(fixture.provenance.claim_boundary, /not a customer home.*full historical environment checkout/i);
   const root = fs.mkdtempSync(path.join(os.tmpdir(), "larkin-runtime-upgrade-in-place-"));
-  const store = createAgentStateStore(root, fixture.agent_id);
+  const store = createAgentStateStore(root, fixture.agent_id, {
+    inspectProcess: (pid) => ({ ok: true, dead: false, startToken: `issue124-upgrade-${pid}` }),
+  });
   fs.mkdirSync(store.paths.root, { recursive: true, mode: 0o700 });
   const files = structuredClone(fixture.files);
   mutate(files);

--- a/test/integration/build/runtime-upgrade-in-place.test.mjs
+++ b/test/integration/build/runtime-upgrade-in-place.test.mjs
@@ -120,6 +120,9 @@ test("invalid or missing legacy canonical rows are quarantined visibly without t
     ["missing", (files) => { files["feishu-inbox.ndjson"] = null; }],
     ["orphan-thread", (files) => { delete files["feishu-inbox.ndjson"][0].chat_id; }],
     ["conflicting-target", (files) => { files["feishu-inbox.ndjson"][0].target = "chat:oc_wrong"; }],
+    ["conflicting-sequence", (files) => { files["inbox-state.json"].messages.om_upgrade_033.seq = 2; }],
+    ["malformed-row-sequence", (files) => { files["feishu-inbox.ndjson"][0].target_seq = "one"; }],
+    ["pending-row-marked-consumed", (files) => { files["inbox-state.json"].targets[TARGET].model_seen_seq = 1; }],
     ["duplicate-message-id", (files) => { files["feishu-inbox.ndjson"].push(structuredClone(files["feishu-inbox.ndjson"][0])); }],
     ["syntactically-malformed", (files) => { files["feishu-inbox.ndjson"] = "syntactically-malformed"; }],
   ];

--- a/test/unit/agent/agent-state-store.test.mjs
+++ b/test/unit/agent/agent-state-store.test.mjs
@@ -151,6 +151,33 @@ test("Inbox delivery preparation treats consumed Runtime ownership as final acro
   } finally { fs.rmSync(root, { recursive: true, force: true }); }
 });
 
+test("canonical Inbox append returns the exact persisted shape and deduplicates coherently across consumption", async () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "larkin-state-canonical-append-"));
+  try {
+    const { createAgentStateStore } = await import(moduleUrl);
+    const store = createAgentStateStore(root, "cli_stateCanonicalAppendA1");
+    const candidate = { message_id: "om_canonical_once", chat_id: "oc_canonical", thread_id: "omt_canonical",
+      target: "thread:oc_canonical:omt_canonical", content: "canonical" };
+    const appended = store.appendCanonicalInboxOnce(candidate);
+    assert.equal(appended.status, "appended");
+    assert.deepEqual(store.readNdjson("inbox"), [appended.envelope]);
+    assert.equal(appended.envelope.envelope_version, 2);
+    assert.equal(appended.envelope.target_seq, 1);
+
+    const pendingDuplicate = store.appendCanonicalInboxOnce(candidate);
+    assert.equal(pendingDuplicate.status, "duplicate_pending");
+    assert.deepEqual(pendingDuplicate.envelope, appended.envelope);
+    assert.equal(store.readNdjson("inbox").length, 1);
+    assert.throws(() => store.appendCanonicalInboxOnce({ ...candidate, chat_id: "oc_wrong",
+      target: "thread:oc_wrong:omt_canonical" }), /duplicate message_id conflicts/);
+    assert.equal(store.readNdjson("inbox").length, 1);
+
+    store.pollInbox({ target: candidate.target, limit: 1 });
+    assert.deepEqual(store.appendCanonicalInboxOnce(candidate), { status: "duplicate_consumed", envelope: null });
+    assert.deepEqual(store.readNdjson("inbox"), []);
+  } finally { fs.rmSync(root, { recursive: true, force: true }); }
+});
+
 test("appendInboxOnce remembers a stable provider id after the Inbox row is consumed", async () => {
   const root = fs.mkdtempSync(path.join(os.tmpdir(), "larkin-state-stable-inbox-id-"));
   try {

--- a/test/unit/feishu/host-runtime-delivery-health.test.mjs
+++ b/test/unit/feishu/host-runtime-delivery-health.test.mjs
@@ -1,0 +1,95 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { test } from "bun:test";
+import { createAgentStateStore } from "../../../dist/agent/agent-state-store.mjs";
+import { createHostShell } from "../../../dist/feishu/host-shell.mjs";
+
+const testManagedCli = () => ({ command: { command: "/test/official-lark-cli", argsPrefix: [], version: "1.0.80" }, env: {} });
+
+for (const mode of ["error-receipt", "throw-after-persist", "async-input-error"]) {
+  test(`HostShell ${mode} keeps Inbox durable and degrades visible health without raw Runtime error data`, { timeout: 10_000 }, async () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), `larkin-host-delivery-health-${mode}-`));
+    const agentId = `cli_issue124Health${mode === "error-receipt" ? "Receipt" : mode === "throw-after-persist" ? "Throw" : "Async"}A1`;
+    const store = createAgentStateStore(root, agentId);
+    const secret = "api_key=issue124-super-secret";
+    let listener = () => {};
+    let deliveries = 0;
+    const runtimeHost = {
+      subscribe(next) { listener = next; return () => {}; },
+      async start() { listener({ type: "agent-status", agentId, status: "active", readiness: { runtime: "codex", state: "ready" } }); },
+      async deliver() {
+        deliveries += 1;
+        if (mode === "throw-after-persist") throw new Error(`provider raw failure ${secret}`);
+        if (mode === "async-input-error") return { status: "accepted", deliveryId: "delivery-async" };
+        return { status: "error", deliveryId: `unsafe-${secret}`, reason: `raw rejected payload ${secret}`, retryable: false };
+      },
+      async stop() {},
+      async shutdown() {},
+    };
+    const agent = {
+      agentId, name: agentId, runtime: "codex", model: "fixture", feishuAppId: agentId, feishuProfile: agentId,
+      larkConfigDir: path.join(store.paths.root, "lark-cli-config"), workspaceDir: path.join(root, "agents", agentId), stateDir: store.paths.root,
+    };
+    const logs = [];
+    const host = createHostShell({
+      env: {
+        LARKIN_HOME: root, LARKIN_CONFIG_DIR: root, LARKIN_SERVER_ID: "server-issue124-health",
+        LARKIN_AGENTS_CONFIG: JSON.stringify([agent]), LARKIN_FEISHU_DRYRUN: "1",
+        LARKIN_FEISHU_EVENT_FILE: path.join(root, "events.ndjson"), LARKIN_INBOUND_DROUGHT_SEC: "0",
+      }, runtimeHost, stateStoreForImpl: () => store, managedCliForAgent: testManagedCli,
+      eventSourceStartDelayMs: 60_000, logImpl: (...parts) => logs.push(parts.join(" ")),
+      execFileImpl(_command, _args, _options, callback) {
+        callback(null, JSON.stringify({ ok: true, data: { items: [{ member_id: "ou_health_sender", name: "Sender" }] } }), "");
+        return {};
+      },
+    });
+    const event = {
+      chat_id: "oc_issue124_health", chat_type: "group", sender_id: "ou_health_sender",
+      message_id: `om_issue124_health_${mode}`, event_id: `evt_issue124_health_${mode}`,
+      content: "raw inbound body must not enter delivery health", create_time: "1786819563000",
+      thread_id: "omt_issue124_health", _mentioned_bot: true, _mention_all: false, _sender_is_bot: true,
+    };
+    try {
+      await host.start();
+      assert.equal(store.readJson("status", {}).runtimeReadiness.state, "ready");
+      await host.ingest(agentId, event);
+      assert.equal(deliveries, 1);
+      if (mode === "async-input-error") {
+        listener({ type: "runtime", agentId, event: { type: "input-error", inputId: "delivery-async",
+          retryable: false, willRetry: false, errorCategory: "provider",
+          message: `raw asynchronous provider payload ${secret}`, nextAction: `unsafe next action ${secret}` } });
+        listener({ type: "delivery", agentId, deliveryId: "delivery-async", messageId: event.message_id,
+          status: "error", reason: `raw asynchronous delivery reason ${secret}` });
+      }
+      const rows = store.readNdjson("inbox");
+      assert.equal(rows.length, 1);
+      assert.deepEqual({ message_id: rows[0].message_id, target: rows[0].target }, {
+        message_id: event.message_id,
+        target: `thread:${event.chat_id}:${event.thread_id}`,
+      });
+      const inboxState = store.readJson("inboxState", {});
+      assert.equal(inboxState.targets[rows[0].target].model_seen_seq, 0, "delivery failure must not mark Agent model-seen");
+
+      const status = store.readJson("status", {});
+      assert.equal(status.runtimeReadiness.state, "incompatible");
+      assert.equal(status.inboundDeliveryHealth.state, "error");
+      const expectedCode = mode === "error-receipt" ? "non_retryable_receipt"
+        : mode === "throw-after-persist" ? "runtime_delivery_exception" : "runtime_delivery_event";
+      assert.equal(status.inboundDeliveryHealth.code, expectedCode);
+      assert.match(status.runtimeReadiness.nextAction, /inspect.*restart.*replay/i);
+      const errorDeliveryLog = (status.deliverLog || []).filter((entry) => entry.status === "error");
+      const visible = JSON.stringify({ health: status.inboundDeliveryHealth, readiness: status.runtimeReadiness,
+        recentErrors: status.recentErrors, errorDeliveryLog, logs });
+      assert.doesNotMatch(visible, /issue124-super-secret|raw rejected payload|raw asynchronous|unsafe next action|raw inbound body/);
+
+      await host.ingest(agentId, event);
+      assert.equal(deliveries, 1, "transport duplicate must not create a second delivery attempt");
+      assert.equal(store.readNdjson("inbox").length, 1, "transport duplicate must not append a second durable row");
+    } finally {
+      await host.shutdown("delivery health test complete");
+      fs.rmSync(root, { recursive: true, force: true });
+    }
+  });
+}

--- a/test/unit/feishu/host-runtime-delivery-health.test.mjs
+++ b/test/unit/feishu/host-runtime-delivery-health.test.mjs
@@ -12,7 +12,9 @@ for (const mode of ["error-receipt", "throw-after-persist", "async-input-error"]
   test(`HostShell ${mode} keeps Inbox durable and degrades visible health without raw Runtime error data`, { timeout: 10_000 }, async () => {
     const root = fs.mkdtempSync(path.join(os.tmpdir(), `larkin-host-delivery-health-${mode}-`));
     const agentId = `cli_issue124Health${mode === "error-receipt" ? "Receipt" : mode === "throw-after-persist" ? "Throw" : "Async"}A1`;
-    const store = createAgentStateStore(root, agentId);
+    const store = createAgentStateStore(root, agentId, {
+      inspectProcess: (pid) => ({ ok: true, dead: false, startToken: `issue124-health-${pid}` }),
+    });
     const secret = "api_key=issue124-super-secret";
     let listener = () => {};
     let deliveries = 0;

--- a/test/unit/runtime/runtime-host.test.mjs
+++ b/test/unit/runtime/runtime-host.test.mjs
@@ -406,10 +406,11 @@ test("delivery ownership, dedupe and correlation survive recreation and reach co
   const adapter = { id: "codex", capabilities: {}, async createSession() { const session = new FakeSession(); session.sessionId = `session-${sessions.length + 1}`; sessions.push(session); return session; } };
   const config = { agentId, name: agentId, runtime: "codex", model: "gpt", workspaceDir: path.join(root, "agents", agentId), stateDir: store.paths.root };
   try {
-    store.appendNdjson("inbox", { message_id: "om_persist", target: "chat:oc_persist", content: "canonical" });
+    const persistedEnvelope = { message_id: "om_persist", target: "chat:oc_persist", chat_id: "oc_persist", content: "canonical" };
+    store.appendNdjson("inbox", persistedEnvelope);
     const host1 = createRuntimeHost({ adapterFor: () => adapter, promptBuilder: new ContextPromptBuilder(), stateStoreFor: () => store });
     await host1.start([config]);
-    const accepted = await host1.deliver(agentId, { message_id: "om_persist" });
+    const accepted = await host1.deliver(agentId, persistedEnvelope);
     await host1.shutdown("simulated process exit");
 
     const events = [];
@@ -417,7 +418,7 @@ test("delivery ownership, dedupe and correlation survive recreation and reach co
     host2.subscribe((event) => events.push(event));
     await host2.start([config]);
     assert.equal(sessions[1].prompts[0].inputId, accepted.deliveryId, "pending reconstruction preserves deliveryId");
-    assert.deepEqual(await host2.deliver(agentId, { message_id: "om_persist" }), { status: "duplicate", deliveryId: accepted.deliveryId });
+    assert.deepEqual(await host2.deliver(agentId, persistedEnvelope), { status: "duplicate", deliveryId: accepted.deliveryId });
     store.drainInbox();
     await new Promise((resolve) => setTimeout(resolve, 300));
     assert.ok(events.some((event) => event.type === "delivery" && event.status === "consumed" && event.deliveryId === accepted.deliveryId));
@@ -525,7 +526,7 @@ test("turn end retries an accepted wake when the Agent never polls without advan
   }
 });
 
-test("startup migration consumes orphan synthetic active deliveries but never guesses for real om_ messages", async () => {
+test("startup migration consumes orphan synthetic active deliveries and quarantines a real message without canonical Inbox evidence", async () => {
   const root = fs.mkdtempSync(path.join(os.tmpdir(), "larkin-runtime-synthetic-migration-"));
   const agentId = "cli_migrateA1";
   const store = createAgentStateStore(root, agentId);
@@ -540,13 +541,16 @@ test("startup migration consumes orphan synthetic active deliveries but never gu
     promptBuilder: new ContextPromptBuilder(), stateStoreFor: () => store });
   try {
     await host.start([{ agentId, name: agentId, runtime: "codex", model: "g", workspaceDir: path.join(root, "agents", agentId), stateDir: store.paths.root }]);
-    assert.deepEqual(session.prompts.map((input) => input.inputId), ["delivery-real"], "only the real message retains delivery ownership");
-    const statuses = Object.fromEntries(store.readJson("runtimeDeliveries", { records: [] }).records
-      .map((item) => [item.messageId, item.status]));
-    assert.equal(statuses.redeliver_509c, "consumed");
-    assert.equal(statuses.rem_legacy, "consumed");
-    assert.equal(statuses.interaction_run_missing, "consumed");
-    assert.equal(statuses.om_real_missing, "accepted", "real Feishu delivery is never blindly consumed without Inbox evidence");
+    assert.deepEqual(session.prompts, [], "a real message without canonical Inbox evidence is never resubmitted from stale text");
+    const records = Object.fromEntries(store.readJson("runtimeDeliveries", { records: [] }).records
+      .map((item) => [item.messageId, item]));
+    assert.equal(records.redeliver_509c.status, "consumed");
+    assert.equal(records.rem_legacy.status, "consumed");
+    assert.equal(records.interaction_run_missing.status, "consumed");
+    assert.equal(records.om_real_missing.status, "error");
+    assert.equal(records.om_real_missing.retryable, false);
+    assert.match(records.om_real_missing.reason, /canonical_inbox_row_missing/);
+    assert.notEqual(records.om_real_missing.input.text, "check", "quarantine scrubs the stale targetless Runtime input");
   } finally {
     await host.shutdown("test complete");
     fs.rmSync(root, { recursive: true, force: true });

--- a/test/unit/runtime/runtime-inbox-target.test.mjs
+++ b/test/unit/runtime/runtime-inbox-target.test.mjs
@@ -179,6 +179,39 @@ test("persistence rejects legacy and malformed targets and leaves durable old ro
   }
 });
 
+test("issue 124 former split envelope fails while the exact persisted canonical object reaches Runtime", async () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "larkin-issue124-envelope-counterfactual-"));
+  const agentId = "cli_issue124CounterfactualA1";
+  const store = createAgentStateStore(root, agentId);
+  const session = new FakeSession();
+  const host = createRuntimeHost({
+    adapterFor: () => ({ id: "codex", capabilities: {}, async createSession() { return session; } }),
+    promptBuilder: new ContextPromptBuilder(), stateStoreFor: () => store,
+  });
+  const canonical = { message_id: "om_issue124_counterfactual", target: "thread:oc_issue124:omt_issue124",
+    chat_id: "oc_issue124", thread_id: "omt_issue124", content: "canonical" };
+  try {
+    store.appendNdjson("inbox", canonical);
+    await host.start([{ agentId, name: agentId, runtime: "codex", model: "g", workspaceDir: ".", stateDir: store.paths.root }]);
+    const formerRawEnvelope = { ...canonical };
+    delete formerRawEnvelope.chat_id;
+    const former = await host.deliver(agentId, formerRawEnvelope);
+    assert.equal(former.status, "error");
+    assert.match(former.reason, /thread locator requires nonempty chat_id/);
+    assert.equal(session.prompts.length, 0);
+    assert.deepEqual(store.readJson("runtimeDeliveries", { records: [] }).records, []);
+
+    const fixed = await host.deliver(agentId, canonical);
+    assert.equal(fixed.status, "accepted");
+    assert.equal(session.prompts.length, 1);
+    assert.match(session.prompts[0].text, /Inbox changed for thread:oc_issue124:omt_issue124/);
+    assert.equal(store.readJson("runtimeDeliveries", { records: [] }).records[0].messageId, canonical.message_id);
+  } finally {
+    await host.shutdown("issue124 counterfactual complete");
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});
+
 test("Runtime final inputs use exact targets and malformed deliveries fail closed before prompt or ledger acceptance", async () => {
   const root = fs.mkdtempSync(path.join(os.tmpdir(), "larkin-runtime-target-defense-"));
   const store = createAgentStateStore(root, "cli_targetDefenseA1", {
@@ -203,7 +236,10 @@ test("Runtime final inputs use exact targets and malformed deliveries fail close
   ];
   try {
     await host.start([{ agentId, name: agentId, runtime: "codex", model: "g", workspaceDir: ".", stateDir: store.paths.root }]);
-    for (const [envelope] of cases) assert.equal((await host.deliver(agentId, envelope)).status, "accepted");
+    for (const [envelope] of cases) {
+      store.appendNdjson("inbox", envelope);
+      assert.equal((await host.deliver(agentId, envelope)).status, "accepted");
+    }
 
     const finalInputs = [...session.prompts, ...session.steers];
     assert.equal(finalInputs.length, cases.length);
@@ -218,6 +254,7 @@ test("Runtime final inputs use exact targets and malformed deliveries fail close
       { message_id: "generic_runtime", target: "runtime:system" },
       { message_id: "empty_chat_runtime", target: "chat:" },
       { message_id: "empty_thread_runtime", target: "thread:" },
+      { message_id: "orphan_thread_runtime", thread_id: "omt_orphan" },
       { message_id: "rem_runtime_prefix_only" },
       { message_id: "om_runtime_kind_only", kind: "reminder" },
       { message_id: "om_runtime_target_only", target: RUNTIME_REMINDER_TARGET },


### PR DESCRIPTION
## Summary

Emergency repair for the inbound thread-delivery regression, based directly on `4544c837d7887cd087c91bde742356e1f4d4f605`.

- Persist and deliver one canonical Inbox envelope object; the Runtime no longer receives a pre-normalization sibling object.
- Store a structured canonical target in new Runtime delivery records and rebuild every startup/retry notice from canonical Inbox row/state under the Inbox lock.
- Quarantine missing, malformed, duplicate, or conflicting legacy evidence visibly and terminally instead of guessing a DM/generic fallback or submitting stale text.
- Preserve Inbox/model-seen state on non-retryable receipt, exception, and asynchronous input-error paths while projecting safe degraded health and a replay next action without raw provider payloads/secrets.
- Upgrade the package version to `0.4.1`, add bounded v0.2.79/v0.3.3 fixtures, exercise an active same-home ledger in release smoke, and add the focused issue-124 contracts to the native Windows gate.

## Root cause and why prior tests passed

The production HostShell wrote the normalized `projectInboxEnvelope(...)` result, but passed a different, earlier object to `RuntimeHost.deliver(...)`. A real thread could therefore be correct on disk while the Runtime path failed strict source/target coherence. Active Runtime records also persisted only wake text, so restart/retry had no structured target authority and could replay stale targetless text.

Exact call chain: `src/feishu/host-shell.ts` `createHostShell()` inbound `receive()` projected two sibling objects, appended one, then called `runtimeHost.deliver()` with the other; `src/runtime/runtime-host.ts` `createRuntimeHost()` persisted that delivery and `start()` / `retryPending()` / `submit()` reused its text without canonical Inbox re-resolution.

The old coverage missed this because:

1. HostShell tests stubbed RuntimeHost and did not assert persisted-object identity at the production boundary.
2. The production mock's opposite case used `thread_id: null`, so it never crossed the real thread branch.
3. Validator fixtures started already coherent instead of injecting the former raw-vs-canonical split.
4. Package/release smoke used only a clean home and did not load an already-active inbound Runtime ledger.

## Upgrade and failure safety

- `pending`, `submitting`, and `accepted` records from both captured historical shapes are rebuilt from canonical Inbox state and submitted with the same delivery/input identity.
- Consumed rows close ownership without replay, including startup and partial-poll races.
- Canonical-row absence, malformed NDJSON, duplicate message IDs, Inbox-state conflict, or structured-target conflict produces a safe terminal quarantine code. Stale targetless prompt text is scrubbed and never submitted.
- Persistent quarantines are re-projected after restart so the operator does not lose the terminal status/next action.
- Fixtures are provenance-bounded source-tag API captures from exact v0.2.79 and v0.3.3 commits. They are not claimed to be customer-home, npm-install, standalone-binary, or full historical-environment captures.

## Counterfactual and acceptance evidence

- The injected former HostShell split envelope fails the strict target/coherence boundary.
- Passing the exact normalized object returned by canonical persistence succeeds for a real thread target.
- Native `inbox poll` returns the same target/message identity; native reply payload keeps `--reply-in-thread` for the thread and omits it for the chat-level opposite case.
- Duplicate events do not append/redeliver, and poll/startup races produce one consumption transition with no stale prompt.
- Error-receipt, throw-after-persist, and asynchronous terminal input-error cases retain the Inbox row and expose safe degraded health without the injected secret/raw payload.

## Validation

Local, with inherited `LARKIN_*`, `LARKSUITE_*`, and `LARK_CHANNEL*` variables unset where applicable:

- `bun run typecheck` — pass
- `bun run build` — pass
- Focused issue-124/unit/upgrade/E2E contract set — **75 passed, 0 failed**
- Full unit suite — **412 passed, 4 expected opt-in skips, 0 failed**
- Full E2E suite — **21 passed, 0 failed**
- Integration suite partitioned under the agent's mandatory 60-second foreground cap: setup **9/9**, platform **24/24**, runtime **1 pass + 1 opt-in skip**, dashboard **1 pass + 4 opt-in skips**, package **1 opt-in skip**, plus affected agent/app/build/Feishu files passed in bounded shards. The one-shot umbrella itself exceeded the tool cap and is not presented as a completion signal.
- Hosted Linux `source-checks` — pass: complete `bun run test` plus the official lark-channel bind gate.
- Frontend — **24 passed, 0 failed**
- Local `--isolate` simulation of the issue-124 native-Windows subset — **16 passed, 0 failed**. Hosted Windows 11 x64 then passed the focused source contracts and exact cross-built standalone smoke. Issue-specific fixtures inject deterministic process ownership so unrelated CIM timing remains owned by its dedicated suites; the standalone check still uses the native production path.
- Clean-source darwin-arm64 standalone build + release smoke — pass: exact HEAD manifest with `sourceDirty: false`, version `0.4.1`, embedded dashboard HTTP 200, captured v0.3.3 active targetless ledger rebuilt/replayed, and standalone read-only same-home check passed.
- `publication:check:tree` — pass (336 files)
- `licenses:check` — pass (212 package versions)
- `gitleaks --no-git` current-tree scan — no leaks
- `git diff --check` — pass

## Scope / claim boundaries

This proves deterministic local/runtime/payload contracts and upgrade behavior. It does not claim a real Feishu provider write, client rendering, or a customer-home migration. Native Windows evidence is limited to the hosted Windows 11 x64 gate; the paused Windows host was not changed. No production host/configuration, npm publication, GitHub release, issue state, merge state, or release tag was changed.

Refs #124
