### PR TITLE
test(hold-host): unflake ready proof mtime vs daemonStarted

### DIFF
--- a/test/unit/app/runtime-agent-interface-v2-live-safety.test.mjs
+++ b/test/unit/app/runtime-agent-interface-v2-live-safety.test.mjs
@@ -342,6 +342,7 @@ test("ready proof binds a fresh channel to the live exact process, root inode, c
   const target = freshHoldRoot();
   const claim = claimHoldHostRoot(target, { nonce: "ready-fixture-nonce", ownerPid: child.pid });
   const agentId = "cli_fixtureA";
+  const daemonStartedAt = new Date(Date.now() - 1000).toISOString();
   const connectedAt = new Date().toISOString();
   try {
     writePrivateJson(path.join(claim.targetRoot, "config.json"), {
@@ -349,7 +350,7 @@ test("ready proof binds a fresh channel to the live exact process, root inode, c
       agents: { [agentId]: { runtime: "codex", model: "fixture" } },
     });
     writePrivateJson(path.join(claim.targetRoot, "daemon-status.json"), {
-      pid: child.pid, processStartToken: inspected.startToken, commandToken: HOLD_HOST_COMMAND_TOKEN, agents: [agentId], startedAt: connectedAt,
+      pid: child.pid, processStartToken: inspected.startToken, commandToken: HOLD_HOST_COMMAND_TOKEN, agents: [agentId], startedAt: daemonStartedAt,
     });
     writeJson(path.join(claim.targetRoot, "state", "agents", agentId, "status.json"), {
       connectedVia: "channel", connectedAt, reconnectingAt: null,
@@ -360,7 +361,7 @@ test("ready proof binds a fresh channel to the live exact process, root inode, c
     fs.writeFileSync(traceFile, "", { mode: 0o600 });
     fs.writeFileSync(traceFile, `${JSON.stringify({ at: connectedAt, epoch: connectedAt, pid: child.pid, ppid: process.pid, phase: "hold-host:ready-boundary" })}\n`, { mode: 0o600 });
     const identity = { pid: child.pid, processStartToken: inspected.startToken, commandToken: HOLD_HOST_COMMAND_TOKEN };
-    writePrivateJson(claim.readyFile, readyProofFor(claim, { agentId, identity, connectedAt }));
+    writePrivateJson(claim.readyFile, readyProofFor(claim, { agentId, identity, connectedAt, daemonStartedAt }));
     const validated = validateLiveHoldHostReady(claim.targetRoot, agentId);
     assert.equal(validated.inspected.startToken, inspected.startToken);
     assert.throws(() => validateLiveHoldHostReady(claim.targetRoot, agentId, {
@@ -422,7 +423,7 @@ test("ready proof binds a fresh channel to the live exact process, root inode, c
     assert.equal(barrierProviderCalls, 0, "provider side effect must remain zero after a post-final-check epoch mutation");
     assert.equal(fs.existsSync(barrierOutput), false, "post-final epoch mutation must leave fake provider output absent");
     fs.writeFileSync(path.join(claim.targetRoot, "daemon-status.json"), `${JSON.stringify({
-      pid: child.pid, processStartToken: inspected.startToken, commandToken: HOLD_HOST_COMMAND_TOKEN, agents: [agentId], startedAt: connectedAt,
+      pid: child.pid, processStartToken: inspected.startToken, commandToken: HOLD_HOST_COMMAND_TOKEN, agents: [agentId], startedAt: daemonStartedAt,
     })}\n`, { mode: 0o600 });
 
     const validOutput = path.join(claim.targetRoot, "fake-provider-valid-output.json");


### PR DESCRIPTION
## Why

v0.4.7 Publish release failed in `validate` on:

`ready proof binds a fresh channel to the live exact process, root inode, config, and daemon status`

Error: `hold-host channel, Runtime, session, or status boundary is not current`.

## Root cause

The fixture used one ISO timestamp for `daemon.startedAt` and channel/session fields. Those equalities cannot fail. The remaining check is `status.json` mtime vs `Date.parse(daemonStarted)`. That comparison has no 1s slop; sibling product code already allows 1000ms.

#135 did not touch hold-host files. Same SHA Linux `source-checks` passed. This is a test fixture flake from #136 tightness.

Windows CIM / #124 timeouts are out of scope.

## Change

Set `daemonStartedAt` one second before `connectedAt` and keep the ready proof aligned.

## Non-goals

No product change. No release, retag, or issue close.

## Test

`bun test test/unit/app/runtime-agent-interface-v2-live-safety.test.mjs` → 16 pass / 0 fail.