### PR TITLE
fix(release): bind recovery smoke to immutable candidate

### DIFF
--- a/.github/workflows/release-platform-smoke.yml
+++ b/.github/workflows/release-platform-smoke.yml
@@ -124,7 +124,7 @@ jobs:
         run: bun run build
 
       - name: Run focused Windows unit and integration tests
-        run: bun test --isolate --max-concurrency 1 test/unit/agent/host-reminder-orchestrator.test.mjs test/unit/feishu/host-business-state.test.mjs test/unit/feishu/host-runtime-delivery-health.test.mjs test/unit/platform/release-artifacts.test.mjs test/unit/runtime/pi-inline-extensions.test.mjs test/unit/runtime/runtime-adapters.test.mjs test/unit/runtime/runtime-inbox-target.test.mjs test/integration/build/runtime-clean-cutover.test.mjs test/integration/build/runtime-upgrade-in-place.test.mjs test/e2e/issue124-thread-runtime-envelope-e2e.test.mjs test/integration/build/release-platform-ci.test.mjs
+        run: bun test --isolate --max-concurrency 1 test/unit/agent/host-reminder-orchestrator.test.mjs test/unit/feishu/host-business-state.test.mjs test/unit/feishu/host-runtime-delivery-health.test.mjs test/unit/platform/release-artifacts.test.mjs test/unit/runtime/pi-inline-extensions.test.mjs test/unit/runtime/runtime-adapters.test.mjs test/unit/runtime/runtime-inbox-target.test.mjs test/integration/build/runtime-clean-cutover.test.mjs test/integration/build/runtime-upgrade-in-place.test.mjs test/integration/build/release-smoke-candidate-root.test.mjs test/e2e/issue124-thread-runtime-envelope-e2e.test.mjs test/integration/build/release-platform-ci.test.mjs
 
       - name: Download exact Windows standalone build
         uses: actions/download-artifact@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -476,7 +476,12 @@ jobs:
           $actual = (Get-FileHash (Join-Path artifacts/release $record.file) -Algorithm SHA256).Hash.ToLowerInvariant()
           if ($expected -ne $record.sha256 -or $actual -ne $record.sha256) { throw "Windows artifact checksum mismatch" }
 
+      - name: Build exact immutable candidate source for Runtime upgrade smoke
+        run: bun run build
+
       - name: Smoke exact assembled Windows executable natively
+        env:
+          LARKIN_RELEASE_CANDIDATE_ROOT: ${{ github.workspace }}/release-source
         run: bun "${{ github.workspace }}/release-tooling/scripts/release/smoke.ts" --release-dir artifacts/release
 
   publish:

--- a/scripts/release/smoke.ts
+++ b/scripts/release/smoke.ts
@@ -3,6 +3,7 @@ import fs from "node:fs";
 import net from "node:net";
 import os from "node:os";
 import path from "node:path";
+import { pathToFileURL } from "node:url";
 import { spawn, spawnSync, type ChildProcess } from "node:child_process";
 import {
   selectReleaseArtifact,
@@ -15,15 +16,129 @@ import {
   smokeArtifactEnvironment,
   smokeTerminationPlan,
 } from "./smoke-support.js";
-// Release smoke runs only after `bun run build`; exercising dist keeps the
-// same compiled module graph used to construct the standalone.
-// @ts-expect-error dist is generated and intentionally has no declaration file.
-import { createAgentStateStore } from "../../dist/agent/agent-state-store.mjs";
-// @ts-expect-error dist is generated and intentionally has no declaration file.
-import { ContextPromptBuilder } from "../../dist/agent/context-prompt.mjs";
-// @ts-expect-error dist is generated and intentionally has no declaration file.
-import { createRuntimeHost } from "../../dist/runtime/runtime-host.mjs";
 import type { RuntimeInput, RuntimeSession } from "../../src/runtime/runtime-contracts.js";
+
+type CreateAgentStateStore = typeof import("../../src/agent/agent-state-store.js")["createAgentStateStore"];
+type ContextPromptBuilderConstructor = typeof import("../../src/agent/context-prompt.js")["ContextPromptBuilder"];
+type CreateRuntimeHost = typeof import("../../src/runtime/runtime-host.js")["createRuntimeHost"];
+
+const RELEASE_CANDIDATE_ROOT_ENV = "LARKIN_RELEASE_CANDIDATE_ROOT";
+const RUNTIME_UPGRADE_CANDIDATE_FILES = Object.freeze({
+  package: "package.json",
+  fixture: "test/fixtures/runtime-upgrade/v0.3.3-active-thread.json",
+  agentStateStore: "dist/agent/agent-state-store.mjs",
+  contextPrompt: "dist/agent/context-prompt.mjs",
+  runtimeHost: "dist/runtime/runtime-host.mjs",
+});
+
+export interface CandidateRuntimeUpgradeModules {
+  candidateRoot: string;
+  upgradeFixtureFile: string;
+  moduleOrigins: Readonly<{
+    agentStateStore: string;
+    contextPrompt: string;
+    runtimeHost: string;
+  }>;
+  createAgentStateStore: CreateAgentStateStore;
+  ContextPromptBuilder: ContextPromptBuilderConstructor;
+  createRuntimeHost: CreateRuntimeHost;
+}
+
+function canonicalDirectory(directory: string, label: string): string {
+  let stat: fs.Stats;
+  try {
+    stat = fs.lstatSync(directory);
+  } catch {
+    throw new Error(`${label} is unavailable: ${directory}`);
+  }
+  if (!stat.isDirectory()) throw new Error(`${label} is not a directory: ${directory}`);
+  return fs.realpathSync.native(directory);
+}
+
+function isWithin(root: string, candidate: string): boolean {
+  const relative = path.relative(root, candidate);
+  return relative === "" || (!path.isAbsolute(relative) && relative !== ".." && !relative.startsWith(`..${path.sep}`));
+}
+
+function candidateRegularFile(candidateRoot: string, relativeFile: string): string {
+  const unresolved = path.resolve(candidateRoot, relativeFile);
+  if (!isWithin(candidateRoot, unresolved) || unresolved === candidateRoot) {
+    throw new Error(`release smoke candidate path escaped its root: ${relativeFile}`);
+  }
+  let stat: fs.Stats;
+  try {
+    stat = fs.lstatSync(unresolved);
+  } catch {
+    throw new Error(`release smoke candidate file is missing: ${relativeFile}`);
+  }
+  if (!stat.isFile()) throw new Error(`release smoke candidate path is not a regular file: ${relativeFile}`);
+  const canonicalFile = fs.realpathSync.native(unresolved);
+  if (!isWithin(candidateRoot, canonicalFile)) {
+    throw new Error(`release smoke candidate file escaped its root: ${relativeFile}`);
+  }
+  return canonicalFile;
+}
+
+function releaseCandidateRoot(): string {
+  const workingRoot = canonicalDirectory(process.cwd(), "release smoke working directory");
+  const configuredRoot = process.env[RELEASE_CANDIDATE_ROOT_ENV];
+  if (configuredRoot === undefined) return workingRoot;
+  if (!configuredRoot || /[\0\r\n]/.test(configuredRoot) || !path.isAbsolute(configuredRoot)) {
+    throw new Error(`${RELEASE_CANDIDATE_ROOT_ENV} must be one absolute directory path`);
+  }
+  const candidateRoot = canonicalDirectory(configuredRoot, `${RELEASE_CANDIDATE_ROOT_ENV} candidate root`);
+  if (path.relative(workingRoot, candidateRoot) !== "") {
+    throw new Error(`${RELEASE_CANDIDATE_ROOT_ENV} does not match the release smoke working directory`);
+  }
+  return candidateRoot;
+}
+
+// Recovery runs may execute this script from a newer release-tooling checkout.
+// The immutable candidate working directory is the sole authority for Runtime
+// modules and fixtures; there is intentionally no import.meta.dirname fallback.
+export async function loadCandidateRuntimeUpgradeModules(expectedVersion: string): Promise<CandidateRuntimeUpgradeModules> {
+  const candidateRoot = releaseCandidateRoot();
+  const packageFile = candidateRegularFile(candidateRoot, RUNTIME_UPGRADE_CANDIDATE_FILES.package);
+  const upgradeFixtureFile = candidateRegularFile(candidateRoot, RUNTIME_UPGRADE_CANDIDATE_FILES.fixture);
+  const agentStateStoreFile = candidateRegularFile(candidateRoot, RUNTIME_UPGRADE_CANDIDATE_FILES.agentStateStore);
+  const contextPromptFile = candidateRegularFile(candidateRoot, RUNTIME_UPGRADE_CANDIDATE_FILES.contextPrompt);
+  const runtimeHostFile = candidateRegularFile(candidateRoot, RUNTIME_UPGRADE_CANDIDATE_FILES.runtimeHost);
+
+  let candidatePackage: { name?: unknown; version?: unknown };
+  try {
+    candidatePackage = JSON.parse(fs.readFileSync(packageFile, "utf8")) as { name?: unknown; version?: unknown };
+  } catch {
+    throw new Error("release smoke candidate package.json is invalid");
+  }
+  if (candidatePackage.name !== "larkin" || candidatePackage.version !== expectedVersion) {
+    throw new Error(`release smoke candidate package identity does not match manifest version ${expectedVersion}`);
+  }
+
+  // Every expected path is checked above before any candidate code is loaded.
+  const moduleOrigins = Object.freeze({
+    agentStateStore: pathToFileURL(agentStateStoreFile).href,
+    contextPrompt: pathToFileURL(contextPromptFile).href,
+    runtimeHost: pathToFileURL(runtimeHostFile).href,
+  });
+  const [agentStateStoreModule, contextPromptModule, runtimeHostModule] = await Promise.all([
+    import(moduleOrigins.agentStateStore),
+    import(moduleOrigins.contextPrompt),
+    import(moduleOrigins.runtimeHost),
+  ]);
+  if (typeof agentStateStoreModule.createAgentStateStore !== "function"
+    || typeof contextPromptModule.ContextPromptBuilder !== "function"
+    || typeof runtimeHostModule.createRuntimeHost !== "function") {
+    throw new Error("release smoke candidate Runtime modules do not expose the expected API");
+  }
+  return {
+    candidateRoot,
+    upgradeFixtureFile,
+    moduleOrigins,
+    createAgentStateStore: agentStateStoreModule.createAgentStateStore as CreateAgentStateStore,
+    ContextPromptBuilder: contextPromptModule.ContextPromptBuilder as ContextPromptBuilderConstructor,
+    createRuntimeHost: runtimeHostModule.createRuntimeHost as CreateRuntimeHost,
+  };
+}
 
 async function freePort(): Promise<number> {
   const server = net.createServer();
@@ -92,6 +207,12 @@ export async function main(argv: string[] = process.argv.slice(2)): Promise<void
   const record = selectReleaseArtifact(manifest, platform, arch);
   verifyReleaseNotices(releaseDir, manifest);
   const artifact = verifyReleaseArtifact(releaseDir, record);
+  const {
+    createAgentStateStore,
+    ContextPromptBuilder,
+    createRuntimeHost,
+    upgradeFixtureFile,
+  } = await loadCandidateRuntimeUpgradeModules(manifest.version);
 
   const temporaryRoot = fs.mkdtempSync(path.join(os.tmpdir(), "larkin-release-smoke-"));
   const home = path.join(temporaryRoot, "home");
@@ -115,7 +236,6 @@ export async function main(argv: string[] = process.argv.slice(2)): Promise<void
     // bounded in the fixture; the candidate Runtime must migrate and replay its
     // same-home active targetless ledger, then the standalone must read that
     // upgraded Inbox/ledger state without an extra mutation.
-    const upgradeFixtureFile = path.resolve(import.meta.dirname, "../../test/fixtures/runtime-upgrade/v0.3.3-active-thread.json");
     const upgradeFixture = JSON.parse(fs.readFileSync(upgradeFixtureFile, "utf8")) as {
       provenance: { release_tag: string; claim_boundary: string };
       agent_id: string;

--- a/test/integration/build/release-platform-ci.test.mjs
+++ b/test/integration/build/release-platform-ci.test.mjs
@@ -54,6 +54,7 @@ test("PR and main CI retain Linux source checks and add a blocking native Window
     "test/unit/runtime/runtime-inbox-target.test.mjs",
     "test/integration/build/runtime-clean-cutover.test.mjs",
     "test/integration/build/runtime-upgrade-in-place.test.mjs",
+    "test/integration/build/release-smoke-candidate-root.test.mjs",
     "test/e2e/issue124-thread-runtime-envelope-e2e.test.mjs",
     "test/integration/build/release-platform-ci.test.mjs",
   ];
@@ -70,9 +71,14 @@ test("PR and main CI retain Linux source checks and add a blocking native Window
   for (const issue124Test of [
     "test/unit/feishu/host-runtime-delivery-health.test.mjs",
     "test/integration/build/runtime-upgrade-in-place.test.mjs",
+    "test/integration/build/release-smoke-candidate-root.test.mjs",
     "test/e2e/issue124-thread-runtime-envelope-e2e.test.mjs",
   ]) assert.ok(expectedWindowsTestInputs.includes(issue124Test), `${issue124Test} covers issue 124 natively`);
   assert.match(releaseSmoke, /v0\.3\.3-active-thread\.json/);
+  assert.match(releaseSmoke, /LARKIN_RELEASE_CANDIDATE_ROOT/);
+  assert.match(releaseSmoke, /pathToFileURL/);
+  assert.match(releaseSmoke, /loadCandidateRuntimeUpgradeModules/);
+  assert.doesNotMatch(releaseSmoke, /from "\.\.\/\.\.\/dist\//);
   assert.match(releaseSmoke, /createRuntimeHost/);
   assert.match(releaseSmoke, /candidate Runtime did not migrate the active targetless v0\.3\.3 ledger/);
   assert.match(releaseSmoke, /artifact v0\.3\.3 same-home upgrade state/);
@@ -91,6 +97,7 @@ test("PR and main CI retain Linux source checks and add a blocking native Window
 
 test("package version and explicit tag publication share one immutable combined-release run", () => {
   const workflow = read(".github/workflows/release.yml");
+  const verifyWindowsJob = workflow.slice(workflow.indexOf("  verify-windows-release:"), workflow.indexOf("  publish:"));
   const intent = read("scripts/release/intent.mjs");
   assert.equal(fs.existsSync(path.join(ROOT, ".github/workflows/bump-patch-version.yml")), false);
   assert.equal(fs.existsSync(path.join(ROOT, "scripts/bump-patch-version.mjs")), false);
@@ -169,6 +176,12 @@ test("package version and explicit tag publication share one immutable combined-
   assert.match(workflow, /assemble-release:[\s\S]*bun scripts\/release\/assemble\.ts[\s\S]*actions\/upload-artifact@v4/);
   assert.match(workflow, /verify-windows-release:[\s\S]*always\(\)[\s\S]*needs\.assemble-release\.result == 'success'[\s\S]*runs-on: windows-latest/);
   assert.match(workflow, /verify-windows-release:[\s\S]*ref: \$\{\{ github\.workflow_sha \}\}[\s\S]*path: release-tooling[\s\S]*actions\/download-artifact@v4[\s\S]*Get-FileHash[\s\S]*release-tooling\/scripts\/release\/smoke\.ts" --release-dir artifacts\/release/);
+  assert.match(verifyWindowsJob, /name: Verify immutable source, Windows manifest, and SHA256SUMS[\s\S]*Get-FileHash[\s\S]*name: Build exact immutable candidate source for Runtime upgrade smoke\n\s+run: bun run build[\s\S]*name: Smoke exact assembled Windows executable natively\n\s+env:\n\s+LARKIN_RELEASE_CANDIDATE_ROOT: \$\{\{ github\.workspace \}\}\/release-source\n\s+run: bun "\$\{\{ github\.workspace \}\}\/release-tooling\/scripts\/release\/smoke\.ts" --release-dir artifacts\/release/);
+  assert.equal(verifyWindowsJob.match(/bun run build/g)?.length, 1, "the recovery Windows gate builds the exact candidate once before smoke");
+  assert.ok(verifyWindowsJob.indexOf("Verify immutable source, Windows manifest, and SHA256SUMS")
+    < verifyWindowsJob.indexOf("Build exact immutable candidate source for Runtime upgrade smoke"));
+  assert.ok(verifyWindowsJob.indexOf("Build exact immutable candidate source for Runtime upgrade smoke")
+    < verifyWindowsJob.indexOf("Smoke exact assembled Windows executable natively"));
   assert.match(workflow, /publish:[\s\S]*- verify-windows-release[\s\S]*always\(\)[\s\S]*needs\.verify-windows-release\.result == 'success'[\s\S]*Download Windows-verified assembled release[\s\S]*Finalize GitHub release/);
   assert.ok(workflow.indexOf("  verify-windows-release:") < workflow.indexOf("  publish:"));
   assert.match(workflow, /gh release edit[\s\S]*--draft=false/);

--- a/test/integration/build/release-smoke-candidate-root.test.mjs
+++ b/test/integration/build/release-smoke-candidate-root.test.mjs
@@ -1,0 +1,179 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { spawnSync } from "node:child_process";
+import { pathToFileURL } from "node:url";
+import { test } from "bun:test";
+
+const ROOT = path.resolve(import.meta.dirname, "../../..");
+const VERSION = "0.4.1";
+
+function copyFile(source, destination) {
+  fs.mkdirSync(path.dirname(destination), { recursive: true });
+  fs.copyFileSync(source, destination);
+}
+
+function writeFile(file, content) {
+  fs.mkdirSync(path.dirname(file), { recursive: true });
+  fs.writeFileSync(file, content);
+}
+
+function createCandidate(candidateRoot, markerFile, missingModule = null) {
+  writeFile(path.join(candidateRoot, "package.json"), `${JSON.stringify({ name: "larkin", version: VERSION })}\n`);
+  writeFile(path.join(candidateRoot, "test/fixtures/runtime-upgrade/v0.3.3-active-thread.json"), "{}\n");
+  const marker = JSON.stringify(markerFile);
+  const modules = {
+    agentStateStore: ["dist/agent/agent-state-store.mjs", `
+import fs from "node:fs";
+fs.appendFileSync(${marker}, "agent-state-store\\n");
+export function createAgentStateStore() {
+  return { kind: "candidate-agent-state-store", origin: import.meta.url };
+}
+`],
+    contextPrompt: ["dist/agent/context-prompt.mjs", `
+import fs from "node:fs";
+fs.appendFileSync(${marker}, "context-prompt\\n");
+export class ContextPromptBuilder {
+  constructor() {
+    this.payload = { kind: "candidate-context-prompt", origin: import.meta.url };
+  }
+}
+`],
+    runtimeHost: ["dist/runtime/runtime-host.mjs", `
+import fs from "node:fs";
+fs.appendFileSync(${marker}, "runtime-host\\n");
+export function createRuntimeHost() {
+  return { kind: "candidate-runtime-host", origin: import.meta.url };
+}
+`],
+  };
+  for (const [name, [relativeFile, content]] of Object.entries(modules)) {
+    if (name !== missingModule) writeFile(path.join(candidateRoot, relativeFile), content.trimStart());
+  }
+}
+
+function createTopology({ missingModule = null } = {}) {
+  const temporaryRoot = fs.mkdtempSync(path.join(os.tmpdir(), "larkin-release-recovery-topology-"));
+  const toolingRoot = path.join(temporaryRoot, "release-tooling");
+  const candidateRoot = path.join(temporaryRoot, "release-source");
+  const markerFile = path.join(temporaryRoot, "candidate-imports.txt");
+  copyFile(path.join(ROOT, "scripts/release/smoke.ts"), path.join(toolingRoot, "scripts/release/smoke.ts"));
+  copyFile(path.join(ROOT, "scripts/release/smoke-support.ts"), path.join(toolingRoot, "scripts/release/smoke-support.ts"));
+  copyFile(path.join(ROOT, "src/platform/release-artifacts.ts"), path.join(toolingRoot, "src/platform/release-artifacts.ts"));
+  createCandidate(candidateRoot, markerFile, missingModule);
+  return {
+    temporaryRoot,
+    toolingRoot,
+    toolingSmoke: path.join(toolingRoot, "scripts/release/smoke.ts"),
+    candidateRoot,
+    markerFile,
+  };
+}
+
+function runCandidateProbe(topology, { cwd = topology.candidateRoot, candidateRoot = topology.candidateRoot } = {}) {
+  const probe = path.join(topology.toolingRoot, "candidate-probe.ts");
+  writeFile(probe, `
+import { loadCandidateRuntimeUpgradeModules } from ${JSON.stringify(pathToFileURL(topology.toolingSmoke).href)};
+const loaded = await loadCandidateRuntimeUpgradeModules(${JSON.stringify(VERSION)});
+const agentStateStore = loaded.createAgentStateStore();
+const contextPrompt = new loaded.ContextPromptBuilder().payload;
+const runtimeHost = loaded.createRuntimeHost();
+process.stdout.write(JSON.stringify({
+  candidateRoot: loaded.candidateRoot,
+  fixture: loaded.upgradeFixtureFile,
+  origins: loaded.moduleOrigins,
+  payloads: { agentStateStore, contextPrompt, runtimeHost },
+}));
+`.trimStart());
+  return spawnSync(process.execPath, [probe], {
+    cwd,
+    env: { ...process.env, LARKIN_RELEASE_CANDIDATE_ROOT: candidateRoot },
+    encoding: "utf8",
+    timeout: 15_000,
+    windowsHide: true,
+  });
+}
+
+function moduleUrl(candidateRoot, relativeFile) {
+  return pathToFileURL(fs.realpathSync.native(path.join(candidateRoot, relativeFile))).href;
+}
+
+test("recovery tooling loads the candidate-only Runtime modules and the old script-relative counterfactual fails", () => {
+  const topology = createTopology();
+  try {
+    const oldStaticRelativeModule = path.resolve(path.dirname(topology.toolingSmoke), "../../dist/agent/agent-state-store.mjs");
+    assert.equal(fs.existsSync(oldStaticRelativeModule), false, "the tooling checkout intentionally has no candidate dist");
+    const counterfactual = spawnSync(process.execPath, ["-e", `await import(${JSON.stringify(pathToFileURL(oldStaticRelativeModule).href)})`], {
+      cwd: topology.candidateRoot,
+      encoding: "utf8",
+      timeout: 15_000,
+      windowsHide: true,
+    });
+    assert.notEqual(counterfactual.status, 0, "the former static script-relative import must fail in recovery topology");
+
+    const result = runCandidateProbe(topology);
+    assert.equal(result.status, 0, `candidate probe failed\nstdout:\n${result.stdout}\nstderr:\n${result.stderr}`);
+    const payload = JSON.parse(result.stdout);
+    const expectedOrigins = {
+      agentStateStore: moduleUrl(topology.candidateRoot, "dist/agent/agent-state-store.mjs"),
+      contextPrompt: moduleUrl(topology.candidateRoot, "dist/agent/context-prompt.mjs"),
+      runtimeHost: moduleUrl(topology.candidateRoot, "dist/runtime/runtime-host.mjs"),
+    };
+    assert.equal(payload.candidateRoot, fs.realpathSync.native(topology.candidateRoot));
+    assert.equal(payload.fixture, fs.realpathSync.native(path.join(topology.candidateRoot, "test/fixtures/runtime-upgrade/v0.3.3-active-thread.json")));
+    assert.deepEqual(payload.origins, expectedOrigins);
+    assert.deepEqual(payload.payloads, {
+      agentStateStore: { kind: "candidate-agent-state-store", origin: expectedOrigins.agentStateStore },
+      contextPrompt: { kind: "candidate-context-prompt", origin: expectedOrigins.contextPrompt },
+      runtimeHost: { kind: "candidate-runtime-host", origin: expectedOrigins.runtimeHost },
+    });
+    assert.deepEqual(fs.readFileSync(topology.markerFile, "utf8").trim().split("\n").sort(), [
+      "agent-state-store",
+      "context-prompt",
+      "runtime-host",
+    ]);
+  } finally {
+    fs.rmSync(topology.temporaryRoot, { recursive: true, force: true });
+  }
+});
+
+test("recovery candidate authority fails closed when the explicit root is missing", () => {
+  const topology = createTopology();
+  try {
+    const result = runCandidateProbe(topology, { candidateRoot: path.join(topology.temporaryRoot, "missing-release-source") });
+    assert.notEqual(result.status, 0);
+    assert.match(result.stderr, /LARKIN_RELEASE_CANDIDATE_ROOT candidate root is unavailable/);
+    assert.equal(fs.existsSync(topology.markerFile), false, "a missing root must not import candidate code");
+  } finally {
+    fs.rmSync(topology.temporaryRoot, { recursive: true, force: true });
+  }
+});
+
+test("recovery candidate validation rejects missing dist before importing any candidate module", () => {
+  const topology = createTopology({ missingModule: "runtimeHost" });
+  try {
+    const result = runCandidateProbe(topology);
+    assert.notEqual(result.status, 0);
+    assert.match(result.stderr, /release smoke candidate file is missing: dist[\\/]runtime[\\/]runtime-host\.mjs/);
+    assert.equal(fs.existsSync(topology.markerFile), false, "all candidate files must validate before the first dynamic import");
+  } finally {
+    fs.rmSync(topology.temporaryRoot, { recursive: true, force: true });
+  }
+});
+
+test("recovery candidate validation rejects an explicit root that mismatches the working source", () => {
+  const topology = createTopology();
+  const otherCandidateRoot = path.join(topology.temporaryRoot, "other-release-source");
+  const otherMarkerFile = path.join(topology.temporaryRoot, "other-candidate-imports.txt");
+  createCandidate(otherCandidateRoot, otherMarkerFile);
+  try {
+    const result = runCandidateProbe(topology, { candidateRoot: otherCandidateRoot });
+    assert.notEqual(result.status, 0);
+    assert.match(result.stderr, /LARKIN_RELEASE_CANDIDATE_ROOT does not match the release smoke working directory/);
+    assert.equal(fs.existsSync(topology.markerFile), false);
+    assert.equal(fs.existsSync(otherMarkerFile), false, "a mismatched explicit root must not import either candidate");
+  } finally {
+    fs.rmSync(topology.temporaryRoot, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
## Summary

- Resolve the issue-124 Runtime upgrade fixture and compiled Runtime modules from one explicit immutable candidate root instead of the release-tooling script location.
- Validate the candidate root, package identity, fixture, and all three regular module files before using `pathToFileURL()` dynamic imports; an explicit root must match the smoke working directory and never falls back.
- Build the exact recovery candidate in `verify-windows-release` before retaining the assembled-manifest/SHA gate and native Windows executable smoke.
- Add a recovery-topology regression to the native Windows source gate.

## Failure and root cause

Recovery run https://github.com/eddiearc/larkin/actions/runs/31924011327 reached job https://github.com/eddiearc/larkin/actions/runs/31924011327/job/95110346940 with the exact Windows manifest and SHA256SUMS verified, then failed before executable behavior was exercised:

```text
Cannot find module '../../dist/agent/agent-state-store.mjs' from 'D:\a\larkin\larkin\release-tooling\scripts\release\smoke.ts'
```

The recovery workflow intentionally executes current tooling from `release-tooling/` while the immutable v0.4.1 candidate is under `release-source/`. PR #125's new static `../../dist/...` imports were therefore anchored to the tooling checkout. Recovery also installed candidate dependencies but did not build candidate `dist`; normal platform jobs already did both.

## Regression evidence

The new integration test creates separate `release-tooling/` and `release-source/` trees with candidate modules only under `release-source/dist`. It executes the old script-relative import as a failing counterfactual, then loads the copied smoke tooling and inspects the final module URLs and exported payload origins. Missing root, missing dist (before any candidate import), and valid-but-mismatched root cases all fail closed.

## Validation

- `bun run typecheck` — pass
- `bun run build` — pass
- Native-Windows focused contract command, simulated locally — **113 passed, 0 failed**
- Full release-relevant set — **12 passed, 1 expected opt-in skip, 0 failed**
- Candidate-root topology regression — **4 passed, 0 failed**
- darwin-arm64 standalone release smoke using both cwd authority and explicit candidate-root authority — pass; local artifact was intentionally dirty and is not immutable-release provenance evidence
- `bun run licenses:check` — 212 package versions
- `bun run publication:check:tree` — 337 files
- Hosted run https://github.com/eddiearc/larkin/actions/runs/31925922380 — pass: Linux source checks (frontend **24/24**; unit **621 passed, 2 skipped, 0 failed**; integration **187 passed, 17 skipped, 0 failed**; E2E **14/14**; official bind **1/1**), Windows artifact build, native focused gate **113/113**, and native Windows standalone smoke (`HTTP 200`)

## Side effects and claim boundaries

Recovery Windows verification gains one candidate `bun run build`; manifest/SHA verification and native executable smoke remain blocking and unchanged. Normal Linux/macOS/Windows source/platform smoke continues to use its source working directory. Package version remains `0.4.1`. Additional broad local sweeps are not claimed: existing process-lock/CIM timing and process-identity cases failed under this Agent environment, while the complete hosted Linux suite passed; this PR deliberately makes no CIM/O_NOFOLLOW changes. Hosted source CI proves the PR topology, not the still-unrerun official recovery topology. This PR does not touch a production or Windows host, tag, draft, release, npm, issue state, or existing assets.

## Recovery plan

After review and merge only, rerun the existing official `Publish release` recovery workflow for tag `v0.4.1` and immutable source `880f8312696170c10dc5dbf89a2f111cc0f338ac`, reusing the existing draft/assets. Do not create or edit another draft, move the tag, or publish outside that workflow.

Refs #124
