### PR TITLE
fix(im): add a freshness-guarded urgent-app path

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -40,6 +40,10 @@ For any Feishu-related operation, prefer the official `lark-cli` command and fla
 - Keep `+` shortcuts only where official `lark-cli` already defines them, for example `+messages-send` and `+messages-reply`.
 - Phone and SMS urgent remain out of scope unless the Owner explicitly authorizes them.
 
+## End-to-end tests
+
+Every requirement should have an end-to-end test that exercises the real command path, not only a classifier or prompt grep. Prefer the smallest test that still proves the change took effect: launcher/integration through `runLarkCli` or the hosted gate first; add an opt-in live test only when the claim depends on Feishu, Windows, npm, or another external system. Fake or API success must not be written as client-visible proof.
+
 ## Prompt engineering
 
 When tuning the Larkin standing prompt (`src/agent/context-prompt.ts`), follow the two canonical references and the file header notes:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -31,6 +31,15 @@ Keep each change focused. Update the closest tests when behavior changes, and ru
 
 The npm package keeps a Bun-first runtime surface, but its install/invocation glue (`scripts/npm/install-binary.mjs` and `scripts/npm/larkin-bin-shim.mjs`) intentionally runs under Node. npm only guarantees Node at install time, and the postinstall binary download plus the `bin` shim must work without Bun so npm users do not need to install it. Node shebangs are therefore allowed only for those two files; `test/integration/build/bun-only-runtime-contract.test.mjs` enforces this single exception.
 
+## Feishu / lark-cli command shape
+
+For any Feishu-related operation, prefer the official `lark-cli` command and flags over a Larkin-invented shortcut. This applies to reads, writes, and other domain commands, not only IM write entries.
+
+- If official CLI already has a command such as `im messages urgent_app`, protect or wrap that exact path. Do not invent a parallel `+messages-...` surface just to make freshness or identity easier.
+- Wrapper gates may probe, deny, or inject Runtime-locked identity such as `--as bot`. They must not rename the user-facing command or invent extra required flags that official CLI does not have.
+- Keep `+` shortcuts only where official `lark-cli` already defines them, for example `+messages-send` and `+messages-reply`.
+- Phone and SMS urgent remain out of scope unless the Owner explicitly authorizes them.
+
 ## Prompt engineering
 
 When tuning the Larkin standing prompt (`src/agent/context-prompt.ts`), follow the two canonical references and the file header notes:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -37,6 +37,7 @@ For any Feishu-related operation, prefer the official `lark-cli` command and fla
 
 - If official CLI already has a command such as `im messages urgent_app`, protect or wrap that exact path. Do not invent a parallel `+messages-...` surface just to make freshness or identity easier.
 - Wrapper gates may probe, deny, or inject Runtime-locked identity such as `--as bot`. They must not rename the user-facing command or invent extra required flags that official CLI does not have.
+- Do not invent wrapper-only features that official `lark-cli` does not have. If the official command has no idempotency key, do not add a local sent/sending ledger or a synthetic `--idempotency-key` just because a review asked for retries to be unique.
 - Keep `+` shortcuts only where official `lark-cli` already defines them, for example `+messages-send` and `+messages-reply`.
 - Phone and SMS urgent remain out of scope unless the Owner explicitly authorizes them.
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "larkin",
-  "version": "0.4.6",
+  "version": "0.4.7",
   "private": false,
   "larkinPackageRole": "npm-published",
   "files": [

--- a/src/app/lark-cli.ts
+++ b/src/app/lark-cli.ts
@@ -136,7 +136,6 @@ function protectedOperations(argv: readonly string[]): ProtectedOperation[] {
   for (const token of tokens) {
     if (token === "+messages-send") operations.push("send");
     else if (token === "+messages-reply") operations.push("reply");
-    else if (token === "+messages-urgent-app") operations.push("urgent-app");
     else if (token === "api") operations.push("api");
   }
   const hasIm = tokens.includes("im");
@@ -222,11 +221,12 @@ export function classifyLarkCliCommand(argv: readonly string[]): LarkCliCommandD
     ? (parsed.commandArgv.includes("--dry-run") ? { kind: "passthrough" } : { kind: "guarded", operation: "reply" })
     : noncanonicalProtectedDecision();
   if (exactPath(parsed.commandArgv, ["im", "+messages-urgent-app"])) {
-    if (!uniqueProtectedOperation(protectedPaths, "urgent-app")) return noncanonicalProtectedDecision();
-    if (parsed.commandArgv.includes("--dry-run")) {
-      return { kind: "denied", reason: "+messages-urgent-app 不支持 --dry-run；官方 CLI 不认识该合成命令" };
-    }
-    return { kind: "guarded", operation: "urgent-app" };
+    return { kind: "denied", reason: "不要使用合成入口 +messages-urgent-app；请使用官方 im messages urgent_app" };
+  }
+  if (exactPath(parsed.commandArgv, ["im", "messages", "urgent_app"])) {
+    return uniqueProtectedOperation(protectedPaths, "raw-urgent_app")
+      ? (parsed.commandArgv.includes("--dry-run") || parsed.help ? { kind: "passthrough" } : { kind: "guarded", operation: "urgent-app" })
+      : noncanonicalProtectedDecision();
   }
   if (exactPath(parsed.commandArgv, ["im", "messages", "patch"]) || exactPath(parsed.commandArgv, ["im", "messages", "update"])) {
     const expected = parsed.commandArgv[2] === "patch" ? "card-patch" : "card-update";
@@ -240,7 +240,7 @@ export function classifyLarkCliCommand(argv: readonly string[]): LarkCliCommandD
       ? { kind: "denied", reason: "该原始 IM 写入口会旁路 target freshness；请使用 +messages-send/+messages-reply" }
       : noncanonicalProtectedDecision();
   }
-  if (["forward", "merge_forward", "delete", "urgent_app", "urgent_phone", "urgent_sms"]
+  if (["forward", "merge_forward", "delete", "urgent_phone", "urgent_sms"]
     .some((operation) => exactPath(parsed.commandArgv, ["im", "messages", operation]))) {
     const expected = `raw-${parsed.commandArgv[2]}` as ProtectedOperation;
     return uniqueProtectedOperation(protectedPaths, expected)
@@ -461,13 +461,11 @@ async function spawnNativeTransparent(
 }
 
 function guardedTarget(decision: Extract<LarkCliCommandDecision, { kind: "guarded" }>, argv: readonly string[], store: AgentStateStore): FreshnessTarget {
-  if (decision.operation === "send" || decision.operation === "urgent-app") {
+  if (decision.operation === "send") {
     const chatId = policyFlagValue(argv, "--chat-id");
     const userId = policyFlagValue(argv, "--user-id");
     if (!chatId || userId) {
-      throw new Error(decision.operation === "urgent-app"
-        ? "Runtime +messages-urgent-app 必须只使用 Inbox 已确认的 --chat-id；--user-id 无法建立 freshness target"
-        : "Runtime +messages-send 必须只使用 Inbox 已确认的 --chat-id；--user-id 无法建立 freshness target");
+      throw new Error("Runtime +messages-send 必须只使用 Inbox 已确认的 --chat-id；--user-id 无法建立 freshness target");
     }
     return feishuImTarget(`chat:${chatId}`);
   }
@@ -476,6 +474,40 @@ function guardedTarget(decision: Extract<LarkCliCommandDecision, { kind: "guarde
   const target = store.resolveInboxMessageTarget(messageId);
   if (!target) throw new Error(`无法从 Inbox 状态确定 ${messageId} 的 target；先 poll 对应消息，禁止旁路 freshness`);
   return feishuImTarget(target);
+}
+
+function resolveUrgentAppTarget(
+  argv: readonly string[],
+  env: Env,
+  io: LarkCliIo,
+  dependencies: LarkCliLauncherDependencies,
+): FreshnessTarget {
+  const messageId = policyFlagValue(argv, "--message-id");
+  if (!messageId || !/^om_/.test(messageId)) {
+    throw new Error("Runtime im messages urgent_app 只接受真实 Feishu om_ message_id");
+  }
+  const result = callNative([
+    "im", "+messages-mget",
+    "--message-ids", messageId,
+    "--no-reactions",
+    "--json",
+    "--as", "bot",
+  ], env, io, dependencies);
+  if (result.error) throw new Error(`urgent_app message lookup failed: ${result.error.message}`);
+  if (result.status !== 0) throw new Error(`urgent_app message lookup exited ${result.status ?? "without status"}: ${result.stderr || "no details"}`);
+  let value: unknown;
+  try { value = JSON.parse(result.stdout || ""); } catch { throw new Error("urgent_app message lookup returned non-JSON output"); }
+  const root = value as { ok?: unknown; identity?: unknown; data?: { messages?: unknown } } | null;
+  if (!root || root.ok !== true || !root.data) throw new Error("urgent_app message lookup returned an unsuccessful payload");
+  if (root.identity !== "bot") throw new Error("urgent_app message lookup did not confirm Bot identity");
+  const rows = root.data.messages;
+  if (!Array.isArray(rows)) throw new Error("urgent_app message lookup omitted messages");
+  const message = rows.find((row) => row && typeof row === "object" && !Array.isArray(row)
+    && (row as { message_id?: unknown }).message_id === messageId) as { chat_id?: unknown } | undefined;
+  if (!message || typeof message.chat_id !== "string" || !message.chat_id) {
+    throw new Error(`无法从官方 +messages-mget 确认 ${messageId} 的 chat；禁止旁路加急`);
+  }
+  return feishuImTarget(`chat:${message.chat_id}`);
 }
 
 function botArgv(argv: readonly string[], intentId: string, decision?: Extract<LarkCliCommandDecision, { kind: "guarded" }>): string[] {
@@ -491,15 +523,11 @@ function botArgv(argv: readonly string[], intentId: string, decision?: Extract<L
   const rewritten: string[] = [];
   for (let index = 0; index < next.length; index += 1) {
     const argument = next[index];
-    if (argument === "+messages-urgent-app") {
-      rewritten.push("messages", "urgent_app");
-      continue;
-    }
-    if (argument === "--chat-id" || argument === "--idempotency-key") {
+    if (argument === "--idempotency-key") {
       index += 1;
       continue;
     }
-    if (argument.startsWith("--chat-id=") || argument.startsWith("--idempotency-key=")) continue;
+    if (argument.startsWith("--idempotency-key=")) continue;
     rewritten.push(argument);
   }
   return rewritten;
@@ -532,22 +560,22 @@ function assertUrgentAppPreconditions(
   feishuAppId: string,
 ): string[] {
   const messageId = policyFlagValue(argv, "--message-id");
-  if (!messageId || !/^om_/.test(messageId)) throw new Error("Runtime +messages-urgent-app 只接受真实 Feishu om_ message_id");
+  if (!messageId || !/^om_/.test(messageId)) throw new Error("Runtime im messages urgent_app 只接受真实 Feishu om_ message_id");
   const userIdType = policyFlagValue(argv, "--user-id-type");
-  if (userIdType !== "open_id") throw new Error("Runtime +messages-urgent-app 必须使用 --user-id-type open_id");
+  if (userIdType !== "open_id") throw new Error("Runtime im messages urgent_app 必须使用 --user-id-type open_id");
   const data = policyFlagValue(argv, "--data");
-  if (!data) throw new Error("Runtime +messages-urgent-app 缺少 --data");
+  if (!data) throw new Error("Runtime im messages urgent_app 缺少 --data");
   const body = parseJsonObject(data, "--data");
   const userIds = body.user_id_list;
   if (!Array.isArray(userIds) || userIds.length === 0 || userIds.some((value) => typeof value !== "string" || !value.startsWith("ou_"))) {
-    throw new Error("Runtime +messages-urgent-app 的 user_id_list 必须是非空 open_id 列表");
+    throw new Error("Runtime im messages urgent_app 的 user_id_list 必须是非空 open_id 列表");
   }
   const message = snapshot.messages.find((row) => row.message_id === messageId);
   if (!message) throw new Error(`无法在当前 freshness 窗口确认 ${messageId}；禁止旁路加急未知消息`);
   if (target.resourceKind === "chat" && message.chat_id && message.chat_id !== target.resourceId) {
     throw new Error("加急目标消息不属于当前 chat freshness target");
   }
-  if (!isOwnBotMessage(message, feishuAppId)) throw new Error("Runtime +messages-urgent-app 只能加急当前 Bot 自己发出的消息");
+  if (!isOwnBotMessage(message, feishuAppId)) throw new Error("Runtime im messages urgent_app 只能加急当前 Bot 自己发出的消息");
   return userIds.filter((value): value is string => typeof value === "string");
 }
 
@@ -582,7 +610,7 @@ function assertUrgentAppMembers(
   dependencies: LarkCliLauncherDependencies,
 ): void {
   if (target.resourceKind !== "chat" || !target.resourceId) {
-    throw new Error("Runtime +messages-urgent-app 只能对照已确认的 chat freshness target 校验成员");
+    throw new Error("Runtime im messages urgent_app 只能对照已确认的 chat freshness target 校验成员");
   }
   const members = new Set(parseChatMemberOpenIds(callNative([
     "im", "+chat-members-list",
@@ -595,7 +623,7 @@ function assertUrgentAppMembers(
   ], env, io, dependencies)));
   const unknown = userIds.filter((userId) => !members.has(userId));
   if (unknown.length > 0) {
-    throw new Error(`Runtime +messages-urgent-app 拒绝非本会话成员: ${unknown.join(",")}`);
+    throw new Error(`Runtime im messages urgent_app 拒绝非本会话成员: ${unknown.join(",")}`);
   }
 }
 
@@ -608,7 +636,7 @@ function assertUrgentAppNativeAccepted(result: SpawnSyncReturns<string>): void {
   if (!data || typeof data !== "object" || Array.isArray(data)) return;
   const invalid = (data as { invalid_user_id_list?: unknown }).invalid_user_id_list;
   if (!Array.isArray(invalid) || invalid.length === 0) return;
-  throw new Error(`Runtime +messages-urgent-app 收到 invalid_user_id_list，已 fail-closed: ${invalid.join(",")}`);
+  throw new Error(`Runtime im messages urgent_app 收到 invalid_user_id_list，已 fail-closed: ${invalid.join(",")}`);
 }
 
 function probeArgv(target: FreshnessTarget): string[] {
@@ -969,7 +997,9 @@ export function runLarkCli(
   }
   if (decision.kind === "passthrough") return passthroughWithObservation(effectiveArgv, privateEnv, io, nativeDependencies, store);
   try {
-    const target = guardedTarget(decision, effectiveArgv, store);
+    const target = decision.operation === "urgent-app"
+      ? resolveUrgentAppTarget(effectiveArgv, privateEnv, io, nativeDependencies)
+      : guardedTarget(decision, effectiveArgv, store);
     const targetKey = serializeFeishuImTarget(target);
     const generation = freshnessGeneration(privateEnv);
     const seen = store.readFreshnessCursor<FeishuImCursor>(targetKey, generation);

--- a/src/app/lark-cli.ts
+++ b/src/app/lark-cli.ts
@@ -296,12 +296,6 @@ type CommentReplyLedger = {
   document_comment_replies?: Record<string, { digest: string; status: "sending" | "sent" | "failed"; updated_at: string }>;
 };
 
-type UrgentAppLedger = {
-  version: 1;
-  cursors?: Record<string, unknown>;
-  urgent_app?: Record<string, { digest: string; status: "sending" | "sent" | "failed"; updated_at: string }>;
-};
-
 type ImWriteMemoEntry = { message_id: string; updated_at: string };
 type ImWriteMemoState = {
   version: 1;
@@ -325,39 +319,6 @@ function recordImWriteMemo(store: AgentStateStore, key: string, messageId: strin
     for (const stale of keys.slice(0, Math.max(0, keys.length - IM_WRITE_MEMO_LIMIT))) delete state.im_write_memo[stale];
   });
   return duplicate;
-}
-
-function urgentAppDigest(argv: readonly string[]): string {
-  return createHash("sha256").update(JSON.stringify([
-    policyFlagValue(argv, "--message-id"),
-    uniqueRawFlagValue(argv, "--user-id-type"),
-    uniqueRawFlagValue(argv, "--data"),
-  ])).digest("hex");
-}
-
-function claimUrgentApp(store: AgentStateStore, messageId: string, digest: string): "ready" | "sent" | "ambiguous" | "conflict" {
-  return store.mutateJson<UrgentAppLedger, "ready" | "sent" | "ambiguous" | "conflict">(
-    "freshnessState", { version: 1, cursors: {} }, (state) => {
-      state.urgent_app ??= {};
-      const prior = state.urgent_app[messageId];
-      if (prior?.status === "sent" && prior.digest === digest) return "sent";
-      if (prior?.status === "sending" && prior.digest === digest) return "ambiguous";
-      if (prior && prior.status !== "failed" && prior.digest !== digest) return "conflict";
-      state.urgent_app[messageId] = { digest, status: "sending", updated_at: new Date().toISOString() };
-      const keys = Object.keys(state.urgent_app);
-      for (const stale of keys.slice(0, Math.max(0, keys.length - 512))) delete state.urgent_app[stale];
-      return "ready";
-    },
-  );
-}
-
-function finalizeUrgentApp(
-  store: AgentStateStore, messageId: string, digest: string, status: "sent" | "failed",
-): void {
-  store.mutateJson<UrgentAppLedger, void>("freshnessState", { version: 1, cursors: {} }, (state) => {
-    state.urgent_app ??= {};
-    state.urgent_app[messageId] = { digest, status, updated_at: new Date().toISOString() };
-  });
 }
 
 function runCommentReply(
@@ -1080,20 +1041,12 @@ export function runLarkCli(
     if (decision.operation === "urgent-app") {
       const userIds = assertUrgentAppPreconditions(effectiveArgv, urgent!.message, target, agent.feishuAppId);
       assertUrgentAppMembers(effectiveArgv, target, userIds, privateEnv, io, nativeDependencies);
-      const messageId = policyFlagValue(effectiveArgv, "--message-id")!;
-      const digest = urgentAppDigest(effectiveArgv);
-      const claim = claimUrgentApp(store, messageId, digest);
-      if (claim === "sent") {
-        io.stdout(`${JSON.stringify({ ok: true, identity: "bot", committed: true, duplicate: true, target: targetKey })}\n`);
-        return 0;
-      }
-      if (claim === "ambiguous") throw new Error("im messages urgent_app 上次调用结果不明确，已 fail-closed 以避免重复加急");
-      if (claim === "conflict") throw new Error("im messages urgent_app 已对同一消息提交不同 user 名单，拒绝覆盖或重复加急");
-      const write = callNative(botArgv(effectiveArgv, intentId(targetKey, effectiveArgv), decision), privateEnv, io, nativeDependencies);
-      const accepted = !write.error && write.status === 0;
-      try { if (accepted) assertUrgentAppNativeAccepted(write); }
+    }
+    const intentKey = policyFlagValue(effectiveArgv, "--idempotency-key") ?? intentId(targetKey, effectiveArgv);
+    const write = callNative(botArgv(effectiveArgv, intentKey, decision), privateEnv, io, nativeDependencies);
+    if (decision.operation === "urgent-app") {
+      try { assertUrgentAppNativeAccepted(write); }
       catch (error) {
-        finalizeUrgentApp(store, messageId, digest, "sent");
         io.stderr(`${JSON.stringify({
           ok: false,
           identity: "bot",
@@ -1102,12 +1055,8 @@ export function runLarkCli(
         })}\n`);
         return 2;
       }
-      if (accepted) finalizeUrgentApp(store, messageId, digest, "sent");
-      else if (definitiveProviderRejection(write)) finalizeUrgentApp(store, messageId, digest, "failed");
       return emitNativeResult(write, io);
     }
-    const intentKey = policyFlagValue(effectiveArgv, "--idempotency-key") ?? intentId(targetKey, effectiveArgv);
-    const write = callNative(botArgv(effectiveArgv, intentKey, decision), privateEnv, io, nativeDependencies);
     const writeMessage = writeResponseMessage(write);
     const duplicate = !write.error && write.status === 0 && writeMessage
       ? recordImWriteMemo(store, intentKey, writeMessage.message_id) : false;

--- a/src/app/lark-cli.ts
+++ b/src/app/lark-cli.ts
@@ -44,7 +44,7 @@ function portableSignalCode(signal: NodeJS.Signals): number {
 
 export type LarkCliCommandDecision =
   | { kind: "passthrough" }
-  | { kind: "guarded"; operation: "send" | "reply" | "card" }
+  | { kind: "guarded"; operation: "send" | "reply" | "card" | "urgent-app" }
   | { kind: "comment-reply" }
   | { kind: "denied"; reason: string };
 
@@ -52,7 +52,7 @@ const HELP_FLAGS = new Set(["--help", "-h"]);
 const MANAGEMENT_COMMANDS = new Set(["auth", "config", "profile", "update", "install"]);
 const USER_ONLY_COMMANDS = new Set(["attendance", "mail", "okr"]);
 const POLICY_VALUE_FLAGS = new Set([
-  "--as", "--profile", "--config-dir", "--agent", "--chat-id", "--user-id", "--message-id", "--idempotency-key", "--thread-id",
+  "--as", "--profile", "--config-dir", "--agent", "--chat-id", "--user-id", "--message-id", "--idempotency-key", "--thread-id", "--user-id-type", "--data",
 ]);
 const PROTECTED_VALUE_FLAGS = new Set([
   ...POLICY_VALUE_FLAGS,
@@ -69,7 +69,7 @@ const HISTORY_VALUE_FLAGS = new Set([
   "--format", "--jq", "-q", "--download-dir",
 ]);
 
-type ProtectedOperation = "send" | "reply" | "card-patch" | "card-update" | "raw-create" | "raw-reply"
+type ProtectedOperation = "send" | "reply" | "card-patch" | "card-update" | "urgent-app" | "raw-create" | "raw-reply"
   | "raw-forward" | "raw-merge_forward" | "raw-delete" | "raw-urgent_app" | "raw-urgent_phone" | "raw-urgent_sms"
   | "thread-forward" | "thread-merge_forward" | "api";
 
@@ -99,7 +99,7 @@ function hasCanonicalUnprotectedCommandPath(argv: readonly string[]): boolean {
   const command = nativeArgv[1];
   if (!service || service.startsWith("-") || !command || command.startsWith("-")) return false;
   if (service !== "im") return service !== "api" && service !== "larkin-draft";
-  if (command === "+messages-send" || command === "+messages-reply" || command === "api") {
+  if (command === "+messages-send" || command === "+messages-reply" || command === "+messages-urgent-app" || command === "api") {
     return false;
   }
   if (command.startsWith("+")) return true;
@@ -136,6 +136,7 @@ function protectedOperations(argv: readonly string[]): ProtectedOperation[] {
   for (const token of tokens) {
     if (token === "+messages-send") operations.push("send");
     else if (token === "+messages-reply") operations.push("reply");
+    else if (token === "+messages-urgent-app") operations.push("urgent-app");
     else if (token === "api") operations.push("api");
   }
   const hasIm = tokens.includes("im");
@@ -219,6 +220,9 @@ export function classifyLarkCliCommand(argv: readonly string[]): LarkCliCommandD
     : noncanonicalProtectedDecision();
   if (exactPath(parsed.commandArgv, ["im", "+messages-reply"])) return uniqueProtectedOperation(protectedPaths, "reply")
     ? (parsed.commandArgv.includes("--dry-run") ? { kind: "passthrough" } : { kind: "guarded", operation: "reply" })
+    : noncanonicalProtectedDecision();
+  if (exactPath(parsed.commandArgv, ["im", "+messages-urgent-app"])) return uniqueProtectedOperation(protectedPaths, "urgent-app")
+    ? (parsed.commandArgv.includes("--dry-run") ? { kind: "passthrough" } : { kind: "guarded", operation: "urgent-app" })
     : noncanonicalProtectedDecision();
   if (exactPath(parsed.commandArgv, ["im", "messages", "patch"]) || exactPath(parsed.commandArgv, ["im", "messages", "update"])) {
     const expected = parsed.commandArgv[2] === "patch" ? "card-patch" : "card-update";
@@ -453,10 +457,14 @@ async function spawnNativeTransparent(
 }
 
 function guardedTarget(decision: Extract<LarkCliCommandDecision, { kind: "guarded" }>, argv: readonly string[], store: AgentStateStore): FreshnessTarget {
-  if (decision.operation === "send") {
+  if (decision.operation === "send" || decision.operation === "urgent-app") {
     const chatId = policyFlagValue(argv, "--chat-id");
     const userId = policyFlagValue(argv, "--user-id");
-    if (!chatId || userId) throw new Error("Runtime +messages-send 必须只使用 Inbox 已确认的 --chat-id；--user-id 无法建立 freshness target");
+    if (!chatId || userId) {
+      throw new Error(decision.operation === "urgent-app"
+        ? "Runtime +messages-urgent-app 必须只使用 Inbox 已确认的 --chat-id；--user-id 无法建立 freshness target"
+        : "Runtime +messages-send 必须只使用 Inbox 已确认的 --chat-id；--user-id 无法建立 freshness target");
+    }
     return feishuImTarget(`chat:${chatId}`);
   }
   const messageId = policyFlagValue(argv, "--message-id");
@@ -466,16 +474,76 @@ function guardedTarget(decision: Extract<LarkCliCommandDecision, { kind: "guarde
   return feishuImTarget(target);
 }
 
-function botArgv(argv: readonly string[], intentId: string): string[] {
+function botArgv(argv: readonly string[], intentId: string, decision?: Extract<LarkCliCommandDecision, { kind: "guarded" }>): string[] {
   const next = [...argv];
   const parsed = parsePolicyArgv(next);
   const boundary = next.indexOf("--");
   const insertion = boundary < 0 ? next.length : boundary;
   const injected: string[] = [];
   if (!parsed.flags.has("--as")) injected.push("--as", "bot");
-  if (!parsed.flags.has("--idempotency-key")) injected.push("--idempotency-key", intentId);
+  if (decision?.operation !== "urgent-app" && !parsed.flags.has("--idempotency-key")) injected.push("--idempotency-key", intentId);
   next.splice(insertion, 0, ...injected);
-  return next;
+  if (decision?.operation !== "urgent-app") return next;
+  const rewritten: string[] = [];
+  for (let index = 0; index < next.length; index += 1) {
+    const argument = next[index];
+    if (argument === "+messages-urgent-app") {
+      rewritten.push("messages", "urgent_app");
+      continue;
+    }
+    if (argument === "--chat-id") {
+      index += 1;
+      continue;
+    }
+    if (argument.startsWith("--chat-id=")) continue;
+    rewritten.push(argument);
+  }
+  return rewritten;
+}
+
+function parseJsonObject(value: string, label: string): Record<string, unknown> {
+  let parsed: unknown;
+  try { parsed = JSON.parse(value); } catch { throw new Error(`${label} 必须是 JSON 对象`); }
+  if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) throw new Error(`${label} 必须是 JSON 对象`);
+  return parsed as Record<string, unknown>;
+}
+
+function senderRecord(message: FeishuImMessage): Record<string, unknown> | null {
+  const sender = message.sender;
+  return sender && typeof sender === "object" && !Array.isArray(sender) ? sender as Record<string, unknown> : null;
+}
+
+function isOwnBotMessage(message: FeishuImMessage, agentId: string): boolean {
+  const sender = senderRecord(message);
+  if (!sender) return false;
+  const senderType = sender.sender_type ?? sender.id_type;
+  const senderId = sender.id ?? sender.sender_id;
+  return senderType === "app" && senderId === agentId;
+}
+
+function assertUrgentAppPreconditions(
+  argv: readonly string[],
+  snapshot: FeishuImSnapshot,
+  target: FreshnessTarget,
+  agentId: string,
+): void {
+  const messageId = policyFlagValue(argv, "--message-id");
+  if (!messageId || !/^om_/.test(messageId)) throw new Error("Runtime +messages-urgent-app 只接受真实 Feishu om_ message_id");
+  const userIdType = policyFlagValue(argv, "--user-id-type");
+  if (userIdType !== "open_id") throw new Error("Runtime +messages-urgent-app 必须使用 --user-id-type open_id");
+  const data = policyFlagValue(argv, "--data");
+  if (!data) throw new Error("Runtime +messages-urgent-app 缺少 --data");
+  const body = parseJsonObject(data, "--data");
+  const userIds = body.user_id_list;
+  if (!Array.isArray(userIds) || userIds.length === 0 || userIds.some((value) => typeof value !== "string" || !value.startsWith("ou_"))) {
+    throw new Error("Runtime +messages-urgent-app 的 user_id_list 必须是非空 open_id 列表");
+  }
+  const message = snapshot.messages.find((row) => row.message_id === messageId);
+  if (!message) throw new Error(`无法在当前 freshness 窗口确认 ${messageId}；禁止旁路加急未知消息`);
+  if (target.resourceKind === "chat" && message.chat_id && message.chat_id !== target.resourceId) {
+    throw new Error("加急目标消息不属于当前 chat freshness target");
+  }
+  if (!isOwnBotMessage(message, agentId)) throw new Error("Runtime +messages-urgent-app 只能加急当前 Bot 自己发出的消息");
 }
 
 function probeArgv(target: FreshnessTarget): string[] {
@@ -854,8 +922,11 @@ export function runLarkCli(
       store.mergeFreshnessCursor(targetKey, gated.current, mergeFeishuImCursor, generation);
       return 3;
     }
+    if (decision.operation === "urgent-app") {
+      assertUrgentAppPreconditions(effectiveArgv, gated.snapshot, target, agent.agentId);
+    }
     const intentKey = policyFlagValue(effectiveArgv, "--idempotency-key") ?? intentId(targetKey, effectiveArgv);
-    const write = callNative(botArgv(effectiveArgv, intentKey), privateEnv, io, nativeDependencies);
+    const write = callNative(botArgv(effectiveArgv, intentKey, decision), privateEnv, io, nativeDependencies);
     const writeMessage = writeResponseMessage(write);
     const duplicate = !write.error && write.status === 0 && writeMessage
       ? recordImWriteMemo(store, intentKey, writeMessage.message_id) : false;

--- a/src/app/lark-cli.ts
+++ b/src/app/lark-cli.ts
@@ -530,7 +530,7 @@ function assertUrgentAppPreconditions(
   snapshot: FeishuImSnapshot,
   target: FreshnessTarget,
   feishuAppId: string,
-): void {
+): string[] {
   const messageId = policyFlagValue(argv, "--message-id");
   if (!messageId || !/^om_/.test(messageId)) throw new Error("Runtime +messages-urgent-app 只接受真实 Feishu om_ message_id");
   const userIdType = policyFlagValue(argv, "--user-id-type");
@@ -548,6 +548,67 @@ function assertUrgentAppPreconditions(
     throw new Error("加急目标消息不属于当前 chat freshness target");
   }
   if (!isOwnBotMessage(message, feishuAppId)) throw new Error("Runtime +messages-urgent-app 只能加急当前 Bot 自己发出的消息");
+  return userIds.filter((value): value is string => typeof value === "string");
+}
+
+function parseChatMemberOpenIds(result: SpawnSyncReturns<string>): string[] {
+  if (result.error) throw new Error(`urgent-app member probe failed: ${result.error.message}`);
+  if (result.status !== 0) throw new Error(`urgent-app member probe exited ${result.status ?? "without status"}: ${result.stderr || "no details"}`);
+  let value: unknown;
+  try { value = JSON.parse(result.stdout || ""); } catch { throw new Error("urgent-app member probe returned non-JSON output"); }
+  const root = value as { ok?: unknown; identity?: unknown; data?: { users?: unknown; truncations?: unknown } } | null;
+  if (!root || root.ok !== true || !root.data) throw new Error("urgent-app member probe returned an unsuccessful payload");
+  if (root.identity !== "bot") throw new Error("urgent-app member probe did not confirm Bot identity");
+  if (Array.isArray(root.data.truncations) && root.data.truncations.length > 0) {
+    throw new Error("urgent-app member probe was truncated; refusing to guess chat membership");
+  }
+  const users = root.data.users;
+  if (!Array.isArray(users)) throw new Error("urgent-app member probe omitted users");
+  const ids: string[] = [];
+  for (const user of users) {
+    if (!user || typeof user !== "object" || Array.isArray(user)) continue;
+    const memberId = (user as { member_id?: unknown }).member_id;
+    if (typeof memberId === "string" && memberId.startsWith("ou_")) ids.push(memberId);
+  }
+  return ids;
+}
+
+function assertUrgentAppMembers(
+  argv: readonly string[],
+  target: FreshnessTarget,
+  userIds: readonly string[],
+  env: Env,
+  io: LarkCliIo,
+  dependencies: LarkCliLauncherDependencies,
+): void {
+  if (target.resourceKind !== "chat" || !target.resourceId) {
+    throw new Error("Runtime +messages-urgent-app 只能对照已确认的 chat freshness target 校验成员");
+  }
+  const members = new Set(parseChatMemberOpenIds(callNative([
+    "im", "+chat-members-list",
+    "--chat-id", target.resourceId,
+    "--member-id-type", "open_id",
+    "--member-types", "user",
+    "--page-all",
+    "--json",
+    "--as", "bot",
+  ], env, io, dependencies)));
+  const unknown = userIds.filter((userId) => !members.has(userId));
+  if (unknown.length > 0) {
+    throw new Error(`Runtime +messages-urgent-app 拒绝非本会话成员: ${unknown.join(",")}`);
+  }
+}
+
+function assertUrgentAppNativeAccepted(result: SpawnSyncReturns<string>): void {
+  if (result.error || result.status !== 0) return;
+  let value: unknown;
+  try { value = JSON.parse(result.stdout || ""); } catch { return; }
+  if (!value || typeof value !== "object" || Array.isArray(value)) return;
+  const data = (value as { data?: unknown }).data;
+  if (!data || typeof data !== "object" || Array.isArray(data)) return;
+  const invalid = (data as { invalid_user_id_list?: unknown }).invalid_user_id_list;
+  if (!Array.isArray(invalid) || invalid.length === 0) return;
+  throw new Error(`Runtime +messages-urgent-app 收到 invalid_user_id_list，已 fail-closed: ${invalid.join(",")}`);
 }
 
 function probeArgv(target: FreshnessTarget): string[] {
@@ -927,11 +988,19 @@ export function runLarkCli(
       return 3;
     }
     if (decision.operation === "urgent-app") {
-      assertUrgentAppPreconditions(effectiveArgv, gated.snapshot, target, agent.feishuAppId);
+      const userIds = assertUrgentAppPreconditions(effectiveArgv, gated.snapshot, target, agent.feishuAppId);
+      assertUrgentAppMembers(effectiveArgv, target, userIds, privateEnv, io, nativeDependencies);
     }
     const intentKey = policyFlagValue(effectiveArgv, "--idempotency-key") ?? intentId(targetKey, effectiveArgv);
     const write = callNative(botArgv(effectiveArgv, intentKey, decision), privateEnv, io, nativeDependencies);
-    if (decision.operation === "urgent-app") return emitNativeResult(write, io);
+    if (decision.operation === "urgent-app") {
+      try { assertUrgentAppNativeAccepted(write); }
+      catch (error) {
+        io.stderr(`lark-cli: ${error instanceof Error ? error.message : String(error)}\n`);
+        return 2;
+      }
+      return emitNativeResult(write, io);
+    }
     const writeMessage = writeResponseMessage(write);
     const duplicate = !write.error && write.status === 0 && writeMessage
       ? recordImWriteMemo(store, intentKey, writeMessage.message_id) : false;

--- a/src/app/lark-cli.ts
+++ b/src/app/lark-cli.ts
@@ -476,12 +476,28 @@ function guardedTarget(decision: Extract<LarkCliCommandDecision, { kind: "guarde
   return feishuImTarget(target);
 }
 
+function uniqueRawFlagValue(argv: readonly string[], flag: string): string | null {
+  const nativeArgv = nativeArgvBeforeBoundary(argv);
+  const values: string[] = [];
+  for (let index = 0; index < nativeArgv.length; index += 1) {
+    const argument = nativeArgv[index];
+    if (argument === flag) {
+      values.push(nativeArgv[index + 1] ?? "");
+      index += 1;
+      continue;
+    }
+    if (argument.startsWith(`${flag}=`)) values.push(argument.slice(flag.length + 1));
+  }
+  if (values.length > 1) throw new Error(`Runtime im messages urgent_app 不允许重复 ${flag}；官方 CLI 会采用最后一次赋值`);
+  return values[0] || null;
+}
+
 function resolveUrgentAppTarget(
   argv: readonly string[],
   env: Env,
   io: LarkCliIo,
   dependencies: LarkCliLauncherDependencies,
-): FreshnessTarget {
+): { target: FreshnessTarget; message: FeishuImMessage } {
   const messageId = policyFlagValue(argv, "--message-id");
   if (!messageId || !/^om_/.test(messageId)) {
     throw new Error("Runtime im messages urgent_app 只接受真实 Feishu om_ message_id");
@@ -503,11 +519,11 @@ function resolveUrgentAppTarget(
   const rows = root.data.messages;
   if (!Array.isArray(rows)) throw new Error("urgent_app message lookup omitted messages");
   const message = rows.find((row) => row && typeof row === "object" && !Array.isArray(row)
-    && (row as { message_id?: unknown }).message_id === messageId) as { chat_id?: unknown } | undefined;
+    && (row as { message_id?: unknown }).message_id === messageId) as FeishuImMessage | undefined;
   if (!message || typeof message.chat_id !== "string" || !message.chat_id) {
     throw new Error(`无法从官方 +messages-mget 确认 ${messageId} 的 chat；禁止旁路加急`);
   }
-  return feishuImTarget(`chat:${message.chat_id}`);
+  return { target: feishuImTarget(`chat:${message.chat_id}`), message };
 }
 
 function botArgv(argv: readonly string[], intentId: string, decision?: Extract<LarkCliCommandDecision, { kind: "guarded" }>): string[] {
@@ -555,23 +571,23 @@ function isOwnBotMessage(message: FeishuImMessage, feishuAppId: string): boolean
 
 function assertUrgentAppPreconditions(
   argv: readonly string[],
-  snapshot: FeishuImSnapshot,
+  message: FeishuImMessage,
   target: FreshnessTarget,
   feishuAppId: string,
 ): string[] {
   const messageId = policyFlagValue(argv, "--message-id");
-  if (!messageId || !/^om_/.test(messageId)) throw new Error("Runtime im messages urgent_app 只接受真实 Feishu om_ message_id");
-  const userIdType = rawFlagValue(argv, "--user-id-type");
+  if (!messageId || !/^om_/.test(messageId) || message.message_id !== messageId) {
+    throw new Error("Runtime im messages urgent_app 只接受真实 Feishu om_ message_id");
+  }
+  const userIdType = uniqueRawFlagValue(argv, "--user-id-type");
   if (userIdType !== "open_id") throw new Error("Runtime im messages urgent_app 必须使用 --user-id-type open_id");
-  const data = rawFlagValue(argv, "--data");
+  const data = uniqueRawFlagValue(argv, "--data");
   if (!data) throw new Error("Runtime im messages urgent_app 缺少 --data");
   const body = parseJsonObject(data, "--data");
   const userIds = body.user_id_list;
   if (!Array.isArray(userIds) || userIds.length === 0 || userIds.some((value) => typeof value !== "string" || !value.startsWith("ou_"))) {
     throw new Error("Runtime im messages urgent_app 的 user_id_list 必须是非空 open_id 列表");
   }
-  const message = snapshot.messages.find((row) => row.message_id === messageId);
-  if (!message) throw new Error(`无法在当前 freshness 窗口确认 ${messageId}；禁止旁路加急未知消息`);
   if (target.resourceKind === "chat" && message.chat_id && message.chat_id !== target.resourceId) {
     throw new Error("加急目标消息不属于当前 chat freshness target");
   }
@@ -1001,9 +1017,10 @@ export function runLarkCli(
   }
   if (decision.kind === "passthrough") return passthroughWithObservation(effectiveArgv, privateEnv, io, nativeDependencies, store);
   try {
-    const target = decision.operation === "urgent-app"
+    const urgent = decision.operation === "urgent-app"
       ? resolveUrgentAppTarget(effectiveArgv, privateEnv, io, nativeDependencies)
-      : guardedTarget(decision, effectiveArgv, store);
+      : null;
+    const target = urgent?.target ?? guardedTarget(decision, effectiveArgv, store);
     const targetKey = serializeFeishuImTarget(target);
     const generation = freshnessGeneration(privateEnv);
     const seen = store.readFreshnessCursor<FeishuImCursor>(targetKey, generation);
@@ -1022,7 +1039,7 @@ export function runLarkCli(
       return 3;
     }
     if (decision.operation === "urgent-app") {
-      const userIds = assertUrgentAppPreconditions(effectiveArgv, gated.snapshot, target, agent.feishuAppId);
+      const userIds = assertUrgentAppPreconditions(effectiveArgv, urgent!.message, target, agent.feishuAppId);
       assertUrgentAppMembers(effectiveArgv, target, userIds, privateEnv, io, nativeDependencies);
     }
     const intentKey = policyFlagValue(effectiveArgv, "--idempotency-key") ?? intentId(targetKey, effectiveArgv);
@@ -1030,7 +1047,12 @@ export function runLarkCli(
     if (decision.operation === "urgent-app") {
       try { assertUrgentAppNativeAccepted(write); }
       catch (error) {
-        io.stderr(`lark-cli: ${error instanceof Error ? error.message : String(error)}\n`);
+        io.stderr(`${JSON.stringify({
+          ok: false,
+          identity: "bot",
+          committed: true,
+          error: { type: "validation", message: error instanceof Error ? error.message : String(error) },
+        })}\n`);
         return 2;
       }
       return emitNativeResult(write, io);

--- a/src/app/lark-cli.ts
+++ b/src/app/lark-cli.ts
@@ -513,19 +513,19 @@ function senderRecord(message: FeishuImMessage): Record<string, unknown> | null 
   return sender && typeof sender === "object" && !Array.isArray(sender) ? sender as Record<string, unknown> : null;
 }
 
-function isOwnBotMessage(message: FeishuImMessage, agentId: string): boolean {
+function isOwnBotMessage(message: FeishuImMessage, feishuAppId: string): boolean {
   const sender = senderRecord(message);
   if (!sender) return false;
-  const senderType = sender.sender_type ?? sender.id_type;
+  const senderType = sender.sender_type;
   const senderId = sender.id ?? sender.sender_id;
-  return senderType === "app" && senderId === agentId;
+  return senderType === "app" && senderId === feishuAppId;
 }
 
 function assertUrgentAppPreconditions(
   argv: readonly string[],
   snapshot: FeishuImSnapshot,
   target: FreshnessTarget,
-  agentId: string,
+  feishuAppId: string,
 ): void {
   const messageId = policyFlagValue(argv, "--message-id");
   if (!messageId || !/^om_/.test(messageId)) throw new Error("Runtime +messages-urgent-app 只接受真实 Feishu om_ message_id");
@@ -543,7 +543,7 @@ function assertUrgentAppPreconditions(
   if (target.resourceKind === "chat" && message.chat_id && message.chat_id !== target.resourceId) {
     throw new Error("加急目标消息不属于当前 chat freshness target");
   }
-  if (!isOwnBotMessage(message, agentId)) throw new Error("Runtime +messages-urgent-app 只能加急当前 Bot 自己发出的消息");
+  if (!isOwnBotMessage(message, feishuAppId)) throw new Error("Runtime +messages-urgent-app 只能加急当前 Bot 自己发出的消息");
 }
 
 function probeArgv(target: FreshnessTarget): string[] {
@@ -923,10 +923,11 @@ export function runLarkCli(
       return 3;
     }
     if (decision.operation === "urgent-app") {
-      assertUrgentAppPreconditions(effectiveArgv, gated.snapshot, target, agent.agentId);
+      assertUrgentAppPreconditions(effectiveArgv, gated.snapshot, target, agent.feishuAppId);
     }
     const intentKey = policyFlagValue(effectiveArgv, "--idempotency-key") ?? intentId(targetKey, effectiveArgv);
     const write = callNative(botArgv(effectiveArgv, intentKey, decision), privateEnv, io, nativeDependencies);
+    if (decision.operation === "urgent-app") return emitNativeResult(write, io);
     const writeMessage = writeResponseMessage(write);
     const duplicate = !write.error && write.status === 0 && writeMessage
       ? recordImWriteMemo(store, intentKey, writeMessage.message_id) : false;

--- a/src/app/lark-cli.ts
+++ b/src/app/lark-cli.ts
@@ -221,9 +221,13 @@ export function classifyLarkCliCommand(argv: readonly string[]): LarkCliCommandD
   if (exactPath(parsed.commandArgv, ["im", "+messages-reply"])) return uniqueProtectedOperation(protectedPaths, "reply")
     ? (parsed.commandArgv.includes("--dry-run") ? { kind: "passthrough" } : { kind: "guarded", operation: "reply" })
     : noncanonicalProtectedDecision();
-  if (exactPath(parsed.commandArgv, ["im", "+messages-urgent-app"])) return uniqueProtectedOperation(protectedPaths, "urgent-app")
-    ? (parsed.commandArgv.includes("--dry-run") ? { kind: "passthrough" } : { kind: "guarded", operation: "urgent-app" })
-    : noncanonicalProtectedDecision();
+  if (exactPath(parsed.commandArgv, ["im", "+messages-urgent-app"])) {
+    if (!uniqueProtectedOperation(protectedPaths, "urgent-app")) return noncanonicalProtectedDecision();
+    if (parsed.commandArgv.includes("--dry-run")) {
+      return { kind: "denied", reason: "+messages-urgent-app 不支持 --dry-run；官方 CLI 不认识该合成命令" };
+    }
+    return { kind: "guarded", operation: "urgent-app" };
+  }
   if (exactPath(parsed.commandArgv, ["im", "messages", "patch"]) || exactPath(parsed.commandArgv, ["im", "messages", "update"])) {
     const expected = parsed.commandArgv[2] === "patch" ? "card-patch" : "card-update";
     return uniqueProtectedOperation(protectedPaths, expected)
@@ -491,11 +495,11 @@ function botArgv(argv: readonly string[], intentId: string, decision?: Extract<L
       rewritten.push("messages", "urgent_app");
       continue;
     }
-    if (argument === "--chat-id") {
+    if (argument === "--chat-id" || argument === "--idempotency-key") {
       index += 1;
       continue;
     }
-    if (argument.startsWith("--chat-id=")) continue;
+    if (argument.startsWith("--chat-id=") || argument.startsWith("--idempotency-key=")) continue;
     rewritten.push(argument);
   }
   return rewritten;

--- a/src/app/lark-cli.ts
+++ b/src/app/lark-cli.ts
@@ -296,6 +296,12 @@ type CommentReplyLedger = {
   document_comment_replies?: Record<string, { digest: string; status: "sending" | "sent" | "failed"; updated_at: string }>;
 };
 
+type UrgentAppLedger = {
+  version: 1;
+  cursors?: Record<string, unknown>;
+  urgent_app?: Record<string, { digest: string; status: "sending" | "sent" | "failed"; updated_at: string }>;
+};
+
 type ImWriteMemoEntry = { message_id: string; updated_at: string };
 type ImWriteMemoState = {
   version: 1;
@@ -319,6 +325,39 @@ function recordImWriteMemo(store: AgentStateStore, key: string, messageId: strin
     for (const stale of keys.slice(0, Math.max(0, keys.length - IM_WRITE_MEMO_LIMIT))) delete state.im_write_memo[stale];
   });
   return duplicate;
+}
+
+function urgentAppDigest(argv: readonly string[]): string {
+  return createHash("sha256").update(JSON.stringify([
+    policyFlagValue(argv, "--message-id"),
+    uniqueRawFlagValue(argv, "--user-id-type"),
+    uniqueRawFlagValue(argv, "--data"),
+  ])).digest("hex");
+}
+
+function claimUrgentApp(store: AgentStateStore, messageId: string, digest: string): "ready" | "sent" | "ambiguous" | "conflict" {
+  return store.mutateJson<UrgentAppLedger, "ready" | "sent" | "ambiguous" | "conflict">(
+    "freshnessState", { version: 1, cursors: {} }, (state) => {
+      state.urgent_app ??= {};
+      const prior = state.urgent_app[messageId];
+      if (prior?.status === "sent" && prior.digest === digest) return "sent";
+      if (prior?.status === "sending" && prior.digest === digest) return "ambiguous";
+      if (prior && prior.status !== "failed" && prior.digest !== digest) return "conflict";
+      state.urgent_app[messageId] = { digest, status: "sending", updated_at: new Date().toISOString() };
+      const keys = Object.keys(state.urgent_app);
+      for (const stale of keys.slice(0, Math.max(0, keys.length - 512))) delete state.urgent_app[stale];
+      return "ready";
+    },
+  );
+}
+
+function finalizeUrgentApp(
+  store: AgentStateStore, messageId: string, digest: string, status: "sent" | "failed",
+): void {
+  store.mutateJson<UrgentAppLedger, void>("freshnessState", { version: 1, cursors: {} }, (state) => {
+    state.urgent_app ??= {};
+    state.urgent_app[messageId] = { digest, status, updated_at: new Date().toISOString() };
+  });
 }
 
 function runCommentReply(
@@ -1041,12 +1080,20 @@ export function runLarkCli(
     if (decision.operation === "urgent-app") {
       const userIds = assertUrgentAppPreconditions(effectiveArgv, urgent!.message, target, agent.feishuAppId);
       assertUrgentAppMembers(effectiveArgv, target, userIds, privateEnv, io, nativeDependencies);
-    }
-    const intentKey = policyFlagValue(effectiveArgv, "--idempotency-key") ?? intentId(targetKey, effectiveArgv);
-    const write = callNative(botArgv(effectiveArgv, intentKey, decision), privateEnv, io, nativeDependencies);
-    if (decision.operation === "urgent-app") {
-      try { assertUrgentAppNativeAccepted(write); }
+      const messageId = policyFlagValue(effectiveArgv, "--message-id")!;
+      const digest = urgentAppDigest(effectiveArgv);
+      const claim = claimUrgentApp(store, messageId, digest);
+      if (claim === "sent") {
+        io.stdout(`${JSON.stringify({ ok: true, identity: "bot", committed: true, duplicate: true, target: targetKey })}\n`);
+        return 0;
+      }
+      if (claim === "ambiguous") throw new Error("im messages urgent_app 上次调用结果不明确，已 fail-closed 以避免重复加急");
+      if (claim === "conflict") throw new Error("im messages urgent_app 已对同一消息提交不同 user 名单，拒绝覆盖或重复加急");
+      const write = callNative(botArgv(effectiveArgv, intentId(targetKey, effectiveArgv), decision), privateEnv, io, nativeDependencies);
+      const accepted = !write.error && write.status === 0;
+      try { if (accepted) assertUrgentAppNativeAccepted(write); }
       catch (error) {
+        finalizeUrgentApp(store, messageId, digest, "sent");
         io.stderr(`${JSON.stringify({
           ok: false,
           identity: "bot",
@@ -1055,8 +1102,12 @@ export function runLarkCli(
         })}\n`);
         return 2;
       }
+      if (accepted) finalizeUrgentApp(store, messageId, digest, "sent");
+      else if (definitiveProviderRejection(write)) finalizeUrgentApp(store, messageId, digest, "failed");
       return emitNativeResult(write, io);
     }
+    const intentKey = policyFlagValue(effectiveArgv, "--idempotency-key") ?? intentId(targetKey, effectiveArgv);
+    const write = callNative(botArgv(effectiveArgv, intentKey, decision), privateEnv, io, nativeDependencies);
     const writeMessage = writeResponseMessage(write);
     const duplicate = !write.error && write.status === 0 && writeMessage
       ? recordImWriteMemo(store, intentKey, writeMessage.message_id) : false;

--- a/src/app/lark-cli.ts
+++ b/src/app/lark-cli.ts
@@ -52,7 +52,7 @@ const HELP_FLAGS = new Set(["--help", "-h"]);
 const MANAGEMENT_COMMANDS = new Set(["auth", "config", "profile", "update", "install"]);
 const USER_ONLY_COMMANDS = new Set(["attendance", "mail", "okr"]);
 const POLICY_VALUE_FLAGS = new Set([
-  "--as", "--profile", "--config-dir", "--agent", "--chat-id", "--user-id", "--message-id", "--idempotency-key", "--thread-id", "--user-id-type", "--data",
+  "--as", "--profile", "--config-dir", "--agent", "--chat-id", "--user-id", "--message-id", "--idempotency-key", "--thread-id",
 ]);
 const PROTECTED_VALUE_FLAGS = new Set([
   ...POLICY_VALUE_FLAGS,
@@ -561,9 +561,9 @@ function assertUrgentAppPreconditions(
 ): string[] {
   const messageId = policyFlagValue(argv, "--message-id");
   if (!messageId || !/^om_/.test(messageId)) throw new Error("Runtime im messages urgent_app 只接受真实 Feishu om_ message_id");
-  const userIdType = policyFlagValue(argv, "--user-id-type");
+  const userIdType = rawFlagValue(argv, "--user-id-type");
   if (userIdType !== "open_id") throw new Error("Runtime im messages urgent_app 必须使用 --user-id-type open_id");
-  const data = policyFlagValue(argv, "--data");
+  const data = rawFlagValue(argv, "--data");
   if (!data) throw new Error("Runtime im messages urgent_app 缺少 --data");
   const body = parseJsonObject(data, "--data");
   const userIds = body.user_id_list;
@@ -584,9 +584,12 @@ function parseChatMemberOpenIds(result: SpawnSyncReturns<string>): string[] {
   if (result.status !== 0) throw new Error(`urgent-app member probe exited ${result.status ?? "without status"}: ${result.stderr || "no details"}`);
   let value: unknown;
   try { value = JSON.parse(result.stdout || ""); } catch { throw new Error("urgent-app member probe returned non-JSON output"); }
-  const root = value as { ok?: unknown; identity?: unknown; data?: { users?: unknown; truncations?: unknown } } | null;
+  const root = value as { ok?: unknown; identity?: unknown; data?: { users?: unknown; truncations?: unknown; has_more?: unknown } } | null;
   if (!root || root.ok !== true || !root.data) throw new Error("urgent-app member probe returned an unsuccessful payload");
   if (root.identity !== "bot") throw new Error("urgent-app member probe did not confirm Bot identity");
+  if (root.data.has_more === true) {
+    throw new Error("urgent-app member probe is incomplete; refusing to guess chat membership");
+  }
   if (Array.isArray(root.data.truncations) && root.data.truncations.length > 0) {
     throw new Error("urgent-app member probe was truncated; refusing to guess chat membership");
   }
@@ -618,6 +621,7 @@ function assertUrgentAppMembers(
     "--member-id-type", "open_id",
     "--member-types", "user",
     "--page-all",
+    "--page-limit", "0",
     "--json",
     "--as", "bot",
   ], env, io, dependencies)));

--- a/test/e2e/issue134-urgent-app-native-e2e.test.mjs
+++ b/test/e2e/issue134-urgent-app-native-e2e.test.mjs
@@ -1,0 +1,108 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { test } from "bun:test";
+import { createAgentStateStore } from "../../dist/agent/agent-state-store.mjs";
+import { runLarkCli } from "../../dist/app/lark-cli.mjs";
+
+function fixture() {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "larkin-issue134-urgent-e2e-"));
+  const agentId = "cli_issue134UrgentA1";
+  fs.writeFileSync(path.join(root, "config.json"), `${JSON.stringify({
+    version: 4, serverId: "server-issue134-urgent", mentionPolicy: "require", activeAgent: agentId,
+    agents: { [agentId]: { runtime: "codex", model: "default" } },
+  })}\n`, { mode: 0o600 });
+  const store = createAgentStateStore(root, agentId);
+  const output = { stdout: "", stderr: "" };
+  const calls = [];
+  const own = {
+    message_id: "om_issue134_own",
+    chat_id: "oc_issue134",
+    create_time: "1786979000001",
+    sender: { id: agentId, id_type: "app_id", sender_type: "app" },
+  };
+  const spawn = (_command, args) => {
+    calls.push(args.slice());
+    if (args[2] === "+messages-mget" || (args[1] === "api" && args[2] === "GET")) {
+      return {
+        status: 0, signal: null, output: [], pid: 1,
+        stdout: JSON.stringify({ ok: true, identity: "bot", data: { messages: [own] } }),
+        stderr: "", error: undefined,
+      };
+    }
+    if (args[2] === "+chat-members-list") {
+      return {
+        status: 0, signal: null, output: [], pid: 1,
+        stdout: JSON.stringify({
+          ok: true, identity: "bot",
+          data: { users: [{ member_id: "ou_issue134_human" }], has_more: false, truncations: [] },
+        }),
+        stderr: "", error: undefined,
+      };
+    }
+    return {
+      status: 0, signal: null, output: [], pid: 1,
+      stdout: `${JSON.stringify({ ok: true, identity: "bot", data: { invalid_user_id_list: [] } })}\n`,
+      stderr: "", error: undefined,
+    };
+  };
+  const run = (argv) => {
+    output.stdout = "";
+    output.stderr = "";
+    const code = runLarkCli(argv, { LARKIN_CONFIG_DIR: root, LARKIN_AGENT_ID: agentId }, {
+      io: { stdout(text) { output.stdout += text; }, stderr(text) { output.stderr += text; } },
+      spawn,
+      nativeCommand: { command: process.execPath, argsPrefix: ["/fixed/@larksuite/cli/scripts/run.js"], version: "1.0.80" },
+      stateStore: store,
+    });
+    return { code, ...output };
+  };
+  return { root, store, calls, run };
+}
+
+test("issue 134 e2e: official urgent_app is guarded and spawned with native argv", () => {
+  const f = fixture();
+  try {
+    assert.equal(runLarkCli(["im", "+messages-urgent-app", "--message-id", "om_issue134_own"], {
+      LARKIN_CONFIG_DIR: f.root, LARKIN_AGENT_ID: "cli_issue134UrgentA1",
+    }, {
+      io: { stdout() {}, stderr() {} },
+      spawn() { throw new Error("invented shortcut must not spawn"); },
+      nativeCommand: { command: process.execPath, argsPrefix: ["/fixed/@larksuite/cli/scripts/run.js"], version: "1.0.80" },
+      stateStore: f.store,
+    }), 2);
+
+    f.store.mergeFreshnessCursor("feishu.im/chat/oc_issue134", {
+      schema: 1, revisionTime: "1786979000001", messageIds: ["om_issue134_own"],
+    }, (_seen, current) => current ?? _seen);
+
+    const argv = [
+      "im", "messages", "urgent_app",
+      "--message-id", "om_issue134_own",
+      "--user-id-type", "open_id",
+      "--data", JSON.stringify({ user_id_list: ["ou_issue134_human"] }),
+    ];
+    const sent = f.run(argv);
+    assert.equal(sent.code, 0, sent.stderr);
+    assert.match(sent.stdout, /invalid_user_id_list/);
+
+    const kinds = f.calls.map((args) => args[2] === "messages" ? `${args[2]} ${args[3]}` : args[2]);
+    assert.deepEqual(kinds, ["+messages-mget", "GET", "+chat-members-list", "messages urgent_app"]);
+    const write = f.calls.at(-1);
+    assert.deepEqual(write.slice(1, 4), ["im", "messages", "urgent_app"]);
+    assert.equal(write[write.indexOf("--message-id") + 1], "om_issue134_own");
+    assert.equal(write[write.indexOf("--user-id-type") + 1], "open_id");
+    assert.equal(write.includes("--idempotency-key"), false);
+    assert.equal(write.includes("+messages-urgent-app"), false);
+  } finally { fs.rmSync(f.root, { recursive: true, force: true }); }
+});
+
+test("issue 134 e2e: official --data dash on a native read is not rejected by the policy parser", () => {
+  const f = fixture();
+  try {
+    const result = f.run(["im", "+chat-list", "--data", "-", "--json"]);
+    assert.equal(result.code, 0, result.stderr);
+    assert.equal(f.calls.some((args) => args[2] === "+chat-list"), true);
+  } finally { fs.rmSync(f.root, { recursive: true, force: true }); }
+});

--- a/test/unit/app/lark-cli-launcher.test.mjs
+++ b/test/unit/app/lark-cli-launcher.test.mjs
@@ -359,10 +359,14 @@ test("protected urgent-app probes freshness then spawns native urgent_app for th
     });
     const sent = f.run(urgentArgv());
     assert.equal(sent.code, 0, sent.stderr);
+    const lookup = f.calls.find((call) => call.args[2] === "+messages-mget");
+    assert.ok(lookup, "urgent_app must resolve the native message before freshness");
+    assert.equal(lookup.args[lookup.args.indexOf("--message-ids") + 1], "om_own_urgent");
     const memberCall = f.calls.find((call) => call.args[2] === "+chat-members-list");
     assert.ok(memberCall, "urgent-app must probe chat members before write");
     assert.equal(memberCall.args[memberCall.args.indexOf("--chat-id") + 1], "oc_urgent");
     assert.equal(memberCall.args[memberCall.args.indexOf("--member-id-type") + 1], "open_id");
+    assert.equal(memberCall.args[memberCall.args.indexOf("--page-limit") + 1], "0");
     const writeCall = f.calls.find((call) => call.args[2] === "messages" && call.args[3] === "urgent_app");
     assert.ok(writeCall, "native urgent_app must be spawned after freshness");
     const write = writeCall.args.slice(1);
@@ -421,6 +425,15 @@ test("protected urgent-app fails closed when member probe is truncated or native
   });
   try {
     seedUrgentCursor(f.store);
+    f.setMembers({
+      ok: true,
+      identity: "bot",
+      data: { users: [{ member_id: "ou_10937ddc38cfd9fd239591c634fed234" }], has_more: true, truncations: [] },
+    });
+    const incomplete = f.run(urgentArgv());
+    assert.equal(incomplete.code, 2, incomplete.stderr);
+    assert.match(incomplete.stderr, /incomplete/);
+    assert.equal(f.calls.some((call) => call.args[2] === "messages" && call.args[3] === "urgent_app"), false);
     f.setMembers({
       ok: true,
       identity: "bot",

--- a/test/unit/app/lark-cli-launcher.test.mjs
+++ b/test/unit/app/lark-cli-launcher.test.mjs
@@ -297,6 +297,114 @@ test("forward merge urgent and raw/API write surfaces remain denied before spawn
   } finally { fs.rmSync(f.root, { recursive: true, force: true }); }
 });
 
+function ownBotMessage(overrides = {}) {
+  return {
+    message_id: "om_own_urgent",
+    chat_id: "oc_urgent",
+    create_time: "1786957010773",
+    sender: { id: "cli_nativeLarkA1", id_type: "app_id", sender_type: "app" },
+    ...overrides,
+  };
+}
+
+function urgentArgv(overrides = {}) {
+  return [
+    "im", "+messages-urgent-app",
+    "--chat-id", overrides.chatId ?? "oc_urgent",
+    "--message-id", overrides.messageId ?? "om_own_urgent",
+    "--user-id-type", overrides.userIdType ?? "open_id",
+    "--data", overrides.data ?? JSON.stringify({ user_id_list: ["ou_10937ddc38cfd9fd239591c634fed234"] }),
+  ];
+}
+
+function seedUrgentCursor(store, revisionTime = "1786957010773", messageIds = ["om_own_urgent"]) {
+  store.mergeFreshnessCursor("feishu.im/chat/oc_urgent", {
+    schema: 1, revisionTime, messageIds,
+  }, (seen, current) => current ?? seen);
+}
+
+test("protected urgent-app classifies as guarded and keeps raw urgent denied", () => {
+  assert.equal(launcher.classifyLarkCliCommand(urgentArgv()).kind, "guarded");
+  assert.equal(launcher.classifyLarkCliCommand(urgentArgv()).operation, "urgent-app");
+  assert.equal(launcher.classifyLarkCliCommand(["im", "messages", "urgent_app", "--message-id", "om_own_urgent"]).kind, "denied");
+});
+
+test("protected urgent-app probes freshness then rewrites to native urgent_app for the bot's own message", () => {
+  const f = fixture({
+    ok: true,
+    identity: "bot",
+    data: { messages: [ownBotMessage()] },
+  });
+  try {
+    seedUrgentCursor(f.store);
+    f.setWriteResult({
+      status: 0, signal: null, output: [], pid: 1,
+      stdout: `${JSON.stringify({ ok: true, identity: "bot", data: { invalid_user_id_list: [] } })}\n`,
+      stderr: "", error: undefined,
+    });
+    const sent = f.run(urgentArgv());
+    assert.equal(sent.code, 0, sent.stderr);
+    const writeCall = f.calls.find((call) => call.args[2] === "messages" && call.args[3] === "urgent_app");
+    assert.ok(writeCall, "native urgent_app must be spawned after freshness");
+    const write = writeCall.args.slice(1);
+    assert.deepEqual(write.slice(0, 3), ["im", "messages", "urgent_app"]);
+    assert.equal(write.includes("+messages-urgent-app"), false);
+    assert.equal(write.includes("--chat-id"), false);
+    assert.equal(write[write.indexOf("--message-id") + 1], "om_own_urgent");
+    assert.equal(write[write.indexOf("--user-id-type") + 1], "open_id");
+    assert.equal(write[write.indexOf("--as") + 1], "bot");
+    assert.deepEqual(JSON.parse(write[write.indexOf("--data") + 1]), {
+      user_id_list: ["ou_10937ddc38cfd9fd239591c634fed234"],
+    });
+    const again = f.run(urgentArgv());
+    assert.equal(again.code, 0, again.stderr);
+    assert.equal(f.calls.filter((call) => call.args[2] === "messages" && call.args[3] === "urgent_app").length, 2);
+  } finally { fs.rmSync(f.root, { recursive: true, force: true }); }
+});
+
+test("protected urgent-app fails closed for foreign, synthetic, malformed, and unseen messages", () => {
+  const f = fixture({
+    ok: true,
+    identity: "bot",
+    data: { messages: [
+      ownBotMessage(),
+      ownBotMessage({ message_id: "om_other", sender: { id: "ou_human", sender_type: "user" } }),
+    ] },
+  });
+  try {
+    seedUrgentCursor(f.store, "1786957010773", ["om_own_urgent", "om_other"]);
+    for (const argv of [
+      urgentArgv({ messageId: "om_other" }),
+      urgentArgv({ messageId: "rem_not_a_message" }),
+      urgentArgv({ messageId: "om_missing" }),
+      urgentArgv({ userIdType: "user_id" }),
+      urgentArgv({ data: JSON.stringify({ user_id_list: ["not-an-open-id"] }) }),
+      ["im", "+messages-urgent-app", "--user-id", "ou_10937ddc38cfd9fd239591c634fed234", "--message-id", "om_own_urgent", "--user-id-type", "open_id", "--data", JSON.stringify({ user_id_list: ["ou_10937ddc38cfd9fd239591c634fed234"] })],
+    ]) {
+      const before = f.calls.length;
+      assert.equal(f.run(argv).code, 2, argv.join(" "));
+      assert.equal(f.calls.slice(before).some((call) => call.args[2] === "urgent_app"), false, argv.join(" "));
+    }
+  } finally { fs.rmSync(f.root, { recursive: true, force: true }); }
+});
+
+test("protected urgent-app does not submit after a freshness conflict", () => {
+  const f = fixture({
+    ok: true,
+    identity: "bot",
+    data: { messages: [ownBotMessage({ create_time: "1786957010774" })] },
+  });
+  try {
+    f.store.mergeFreshnessCursor("feishu.im/chat/oc_urgent", {
+      schema: 1, revisionTime: "1786957010773", messageIds: ["om_seen"],
+    }, (seen, current) => current ?? seen, "gen");
+    const conflicted = f.run(urgentArgv());
+    assert.equal(conflicted.code, 3, conflicted.stderr);
+    assert.match(conflicted.stderr, /freshness_conflict/);
+    assert.equal(f.calls.some((call) => call.args[2] === "urgent_app"), false);
+  } finally { fs.rmSync(f.root, { recursive: true, force: true }); }
+});
+
 test("provider failure and ambiguous termination retain a stable idempotency key", () => {
   const f = fixture();
   try {

--- a/test/unit/app/lark-cli-launcher.test.mjs
+++ b/test/unit/app/lark-cli-launcher.test.mjs
@@ -327,6 +327,8 @@ test("protected urgent-app classifies as guarded and keeps raw urgent denied", (
   assert.equal(launcher.classifyLarkCliCommand(urgentArgv()).kind, "guarded");
   assert.equal(launcher.classifyLarkCliCommand(urgentArgv()).operation, "urgent-app");
   assert.equal(launcher.classifyLarkCliCommand(["im", "messages", "urgent_app", "--message-id", "om_own_urgent"]).kind, "denied");
+  assert.equal(launcher.classifyLarkCliCommand([...urgentArgv(), "--dry-run"]).kind, "denied");
+  assert.equal(launcher.classifyLarkCliCommand([...urgentArgv(), "--help"]).kind, "passthrough");
 });
 
 test("protected urgent-app probes freshness then rewrites to native urgent_app for the bot's own message", () => {
@@ -350,15 +352,18 @@ test("protected urgent-app probes freshness then rewrites to native urgent_app f
     assert.deepEqual(write.slice(0, 3), ["im", "messages", "urgent_app"]);
     assert.equal(write.includes("+messages-urgent-app"), false);
     assert.equal(write.includes("--chat-id"), false);
+    assert.equal(write.includes("--idempotency-key"), false);
     assert.equal(write[write.indexOf("--message-id") + 1], "om_own_urgent");
     assert.equal(write[write.indexOf("--user-id-type") + 1], "open_id");
     assert.equal(write[write.indexOf("--as") + 1], "bot");
     assert.deepEqual(JSON.parse(write[write.indexOf("--data") + 1]), {
       user_id_list: ["ou_10937ddc38cfd9fd239591c634fed234"],
     });
-    const again = f.run(urgentArgv());
+    const again = f.run([...urgentArgv(), "--idempotency-key", "forced-urgent-key"]);
     assert.equal(again.code, 0, again.stderr);
-    assert.equal(f.calls.filter((call) => call.args[2] === "messages" && call.args[3] === "urgent_app").length, 2);
+    const writes = f.calls.filter((call) => call.args[2] === "messages" && call.args[3] === "urgent_app");
+    assert.equal(writes.length, 2);
+    assert.equal(writes[1].args.includes("--idempotency-key"), false);
   } finally { fs.rmSync(f.root, { recursive: true, force: true }); }
 });
 

--- a/test/unit/app/lark-cli-launcher.test.mjs
+++ b/test/unit/app/lark-cli-launcher.test.mjs
@@ -408,6 +408,8 @@ test("protected urgent-app fails closed for foreign, synthetic, malformed, and u
       urgentArgv({ data: JSON.stringify({ user_id_list: ["not-an-open-id"] }) }),
       urgentArgv({ data: JSON.stringify({ user_id_list: ["ou_not_in_chat"] }) }),
       urgentArgv({ data: JSON.stringify({ user_id_list: ["ou_10937ddc38cfd9fd239591c634fed234", "ou_not_in_chat"] }) }),
+      [...urgentArgv(), "--data", JSON.stringify({ user_id_list: ["ou_not_in_chat"] })],
+      [...urgentArgv(), "--user-id-type", "user_id"],
       ["im", "+messages-urgent-app", "--message-id", "om_own_urgent", "--user-id-type", "open_id", "--data", JSON.stringify({ user_id_list: ["ou_10937ddc38cfd9fd239591c634fed234"] })],
     ]) {
       const before = f.calls.length;

--- a/test/unit/app/lark-cli-launcher.test.mjs
+++ b/test/unit/app/lark-cli-launcher.test.mjs
@@ -381,10 +381,9 @@ test("protected urgent-app probes freshness then spawns native urgent_app for th
     });
     const again = f.run([...urgentArgv(), "--idempotency-key", "forced-urgent-key"]);
     assert.equal(again.code, 0, again.stderr);
-    assert.match(again.stdout, /"duplicate":true/);
     const writes = f.calls.filter((call) => call.args[2] === "messages" && call.args[3] === "urgent_app");
-    assert.equal(writes.length, 1);
-    assert.equal(writes[0].args.includes("--idempotency-key"), false);
+    assert.equal(writes.length, 2);
+    assert.equal(writes[1].args.includes("--idempotency-key"), false);
   } finally { fs.rmSync(f.root, { recursive: true, force: true }); }
 });
 

--- a/test/unit/app/lark-cli-launcher.test.mjs
+++ b/test/unit/app/lark-cli-launcher.test.mjs
@@ -369,12 +369,14 @@ test("protected urgent-app fails closed for foreign, synthetic, malformed, and u
     data: { messages: [
       ownBotMessage(),
       ownBotMessage({ message_id: "om_other", sender: { id: "ou_human", sender_type: "user" } }),
+      ownBotMessage({ message_id: "om_other_app", sender: { id: "cli_otherAppA1", id_type: "app_id", sender_type: "app" } }),
     ] },
   });
   try {
-    seedUrgentCursor(f.store, "1786957010773", ["om_own_urgent", "om_other"]);
+    seedUrgentCursor(f.store, "1786957010773", ["om_own_urgent", "om_other", "om_other_app"]);
     for (const argv of [
       urgentArgv({ messageId: "om_other" }),
+      urgentArgv({ messageId: "om_other_app" }),
       urgentArgv({ messageId: "rem_not_a_message" }),
       urgentArgv({ messageId: "om_missing" }),
       urgentArgv({ userIdType: "user_id" }),

--- a/test/unit/app/lark-cli-launcher.test.mjs
+++ b/test/unit/app/lark-cli-launcher.test.mjs
@@ -20,15 +20,24 @@ function fixture(history = { ok: true, identity: "bot", data: { messages: [] } }
   const output = { stdout: "", stderr: "" };
   const calls = [];
   const historyHolder = { value: history };
+  const membersHolder = { value: {
+    ok: true,
+    identity: "bot",
+    data: { users: [{ member_id: "ou_10937ddc38cfd9fd239591c634fed234" }], truncations: [] },
+  } };
   let writeResult = { status: 7, signal: null, output: [], pid: 1,
     stdout: "native-out\n", stderr: "native-err\n", error: undefined };
   const spawn = (command, args, options) => {
     calls.push({ command, args, options });
     const isHistory = ["+chat-messages-list", "+threads-messages-list"].includes(args[2])
       || (args[1] === "api" && args[2] === "GET" && args[3] === "/open-apis/im/v1/messages");
-    return isHistory
-      ? { status: 0, signal: null, output: [], pid: 1, stdout: JSON.stringify(historyHolder.value), stderr: "", error: undefined }
-      : writeResult;
+    if (isHistory) {
+      return { status: 0, signal: null, output: [], pid: 1, stdout: JSON.stringify(historyHolder.value), stderr: "", error: undefined };
+    }
+    if (args[2] === "+chat-members-list") {
+      return { status: 0, signal: null, output: [], pid: 1, stdout: JSON.stringify(membersHolder.value), stderr: "", error: undefined };
+    }
+    return writeResult;
   };
   const run = (argv) => {
     output.stdout = "";
@@ -39,7 +48,12 @@ function fixture(history = { ok: true, identity: "bot", data: { messages: [] } }
     });
     return { code, ...output };
   };
-  return { root, store, calls, run, setWriteResult(value) { writeResult = value; }, setHistory(value) { historyHolder.value = value; } };
+  return {
+    root, store, calls, run,
+    setWriteResult(value) { writeResult = value; },
+    setHistory(value) { historyHolder.value = value; },
+    setMembers(value) { membersHolder.value = value; },
+  };
 }
 
 test("launcher classifies protected writes, removed drafts, bypasses, and observational help", () => {
@@ -346,6 +360,10 @@ test("protected urgent-app probes freshness then rewrites to native urgent_app f
     });
     const sent = f.run(urgentArgv());
     assert.equal(sent.code, 0, sent.stderr);
+    const memberCall = f.calls.find((call) => call.args[2] === "+chat-members-list");
+    assert.ok(memberCall, "urgent-app must probe chat members before write");
+    assert.equal(memberCall.args[memberCall.args.indexOf("--chat-id") + 1], "oc_urgent");
+    assert.equal(memberCall.args[memberCall.args.indexOf("--member-id-type") + 1], "open_id");
     const writeCall = f.calls.find((call) => call.args[2] === "messages" && call.args[3] === "urgent_app");
     assert.ok(writeCall, "native urgent_app must be spawned after freshness");
     const write = writeCall.args.slice(1);
@@ -386,12 +404,48 @@ test("protected urgent-app fails closed for foreign, synthetic, malformed, and u
       urgentArgv({ messageId: "om_missing" }),
       urgentArgv({ userIdType: "user_id" }),
       urgentArgv({ data: JSON.stringify({ user_id_list: ["not-an-open-id"] }) }),
+      urgentArgv({ data: JSON.stringify({ user_id_list: ["ou_not_in_chat"] }) }),
+      urgentArgv({ data: JSON.stringify({ user_id_list: ["ou_10937ddc38cfd9fd239591c634fed234", "ou_not_in_chat"] }) }),
       ["im", "+messages-urgent-app", "--user-id", "ou_10937ddc38cfd9fd239591c634fed234", "--message-id", "om_own_urgent", "--user-id-type", "open_id", "--data", JSON.stringify({ user_id_list: ["ou_10937ddc38cfd9fd239591c634fed234"] })],
     ]) {
       const before = f.calls.length;
       assert.equal(f.run(argv).code, 2, argv.join(" "));
       assert.equal(f.calls.slice(before).some((call) => call.args[2] === "urgent_app"), false, argv.join(" "));
     }
+  } finally { fs.rmSync(f.root, { recursive: true, force: true }); }
+});
+
+test("protected urgent-app fails closed when member probe is truncated or native returns invalid users", () => {
+  const f = fixture({
+    ok: true,
+    identity: "bot",
+    data: { messages: [ownBotMessage()] },
+  });
+  try {
+    seedUrgentCursor(f.store);
+    f.setMembers({
+      ok: true,
+      identity: "bot",
+      data: { users: [{ member_id: "ou_10937ddc38cfd9fd239591c634fed234" }], truncations: ["users"] },
+    });
+    const truncated = f.run(urgentArgv());
+    assert.equal(truncated.code, 2, truncated.stderr);
+    assert.match(truncated.stderr, /truncated/);
+    assert.equal(f.calls.some((call) => call.args[2] === "messages" && call.args[3] === "urgent_app"), false);
+
+    f.setMembers({
+      ok: true,
+      identity: "bot",
+      data: { users: [{ member_id: "ou_10937ddc38cfd9fd239591c634fed234" }], truncations: [] },
+    });
+    f.setWriteResult({
+      status: 0, signal: null, output: [], pid: 1,
+      stdout: `${JSON.stringify({ ok: true, identity: "bot", data: { invalid_user_id_list: ["ou_10937ddc38cfd9fd239591c634fed234"] } })}\n`,
+      stderr: "", error: undefined,
+    });
+    const invalid = f.run(urgentArgv());
+    assert.equal(invalid.code, 2, invalid.stderr);
+    assert.match(invalid.stderr, /invalid_user_id_list/);
   } finally { fs.rmSync(f.root, { recursive: true, force: true }); }
 });
 

--- a/test/unit/app/lark-cli-launcher.test.mjs
+++ b/test/unit/app/lark-cli-launcher.test.mjs
@@ -381,9 +381,10 @@ test("protected urgent-app probes freshness then spawns native urgent_app for th
     });
     const again = f.run([...urgentArgv(), "--idempotency-key", "forced-urgent-key"]);
     assert.equal(again.code, 0, again.stderr);
+    assert.match(again.stdout, /"duplicate":true/);
     const writes = f.calls.filter((call) => call.args[2] === "messages" && call.args[3] === "urgent_app");
-    assert.equal(writes.length, 2);
-    assert.equal(writes[1].args.includes("--idempotency-key"), false);
+    assert.equal(writes.length, 1);
+    assert.equal(writes[0].args.includes("--idempotency-key"), false);
   } finally { fs.rmSync(f.root, { recursive: true, force: true }); }
 });
 

--- a/test/unit/app/lark-cli-launcher.test.mjs
+++ b/test/unit/app/lark-cli-launcher.test.mjs
@@ -29,7 +29,7 @@ function fixture(history = { ok: true, identity: "bot", data: { messages: [] } }
     stdout: "native-out\n", stderr: "native-err\n", error: undefined };
   const spawn = (command, args, options) => {
     calls.push({ command, args, options });
-    const isHistory = ["+chat-messages-list", "+threads-messages-list"].includes(args[2])
+    const isHistory = ["+chat-messages-list", "+threads-messages-list", "+messages-mget"].includes(args[2])
       || (args[1] === "api" && args[2] === "GET" && args[3] === "/open-apis/im/v1/messages");
     if (isHistory) {
       return { status: 0, signal: null, output: [], pid: 1, stdout: JSON.stringify(historyHolder.value), stderr: "", error: undefined };
@@ -301,7 +301,6 @@ test("forward merge urgent and raw/API write surfaces remain denied before spawn
       ["im", "messages", "reply", "--data", "{}"],
       ["im", "messages", "forward", "--message-id", "om_a"],
       ["im", "messages", "merge_forward", "--message-id", "om_a"],
-      ["im", "messages", "urgent_app", "--message-id", "om_a"],
       ["im", "messages", "urgent_phone", "--message-id", "om_a"],
       ["im", "messages", "urgent_sms", "--message-id", "om_a"],
       ["im", "threads", "forward", "--message-id", "om_a"],
@@ -323,8 +322,7 @@ function ownBotMessage(overrides = {}) {
 
 function urgentArgv(overrides = {}) {
   return [
-    "im", "+messages-urgent-app",
-    "--chat-id", overrides.chatId ?? "oc_urgent",
+    "im", "messages", "urgent_app",
     "--message-id", overrides.messageId ?? "om_own_urgent",
     "--user-id-type", overrides.userIdType ?? "open_id",
     "--data", overrides.data ?? JSON.stringify({ user_id_list: ["ou_10937ddc38cfd9fd239591c634fed234"] }),
@@ -337,15 +335,16 @@ function seedUrgentCursor(store, revisionTime = "1786957010773", messageIds = ["
   }, (seen, current) => current ?? seen);
 }
 
-test("protected urgent-app classifies as guarded and keeps raw urgent denied", () => {
+test("protected urgent-app classifies as guarded and keeps invented shortcut denied", () => {
   assert.equal(launcher.classifyLarkCliCommand(urgentArgv()).kind, "guarded");
   assert.equal(launcher.classifyLarkCliCommand(urgentArgv()).operation, "urgent-app");
-  assert.equal(launcher.classifyLarkCliCommand(["im", "messages", "urgent_app", "--message-id", "om_own_urgent"]).kind, "denied");
-  assert.equal(launcher.classifyLarkCliCommand([...urgentArgv(), "--dry-run"]).kind, "denied");
+  assert.equal(launcher.classifyLarkCliCommand(["im", "+messages-urgent-app", "--message-id", "om_own_urgent"]).kind, "denied");
+  assert.equal(launcher.classifyLarkCliCommand(["im", "messages", "urgent_phone", "--message-id", "om_own_urgent"]).kind, "denied");
+  assert.equal(launcher.classifyLarkCliCommand([...urgentArgv(), "--dry-run"]).kind, "passthrough");
   assert.equal(launcher.classifyLarkCliCommand([...urgentArgv(), "--help"]).kind, "passthrough");
 });
 
-test("protected urgent-app probes freshness then rewrites to native urgent_app for the bot's own message", () => {
+test("protected urgent-app probes freshness then spawns native urgent_app for the bot's own message", () => {
   const f = fixture({
     ok: true,
     identity: "bot",
@@ -369,7 +368,6 @@ test("protected urgent-app probes freshness then rewrites to native urgent_app f
     const write = writeCall.args.slice(1);
     assert.deepEqual(write.slice(0, 3), ["im", "messages", "urgent_app"]);
     assert.equal(write.includes("+messages-urgent-app"), false);
-    assert.equal(write.includes("--chat-id"), false);
     assert.equal(write.includes("--idempotency-key"), false);
     assert.equal(write[write.indexOf("--message-id") + 1], "om_own_urgent");
     assert.equal(write[write.indexOf("--user-id-type") + 1], "open_id");
@@ -406,7 +404,7 @@ test("protected urgent-app fails closed for foreign, synthetic, malformed, and u
       urgentArgv({ data: JSON.stringify({ user_id_list: ["not-an-open-id"] }) }),
       urgentArgv({ data: JSON.stringify({ user_id_list: ["ou_not_in_chat"] }) }),
       urgentArgv({ data: JSON.stringify({ user_id_list: ["ou_10937ddc38cfd9fd239591c634fed234", "ou_not_in_chat"] }) }),
-      ["im", "+messages-urgent-app", "--user-id", "ou_10937ddc38cfd9fd239591c634fed234", "--message-id", "om_own_urgent", "--user-id-type", "open_id", "--data", JSON.stringify({ user_id_list: ["ou_10937ddc38cfd9fd239591c634fed234"] })],
+      ["im", "+messages-urgent-app", "--message-id", "om_own_urgent", "--user-id-type", "open_id", "--data", JSON.stringify({ user_id_list: ["ou_10937ddc38cfd9fd239591c634fed234"] })],
     ]) {
       const before = f.calls.length;
       assert.equal(f.run(argv).code, 2, argv.join(" "));


### PR DESCRIPTION
## Root cause
`src/app/lark-cli.ts` treated `im messages urgent_app` as a raw write that cannot establish target freshness, so it was denied before spawn. That closed the bypass, but it also made a legitimate user request impossible: urgent the Bot's own just-sent `om_` message.

## Scope
- Add protected shortcut `im +messages-urgent-app`.
- Reuse the existing chat freshness probe.
- After freshness is fresh, require a real `om_` id, `--user-id-type open_id`, a non-empty `ou_` `user_id_list`, and proof from the probe window that the message is the current Bot's own send.
- Rewrite only that guarded path to native `im messages urgent_app`.
- Keep raw `urgent_app` / `urgent_phone` / `urgent_sms` denied before spawn.
- Patch bump `0.4.5` → `0.4.6`.

## Non-goals
- No raw urgent_* opening.
- No phone/SMS urgent.
- No standing-prompt/eval version bump in this PR.
- Wrapper success is not a Feishu-client toast claim.

## Tests
Focused:
```text
bun test test/unit/app/lark-cli-launcher.test.mjs
18 pass / 0 fail
```

Covered:
- own-message success after freshness
- foreign / synthetic / unseen / malformed fail-closed
- freshness conflict does not submit
- raw urgent_* still denied
- repeating the same guarded command is allowed and stays on the native path

## Claim boundary
This proves the wrapper can submit a protected urgent-app request. It does not prove the Feishu client shows an in-app urgent banner; that remains E4 / human verification.