### PR TITLE
fix(runtime): wake on late Pi background completion

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "larkin",
-  "version": "0.4.9",
+  "version": "0.4.10",
   "private": false,
   "larkinPackageRole": "npm-published",
   "files": [

--- a/src/runtime/pi-subagents-notification.ts
+++ b/src/runtime/pi-subagents-notification.ts
@@ -1,0 +1,136 @@
+export interface CanonicalPiSubagentNotificationOptions {
+  taskId: string;
+  toolUseId?: string;
+  outputFile?: string;
+  status?: string;
+  summary?: string;
+  result?: string;
+  totalTokens?: number;
+  toolUses?: number;
+  durationMs?: number;
+}
+
+export interface CanonicalPiSubagentNotificationBlock {
+  taskId: string;
+  toolUseId?: string;
+  outputFile?: string;
+  status: string;
+  summary: string;
+  result: string;
+}
+
+export interface CanonicalPiSubagentNotification {
+  taskIds: string[];
+  notifications: CanonicalPiSubagentNotificationBlock[];
+  content: string;
+  key: string;
+}
+
+function escapeXml(value: string): string {
+  return value.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
+}
+
+function extractTag(content: string, tagName: string): string | null {
+  const match = new RegExp(`<${tagName}>([\\s\\S]*?)</${tagName}>`).exec(content);
+  return match ? match[1].trim() : null;
+}
+
+function parseTaskNotificationBlock(block: string): CanonicalPiSubagentNotificationBlock | null {
+  const taskId = extractTag(block, "task-id");
+  const status = extractTag(block, "status");
+  const summary = extractTag(block, "summary");
+  const result = extractTag(block, "result");
+  if (!taskId || !status || !summary || !result) return null;
+  if (status !== "Done") return null;
+  if (!/completed\b/i.test(summary)) return null;
+  return {
+    taskId,
+    toolUseId: extractTag(block, "tool-use-id") ?? undefined,
+    outputFile: extractTag(block, "output-file") ?? undefined,
+    status,
+    summary,
+    result,
+  };
+}
+
+function parseCanonicalNotificationContent(content: string): CanonicalPiSubagentNotification | null {
+  const blocks = [...content.matchAll(/<task-notification>([\s\S]*?)<\/task-notification>/g)]
+    .map((match) => match[1]);
+  if (blocks.length === 0) return null;
+  const notifications = blocks.map((block) => parseTaskNotificationBlock(block));
+  if (notifications.some((notification) => notification === null)) return null;
+  const canonical = notifications as CanonicalPiSubagentNotificationBlock[];
+  const taskIds = canonical.map((notification) => notification.taskId);
+  if (taskIds.some((taskId) => !taskId)) return null;
+  return { taskIds, notifications: canonical, content, key: taskIds.join("|") };
+}
+
+function collectCandidateContents(node: unknown, found = new Set<string>()): string[] {
+  const candidates: string[] = [];
+  const visit = (value: unknown): void => {
+    if (value === null || value === undefined) return;
+    if (typeof value === "string") {
+      if (!found.has(value)) { found.add(value); candidates.push(value); }
+      return;
+    }
+    if (Array.isArray(value)) {
+      for (const item of value) visit(item);
+      return;
+    }
+    if (typeof value !== "object") return;
+    const record = value as Record<string, unknown>;
+    if (typeof record.customType === "string" && typeof record.content === "string") visit(record.content);
+    if (typeof record.content === "string") visit(record.content);
+    else if (Array.isArray(record.content)) visit(record.content);
+    if (Array.isArray(record.messages)) visit(record.messages);
+    if (Array.isArray(record.parts)) visit(record.parts);
+  };
+  visit(node);
+  return candidates;
+}
+
+export function buildCanonicalPiSubagentNotificationContent(options: CanonicalPiSubagentNotificationOptions): string {
+  const status = options.status ?? "Done";
+  const summary = options.summary ?? `Agent ${JSON.stringify("Fixture")} completed`;
+  const result = options.result ?? "Fixture result.";
+  const totalTokens = options.totalTokens ?? 12;
+  const toolUses = options.toolUses ?? 1;
+  const durationMs = options.durationMs ?? 34;
+  return [
+    "<task-notification>",
+    `<task-id>${escapeXml(options.taskId)}</task-id>`,
+    options.toolUseId ? `<tool-use-id>${escapeXml(options.toolUseId)}</tool-use-id>` : null,
+    options.outputFile ? `<output-file>${escapeXml(options.outputFile)}</output-file>` : null,
+    `<status>${escapeXml(status)}</status>`,
+    `<summary>${escapeXml(summary)}</summary>`,
+    `<result>${escapeXml(result)}</result>`,
+    `<usage><total_tokens>${totalTokens}</total_tokens><tool_uses>${toolUses}</tool_uses><duration_ms>${durationMs}</duration_ms></usage>`,
+    "</task-notification>",
+  ].filter(Boolean).join("\n");
+}
+
+export function buildCanonicalPiSubagentAssistantMessage(options: CanonicalPiSubagentNotificationOptions): {
+  role: "assistant";
+  content: Array<{ type: "custom"; customType: "subagent-notification"; content: string }>;
+} {
+  return {
+    role: "assistant",
+    content: [{
+      type: "custom",
+      customType: "subagent-notification",
+      content: buildCanonicalPiSubagentNotificationContent(options),
+    }],
+  };
+}
+
+export function extractCanonicalPiSubagentNotification(messages: unknown): CanonicalPiSubagentNotification | null {
+  for (const content of collectCandidateContents(messages)) {
+    const parsed = parseCanonicalNotificationContent(content);
+    if (parsed) return parsed;
+  }
+  return null;
+}
+
+export function extractCanonicalPiSubagentCompletionKeyFromMessages(messages: unknown): string | null {
+  return extractCanonicalPiSubagentNotification(messages)?.key ?? null;
+}

--- a/src/runtime/pi-subagents-notification.ts
+++ b/src/runtime/pi-subagents-notification.ts
@@ -103,19 +103,17 @@ function collectCandidateContents(node: unknown, found = new Set<string>()): str
   const candidates: string[] = [];
   const visit = (value: unknown): void => {
     if (value === null || value === undefined) return;
-    if (typeof value === "string") {
-      if (!found.has(value)) { found.add(value); candidates.push(value); }
-      return;
-    }
     if (Array.isArray(value)) {
       for (const item of value) visit(item);
       return;
     }
     if (typeof value !== "object") return;
     const record = value as Record<string, unknown>;
-    if (typeof record.customType === "string" && typeof record.content === "string") visit(record.content);
-    if (typeof record.content === "string") visit(record.content);
-    else if (Array.isArray(record.content)) visit(record.content);
+    if (record.customType === "subagent-notification" && typeof record.content === "string") {
+      if (!found.has(record.content)) { found.add(record.content); candidates.push(record.content); }
+    } else if (Array.isArray(record.content)) {
+      visit(record.content);
+    }
     if (Array.isArray(record.messages)) visit(record.messages);
     if (Array.isArray(record.parts)) visit(record.parts);
   };

--- a/src/runtime/pi-subagents-notification.ts
+++ b/src/runtime/pi-subagents-notification.ts
@@ -35,14 +35,43 @@ function extractTag(content: string, tagName: string): string | null {
   return match ? match[1].trim() : null;
 }
 
+/**
+ * Pi subagents emit terminal <status> as Done or a display label
+ * (Error: ..., Aborted (...), Stopped, Wrapped up (turn limit)).
+ * Raw tokens completed/error/aborted/stopped/steered/turn-limit are also accepted.
+ */
+const TERMINAL_STATUS_TOKENS = new Set([
+  "done",
+  "completed",
+  "error",
+  "aborted",
+  "stopped",
+  "steered",
+  "turn-limit",
+  "turn_limit",
+]);
+
+export function isCanonicalTerminalPiSubagentStatus(status: string): boolean {
+  const normalized = status.trim().toLowerCase();
+  if (!normalized) return false;
+  if (TERMINAL_STATUS_TOKENS.has(normalized)) return true;
+  if (normalized.startsWith("error:") || normalized.startsWith("error ")) return true;
+  if (normalized.startsWith("aborted")) return true;
+  if (normalized.startsWith("stopped")) return true;
+  if (normalized.includes("turn limit") || normalized.includes("turn-limit") || normalized.includes("turn_limit")) {
+    return true;
+  }
+  if (normalized.includes("steered")) return true;
+  return false;
+}
+
 function parseTaskNotificationBlock(block: string): CanonicalPiSubagentNotificationBlock | null {
   const taskId = extractTag(block, "task-id");
   const status = extractTag(block, "status");
   const summary = extractTag(block, "summary");
   const result = extractTag(block, "result");
   if (!taskId || !status || !summary || !result) return null;
-  if (status !== "Done") return null;
-  if (!/completed\b/i.test(summary)) return null;
+  if (!isCanonicalTerminalPiSubagentStatus(status)) return null;
   return {
     taskId,
     toolUseId: extractTag(block, "tool-use-id") ?? undefined,
@@ -57,12 +86,17 @@ function parseCanonicalNotificationContent(content: string): CanonicalPiSubagent
   const blocks = [...content.matchAll(/<task-notification>([\s\S]*?)<\/task-notification>/g)]
     .map((match) => match[1]);
   if (blocks.length === 0) return null;
-  const notifications = blocks.map((block) => parseTaskNotificationBlock(block));
-  if (notifications.some((notification) => notification === null)) return null;
-  const canonical = notifications as CanonicalPiSubagentNotificationBlock[];
-  const taskIds = canonical.map((notification) => notification.taskId);
-  if (taskIds.some((taskId) => !taskId)) return null;
-  return { taskIds, notifications: canonical, content, key: taskIds.join("|") };
+  const seen = new Set<string>();
+  const notifications: CanonicalPiSubagentNotificationBlock[] = [];
+  for (const block of blocks) {
+    const parsed = parseTaskNotificationBlock(block);
+    if (!parsed || seen.has(parsed.taskId)) continue;
+    seen.add(parsed.taskId);
+    notifications.push(parsed);
+  }
+  if (notifications.length === 0) return null;
+  const taskIds = notifications.map((notification) => notification.taskId);
+  return { taskIds, notifications, content, key: taskIds.join("|") };
 }
 
 function collectCandidateContents(node: unknown, found = new Set<string>()): string[] {

--- a/src/runtime/pi-subagents-notification.ts
+++ b/src/runtime/pi-subagents-notification.ts
@@ -156,11 +156,22 @@ export function buildCanonicalPiSubagentAssistantMessage(options: CanonicalPiSub
 }
 
 export function extractCanonicalPiSubagentNotification(messages: unknown): CanonicalPiSubagentNotification | null {
+  const seen = new Set<string>();
+  const notifications: CanonicalPiSubagentNotificationBlock[] = [];
+  const contents: string[] = [];
   for (const content of collectCandidateContents(messages)) {
     const parsed = parseCanonicalNotificationContent(content);
-    if (parsed) return parsed;
+    if (!parsed) continue;
+    contents.push(parsed.content);
+    for (const notification of parsed.notifications) {
+      if (seen.has(notification.taskId)) continue;
+      seen.add(notification.taskId);
+      notifications.push(notification);
+    }
   }
-  return null;
+  if (notifications.length === 0) return null;
+  const taskIds = notifications.map((notification) => notification.taskId);
+  return { taskIds, notifications, content: contents.join("\n"), key: taskIds.join("|") };
 }
 
 export function extractCanonicalPiSubagentCompletionKeyFromMessages(messages: unknown): string | null {

--- a/src/runtime/runtime-adapters.ts
+++ b/src/runtime/runtime-adapters.ts
@@ -524,6 +524,7 @@ class PiSession extends EventSession {
   private readonly observedAcceptedEpochs = new Set<number>();
   private readonly observedCompletedEpochs = new Set<number>();
   private readonly observedBackgroundCompletionKeys = new Set<string>();
+  private readonly pendingUnownedCompletionKeys = new Set<string>();
   private readonly observedAgentEndEpochs = new Set<number>();
   private firstOutputObserved = false;
   private toolCallOpen = false;
@@ -616,6 +617,7 @@ class PiSession extends EventSession {
       this.observedAcceptedEpochs.clear();
       this.observedCompletedEpochs.clear();
       this.observedBackgroundCompletionKeys.clear();
+      this.pendingUnownedCompletionKeys.clear();
       this.observedAgentEndEpochs.clear();
       this.activeEpoch = null;
       this.settleArmedEpoch = null;
@@ -664,12 +666,20 @@ class PiSession extends EventSession {
       if (completionNotificationKey
         && this.activeEpoch === null
         && !this.observedBackgroundCompletionKeys.has(completionNotificationKey)) {
-        this.observedBackgroundCompletionKeys.add(completionNotificationKey);
-        this.emitObservation("completed", { completionKey: completionNotificationKey });
+        // agent_end can still have an active Pi session. Prompting before
+        // unowned agent_settled is rejected as "Agent is already processing".
+        this.pendingUnownedCompletionKeys.add(completionNotificationKey);
       }
     } else if (event?.type === "agent_settled") {
       const epoch = this.activeEpoch;
-      if (epoch === null || this.settleArmedEpoch !== epoch) return;
+      if (epoch === null) {
+        this.flushPendingUnownedCompletions();
+        return;
+      }
+      if (this.settleArmedEpoch !== epoch) {
+        this.flushPendingUnownedCompletions();
+        return;
+      }
       this.activeEpoch = null;
       this.settleArmedEpoch = null;
       const error = this.finalAssistantError;
@@ -703,6 +713,7 @@ class PiSession extends EventSession {
       this.observedAcceptedEpochs.delete(epoch);
       this.observedCompletedEpochs.delete(epoch);
       this.observedAgentEndEpochs.delete(epoch);
+      this.flushPendingUnownedCompletions();
     }
     else if (event?.type === "tool_execution_start") {
       if (!this.firstOutputObserved) {
@@ -729,6 +740,15 @@ class PiSession extends EventSession {
       const kind = event.assistantMessageEvent.type?.startsWith("thinking") ? "thinking" : "text";
       this.emit({ type: "activity", activity: kind, text: String(event.assistantMessageEvent.delta) });
     }
+  }
+
+  private flushPendingUnownedCompletions(): void {
+    for (const completionKey of this.pendingUnownedCompletionKeys) {
+      if (this.observedBackgroundCompletionKeys.has(completionKey)) continue;
+      this.observedBackgroundCompletionKeys.add(completionKey);
+      this.emitObservation("completed", { completionKey });
+    }
+    this.pendingUnownedCompletionKeys.clear();
   }
 
   private emitObservation(phase: Extract<NormalizedRuntimeEvent, { type: "runtime-observation" }>['phase'], fields: {

--- a/src/runtime/runtime-adapters.ts
+++ b/src/runtime/runtime-adapters.ts
@@ -522,6 +522,7 @@ class PiSession extends EventSession {
   private readonly observedSubmitEpochs = new Set<number>();
   private readonly observedAcceptedEpochs = new Set<number>();
   private readonly observedCompletedEpochs = new Set<number>();
+  private readonly observedBackgroundCompletionNotifications = new Set<string>();
   private readonly observedAgentEndEpochs = new Set<number>();
   private firstOutputObserved = false;
   private toolCallOpen = false;
@@ -613,6 +614,7 @@ class PiSession extends EventSession {
       this.observedSubmitEpochs.clear();
       this.observedAcceptedEpochs.clear();
       this.observedCompletedEpochs.clear();
+      this.observedBackgroundCompletionNotifications.clear();
       this.observedAgentEndEpochs.clear();
       this.activeEpoch = null;
       this.settleArmedEpoch = null;
@@ -634,6 +636,7 @@ class PiSession extends EventSession {
       this.settleArmedEpoch = null;
       this.firstOutputObserved = false;
       this.toolCallOpen = false;
+      this.observedBackgroundCompletionNotifications.clear();
       this.emitObservation("turn_start");
       this.emit({ type: "turn-start", ...(Number.isInteger(event.turnIndex) ? { turnId: `pi-${event.turnIndex}` } : {}) });
     }
@@ -655,6 +658,13 @@ class PiSession extends EventSession {
       }
       if (event.willRetry !== true && this.activeEpoch !== null && !this.observedCompletedEpochs.has(this.activeEpoch)) {
         this.observedCompletedEpochs.add(this.activeEpoch);
+        this.emitObservation("completed");
+      }
+      const completionNotificationKey = Array.isArray(event.messages) ? JSON.stringify(event.messages) : null;
+      if (completionNotificationKey?.includes("subagent-notification")
+        && this.activeEpoch === null
+        && !this.observedBackgroundCompletionNotifications.has(completionNotificationKey)) {
+        this.observedBackgroundCompletionNotifications.add(completionNotificationKey);
         this.emitObservation("completed");
       }
     } else if (event?.type === "agent_settled") {

--- a/src/runtime/runtime-adapters.ts
+++ b/src/runtime/runtime-adapters.ts
@@ -22,6 +22,7 @@ import { BUNDLED_PI_VERSION, piAgentDirectory } from "./pi-provider-config.js";
 import { recordPiRuntimeArtifactProvenance } from "./pi-artifact-provenance.js";
 import { traceProcessBoundary } from "../platform/process-boundary-trace.js";
 import { resolvePiSubagentExtensionArg } from "./pi-subagent-injection.js";
+import { extractCanonicalPiSubagentCompletionKeyFromMessages } from "./pi-subagents-notification.js";
 import { resolvePiBashTimeoutExtensionArg } from "./pi-bash-timeout-injection.js";
 import {
   classifyRuntimePrerequisite,
@@ -522,7 +523,7 @@ class PiSession extends EventSession {
   private readonly observedSubmitEpochs = new Set<number>();
   private readonly observedAcceptedEpochs = new Set<number>();
   private readonly observedCompletedEpochs = new Set<number>();
-  private readonly observedBackgroundCompletionNotifications = new Set<string>();
+  private readonly observedBackgroundCompletionKeys = new Set<string>();
   private readonly observedAgentEndEpochs = new Set<number>();
   private firstOutputObserved = false;
   private toolCallOpen = false;
@@ -614,7 +615,7 @@ class PiSession extends EventSession {
       this.observedSubmitEpochs.clear();
       this.observedAcceptedEpochs.clear();
       this.observedCompletedEpochs.clear();
-      this.observedBackgroundCompletionNotifications.clear();
+      this.observedBackgroundCompletionKeys.clear();
       this.observedAgentEndEpochs.clear();
       this.activeEpoch = null;
       this.settleArmedEpoch = null;
@@ -636,7 +637,6 @@ class PiSession extends EventSession {
       this.settleArmedEpoch = null;
       this.firstOutputObserved = false;
       this.toolCallOpen = false;
-      this.observedBackgroundCompletionNotifications.clear();
       this.emitObservation("turn_start");
       this.emit({ type: "turn-start", ...(Number.isInteger(event.turnIndex) ? { turnId: `pi-${event.turnIndex}` } : {}) });
     }
@@ -660,12 +660,12 @@ class PiSession extends EventSession {
         this.observedCompletedEpochs.add(this.activeEpoch);
         this.emitObservation("completed");
       }
-      const completionNotificationKey = Array.isArray(event.messages) ? JSON.stringify(event.messages) : null;
-      if (completionNotificationKey?.includes("subagent-notification")
+      const completionNotificationKey = extractCanonicalPiSubagentCompletionKeyFromMessages(event.messages);
+      if (completionNotificationKey
         && this.activeEpoch === null
-        && !this.observedBackgroundCompletionNotifications.has(completionNotificationKey)) {
-        this.observedBackgroundCompletionNotifications.add(completionNotificationKey);
-        this.emitObservation("completed");
+        && !this.observedBackgroundCompletionKeys.has(completionNotificationKey)) {
+        this.observedBackgroundCompletionKeys.add(completionNotificationKey);
+        this.emitObservation("completed", { completionKey: completionNotificationKey });
       }
     } else if (event?.type === "agent_settled") {
       const epoch = this.activeEpoch;
@@ -732,7 +732,7 @@ class PiSession extends EventSession {
   }
 
   private emitObservation(phase: Extract<NormalizedRuntimeEvent, { type: "runtime-observation" }>['phase'], fields: {
-    reason?: "manual" | "threshold" | "overflow"; willRetry?: boolean; success?: boolean;
+    reason?: "manual" | "threshold" | "overflow"; willRetry?: boolean; success?: boolean; completionKey?: string;
   } = {}): void {
     const inputId = this.oldestOwnedInput();
     const observation = { type: "runtime-observation" as const, runtime: "pi" as const,
@@ -740,6 +740,7 @@ class PiSession extends EventSession {
     // Correlation is host-internal metadata, not telemetry payload.
     if (this.sessionId) Object.defineProperty(observation, "sessionId", { value: this.sessionId, enumerable: false });
     if (inputId) Object.defineProperty(observation, "inputId", { value: inputId, enumerable: false });
+    if (fields.completionKey) Object.defineProperty(observation, "completionKey", { value: fields.completionKey, enumerable: false });
     this.emit(observation as NormalizedRuntimeEvent);
   }
 

--- a/src/runtime/runtime-contracts.ts
+++ b/src/runtime/runtime-contracts.ts
@@ -41,7 +41,7 @@ export type NormalizedRuntimeEvent =
   | { type: "runtime-observation"; runtime: "pi"; distribution: "builtin" | "external";
       phase: "rpc_submit" | "rpc_accepted" | "compaction_start" | "compaction_end" | "retry_progress"
         | "rpc_timeout" | "rpc_error" | "turn_start" | "first_output" | "tool_call" | "tool_result" | "agent_end" | "completed" | "settled";
-      reason?: "manual" | "threshold" | "overflow"; willRetry?: boolean; success?: boolean; inputId?: string; sessionId?: string }
+      reason?: "manual" | "threshold" | "overflow"; willRetry?: boolean; success?: boolean; inputId?: string; sessionId?: string; completionKey?: string }
   | { type: "turn-start"; turnId?: string }
   | { type: "activity"; activity: "thinking" | "text" | "tool" | "internal"; text?: string; name?: string }
   | { type: "turn-end"; sessionId?: string; turnId?: string }

--- a/src/runtime/runtime-host.ts
+++ b/src/runtime/runtime-host.ts
@@ -692,6 +692,22 @@ export function createRuntimeHost(options: {
     queueMicrotask(() => { void drainBackgroundCompletionQueue(agent); });
   };
 
+  const dropBackgroundCompletion = (agent: ManagedAgent, completionKey: string | null): void => {
+    if (!completionKey) return;
+    if (agent.backgroundCompletionQueue[0] === completionKey) agent.backgroundCompletionQueue.shift();
+    else {
+      const index = agent.backgroundCompletionQueue.indexOf(completionKey);
+      if (index >= 0) agent.backgroundCompletionQueue.splice(index, 1);
+    }
+    agent.backgroundCompletionKeys.add(completionKey);
+    if (agent.backgroundCompletionInFlight === completionKey) {
+      agent.backgroundCompletionInFlight = null;
+      agent.backgroundCompletionWakeInputId = null;
+    }
+    agent.backgroundCompletionRejectStreak = 0;
+    clearBackgroundCompletionRetryTimer(agent);
+  };
+
   const scheduleBackgroundCompletionRetry = (agent: ManagedAgent): void => {
     const streak = agent.backgroundCompletionRejectStreak;
     if (streak < BACKGROUND_COMPLETION_IMMEDIATE_RETRY_LIMIT) {
@@ -699,9 +715,42 @@ export function createRuntimeHost(options: {
       return;
     }
     const delayedAttempt = streak - BACKGROUND_COMPLETION_IMMEDIATE_RETRY_LIMIT;
-    if (delayedAttempt >= retryPolicy.maxAttempts) return;
+    if (delayedAttempt >= retryPolicy.maxAttempts) {
+      const exhausted = agent.backgroundCompletionQueue[0];
+      if (exhausted) {
+        log("background completion wake retries exhausted", exhausted);
+        dropBackgroundCompletion(agent, exhausted);
+      }
+      if (agent.backgroundCompletionQueue.length > 0) scheduleBackgroundCompletionDrain(agent);
+      return;
+    }
     const delay = Math.min(retryPolicy.maxDelayMs, retryPolicy.baseDelayMs * 2 ** delayedAttempt);
     scheduleBackgroundCompletionDrain(agent, delay);
+  };
+
+  const isPersistentBackgroundWakeFailure = (event?: {
+    retryable?: boolean; errorCategory?: string;
+  }): boolean => {
+    if (!event) return false;
+    const category = event.errorCategory;
+    if (category === "auth" || category === "billing" || category === "quota") return true;
+    return category === "provider" && event.retryable === false;
+  };
+
+  const failBackgroundCompletionWake = (agent: ManagedAgent, event?: {
+    retryable?: boolean; errorCategory?: string;
+  }): void => {
+    const completionKey = agent.backgroundCompletionInFlight ?? agent.backgroundCompletionQueue[0];
+    if (!completionKey) return;
+    rearmBackgroundCompletion(agent, completionKey);
+    if (isPersistentBackgroundWakeFailure(event)) {
+      log("background completion wake dropped", event?.errorCategory ?? "persistent");
+      dropBackgroundCompletion(agent, completionKey);
+      if (agent.backgroundCompletionQueue.length > 0) scheduleBackgroundCompletionDrain(agent);
+      return;
+    }
+    agent.backgroundCompletionRejectStreak += 1;
+    scheduleBackgroundCompletionRetry(agent);
   };
 
   const rearmBackgroundCompletion = (agent: ManagedAgent, completionKey = agent.backgroundCompletionInFlight): void => {
@@ -754,6 +803,18 @@ export function createRuntimeHost(options: {
     if (agent.stopped || agent.busy || agent.turnInProgress || agent.submitting) return;
     if (agent.backgroundCompletionInFlight || !agent.backgroundCompletionQueue.length) return;
     clearBackgroundCompletionRetryTimer(agent);
+    const proactive = agent.piProactiveCompaction
+      && agent.piProactiveCompactionGeneration === agent.generation
+      && agent.piProactiveCompactionSession === agent.session
+      ? agent.piProactiveCompaction : null;
+    if (proactive && await proactive === "failed") return;
+    if (agent.adapter.id === "pi" && agent.piProactiveCompactionFailedGeneration === agent.generation) return;
+    if (agent.adapter.id === "pi" && !agent.busy && !agent.turnInProgress && agent.session) {
+      const idleGate = proactivelyCompactPiAtIdle(agent, agent.session);
+      if (idleGate && await idleGate === "failed") return;
+    }
+    if (agent.stopped || agent.busy || agent.turnInProgress || agent.submitting) return;
+    if (agent.backgroundCompletionInFlight || !agent.backgroundCompletionQueue.length) return;
     agent.submitting = true;
     agent.busy = true;
     const completionKey = agent.backgroundCompletionQueue[0];
@@ -763,7 +824,8 @@ export function createRuntimeHost(options: {
         agent.backgroundCompletionKeys.add(completionKey);
         agent.backgroundCompletionInFlight = completionKey;
         agent.backgroundCompletionWakeInputId = outcome.inputId;
-        agent.backgroundCompletionRejectStreak = 0;
+        // Keep the reject streak until the wake turn actually succeeds. An accepted
+        // prompt that later terminal-fails must not reset the bounded retry budget.
         clearBackgroundCompletionRetryTimer(agent);
       } else if (outcome.status === "dropped") {
         if (agent.stopped) {
@@ -1080,10 +1142,12 @@ export function createRuntimeHost(options: {
       emit({ type: "activity", agentId: agent.config.agentId, activity: "idle", activityKind: "idle", detailKind: "turn_ended" });
       reconcileAcceptedAtTurnEnd(agent);
       if (agent.backgroundCompletionInFlight) {
-        if (agent.turnHadFailure) rearmBackgroundCompletion(agent);
+        if (agent.turnHadFailure) failBackgroundCompletionWake(agent);
         else commitBackgroundCompletion(agent);
       }
-      if (agent.backgroundCompletionQueue.length > 0) scheduleBackgroundCompletionDrain(agent);
+      if (agent.backgroundCompletionQueue.length > 0 && !agent.backgroundCompletionRetryTimer) {
+        scheduleBackgroundCompletionDrain(agent);
+      }
       telemetry?.runtimeEvent(agent.config.agentId, event);
       if (recoveredAuthentication) {
         agent.authFailureActive = false;
@@ -1111,9 +1175,10 @@ export function createRuntimeHost(options: {
     } else if (event.type === "input-error") {
       if (agent.backgroundCompletionInFlight
         && (!event.inputId || !agent.backgroundCompletionWakeInputId
-          || event.inputId === agent.backgroundCompletionWakeInputId)) {
+          || event.inputId === agent.backgroundCompletionWakeInputId)
+        && event.willRetry !== true) {
         agent.turnHadFailure = true;
-        rearmBackgroundCompletion(agent);
+        failBackgroundCompletionWake(agent, event);
       }
       const record = event.inputId
         ? agent.records.get(event.inputId) ?? [...agent.records.values()].find((candidate) => candidate.input.inputId === event.inputId)

--- a/src/runtime/runtime-host.ts
+++ b/src/runtime/runtime-host.ts
@@ -89,6 +89,8 @@ interface ManagedAgent {
   /** Delivery ids already promoted from accepted inbox_update to a wake while idle. */
   promotedInboxUpdateIds: Set<string>;
   backgroundCompletionQueue: string[]; backgroundCompletionKeys: Set<string>;
+  backgroundCompletionInFlight: string | null; backgroundCompletionWakeInputId: string | null;
+  backgroundCompletionRejectStreak: number;
 }
 
 export interface RuntimeHost {
@@ -666,43 +668,83 @@ export function createRuntimeHost(options: {
     await retryPending(agent);
   };
 
-  const wakeOnBackgroundCompletion = async (agent: ManagedAgent): Promise<"accepted" | "retry" | "dropped"> => {
+  const scheduleBackgroundCompletionDrain = (agent: ManagedAgent): void => {
+    if (agent.stopped) return;
+    queueMicrotask(() => { void drainBackgroundCompletionQueue(agent); });
+  };
+
+  const rearmBackgroundCompletion = (agent: ManagedAgent, completionKey = agent.backgroundCompletionInFlight): void => {
+    if (!completionKey) return;
+    agent.backgroundCompletionKeys.delete(completionKey);
+    if (agent.backgroundCompletionInFlight === completionKey) {
+      agent.backgroundCompletionInFlight = null;
+      agent.backgroundCompletionWakeInputId = null;
+    }
+    if (!agent.backgroundCompletionQueue.includes(completionKey)) {
+      agent.backgroundCompletionQueue.unshift(completionKey);
+    }
+  };
+
+  const commitBackgroundCompletion = (agent: ManagedAgent): void => {
+    const completionKey = agent.backgroundCompletionInFlight;
+    if (!completionKey) return;
+    if (agent.backgroundCompletionQueue[0] === completionKey) agent.backgroundCompletionQueue.shift();
+    agent.backgroundCompletionInFlight = null;
+    agent.backgroundCompletionWakeInputId = null;
+    agent.backgroundCompletionRejectStreak = 0;
+  };
+
+  const wakeOnBackgroundCompletion = async (agent: ManagedAgent): Promise<
+    { status: "accepted"; inputId: string } | { status: "retry" } | { status: "dropped" }
+  > => {
     // Caller already reserved submitting/busy so a concurrent idle drain cannot
     // dequeue another head while ensureSession/prompt yields.
     try {
       const session = await ensureSession(agent);
-      if (agent.session !== session || agent.stopped) return "dropped";
+      if (agent.session !== session || agent.stopped) return { status: "dropped" };
       const input = options.promptBuilder.buildRuntimeInput("wake", crypto.randomUUID(), { wakeReason: "background subagent completed" });
       const result = await session.prompt(input);
-      if (agent.session !== session || agent.stopped) return "dropped";
+      if (agent.session !== session || agent.stopped) return { status: "dropped" };
       if (result.status === "accepted") {
         markSessionStable(agent, session);
-        return "accepted";
+        return { status: "accepted", inputId: input.inputId };
       }
       agent.busy = false;
-      return "retry";
+      return { status: "retry" };
     } catch (error) {
       agent.busy = false;
       log("background completion wake failed", error instanceof Error ? error.message : String(error));
-      return "retry";
+      return { status: "retry" };
     }
   };
 
   const drainBackgroundCompletionQueue = async (agent: ManagedAgent): Promise<void> => {
     if (agent.stopped || agent.busy || agent.turnInProgress || agent.submitting) return;
-    if (!agent.backgroundCompletionQueue.length) return;
+    if (agent.backgroundCompletionInFlight || !agent.backgroundCompletionQueue.length) return;
     agent.submitting = true;
     agent.busy = true;
     const completionKey = agent.backgroundCompletionQueue[0];
     try {
       const outcome = await wakeOnBackgroundCompletion(agent);
-      if (outcome === "accepted" || outcome === "dropped") {
-        if (agent.backgroundCompletionQueue[0] === completionKey) {
-          agent.backgroundCompletionQueue.shift();
+      if (outcome.status === "accepted") {
+        agent.backgroundCompletionKeys.add(completionKey);
+        agent.backgroundCompletionInFlight = completionKey;
+        agent.backgroundCompletionWakeInputId = outcome.inputId;
+        agent.backgroundCompletionRejectStreak = 0;
+      } else if (outcome.status === "dropped") {
+        if (agent.stopped) {
+          if (agent.backgroundCompletionQueue[0] === completionKey) agent.backgroundCompletionQueue.shift();
+          agent.backgroundCompletionKeys.delete(completionKey);
+        } else {
+          rearmBackgroundCompletion(agent, completionKey);
+          agent.busy = false;
         }
       } else {
         agent.busy = false;
-        agent.backgroundCompletionKeys.delete(completionKey);
+        agent.backgroundCompletionRejectStreak += 1;
+        // Leave the item at the queue head and schedule another drain. Without
+        // this, a rejected idle wake is never retried because Pi will not re-emit.
+        if (agent.backgroundCompletionRejectStreak < 5) scheduleBackgroundCompletionDrain(agent);
       }
     } finally {
       agent.submitting = false;
@@ -715,8 +757,8 @@ export function createRuntimeHost(options: {
     if (!agent.backgroundCompletionQueue.includes(completionKey)) {
       agent.backgroundCompletionQueue.push(completionKey);
     }
-    if (!agent.busy && !agent.turnInProgress && !agent.submitting) {
-      queueMicrotask(() => { void drainBackgroundCompletionQueue(agent); });
+    if (!agent.busy && !agent.turnInProgress && !agent.submitting && !agent.backgroundCompletionInFlight) {
+      scheduleBackgroundCompletionDrain(agent);
     }
   };
 
@@ -739,6 +781,7 @@ export function createRuntimeHost(options: {
         const proactive = session ? proactivelyCompactPiAtIdle(agent, session) : null;
         if (proactive && await proactive === "failed") return;
         await retryPending(agent);
+        if (agent.backgroundCompletionQueue.length > 0) scheduleBackgroundCompletionDrain(agent);
       }).catch((error) => {
         const readiness = error instanceof RuntimePrerequisiteError ? error.readiness
           : classifyRuntimePrerequisite(agent.adapter.id as RuntimeReadiness["runtime"], error);
@@ -757,7 +800,7 @@ export function createRuntimeHost(options: {
   const replaceSession = (agent: ManagedAgent, session: RuntimeSession, reason: string): void => {
     if (agent.session !== session || agent.stopped) return;
     agent.session = null; agent.busy = false; agent.submitting = false; agent.generation += 1;
-    agent.backgroundCompletionQueue = [];
+    rearmBackgroundCompletion(agent);
     agent.recreateReason = reason;
     if (agent.stabilityTimer) clearTimeout(agent.stabilityTimer);
     agent.stabilityTimer = null;
@@ -772,7 +815,7 @@ export function createRuntimeHost(options: {
     if (agent.session !== session || agent.stopped) return;
     agent.disabledReason = `runtime configuration recovery in progress: ${message}`;
     agent.session = null; agent.busy = false; agent.submitting = false; agent.generation += 1;
-    agent.backgroundCompletionQueue = [];
+    rearmBackgroundCompletion(agent);
     if (agent.stabilityTimer) clearTimeout(agent.stabilityTimer);
     agent.stabilityTimer = null;
     for (const record of agent.records.values()) {
@@ -1000,9 +1043,11 @@ export function createRuntimeHost(options: {
       agent.busy = false;
       emit({ type: "activity", agentId: agent.config.agentId, activity: "idle", activityKind: "idle", detailKind: "turn_ended" });
       reconcileAcceptedAtTurnEnd(agent);
-      if (agent.backgroundCompletionQueue.length > 0) {
-        queueMicrotask(() => { void drainBackgroundCompletionQueue(agent); });
+      if (agent.backgroundCompletionInFlight) {
+        if (agent.turnHadFailure) rearmBackgroundCompletion(agent);
+        else commitBackgroundCompletion(agent);
       }
+      if (agent.backgroundCompletionQueue.length > 0) scheduleBackgroundCompletionDrain(agent);
       telemetry?.runtimeEvent(agent.config.agentId, event);
       if (recoveredAuthentication) {
         agent.authFailureActive = false;
@@ -1028,6 +1073,12 @@ export function createRuntimeHost(options: {
       if (agent.turnInProgress && event.activity !== "internal") agent.turnHadAuthenticatedOutput = true;
       emit({ type: "activity", agentId: agent.config.agentId, activity: event.activity, activityKind: event.activity });
     } else if (event.type === "input-error") {
+      if (agent.backgroundCompletionInFlight
+        && (!event.inputId || !agent.backgroundCompletionWakeInputId
+          || event.inputId === agent.backgroundCompletionWakeInputId)) {
+        agent.turnHadFailure = true;
+        rearmBackgroundCompletion(agent);
+      }
       const record = event.inputId
         ? agent.records.get(event.inputId) ?? [...agent.records.values()].find((candidate) => candidate.input.inputId === event.inputId)
         : undefined;
@@ -1616,7 +1667,9 @@ export function createRuntimeHost(options: {
           piProactiveCompactionFailedGeneration: null, readiness: null,
           turnInProgress: false, turnHadFailure: false, turnHadAuthenticatedOutput: false, authFailureActive: false,
           promotedInboxUpdateIds: new Set(),
-          backgroundCompletionQueue: [], backgroundCompletionKeys: new Set() };
+          backgroundCompletionQueue: [], backgroundCompletionKeys: new Set(),
+          backgroundCompletionInFlight: null, backgroundCompletionWakeInputId: null,
+          backgroundCompletionRejectStreak: 0 };
         const startupConsumed: DeliveryRecord[] = [];
         const startupQuarantined: Array<{ record: DeliveryRecord; code: ReplayFailureCode }> = [];
         for (const record of agent.records.values()) {

--- a/src/runtime/runtime-host.ts
+++ b/src/runtime/runtime-host.ts
@@ -609,6 +609,12 @@ export function createRuntimeHost(options: {
         queueMicrotask(() => { void retryPending(agent); });
       }
       queueMicrotask(() => { void scanAndPromoteAcceptedInboxUpdates(agent); });
+      // A completion queued during this submit has no turn-end if prompt
+      // rejected/threw before turn-start. Drain now that submitting is clear.
+      if (!agent.busy && !agent.turnInProgress && agent.backgroundCompletionQueue.length > 0
+        && !agent.backgroundCompletionRetryTimer) {
+        scheduleBackgroundCompletionDrain(agent);
+      }
     }
   };
 
@@ -1485,6 +1491,11 @@ export function createRuntimeHost(options: {
           candidate.poller.unref?.();
           if (!candidate.authFailureActive) {
             emit({ type: "agent-status", agentId: config.agentId, status: "active", readiness: candidate.readiness ?? readiness });
+          }
+          // Commit clears any inherited backoff timer; reschedule so a queued
+          // completion still drains on the new session.
+          if (candidate.backgroundCompletionQueue.length > 0) {
+            scheduleBackgroundCompletionDrain(candidate);
           }
           await previous.session?.close("runtime candidate committed")
             .catch((error) => log("previous runtime close after candidate commit failed", String(error)));

--- a/src/runtime/runtime-host.ts
+++ b/src/runtime/runtime-host.ts
@@ -666,40 +666,55 @@ export function createRuntimeHost(options: {
     await retryPending(agent);
   };
 
-  const wakeOnBackgroundCompletion = async (agent: ManagedAgent): Promise<void> => {
-    if (agent.busy || agent.turnInProgress || agent.submitting) return;
-    const session = await ensureSession(agent);
-    if (agent.session !== session || agent.stopped || agent.busy || agent.turnInProgress || agent.submitting) return;
-    const input = options.promptBuilder.buildRuntimeInput("wake", crypto.randomUUID(), { wakeReason: "background subagent completed" });
-    agent.submitting = true;
-    agent.busy = true;
+  const wakeOnBackgroundCompletion = async (agent: ManagedAgent): Promise<"accepted" | "retry" | "dropped"> => {
+    // Caller already reserved submitting/busy so a concurrent idle drain cannot
+    // dequeue another head while ensureSession/prompt yields.
     try {
+      const session = await ensureSession(agent);
+      if (agent.session !== session || agent.stopped) return "dropped";
+      const input = options.promptBuilder.buildRuntimeInput("wake", crypto.randomUUID(), { wakeReason: "background subagent completed" });
       const result = await session.prompt(input);
-      if (agent.session !== session || agent.stopped) return;
-      if (result.status === "accepted") markSessionStable(agent, session);
-      else agent.busy = false;
+      if (agent.session !== session || agent.stopped) return "dropped";
+      if (result.status === "accepted") {
+        markSessionStable(agent, session);
+        return "accepted";
+      }
+      agent.busy = false;
+      return "retry";
     } catch (error) {
       agent.busy = false;
       log("background completion wake failed", error instanceof Error ? error.message : String(error));
-    } finally {
-      agent.submitting = false;
+      return "retry";
     }
   };
 
   const drainBackgroundCompletionQueue = async (agent: ManagedAgent): Promise<void> => {
     if (agent.stopped || agent.busy || agent.turnInProgress || agent.submitting) return;
     if (!agent.backgroundCompletionQueue.length) return;
-    agent.backgroundCompletionQueue.shift();
-    await wakeOnBackgroundCompletion(agent);
-    if (!agent.stopped && !agent.busy && !agent.turnInProgress && !agent.submitting && agent.backgroundCompletionQueue.length > 0) {
-      queueMicrotask(() => { void drainBackgroundCompletionQueue(agent); });
+    agent.submitting = true;
+    agent.busy = true;
+    const completionKey = agent.backgroundCompletionQueue[0];
+    try {
+      const outcome = await wakeOnBackgroundCompletion(agent);
+      if (outcome === "accepted" || outcome === "dropped") {
+        if (agent.backgroundCompletionQueue[0] === completionKey) {
+          agent.backgroundCompletionQueue.shift();
+        }
+      } else {
+        agent.busy = false;
+        agent.backgroundCompletionKeys.delete(completionKey);
+      }
+    } finally {
+      agent.submitting = false;
     }
   };
 
   const noteBackgroundCompletion = (agent: ManagedAgent, completionKey: string): void => {
     if (agent.backgroundCompletionKeys.has(completionKey)) return;
     agent.backgroundCompletionKeys.add(completionKey);
-    agent.backgroundCompletionQueue.push(completionKey);
+    if (!agent.backgroundCompletionQueue.includes(completionKey)) {
+      agent.backgroundCompletionQueue.push(completionKey);
+    }
     if (!agent.busy && !agent.turnInProgress && !agent.submitting) {
       queueMicrotask(() => { void drainBackgroundCompletionQueue(agent); });
     }

--- a/src/runtime/runtime-host.ts
+++ b/src/runtime/runtime-host.ts
@@ -665,6 +665,26 @@ export function createRuntimeHost(options: {
     await retryPending(agent);
   };
 
+  const wakeOnBackgroundCompletion = async (agent: ManagedAgent): Promise<void> => {
+    if (agent.busy || agent.turnInProgress || agent.submitting) return;
+    const session = await ensureSession(agent);
+    if (agent.session !== session || agent.stopped || agent.busy || agent.turnInProgress || agent.submitting) return;
+    const input = options.promptBuilder.buildRuntimeInput("wake", crypto.randomUUID(), { wakeReason: "background subagent completed" });
+    agent.submitting = true;
+    agent.busy = true;
+    try {
+      const result = await session.prompt(input);
+      if (agent.session !== session || agent.stopped) return;
+      if (result.status === "accepted") markSessionStable(agent, session);
+      else agent.busy = false;
+    } catch (error) {
+      agent.busy = false;
+      log("background completion wake failed", error instanceof Error ? error.message : String(error));
+    } finally {
+      agent.submitting = false;
+    }
+  };
+
   const scheduleRecreate = (agent: ManagedAgent, reason: string): void => {
     if (agent.stopped || agent.retryTimer || agent.starting || agent.session) return;
     if (agent.recreateAttempts >= retryPolicy.maxAttempts) {
@@ -960,6 +980,10 @@ export function createRuntimeHost(options: {
         if (outcome !== "failed") return retryPending(agent);
       });
       queueMicrotask(() => { void scanAndPromoteAcceptedInboxUpdates(agent); });
+    } else if (event.type === "runtime-observation") {
+      if (event.phase === "completed" && !agent.turnInProgress && !agent.busy && !agent.submitting) {
+        queueMicrotask(() => { void wakeOnBackgroundCompletion(agent); });
+      }
     } else if (event.type === "activity") {
       if (agent.turnInProgress && event.activity !== "internal") agent.turnHadAuthenticatedOutput = true;
       emit({ type: "activity", agentId: agent.config.agentId, activity: event.activity, activityKind: event.activity });

--- a/src/runtime/runtime-host.ts
+++ b/src/runtime/runtime-host.ts
@@ -91,6 +91,7 @@ interface ManagedAgent {
   backgroundCompletionQueue: string[]; backgroundCompletionKeys: Set<string>;
   backgroundCompletionInFlight: string | null; backgroundCompletionWakeInputId: string | null;
   backgroundCompletionRejectStreak: number;
+  backgroundCompletionRetryTimer: NodeJS.Timeout | null;
 }
 
 export interface RuntimeHost {
@@ -151,6 +152,7 @@ export interface StagedRuntimeCandidate {
 }
 
 const MAX_DELIVERIES = 2048;
+const BACKGROUND_COMPLETION_IMMEDIATE_RETRY_LIMIT = 5;
 const now = (): string => new Date().toISOString();
 const isActiveDelivery = (status: DeliveryStatus): boolean => ["pending", "submitting", "accepted"].includes(status);
 type ReplayFailureCode = "canonical_inbox_row_missing" | "canonical_inbox_malformed" | "duplicate_message_id"
@@ -668,9 +670,38 @@ export function createRuntimeHost(options: {
     await retryPending(agent);
   };
 
-  const scheduleBackgroundCompletionDrain = (agent: ManagedAgent): void => {
+  const clearBackgroundCompletionRetryTimer = (agent: ManagedAgent): void => {
+    if (!agent.backgroundCompletionRetryTimer) return;
+    clearTimeout(agent.backgroundCompletionRetryTimer);
+    agent.backgroundCompletionRetryTimer = null;
+  };
+
+  const scheduleBackgroundCompletionDrain = (agent: ManagedAgent, delayMs = 0): void => {
     if (agent.stopped) return;
+    if (delayMs > 0) {
+      if (agent.backgroundCompletionRetryTimer) return;
+      agent.backgroundCompletionRetryTimer = setTimeout(() => {
+        agent.backgroundCompletionRetryTimer = null;
+        if (agent.stopped) return;
+        void drainBackgroundCompletionQueue(agent);
+      }, delayMs);
+      agent.backgroundCompletionRetryTimer.unref?.();
+      return;
+    }
+    clearBackgroundCompletionRetryTimer(agent);
     queueMicrotask(() => { void drainBackgroundCompletionQueue(agent); });
+  };
+
+  const scheduleBackgroundCompletionRetry = (agent: ManagedAgent): void => {
+    const streak = agent.backgroundCompletionRejectStreak;
+    if (streak < BACKGROUND_COMPLETION_IMMEDIATE_RETRY_LIMIT) {
+      scheduleBackgroundCompletionDrain(agent);
+      return;
+    }
+    const delayedAttempt = streak - BACKGROUND_COMPLETION_IMMEDIATE_RETRY_LIMIT;
+    if (delayedAttempt >= retryPolicy.maxAttempts) return;
+    const delay = Math.min(retryPolicy.maxDelayMs, retryPolicy.baseDelayMs * 2 ** delayedAttempt);
+    scheduleBackgroundCompletionDrain(agent, delay);
   };
 
   const rearmBackgroundCompletion = (agent: ManagedAgent, completionKey = agent.backgroundCompletionInFlight): void => {
@@ -692,6 +723,7 @@ export function createRuntimeHost(options: {
     agent.backgroundCompletionInFlight = null;
     agent.backgroundCompletionWakeInputId = null;
     agent.backgroundCompletionRejectStreak = 0;
+    clearBackgroundCompletionRetryTimer(agent);
   };
 
   const wakeOnBackgroundCompletion = async (agent: ManagedAgent): Promise<
@@ -721,6 +753,7 @@ export function createRuntimeHost(options: {
   const drainBackgroundCompletionQueue = async (agent: ManagedAgent): Promise<void> => {
     if (agent.stopped || agent.busy || agent.turnInProgress || agent.submitting) return;
     if (agent.backgroundCompletionInFlight || !agent.backgroundCompletionQueue.length) return;
+    clearBackgroundCompletionRetryTimer(agent);
     agent.submitting = true;
     agent.busy = true;
     const completionKey = agent.backgroundCompletionQueue[0];
@@ -731,10 +764,12 @@ export function createRuntimeHost(options: {
         agent.backgroundCompletionInFlight = completionKey;
         agent.backgroundCompletionWakeInputId = outcome.inputId;
         agent.backgroundCompletionRejectStreak = 0;
+        clearBackgroundCompletionRetryTimer(agent);
       } else if (outcome.status === "dropped") {
         if (agent.stopped) {
           if (agent.backgroundCompletionQueue[0] === completionKey) agent.backgroundCompletionQueue.shift();
           agent.backgroundCompletionKeys.delete(completionKey);
+          clearBackgroundCompletionRetryTimer(agent);
         } else {
           rearmBackgroundCompletion(agent, completionKey);
           agent.busy = false;
@@ -742,9 +777,10 @@ export function createRuntimeHost(options: {
       } else {
         agent.busy = false;
         agent.backgroundCompletionRejectStreak += 1;
-        // Leave the item at the queue head and schedule another drain. Without
-        // this, a rejected idle wake is never retried because Pi will not re-emit.
-        if (agent.backgroundCompletionRejectStreak < 5) scheduleBackgroundCompletionDrain(agent);
+        // Leave the item queued+deduped. Immediate microtask retries cover a
+        // brief reject; after that a bounded timer still drains because Pi will
+        // not re-emit the same completion.
+        scheduleBackgroundCompletionRetry(agent);
       }
     } finally {
       agent.submitting = false;
@@ -1363,10 +1399,12 @@ export function createRuntimeHost(options: {
           if (previous.poller) clearInterval(previous.poller);
           if (previous.retryTimer) clearTimeout(previous.retryTimer);
           if (previous.stabilityTimer) clearTimeout(previous.stabilityTimer);
+          if (previous.backgroundCompletionRetryTimer) clearTimeout(previous.backgroundCompletionRetryTimer);
           const candidate: ManagedAgent = {
             ...previous, config, adapter, session, launchId: crypto.randomUUID(), busy: false, submitting: false,
             starting: null, retryAfterSubmit: false, generation: 0, poller: null, retryTimer: null,
             recreateAttempts: 0, stabilityTimer: null, recreateReason: null, stopped: false,
+            backgroundCompletionRetryTimer: null,
             disabledReason: null, configurationRecovery: null,
             readiness: previous.authFailureActive ? previous.readiness : readiness,
           };
@@ -1669,7 +1707,7 @@ export function createRuntimeHost(options: {
           promotedInboxUpdateIds: new Set(),
           backgroundCompletionQueue: [], backgroundCompletionKeys: new Set(),
           backgroundCompletionInFlight: null, backgroundCompletionWakeInputId: null,
-          backgroundCompletionRejectStreak: 0 };
+          backgroundCompletionRejectStreak: 0, backgroundCompletionRetryTimer: null };
         const startupConsumed: DeliveryRecord[] = [];
         const startupQuarantined: Array<{ record: DeliveryRecord; code: ReplayFailureCode }> = [];
         for (const record of agent.records.values()) {
@@ -1796,6 +1834,7 @@ export function createRuntimeHost(options: {
       if (agent.poller) clearInterval(agent.poller);
       if (agent.retryTimer) clearTimeout(agent.retryTimer);
       if (agent.stabilityTimer) clearTimeout(agent.stabilityTimer);
+      if (agent.backgroundCompletionRetryTimer) clearTimeout(agent.backgroundCompletionRetryTimer);
       if (agent.busy) await agent.session?.cancel(reason);
       await agent.session?.close(reason); managed.delete(agentId);
       emit({ type: "agent-status", agentId, status: "inactive" });

--- a/src/runtime/runtime-host.ts
+++ b/src/runtime/runtime-host.ts
@@ -88,6 +88,7 @@ interface ManagedAgent {
   turnInProgress: boolean; turnHadFailure: boolean; turnHadAuthenticatedOutput: boolean; authFailureActive: boolean;
   /** Delivery ids already promoted from accepted inbox_update to a wake while idle. */
   promotedInboxUpdateIds: Set<string>;
+  backgroundCompletionQueue: string[]; backgroundCompletionKeys: Set<string>;
 }
 
 export interface RuntimeHost {
@@ -685,6 +686,25 @@ export function createRuntimeHost(options: {
     }
   };
 
+  const drainBackgroundCompletionQueue = async (agent: ManagedAgent): Promise<void> => {
+    if (agent.stopped || agent.busy || agent.turnInProgress || agent.submitting) return;
+    if (!agent.backgroundCompletionQueue.length) return;
+    agent.backgroundCompletionQueue.shift();
+    await wakeOnBackgroundCompletion(agent);
+    if (!agent.stopped && !agent.busy && !agent.turnInProgress && !agent.submitting && agent.backgroundCompletionQueue.length > 0) {
+      queueMicrotask(() => { void drainBackgroundCompletionQueue(agent); });
+    }
+  };
+
+  const noteBackgroundCompletion = (agent: ManagedAgent, completionKey: string): void => {
+    if (agent.backgroundCompletionKeys.has(completionKey)) return;
+    agent.backgroundCompletionKeys.add(completionKey);
+    agent.backgroundCompletionQueue.push(completionKey);
+    if (!agent.busy && !agent.turnInProgress && !agent.submitting) {
+      queueMicrotask(() => { void drainBackgroundCompletionQueue(agent); });
+    }
+  };
+
   const scheduleRecreate = (agent: ManagedAgent, reason: string): void => {
     if (agent.stopped || agent.retryTimer || agent.starting || agent.session) return;
     if (agent.recreateAttempts >= retryPolicy.maxAttempts) {
@@ -722,6 +742,7 @@ export function createRuntimeHost(options: {
   const replaceSession = (agent: ManagedAgent, session: RuntimeSession, reason: string): void => {
     if (agent.session !== session || agent.stopped) return;
     agent.session = null; agent.busy = false; agent.submitting = false; agent.generation += 1;
+    agent.backgroundCompletionQueue = [];
     agent.recreateReason = reason;
     if (agent.stabilityTimer) clearTimeout(agent.stabilityTimer);
     agent.stabilityTimer = null;
@@ -736,6 +757,7 @@ export function createRuntimeHost(options: {
     if (agent.session !== session || agent.stopped) return;
     agent.disabledReason = `runtime configuration recovery in progress: ${message}`;
     agent.session = null; agent.busy = false; agent.submitting = false; agent.generation += 1;
+    agent.backgroundCompletionQueue = [];
     if (agent.stabilityTimer) clearTimeout(agent.stabilityTimer);
     agent.stabilityTimer = null;
     for (const record of agent.records.values()) {
@@ -963,6 +985,9 @@ export function createRuntimeHost(options: {
       agent.busy = false;
       emit({ type: "activity", agentId: agent.config.agentId, activity: "idle", activityKind: "idle", detailKind: "turn_ended" });
       reconcileAcceptedAtTurnEnd(agent);
+      if (agent.backgroundCompletionQueue.length > 0) {
+        queueMicrotask(() => { void drainBackgroundCompletionQueue(agent); });
+      }
       telemetry?.runtimeEvent(agent.config.agentId, event);
       if (recoveredAuthentication) {
         agent.authFailureActive = false;
@@ -981,8 +1006,8 @@ export function createRuntimeHost(options: {
       });
       queueMicrotask(() => { void scanAndPromoteAcceptedInboxUpdates(agent); });
     } else if (event.type === "runtime-observation") {
-      if (event.phase === "completed" && !agent.turnInProgress && !agent.busy && !agent.submitting) {
-        queueMicrotask(() => { void wakeOnBackgroundCompletion(agent); });
+      if (event.phase === "completed" && typeof event.completionKey === "string") {
+        noteBackgroundCompletion(agent, event.completionKey);
       }
     } else if (event.type === "activity") {
       if (agent.turnInProgress && event.activity !== "internal") agent.turnHadAuthenticatedOutput = true;
@@ -1575,7 +1600,8 @@ export function createRuntimeHost(options: {
           piProactiveCompaction: null, piProactiveCompactionGeneration: null, piProactiveCompactionSession: null,
           piProactiveCompactionFailedGeneration: null, readiness: null,
           turnInProgress: false, turnHadFailure: false, turnHadAuthenticatedOutput: false, authFailureActive: false,
-          promotedInboxUpdateIds: new Set() };
+          promotedInboxUpdateIds: new Set(),
+          backgroundCompletionQueue: [], backgroundCompletionKeys: new Set() };
         const startupConsumed: DeliveryRecord[] = [];
         const startupQuarantined: Array<{ record: DeliveryRecord; code: ReplayFailureCode }> = [];
         for (const record of agent.records.values()) {

--- a/test/live/pi-subagents-background-live.test.mjs
+++ b/test/live/pi-subagents-background-live.test.mjs
@@ -7,6 +7,7 @@ import { afterAll, test } from "bun:test";
 import { fileURLToPath } from "node:url";
 import { PiRpcClient } from "../../dist/runtime/pi-rpc-client.mjs";
 import { bundledPiSubagentExtensionPath } from "../../dist/runtime/pi-subagent-injection.mjs";
+import { extractCanonicalPiSubagentCompletionKeyFromMessages } from "../../dist/runtime/pi-subagents-notification.mjs";
 import {
   gradePiSubagentsTrace,
   loadPiSubagentsEval,
@@ -97,8 +98,8 @@ async function runScenario(scenario) {
     // For background-delegation scenarios wait for the completion notification turn
     // with a generous timeout (provider latency varies); grade whatever arrived.
     const isNotification = (event) => {
-      if (event?.type !== "agent_end" || !Array.isArray(event.messages)) return false;
-      return JSON.stringify(event.messages).includes("subagent-notification");
+      if (event?.type !== "agent_end") return false;
+      return extractCanonicalPiSubagentCompletionKeyFromMessages(event.messages) !== null;
     };
     try {
       await waitFor(trace, isNotification, 180_000);

--- a/test/support/pi-subagents-background-grader.mjs
+++ b/test/support/pi-subagents-background-grader.mjs
@@ -1,5 +1,6 @@
 import fs from "node:fs";
 import path from "node:path";
+import { extractCanonicalPiSubagentCompletionKeyFromMessages } from "../../dist/runtime/pi-subagents-notification.mjs";
 
 /**
  * pi-subagents 后台行为 rubric。
@@ -70,8 +71,8 @@ export function gradePiSubagentsTrace(scenario, trace) {
     && !trace.some((event) => event?.type === "tool_execution_start" && event.toolName === "get_subagent_result");
 
   results.notification_received = trace.some((event) => {
-    if (event?.type !== "agent_end" || !Array.isArray(event.messages)) return false;
-    return JSON.stringify(event.messages).includes("subagent-notification");
+    if (event?.type !== "agent_end") return false;
+    return extractCanonicalPiSubagentCompletionKeyFromMessages(event.messages) !== null;
   });
 
   results.parallel_agent_calls = agentCalls.length >= 2;
@@ -99,8 +100,8 @@ export function gradePiSubagentsTrace(scenario, trace) {
     && /b-done|\+b|\+dep|busy-b|second task|第二/i.test(wholeText);
 
   const notificationTurnIndex = trace.findIndex((event) => {
-    if (event?.type !== "agent_end" || !Array.isArray(event.messages)) return false;
-    return JSON.stringify(event.messages).includes("subagent-notification");
+    if (event?.type !== "agent_end") return false;
+    return extractCanonicalPiSubagentCompletionKeyFromMessages(event.messages) !== null;
   });
   const notificationSegmentIndex = turnSegments.findIndex((segment) => segment.some((event) => event === trace[notificationTurnIndex]));
   results.second_message_before_a_notification = notificationSegmentIndex > 1 || notificationTurnIndex === -1;

--- a/test/unit/runtime/pi-subagents-notification.test.mjs
+++ b/test/unit/runtime/pi-subagents-notification.test.mjs
@@ -1,0 +1,107 @@
+import assert from "node:assert/strict";
+import { test } from "bun:test";
+import {
+  buildCanonicalPiSubagentAssistantMessage,
+  buildCanonicalPiSubagentNotificationContent,
+  extractCanonicalPiSubagentCompletionKeyFromMessages,
+  extractCanonicalPiSubagentNotification,
+} from "../../../dist/runtime/pi-subagents-notification.mjs";
+
+function mixedContent(blocks) {
+  return {
+    role: "assistant",
+    content: [{
+      type: "custom",
+      customType: "subagent-notification",
+      content: blocks.join("\n"),
+    }],
+  };
+}
+
+test("failed and aborted canonical notifications still produce a completion key", () => {
+  const cases = [
+    {
+      taskId: "task-error-1",
+      status: "Error: provider failed",
+      summary: "Agent \"fixture\" error",
+      result: "partial error output",
+    },
+    {
+      taskId: "task-aborted-1",
+      status: "Aborted (max turns exceeded)",
+      summary: "Agent \"fixture\" aborted (aborted — hit the turn limit before completion; output may be incomplete)",
+      result: "partial aborted output",
+    },
+    {
+      taskId: "task-stopped-1",
+      status: "Stopped",
+      summary: "Agent \"fixture\" stopped (STOPPED BY THE USER before completion — output is partial; the task was NOT finished)",
+      result: "partial stopped output",
+    },
+    {
+      taskId: "task-steered-1",
+      status: "Wrapped up (turn limit)",
+      summary: "Agent \"fixture\" steered (wrapped up at the turn limit — output may be partial)",
+      result: "partial steered output",
+    },
+    {
+      taskId: "task-raw-error",
+      status: "error",
+      summary: "Agent \"fixture\" error",
+      result: "raw error",
+    },
+    {
+      taskId: "task-raw-turn-limit",
+      status: "turn-limit",
+      summary: "Agent \"fixture\" steered",
+      result: "raw turn limit",
+    },
+  ];
+  for (const options of cases) {
+    const key = extractCanonicalPiSubagentCompletionKeyFromMessages([
+      buildCanonicalPiSubagentAssistantMessage(options),
+    ]);
+    assert.equal(key, options.taskId, `terminal status ${options.status} must produce a completion key`);
+  }
+});
+
+test("mixed-status groups keep terminal successes instead of dropping the whole group", () => {
+  const parsed = extractCanonicalPiSubagentNotification([mixedContent([
+    buildCanonicalPiSubagentNotificationContent({
+      taskId: "task-running",
+      status: "running",
+      summary: "Agent \"still going\" running",
+      result: "not done",
+    }),
+    buildCanonicalPiSubagentNotificationContent({
+      taskId: "task-done",
+      status: "Done",
+      summary: "Agent \"ok\" completed",
+      result: "success",
+    }),
+    buildCanonicalPiSubagentNotificationContent({
+      taskId: "task-error",
+      status: "Error: boom",
+      summary: "Agent \"fail\" error",
+      result: "failed",
+    }),
+    "<task-notification><task-id>task-malformed</task-id><status>Done</status></task-notification>",
+  ])]);
+  assert.ok(parsed);
+  assert.deepEqual(parsed.taskIds, ["task-done", "task-error"]);
+  assert.equal(parsed.key, "task-done|task-error");
+  assert.equal(parsed.notifications[0].status, "Done");
+  assert.match(parsed.notifications[1].status, /^Error:/);
+});
+
+test("queued or running notifications do not produce a completion key", () => {
+  const key = extractCanonicalPiSubagentCompletionKeyFromMessages([
+    buildCanonicalPiSubagentAssistantMessage({
+      taskId: "task-running",
+      status: "running",
+      summary: "Agent \"fixture\" running",
+      result: "not terminal",
+    }),
+  ]);
+  assert.equal(key, null);
+});

--- a/test/unit/runtime/pi-subagents-notification.test.mjs
+++ b/test/unit/runtime/pi-subagents-notification.test.mjs
@@ -94,6 +94,26 @@ test("mixed-status groups keep terminal successes instead of dropping the whole 
   assert.match(parsed.notifications[1].status, /^Error:/);
 });
 
+test("only customType subagent-notification content is parsed", () => {
+  const xml = buildCanonicalPiSubagentNotificationContent({
+    taskId: "task-other-type",
+    status: "Done",
+    summary: "Agent \"fixture\" completed",
+    result: "should not parse",
+  });
+  assert.equal(extractCanonicalPiSubagentCompletionKeyFromMessages([{
+    role: "assistant",
+    content: [{ type: "custom", customType: "other-notification", content: xml }],
+  }]), null);
+  assert.equal(extractCanonicalPiSubagentCompletionKeyFromMessages([{
+    role: "assistant",
+    content: xml,
+  }]), null);
+  assert.equal(extractCanonicalPiSubagentCompletionKeyFromMessages([
+    buildCanonicalPiSubagentAssistantMessage({ taskId: "task-official" }),
+  ]), "task-official");
+});
+
 test("queued or running notifications do not produce a completion key", () => {
   const key = extractCanonicalPiSubagentCompletionKeyFromMessages([
     buildCanonicalPiSubagentAssistantMessage({

--- a/test/unit/runtime/pi-subagents-notification.test.mjs
+++ b/test/unit/runtime/pi-subagents-notification.test.mjs
@@ -114,6 +114,38 @@ test("only customType subagent-notification content is parsed", () => {
   ]), "task-official");
 });
 
+test("batched agent_end messages keep every canonical notification", () => {
+  const parsed = extractCanonicalPiSubagentNotification([
+    buildCanonicalPiSubagentAssistantMessage({
+      taskId: "task-batch-a",
+      status: "Done",
+      summary: "Agent \"a\" completed",
+      result: "a",
+    }),
+    {
+      role: "assistant",
+      content: "ordinary assistant text mentioning subagent-notification",
+    },
+    buildCanonicalPiSubagentAssistantMessage({
+      taskId: "task-batch-b",
+      status: "Error: boom",
+      summary: "Agent \"b\" error",
+      result: "b",
+    }),
+    buildCanonicalPiSubagentAssistantMessage({
+      taskId: "task-batch-a",
+      status: "Done",
+      summary: "Agent \"a\" completed again",
+      result: "duplicate",
+    }),
+  ]);
+  assert.ok(parsed);
+  assert.deepEqual(parsed.taskIds, ["task-batch-a", "task-batch-b"]);
+  assert.equal(parsed.key, "task-batch-a|task-batch-b");
+  assert.equal(parsed.notifications[0].status, "Done");
+  assert.match(parsed.notifications[1].status, /^Error:/);
+});
+
 test("queued or running notifications do not produce a completion key", () => {
   const key = extractCanonicalPiSubagentCompletionKeyFromMessages([
     buildCanonicalPiSubagentAssistantMessage({

--- a/test/unit/runtime/runtime-adapters.test.mjs
+++ b/test/unit/runtime/runtime-adapters.test.mjs
@@ -378,6 +378,10 @@ test("Pi canonical late completion notifications bridge once and ignore assistan
   listener({ type: "agent_end", willRetry: false, messages: [canonical] });
   await new Promise((resolve) => setImmediate(resolve));
   assert.deepEqual(events.filter((event) => ["turn-start", "turn-end"].includes(event.type)), []);
+  assert.deepEqual(events.filter((event) => event.type === "runtime-observation"), [],
+    "unowned agent_end must not emit the completion bridge while Pi can still reject prompts");
+  listener({ type: "agent_settled" });
+  await new Promise((resolve) => setImmediate(resolve));
   const observations = events.filter((event) => event.type === "runtime-observation");
   assert.deepEqual(observations.map((event) => event.phase), ["completed"]);
   assert.equal(observations[0].completionKey, "task-bridge-1");
@@ -397,6 +401,7 @@ test("Pi assistant text lookalikes do not trigger the late completion bridge", a
   session.subscribe((event) => events.push(event));
   for (const content of ["ordinary assistant text mentioning subagent-notification", "ordinary assistant text mentioning not-subagent-notification"]) {
     listener({ type: "agent_end", willRetry: false, messages: [{ role: "assistant", stopReason: "stop", content }] });
+    listener({ type: "agent_settled" });
   }
   await new Promise((resolve) => setImmediate(resolve));
   assert.deepEqual(events.filter((event) => event.type !== "session-init"), []);
@@ -425,6 +430,7 @@ test("Pi failed and aborted late notifications still bridge a completion key", a
       result: "partial",
     })],
   });
+  listener({ type: "agent_settled" });
   listener({
     type: "agent_end",
     willRetry: false,
@@ -435,6 +441,7 @@ test("Pi failed and aborted late notifications still bridge a completion key", a
       result: "failed",
     })],
   });
+  listener({ type: "agent_settled" });
   await new Promise((resolve) => setImmediate(resolve));
   const observations = events.filter((event) => event.type === "runtime-observation");
   assert.deepEqual(observations.map((event) => event.phase), ["completed", "completed"]);
@@ -485,6 +492,7 @@ test("Pi mixed-status late notification groups keep terminal successes", async (
       }],
     }],
   });
+  listener({ type: "agent_settled" });
   await new Promise((resolve) => setImmediate(resolve));
   const observations = events.filter((event) => event.type === "runtime-observation");
   assert.deepEqual(observations.map((event) => event.phase), ["completed"]);
@@ -511,7 +519,9 @@ test("Pi repeated canonical late completion notifications only bridge once", asy
     result: "Repeat result.",
   });
   listener({ type: "agent_end", willRetry: false, messages: [canonical] });
+  listener({ type: "agent_settled" });
   listener({ type: "agent_end", willRetry: false, messages: [canonical] });
+  listener({ type: "agent_settled" });
   await new Promise((resolve) => setImmediate(resolve));
   const observations = events.filter((event) => event.type === "runtime-observation");
   assert.deepEqual(observations.map((event) => event.phase), ["completed"]);

--- a/test/unit/runtime/runtime-adapters.test.mjs
+++ b/test/unit/runtime/runtime-adapters.test.mjs
@@ -14,6 +14,7 @@ import {
   requirePiResumeSessionFile,
   resolvePiProcessExtensionArgs,
 } from "../../../dist/runtime/runtime-adapters.mjs";
+import { buildCanonicalPiSubagentAssistantMessage } from "../../../dist/runtime/pi-subagents-notification.mjs";
 import { classifyStrictProviderError } from "../../../dist/runtime/provider-error-classifier.mjs";
 
 const fakeProcesses = new Set();
@@ -352,7 +353,7 @@ test("Codex native notifications normalize start, intermediate output, and termi
   ["turn-start", "activity:thinking", "activity:text", "turn-end"]);
 });
 
-test("Pi late completion notification emits a wake bridge after the turn is idle", async () => {
+test("Pi canonical late completion notifications bridge once and ignore assistant lookalikes", async () => {
   let listener;
   const sdk = {
     sessionId: "pi-late-complete", prompt() {}, steer() {}, abort() {},
@@ -364,10 +365,65 @@ test("Pi late completion notification emits a wake bridge after the turn is idle
   }).createSession(create());
   const events = [];
   session.subscribe((event) => events.push(event));
-  listener({ type: "agent_end", willRetry: false, messages: [{ role: "assistant", stopReason: "stop", content: "subagent-notification" }] });
+  const canonical = buildCanonicalPiSubagentAssistantMessage({
+    taskId: "task-bridge-1",
+    toolUseId: "tool-use-bridge-1",
+    outputFile: "/tmp/task-bridge-1.output",
+    summary: "Agent \"fixture\" completed",
+    result: "Fixture result.",
+  });
+  listener({ type: "agent_end", willRetry: false, messages: [canonical] });
   await new Promise((resolve) => setImmediate(resolve));
   assert.deepEqual(events.filter((event) => ["turn-start", "turn-end"].includes(event.type)), []);
-  assert.deepEqual(events.filter((event) => event.type === "runtime-observation").map((event) => event.phase), ["completed"]);
+  const observations = events.filter((event) => event.type === "runtime-observation");
+  assert.deepEqual(observations.map((event) => event.phase), ["completed"]);
+  assert.equal(observations[0].completionKey, "task-bridge-1");
+});
+
+test("Pi assistant text lookalikes do not trigger the late completion bridge", async () => {
+  let listener;
+  const sdk = {
+    sessionId: "pi-late-complete-lookalike", prompt() {}, steer() {}, abort() {},
+    subscribe(next) { listener = next; return () => {}; },
+  };
+  const session = await createNativeRuntimeAdapter("pi", {
+    createPiSession: async () => sdk,
+    env: { LARKIN_PI_DISTRIBUTION: "builtin" },
+  }).createSession(create());
+  const events = [];
+  session.subscribe((event) => events.push(event));
+  for (const content of ["ordinary assistant text mentioning subagent-notification", "ordinary assistant text mentioning not-subagent-notification"]) {
+    listener({ type: "agent_end", willRetry: false, messages: [{ role: "assistant", stopReason: "stop", content }] });
+  }
+  await new Promise((resolve) => setImmediate(resolve));
+  assert.deepEqual(events.filter((event) => event.type !== "session-init"), []);
+});
+
+test("Pi repeated canonical late completion notifications only bridge once", async () => {
+  let listener;
+  const sdk = {
+    sessionId: "pi-late-complete-repeat", prompt() {}, steer() {}, abort() {},
+    subscribe(next) { listener = next; return () => {}; },
+  };
+  const session = await createNativeRuntimeAdapter("pi", {
+    createPiSession: async () => sdk,
+    env: { LARKIN_PI_DISTRIBUTION: "builtin" },
+  }).createSession(create());
+  const events = [];
+  session.subscribe((event) => events.push(event));
+  const canonical = buildCanonicalPiSubagentAssistantMessage({
+    taskId: "task-bridge-repeat",
+    toolUseId: "tool-use-bridge-repeat",
+    outputFile: "/tmp/task-bridge-repeat.output",
+    summary: "Agent \"repeat fixture\" completed",
+    result: "Repeat result.",
+  });
+  listener({ type: "agent_end", willRetry: false, messages: [canonical] });
+  listener({ type: "agent_end", willRetry: false, messages: [canonical] });
+  await new Promise((resolve) => setImmediate(resolve));
+  const observations = events.filter((event) => event.type === "runtime-observation");
+  assert.deepEqual(observations.map((event) => event.phase), ["completed"]);
+  assert.equal(observations[0].completionKey, "task-bridge-repeat");
 });
 
 test("Codex resume failure falls back to a fresh thread with the same standing prompt", async () => {

--- a/test/unit/runtime/runtime-adapters.test.mjs
+++ b/test/unit/runtime/runtime-adapters.test.mjs
@@ -499,6 +499,44 @@ test("Pi mixed-status late notification groups keep terminal successes", async (
   assert.equal(observations[0].completionKey, "task-mixed-ok|task-mixed-error");
 });
 
+test("Pi batched agent_end messages bridge every canonical notification", async () => {
+  let listener;
+  const sdk = {
+    sessionId: "pi-late-complete-batch",
+    prompt() {}, steer() {}, abort() {},
+    subscribe(next) { listener = next; return () => {}; },
+  };
+  const session = await createNativeRuntimeAdapter("pi", {
+    createPiSession: async () => sdk,
+    env: { LARKIN_PI_DISTRIBUTION: "builtin" },
+  }).createSession(create());
+  const events = [];
+  session.subscribe((event) => events.push(event));
+  listener({
+    type: "agent_end",
+    willRetry: false,
+    messages: [
+      buildCanonicalPiSubagentAssistantMessage({
+        taskId: "task-batch-a",
+        status: "Done",
+        summary: "Agent \"a\" completed",
+        result: "a",
+      }),
+      buildCanonicalPiSubagentAssistantMessage({
+        taskId: "task-batch-b",
+        status: "Error: boom",
+        summary: "Agent \"b\" error",
+        result: "b",
+      }),
+    ],
+  });
+  listener({ type: "agent_settled" });
+  await new Promise((resolve) => setImmediate(resolve));
+  const observations = events.filter((event) => event.type === "runtime-observation");
+  assert.deepEqual(observations.map((event) => event.phase), ["completed"]);
+  assert.equal(observations[0].completionKey, "task-batch-a|task-batch-b");
+});
+
 test("Pi repeated canonical late completion notifications only bridge once", async () => {
   let listener;
   const sdk = {

--- a/test/unit/runtime/runtime-adapters.test.mjs
+++ b/test/unit/runtime/runtime-adapters.test.mjs
@@ -14,7 +14,10 @@ import {
   requirePiResumeSessionFile,
   resolvePiProcessExtensionArgs,
 } from "../../../dist/runtime/runtime-adapters.mjs";
-import { buildCanonicalPiSubagentAssistantMessage } from "../../../dist/runtime/pi-subagents-notification.mjs";
+import {
+  buildCanonicalPiSubagentAssistantMessage,
+  buildCanonicalPiSubagentNotificationContent,
+} from "../../../dist/runtime/pi-subagents-notification.mjs";
 import { classifyStrictProviderError } from "../../../dist/runtime/provider-error-classifier.mjs";
 
 const fakeProcesses = new Set();
@@ -397,6 +400,95 @@ test("Pi assistant text lookalikes do not trigger the late completion bridge", a
   }
   await new Promise((resolve) => setImmediate(resolve));
   assert.deepEqual(events.filter((event) => event.type !== "session-init"), []);
+});
+
+test("Pi failed and aborted late notifications still bridge a completion key", async () => {
+  let listener;
+  const sdk = {
+    sessionId: "pi-late-complete-failed",
+    prompt() {}, steer() {}, abort() {},
+    subscribe(next) { listener = next; return () => {}; },
+  };
+  const session = await createNativeRuntimeAdapter("pi", {
+    createPiSession: async () => sdk,
+    env: { LARKIN_PI_DISTRIBUTION: "builtin" },
+  }).createSession(create());
+  const events = [];
+  session.subscribe((event) => events.push(event));
+  listener({
+    type: "agent_end",
+    willRetry: false,
+    messages: [buildCanonicalPiSubagentAssistantMessage({
+      taskId: "task-aborted-bridge",
+      status: "Aborted (max turns exceeded)",
+      summary: "Agent \"fixture\" aborted (aborted — hit the turn limit before completion; output may be incomplete)",
+      result: "partial",
+    })],
+  });
+  listener({
+    type: "agent_end",
+    willRetry: false,
+    messages: [buildCanonicalPiSubagentAssistantMessage({
+      taskId: "task-error-bridge",
+      status: "Error: provider failed",
+      summary: "Agent \"fixture\" error",
+      result: "failed",
+    })],
+  });
+  await new Promise((resolve) => setImmediate(resolve));
+  const observations = events.filter((event) => event.type === "runtime-observation");
+  assert.deepEqual(observations.map((event) => event.phase), ["completed", "completed"]);
+  assert.deepEqual(observations.map((event) => event.completionKey), ["task-aborted-bridge", "task-error-bridge"]);
+});
+
+test("Pi mixed-status late notification groups keep terminal successes", async () => {
+  let listener;
+  const sdk = {
+    sessionId: "pi-late-complete-mixed",
+    prompt() {}, steer() {}, abort() {},
+    subscribe(next) { listener = next; return () => {}; },
+  };
+  const session = await createNativeRuntimeAdapter("pi", {
+    createPiSession: async () => sdk,
+    env: { LARKIN_PI_DISTRIBUTION: "builtin" },
+  }).createSession(create());
+  const events = [];
+  session.subscribe((event) => events.push(event));
+  listener({
+    type: "agent_end",
+    willRetry: false,
+    messages: [{
+      role: "assistant",
+      content: [{
+        type: "custom",
+        customType: "subagent-notification",
+        content: [
+          buildCanonicalPiSubagentNotificationContent({
+            taskId: "task-running",
+            status: "running",
+            summary: "Agent \"still\" running",
+            result: "not done",
+          }),
+          buildCanonicalPiSubagentNotificationContent({
+            taskId: "task-mixed-ok",
+            status: "Done",
+            summary: "Agent \"ok\" completed",
+            result: "success",
+          }),
+          buildCanonicalPiSubagentNotificationContent({
+            taskId: "task-mixed-error",
+            status: "error",
+            summary: "Agent \"fail\" error",
+            result: "failed",
+          }),
+        ].join("\n"),
+      }],
+    }],
+  });
+  await new Promise((resolve) => setImmediate(resolve));
+  const observations = events.filter((event) => event.type === "runtime-observation");
+  assert.deepEqual(observations.map((event) => event.phase), ["completed"]);
+  assert.equal(observations[0].completionKey, "task-mixed-ok|task-mixed-error");
 });
 
 test("Pi repeated canonical late completion notifications only bridge once", async () => {

--- a/test/unit/runtime/runtime-adapters.test.mjs
+++ b/test/unit/runtime/runtime-adapters.test.mjs
@@ -352,6 +352,24 @@ test("Codex native notifications normalize start, intermediate output, and termi
   ["turn-start", "activity:thinking", "activity:text", "turn-end"]);
 });
 
+test("Pi late completion notification emits a wake bridge after the turn is idle", async () => {
+  let listener;
+  const sdk = {
+    sessionId: "pi-late-complete", prompt() {}, steer() {}, abort() {},
+    subscribe(next) { listener = next; return () => {}; },
+  };
+  const session = await createNativeRuntimeAdapter("pi", {
+    createPiSession: async () => sdk,
+    env: { LARKIN_PI_DISTRIBUTION: "builtin" },
+  }).createSession(create());
+  const events = [];
+  session.subscribe((event) => events.push(event));
+  listener({ type: "agent_end", willRetry: false, messages: [{ role: "assistant", stopReason: "stop", content: "subagent-notification" }] });
+  await new Promise((resolve) => setImmediate(resolve));
+  assert.deepEqual(events.filter((event) => ["turn-start", "turn-end"].includes(event.type)), []);
+  assert.deepEqual(events.filter((event) => event.type === "runtime-observation").map((event) => event.phase), ["completed"]);
+});
+
 test("Codex resume failure falls back to a fresh thread with the same standing prompt", async () => {
   const child = new FakeProcess();
   await createNativeRuntimeAdapter("codex", { spawn: () => child }).createSession(create({ resumeSessionId: "stale-thread" }));

--- a/test/unit/runtime/runtime-host.test.mjs
+++ b/test/unit/runtime/runtime-host.test.mjs
@@ -320,6 +320,44 @@ test("RuntimeHost ignores background completion wake bridges while busy or mid-t
   }
 });
 
+test("RuntimeHost drains a completion queued while a rejected foreground prompt is submitting", async () => {
+  let releaseForeground;
+  const session = new FakeSession();
+  session.prompt = async function(input) {
+    this.prompts.push(input);
+    if (this.prompts.length === 1) {
+      return new Promise((_, reject) => {
+        releaseForeground = () => reject(new Error("foreground prompt rejected before turn-start"));
+      });
+    }
+    return { status: "accepted", inputId: input.inputId };
+  };
+  const adapter = { id: "pi", capabilities: {}, async createSession() { return session; } };
+  const host = createRuntimeHost({ adapterFor: () => adapter, promptBuilder: new ContextPromptBuilder() });
+  try {
+    await host.start([{ agentId: "cli_piWakeSubmitRejectA1", name: "wake-submit-reject", runtime: "pi", model: "model", workspaceDir: "/tmp" }]);
+    const delivering = host.deliver("cli_piWakeSubmitRejectA1", {
+      message_id: "om_pi_wake_submit_reject", chat_id: "oc_pi_wake_submit_reject", content: "start",
+    });
+    const waitForFirst = Date.now() + 1_000;
+    while (session.prompts.length < 1 && Date.now() < waitForFirst) await new Promise((resolve) => setImmediate(resolve));
+    assert.equal(session.prompts.length, 1);
+    session.emit({ type: "runtime-observation", runtime: "pi", distribution: "builtin", phase: "completed", completionKey: "task-submit-reject-1" });
+    await new Promise((resolve) => setImmediate(resolve));
+    assert.equal(session.prompts.length, 1, "must not wake while the foreground prompt is still submitting");
+    releaseForeground();
+    const receipt = await delivering;
+    assert.equal(receipt.status, "deferred");
+    const deadline = Date.now() + 1_000;
+    while (session.prompts.length < 2 && Date.now() < deadline) await new Promise((resolve) => setImmediate(resolve));
+    assert.equal(session.prompts.length, 2, "a later drain must still wake after submit clears without turn-start");
+    assert.equal(session.prompts[1].kind, "wake");
+    assert.match(session.prompts[1].text, /reason=background subagent completed/i);
+  } finally {
+    await host.shutdown("done");
+  }
+});
+
 test("RuntimeHost ignores additional completion wake bridges while a wake prompt is submitting", async () => {
   let releaseWake;
   const session = new FakeSession();
@@ -626,6 +664,53 @@ test("RuntimeHost preserves queued background completions across session replace
     await new Promise((resolve) => setImmediate(resolve));
     assert.ok(sessions[1].prompts.some(isBackgroundCompletionWake),
       "queued completion must wake on the replacement session");
+  } finally {
+    await host.shutdown("done");
+  }
+});
+
+test("RuntimeHost reschedules an inherited completion drain after stage commit clears backoff", async () => {
+  let wakeAttempts = 0;
+  const sessions = [];
+  class StageSession extends FakeSession {
+    async prompt(input) {
+      this.prompts.push(input);
+      if (isBackgroundCompletionWake(input)) {
+        wakeAttempts += 1;
+        if (sessions[0] === this && wakeAttempts <= 5) throw new Error("preflight RPC unavailable");
+      }
+      return { status: "accepted", inputId: input.inputId };
+    }
+  }
+  const adapter = { id: "pi", capabilities: {}, async createSession(input) {
+    const session = new StageSession();
+    session.sessionId = input.model === "next" ? "stage-next" : `stage-old-${sessions.length + 1}`;
+    sessions.push(session);
+    return session;
+  } };
+  const host = createRuntimeHost({
+    adapterFor: () => adapter,
+    promptBuilder: new ContextPromptBuilder(),
+    retryPolicy: { baseDelayMs: 250, maxDelayMs: 250, maxAttempts: 3 },
+  });
+  const base = { agentId: "cli_piWakeStageA1", name: "wake-stage", runtime: "pi", workspaceDir: "/tmp" };
+  try {
+    await host.start([{ ...base, model: "old" }]);
+    await host.deliver(base.agentId, { message_id: "om_pi_wake_stage", chat_id: "oc_pi_wake_stage", content: "start" });
+    sessions[0].emit({ type: "turn-start" });
+    sessions[0].emit({ type: "turn-end" });
+    sessions[0].emit({ type: "runtime-observation", runtime: "pi", distribution: "builtin", phase: "completed", completionKey: "task-stage-1" });
+    for (let i = 0; i < 12; i++) await new Promise((resolve) => setImmediate(resolve));
+    assert.equal(wakeAttempts, 5, "five immediate rejects must arm the inherited backoff timer");
+    const staged = await host.stage({ ...base, model: "next" });
+    await staged.commit();
+    assert.equal(sessions.length, 2);
+    const deadline = Date.now() + 1_000;
+    while (!sessions[1].prompts.some(isBackgroundCompletionWake) && Date.now() < deadline) {
+      await new Promise((resolve) => setImmediate(resolve));
+    }
+    assert.ok(sessions[1].prompts.some(isBackgroundCompletionWake),
+      "stage commit that clears backoff must still drain the inherited queue");
   } finally {
     await host.shutdown("done");
   }

--- a/test/unit/runtime/runtime-host.test.mjs
+++ b/test/unit/runtime/runtime-host.test.mjs
@@ -272,6 +272,26 @@ test("RuntimeHost gates startup replay behind high-water proactive compaction", 
   }
 });
 
+test("RuntimeHost re-wakes an idle Agent when Pi reports a late background completion notification", async () => {
+  const session = new FakeSession();
+  const adapter = { id: "pi", capabilities: {}, async createSession() { return session; } };
+  const host = createRuntimeHost({ adapterFor: () => adapter, promptBuilder: new ContextPromptBuilder() });
+  try {
+    await host.start([{ agentId: "cli_piWakeA1", name: "wake", runtime: "pi", model: "model", workspaceDir: "/tmp" }]);
+    await host.deliver("cli_piWakeA1", { message_id: "om_pi_wake", chat_id: "oc_pi_wake", content: "start" });
+    session.emit({ type: "turn-start" });
+    session.emit({ type: "turn-end" });
+    assert.equal(session.prompts.length, 1);
+    session.emit({ type: "runtime-observation", runtime: "pi", distribution: "builtin", phase: "completed" });
+    await new Promise((resolve) => setImmediate(resolve));
+    assert.equal(session.prompts.length, 2);
+    assert.equal(session.prompts[1].kind, "wake");
+    assert.match(session.prompts[1].text, /Inbox changed|reason=background subagent completed/i);
+  } finally {
+    await host.shutdown("done");
+  }
+});
+
 test("RuntimeHost treats a failed manual compact as an internal fresh-session fallback", async () => {
   const root = fs.mkdtempSync(path.join(os.tmpdir(), "larkin-pi-fallback-"));
   const agentId = "cli_piFallbackA1";

--- a/test/unit/runtime/runtime-host.test.mjs
+++ b/test/unit/runtime/runtime-host.test.mjs
@@ -352,6 +352,70 @@ test("RuntimeHost ignores additional completion wake bridges while a wake prompt
   }
 });
 
+test("RuntimeHost wakes both concurrent idle background completions", async () => {
+  const session = new FakeSession();
+  const adapter = { id: "pi", capabilities: {}, async createSession() { return session; } };
+  const host = createRuntimeHost({ adapterFor: () => adapter, promptBuilder: new ContextPromptBuilder() });
+  try {
+    await host.start([{ agentId: "cli_piWakeBothA1", name: "wake-both", runtime: "pi", model: "model", workspaceDir: "/tmp" }]);
+    await host.deliver("cli_piWakeBothA1", { message_id: "om_pi_wake_both", chat_id: "oc_pi_wake_both", content: "start" });
+    session.emit({ type: "turn-start" });
+    session.emit({ type: "turn-end" });
+    assert.equal(session.prompts.length, 1);
+    session.emit({ type: "runtime-observation", runtime: "pi", distribution: "builtin", phase: "completed", completionKey: "task-concurrent-1" });
+    session.emit({ type: "runtime-observation", runtime: "pi", distribution: "builtin", phase: "completed", completionKey: "task-concurrent-2" });
+    await new Promise((resolve) => setImmediate(resolve));
+    assert.equal(session.prompts.length, 2, "first idle completion must reserve and wake before the second drain can drop the queue head");
+    assert.equal(session.prompts[1].kind, "wake");
+    session.emit({ type: "turn-start" });
+    session.emit({ type: "turn-end" });
+    await new Promise((resolve) => setImmediate(resolve));
+    assert.equal(session.prompts.length, 3, "second concurrent idle completion must still wake after the first turn ends");
+    assert.equal(session.prompts[2].kind, "wake");
+  } finally {
+    await host.shutdown("done");
+  }
+});
+
+const isBackgroundCompletionWake = (input) => input?.kind === "wake"
+  && /reason=background subagent completed/i.test(String(input.text || ""));
+
+test("RuntimeHost retries a rejected background completion wake", async () => {
+  let wakeAttempts = 0;
+  const session = new FakeSession();
+  session.prompt = async function(input) {
+    this.prompts.push(input);
+    if (isBackgroundCompletionWake(input)) {
+      wakeAttempts += 1;
+      if (wakeAttempts === 1) {
+        return { status: "rejected", inputId: input.inputId, retryable: true, reason: "wake rejected" };
+      }
+    }
+    return { status: "accepted", inputId: input.inputId };
+  };
+  const adapter = { id: "pi", capabilities: {}, async createSession() { return session; } };
+  const host = createRuntimeHost({ adapterFor: () => adapter, promptBuilder: new ContextPromptBuilder() });
+  try {
+    await host.start([{ agentId: "cli_piWakeRetryA1", name: "wake-retry", runtime: "pi", model: "model", workspaceDir: "/tmp" }]);
+    await host.deliver("cli_piWakeRetryA1", { message_id: "om_pi_wake_retry", chat_id: "oc_pi_wake_retry", content: "start" });
+    session.emit({ type: "turn-start" });
+    session.emit({ type: "turn-end" });
+    assert.equal(session.prompts.length, 1);
+    session.emit({ type: "runtime-observation", runtime: "pi", distribution: "builtin", phase: "completed", completionKey: "task-retry-1" });
+    await new Promise((resolve) => setImmediate(resolve));
+    assert.equal(session.prompts.length, 2);
+    assert.equal(session.prompts[1].kind, "wake");
+    assert.equal(wakeAttempts, 1);
+    session.emit({ type: "runtime-observation", runtime: "pi", distribution: "builtin", phase: "completed", completionKey: "task-retry-1" });
+    await new Promise((resolve) => setImmediate(resolve));
+    assert.equal(wakeAttempts, 2);
+    assert.equal(session.prompts.length, 3, "the same completion must be able to wake again after a rejected prompt");
+    assert.equal(session.prompts[2].kind, "wake");
+  } finally {
+    await host.shutdown("done");
+  }
+});
+
 test("RuntimeHost treats a failed manual compact as an internal fresh-session fallback", async () => {
   const root = fs.mkdtempSync(path.join(os.tmpdir(), "larkin-pi-fallback-"));
   const agentId = "cli_piFallbackA1";

--- a/test/unit/runtime/runtime-host.test.mjs
+++ b/test/unit/runtime/runtime-host.test.mjs
@@ -487,6 +487,116 @@ test("RuntimeHost keeps an accepted wake queued until the turn succeeds", async 
   }
 });
 
+test("RuntimeHost does not retry a terminal background wake input-error unbounded", async () => {
+  let wakeAttempts = 0;
+  const session = new FakeSession();
+  session.prompt = async function(input) {
+    this.prompts.push(input);
+    if (isBackgroundCompletionWake(input)) wakeAttempts += 1;
+    return { status: "accepted", inputId: input.inputId };
+  };
+  const adapter = { id: "pi", capabilities: {}, async createSession() { return session; } };
+  const host = createRuntimeHost({
+    adapterFor: () => adapter,
+    promptBuilder: new ContextPromptBuilder(),
+    retryPolicy: { baseDelayMs: 15, maxDelayMs: 20, maxAttempts: 1 },
+  });
+  try {
+    await host.start([{ agentId: "cli_piWakeBoundA1", name: "wake-bound", runtime: "pi", model: "model", workspaceDir: "/tmp" }]);
+    await host.deliver("cli_piWakeBoundA1", { message_id: "om_pi_wake_bound", chat_id: "oc_pi_wake_bound", content: "start" });
+    session.emit({ type: "turn-start" });
+    session.emit({ type: "turn-end" });
+    session.emit({ type: "runtime-observation", runtime: "pi", distribution: "builtin", phase: "completed", completionKey: "task-bound-1" });
+    const deadline = Date.now() + 400;
+    while (Date.now() < deadline) {
+      const wake = session.prompts.filter(isBackgroundCompletionWake).at(-1);
+      if (wake) {
+        session.emit({ type: "turn-start" });
+        session.emit({
+          type: "input-error", inputId: wake.inputId, retryable: true, willRetry: false,
+          message: "persistent upstream failure",
+        });
+        session.emit({ type: "turn-end" });
+      }
+      await new Promise((resolve) => setTimeout(resolve, 5));
+    }
+    assert.equal(wakeAttempts, 6, "accepted+terminal input-error must consume the immediate streak and one delayed attempt");
+    await new Promise((resolve) => setTimeout(resolve, 40));
+    assert.equal(wakeAttempts, 6, "an accepted prompt must not reset the wake retry streak");
+  } finally {
+    await host.shutdown("done");
+  }
+});
+
+test("RuntimeHost consults the idle compaction gate before a background completion wake", async () => {
+  const policy = calculatePiCompactionSettings(272_000);
+  const order = [];
+  class GateSession extends FakeSession {
+    usage = { tokens: 100, contextWindow: 272_000 };
+    compactCalls = 0;
+    async getContextUsage() { order.push("usage"); return { ...this.usage }; }
+    async compact() { order.push("compact"); this.compactCalls += 1; this.usage.tokens = 100; }
+    async prompt(input) { order.push("prompt"); return super.prompt(input); }
+  }
+  const session = new GateSession();
+  const adapter = { id: "pi", capabilities: {}, async createSession() { return session; } };
+  const host = createRuntimeHost({ adapterFor: () => adapter, promptBuilder: new ContextPromptBuilder() });
+  try {
+    await host.start([{ agentId: "cli_piWakeCompactA1", name: "wake-compact", runtime: "pi", model: "model", workspaceDir: "/tmp" }]);
+    await host.deliver("cli_piWakeCompactA1", { message_id: "om_pi_wake_compact", chat_id: "oc_pi_wake_compact", content: "start" });
+    session.emit({ type: "turn-start" });
+    session.emit({ type: "turn-end" });
+    const firstPromptAt = order.lastIndexOf("prompt");
+    assert.equal(session.prompts.length, 1);
+    assert.equal(session.compactCalls, 0, "the first delivery stays below the idle threshold");
+    session.usage.tokens = policy.threshold + 1;
+    session.emit({ type: "runtime-observation", runtime: "pi", distribution: "builtin", phase: "completed", completionKey: "task-compact-1" });
+    const deadline = Date.now() + 1_000;
+    while (session.prompts.length < 2 && Date.now() < deadline) await new Promise((resolve) => setTimeout(resolve, 5));
+    assert.equal(session.compactCalls, 1, "the wake drain must consult the idle compaction gate");
+    assert.equal(session.prompts.length, 2);
+    assert.equal(session.prompts[1].kind, "wake");
+    assert.ok(order.indexOf("compact", firstPromptAt) >= 0);
+    assert.ok(order.indexOf("compact", firstPromptAt) < order.indexOf("prompt", firstPromptAt + 1));
+  } finally {
+    await host.shutdown("done");
+  }
+});
+
+test("RuntimeHost does not let an exhausted background wake block a later completion", async () => {
+  let wakeAttempts = 0;
+  const session = new FakeSession();
+  session.prompt = async function(input) {
+    this.prompts.push(input);
+    if (isBackgroundCompletionWake(input)) {
+      wakeAttempts += 1;
+      if (wakeAttempts <= 6) return { status: "rejected", inputId: input.inputId, retryable: true, reason: "head still failing" };
+    }
+    return { status: "accepted", inputId: input.inputId };
+  };
+  const adapter = { id: "pi", capabilities: {}, async createSession() { return session; } };
+  const host = createRuntimeHost({
+    adapterFor: () => adapter,
+    promptBuilder: new ContextPromptBuilder(),
+    retryPolicy: { baseDelayMs: 15, maxDelayMs: 20, maxAttempts: 1 },
+  });
+  try {
+    await host.start([{ agentId: "cli_piWakeSkipA1", name: "wake-skip", runtime: "pi", model: "model", workspaceDir: "/tmp" }]);
+    await host.deliver("cli_piWakeSkipA1", { message_id: "om_pi_wake_skip", chat_id: "oc_pi_wake_skip", content: "start" });
+    session.emit({ type: "turn-start" });
+    session.emit({ type: "turn-end" });
+    session.emit({ type: "runtime-observation", runtime: "pi", distribution: "builtin", phase: "completed", completionKey: "task-skip-head" });
+    session.emit({ type: "runtime-observation", runtime: "pi", distribution: "builtin", phase: "completed", completionKey: "task-skip-later" });
+    const deadline = Date.now() + 400;
+    while (wakeAttempts < 7 && Date.now() < deadline) await new Promise((resolve) => setTimeout(resolve, 5));
+    assert.equal(wakeAttempts, 7, "after the exhausted head is dropped the later completion must still wake");
+    assert.equal(session.prompts.filter(isBackgroundCompletionWake).length, 7);
+    assert.equal(session.prompts.at(-1).kind, "wake");
+  } finally {
+    await host.shutdown("done");
+  }
+});
+
 test("RuntimeHost preserves queued background completions across session replacement", async () => {
   const sessions = [];
   const adapter = { id: "pi", capabilities: {}, async createSession() {

--- a/test/unit/runtime/runtime-host.test.mjs
+++ b/test/unit/runtime/runtime-host.test.mjs
@@ -403,14 +403,83 @@ test("RuntimeHost retries a rejected background completion wake", async () => {
     assert.equal(session.prompts.length, 1);
     session.emit({ type: "runtime-observation", runtime: "pi", distribution: "builtin", phase: "completed", completionKey: "task-retry-1" });
     await new Promise((resolve) => setImmediate(resolve));
-    assert.equal(session.prompts.length, 2);
-    assert.equal(session.prompts[1].kind, "wake");
-    assert.equal(wakeAttempts, 1);
-    session.emit({ type: "runtime-observation", runtime: "pi", distribution: "builtin", phase: "completed", completionKey: "task-retry-1" });
     await new Promise((resolve) => setImmediate(resolve));
-    assert.equal(wakeAttempts, 2);
+    assert.equal(wakeAttempts, 2, "a rejected idle wake must schedule another drain without a second completion event");
     assert.equal(session.prompts.length, 3, "the same completion must be able to wake again after a rejected prompt");
     assert.equal(session.prompts[2].kind, "wake");
+    session.emit({ type: "runtime-observation", runtime: "pi", distribution: "builtin", phase: "completed", completionKey: "task-retry-1" });
+    await new Promise((resolve) => setImmediate(resolve));
+    assert.equal(wakeAttempts, 2, "the accepted retry must keep the completion deduped");
+  } finally {
+    await host.shutdown("done");
+  }
+});
+
+test("RuntimeHost keeps an accepted wake queued until the turn succeeds", async () => {
+  let wakeAttempts = 0;
+  const session = new FakeSession();
+  session.prompt = async function(input) {
+    this.prompts.push(input);
+    if (isBackgroundCompletionWake(input)) wakeAttempts += 1;
+    return { status: "accepted", inputId: input.inputId };
+  };
+  const adapter = { id: "pi", capabilities: {}, async createSession() { return session; } };
+  const host = createRuntimeHost({ adapterFor: () => adapter, promptBuilder: new ContextPromptBuilder() });
+  try {
+    await host.start([{ agentId: "cli_piWakeRearmA1", name: "wake-rearm", runtime: "pi", model: "model", workspaceDir: "/tmp" }]);
+    await host.deliver("cli_piWakeRearmA1", { message_id: "om_pi_wake_rearm", chat_id: "oc_pi_wake_rearm", content: "start" });
+    session.emit({ type: "turn-start" });
+    session.emit({ type: "turn-end" });
+    assert.equal(session.prompts.length, 1);
+    session.emit({ type: "runtime-observation", runtime: "pi", distribution: "builtin", phase: "completed", completionKey: "task-rearm-1" });
+    await new Promise((resolve) => setImmediate(resolve));
+    assert.equal(wakeAttempts, 1);
+    const wake = session.prompts.find(isBackgroundCompletionWake);
+    assert.ok(wake);
+    session.emit({ type: "turn-start" });
+    session.emit({ type: "input-error", inputId: wake.inputId, retryable: true, willRetry: false, message: "Pi assistant turn aborted" });
+    session.emit({ type: "turn-end" });
+    await new Promise((resolve) => setImmediate(resolve));
+    await new Promise((resolve) => setImmediate(resolve));
+    assert.equal(wakeAttempts, 2, "an accepted wake that aborts must be re-armed and drained again");
+    session.emit({ type: "turn-start" });
+    session.emit({ type: "turn-end" });
+    await new Promise((resolve) => setImmediate(resolve));
+    assert.equal(wakeAttempts, 2, "a successful wake turn must dequeue the completion");
+  } finally {
+    await host.shutdown("done");
+  }
+});
+
+test("RuntimeHost preserves queued background completions across session replacement", async () => {
+  const sessions = [];
+  const adapter = { id: "pi", capabilities: {}, async createSession() {
+    const session = new FakeSession();
+    session.sessionId = `wake-replace-${sessions.length + 1}`;
+    sessions.push(session);
+    return session;
+  } };
+  const host = createRuntimeHost({
+    adapterFor: () => adapter,
+    promptBuilder: new ContextPromptBuilder(),
+    retryPolicy: { baseDelayMs: 5, maxDelayMs: 10, maxAttempts: 3 },
+  });
+  try {
+    await host.start([{ agentId: "cli_piWakeReplaceA1", name: "wake-replace", runtime: "pi", model: "model", workspaceDir: "/tmp" }]);
+    await host.deliver("cli_piWakeReplaceA1", { message_id: "om_pi_wake_replace", chat_id: "oc_pi_wake_replace", content: "start" });
+    sessions[0].emit({ type: "turn-start" });
+    sessions[0].emit({ type: "runtime-observation", runtime: "pi", distribution: "builtin", phase: "completed", completionKey: "task-replace-1" });
+    await new Promise((resolve) => setImmediate(resolve));
+    assert.equal(sessions[0].prompts.length, 1, "busy turn must queue the completion instead of waking immediately");
+    sessions[0].emit({ type: "closed", code: 1, signal: null });
+    await new Promise((resolve) => setTimeout(resolve, 30));
+    assert.equal(sessions.length, 2, "closed runtime must be recreated");
+    sessions[1].emit({ type: "turn-start" });
+    sessions[1].emit({ type: "turn-end" });
+    await new Promise((resolve) => setImmediate(resolve));
+    await new Promise((resolve) => setImmediate(resolve));
+    assert.ok(sessions[1].prompts.some(isBackgroundCompletionWake),
+      "queued completion must wake on the replacement session");
   } finally {
     await host.shutdown("done");
   }

--- a/test/unit/runtime/runtime-host.test.mjs
+++ b/test/unit/runtime/runtime-host.test.mjs
@@ -272,7 +272,7 @@ test("RuntimeHost gates startup replay behind high-water proactive compaction", 
   }
 });
 
-test("RuntimeHost re-wakes an idle Agent when Pi reports a late background completion notification", async () => {
+test("RuntimeHost wakes once for a canonical late completion and re-wakes for a later independent one", async () => {
   const session = new FakeSession();
   const adapter = { id: "pi", capabilities: {}, async createSession() { return session; } };
   const host = createRuntimeHost({ adapterFor: () => adapter, promptBuilder: new ContextPromptBuilder() });
@@ -282,11 +282,71 @@ test("RuntimeHost re-wakes an idle Agent when Pi reports a late background compl
     session.emit({ type: "turn-start" });
     session.emit({ type: "turn-end" });
     assert.equal(session.prompts.length, 1);
-    session.emit({ type: "runtime-observation", runtime: "pi", distribution: "builtin", phase: "completed" });
+    session.emit({ type: "runtime-observation", runtime: "pi", distribution: "builtin", phase: "completed", completionKey: "task-bridge-1" });
     await new Promise((resolve) => setImmediate(resolve));
     assert.equal(session.prompts.length, 2);
     assert.equal(session.prompts[1].kind, "wake");
-    assert.match(session.prompts[1].text, /Inbox changed|reason=background subagent completed/i);
+    session.emit({ type: "turn-start" });
+    session.emit({ type: "turn-end" });
+    session.emit({ type: "runtime-observation", runtime: "pi", distribution: "builtin", phase: "completed", completionKey: "task-bridge-1" });
+    await new Promise((resolve) => setImmediate(resolve));
+    assert.equal(session.prompts.length, 2);
+    session.emit({ type: "runtime-observation", runtime: "pi", distribution: "builtin", phase: "completed", completionKey: "task-bridge-2" });
+    await new Promise((resolve) => setImmediate(resolve));
+    assert.equal(session.prompts.length, 3);
+    assert.equal(session.prompts[2].kind, "wake");
+    assert.match(session.prompts[2].text, /Inbox changed|reason=background subagent completed/i);
+  } finally {
+    await host.shutdown("done");
+  }
+});
+
+test("RuntimeHost ignores background completion wake bridges while busy or mid-turn", async () => {
+  const session = new FakeSession();
+  const adapter = { id: "pi", capabilities: {}, async createSession() { return session; } };
+  const host = createRuntimeHost({ adapterFor: () => adapter, promptBuilder: new ContextPromptBuilder() });
+  try {
+    await host.start([{ agentId: "cli_piWakeBusyA1", name: "wake-busy", runtime: "pi", model: "model", workspaceDir: "/tmp" }]);
+    await host.deliver("cli_piWakeBusyA1", { message_id: "om_pi_wake_busy", chat_id: "oc_pi_wake_busy", content: "start" });
+    session.emit({ type: "runtime-observation", runtime: "pi", distribution: "builtin", phase: "completed", completionKey: "task-busy-1" });
+    await new Promise((resolve) => setImmediate(resolve));
+    assert.equal(session.prompts.length, 1);
+    session.emit({ type: "turn-start" });
+    session.emit({ type: "runtime-observation", runtime: "pi", distribution: "builtin", phase: "completed", completionKey: "task-busy-2" });
+    await new Promise((resolve) => setImmediate(resolve));
+    assert.equal(session.prompts.length, 1);
+  } finally {
+    await host.shutdown("done");
+  }
+});
+
+test("RuntimeHost ignores additional completion wake bridges while a wake prompt is submitting", async () => {
+  let releaseWake;
+  const session = new FakeSession();
+  session.prompt = async function(input) {
+    this.prompts.push(input);
+    if (this.prompts.length === 2) return new Promise((resolve) => { releaseWake = () => resolve({ status: "accepted", inputId: input.inputId }); });
+    return { status: "accepted", inputId: input.inputId };
+  };
+  const adapter = { id: "pi", capabilities: {}, async createSession() { return session; } };
+  const host = createRuntimeHost({ adapterFor: () => adapter, promptBuilder: new ContextPromptBuilder() });
+  try {
+    await host.start([{ agentId: "cli_piWakeSubmitA1", name: "wake-submit", runtime: "pi", model: "model", workspaceDir: "/tmp" }]);
+    await host.deliver("cli_piWakeSubmitA1", { message_id: "om_pi_wake_submit", chat_id: "oc_pi_wake_submit", content: "start" });
+    session.emit({ type: "turn-start" });
+    session.emit({ type: "turn-end" });
+    assert.equal(session.prompts.length, 1);
+    session.emit({ type: "runtime-observation", runtime: "pi", distribution: "builtin", phase: "completed", completionKey: "task-submit-1" });
+    await new Promise((resolve) => setImmediate(resolve));
+    assert.equal(session.prompts.length, 2);
+    session.emit({ type: "runtime-observation", runtime: "pi", distribution: "builtin", phase: "completed", completionKey: "task-submit-2" });
+    await new Promise((resolve) => setImmediate(resolve));
+    assert.equal(session.prompts.length, 2);
+    releaseWake();
+    await new Promise((resolve) => setImmediate(resolve));
+    session.emit({ type: "turn-start" });
+    session.emit({ type: "turn-end" });
+    await new Promise((resolve) => setImmediate(resolve));
   } finally {
     await host.shutdown("done");
   }

--- a/test/unit/runtime/runtime-host.test.mjs
+++ b/test/unit/runtime/runtime-host.test.mjs
@@ -415,6 +415,42 @@ test("RuntimeHost retries a rejected background completion wake", async () => {
   }
 });
 
+test("RuntimeHost still wakes after five immediate rejected background completion drains", async () => {
+  let wakeAttempts = 0;
+  const session = new FakeSession();
+  session.prompt = async function(input) {
+    this.prompts.push(input);
+    if (isBackgroundCompletionWake(input)) {
+      wakeAttempts += 1;
+      if (wakeAttempts <= 5) throw new Error("preflight RPC unavailable");
+    }
+    return { status: "accepted", inputId: input.inputId };
+  };
+  const adapter = { id: "pi", capabilities: {}, async createSession() { return session; } };
+  const host = createRuntimeHost({
+    adapterFor: () => adapter,
+    promptBuilder: new ContextPromptBuilder(),
+    retryPolicy: { baseDelayMs: 20, maxDelayMs: 40, maxAttempts: 3 },
+  });
+  try {
+    await host.start([{ agentId: "cli_piWakeBackoffA1", name: "wake-backoff", runtime: "pi", model: "model", workspaceDir: "/tmp" }]);
+    await host.deliver("cli_piWakeBackoffA1", { message_id: "om_pi_wake_backoff", chat_id: "oc_pi_wake_backoff", content: "start" });
+    session.emit({ type: "turn-start" });
+    session.emit({ type: "turn-end" });
+    assert.equal(session.prompts.length, 1);
+    session.emit({ type: "runtime-observation", runtime: "pi", distribution: "builtin", phase: "completed", completionKey: "task-backoff-1" });
+    for (let i = 0; i < 10; i++) await new Promise((resolve) => setImmediate(resolve));
+    assert.equal(wakeAttempts, 5, "five immediate rejects must not abandon the queued completion");
+    assert.equal(session.prompts.filter(isBackgroundCompletionWake).length, 5);
+    const deadline = Date.now() + 200;
+    while (wakeAttempts < 6 && Date.now() < deadline) await new Promise((resolve) => setTimeout(resolve, 5));
+    assert.equal(wakeAttempts, 6, "a later backoff drain must still wake while the item remains queued");
+    assert.equal(session.prompts.at(-1).kind, "wake");
+  } finally {
+    await host.shutdown("done");
+  }
+});
+
 test("RuntimeHost keeps an accepted wake queued until the turn succeeds", async () => {
   let wakeAttempts = 0;
   const session = new FakeSession();


### PR DESCRIPTION
## Scope
- Replace substring matching with canonical Pi subagent completion parsing.
- Deduplicate late completion wakes by canonical task id.
- Keep normal active-turn `agent_end` behavior unchanged.

## Canonical shape
- Real completion notifications are `customType: "subagent-notification"` with `<task-notification>...</task-notification>` XML content (task-id/tool-use-id/output-file/status/summary/result/usage).
- Added a minimal desensitized builder/parser in `src/runtime/pi-subagents-notification.ts`.

## Fix
- Adapter now parses canonical completion notifications and emits `runtime-observation: completed` with a non-enumerable `completionKey`.
- Host now coalesces background-completion wake keys, ignores duplicates while busy/turnInProgress/submitting, and still wakes on later independent completions.

## Verification
- `bun run build`
- `env -u LARKIN_AGENT_ID -u LARKIN_CONFIG_DIR -u LARKIN_INTERNAL_DISPATCH -u LARKIN_STANDALONE LARKIN_BUN_TEST_RUNNER=1 bun test --max-concurrency 1 test/unit/runtime/runtime-adapters.test.mjs test/unit/runtime/runtime-host.test.mjs`
  - current commit: **98 pass / 0 fail** across 2 files

## Counterfactual
- Same build + tests on parent commit `32049bc` (old substring implementation) with the same new tests: **94 pass / 4 fail**.
- Failing cases: canonical positive, assistant-text lookalikes, duplicate canonical notification, and the host wake/re-wake contract.

## Boundary
- Hosted CI still pending; no merge/release/issue close.
