### PR TITLE
fix(runtime): promote leftover inbox_update to wake after idle

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "larkin",
-  "version": "0.4.7",
+  "version": "0.4.8",
   "private": false,
   "larkinPackageRole": "npm-published",
   "files": [

--- a/src/feishu/host-shell.ts
+++ b/src/feishu/host-shell.ts
@@ -1153,6 +1153,9 @@ export function createHostShell({
           }, 80);
           hostState.updateStatus(agent, { droughtReconnectAt, droughtReconnectAbandonedAt: null });
           reconnectFns.get(agent.agentId)?.();
+          void runtimeHost.scanPendingInboxUpdates?.(agent.agentId)?.catch((error) => {
+            log(`drought reconnect inbox scan failed agent=${agent.name}: ${errorMessage(error)}`);
+          });
         }).catch((error) => {
           maintenance.inFlight = false;
           if (shuttingDown || fataling) return;

--- a/src/runtime/runtime-host.ts
+++ b/src/runtime/runtime-host.ts
@@ -1636,6 +1636,7 @@ export function createRuntimeHost(options: {
             : { inputId: existing.deliveryId, deliveryId: existing.deliveryId, kind: "wake", text: "", attempt: priorAttempt + 1 };
           delete existing.reason;
           delete existing.retryable;
+          agent.promotedInboxUpdateIds.delete(existing.deliveryId);
           setRecord(agent, existing, "pending");
           const receipt = await (telemetry?.phase(messageId, "runtime.deliver", SpanKind.PRODUCER,
             () => submit(agent, existing, agent.busy || agent.submitting)) ?? submit(agent, existing, agent.busy || agent.submitting));

--- a/src/runtime/runtime-host.ts
+++ b/src/runtime/runtime-host.ts
@@ -86,6 +86,8 @@ interface ManagedAgent {
   piProactiveCompactionFailedGeneration: number | null;
   readiness: RuntimeReadiness | null;
   turnInProgress: boolean; turnHadFailure: boolean; turnHadAuthenticatedOutput: boolean; authFailureActive: boolean;
+  /** Delivery ids already promoted from accepted inbox_update to a wake while idle. */
+  promotedInboxUpdateIds: Set<string>;
 }
 
 export interface RuntimeHost {
@@ -97,6 +99,8 @@ export interface RuntimeHost {
   shutdown(reason: string): Promise<void>;
   subscribe(listener: (event: RuntimeHostEvent) => void): () => void;
   isBusy?(agentId: string): boolean;
+  /** Promote accepted inbox_update deliveries once after idle / drought reconnect. */
+  scanPendingInboxUpdates?(agentId?: string): Promise<void>;
   resetSession?(agentId: string): Promise<RuntimeSessionResetResult>;
   recoverSession?(agentId: string, reason: "context-overflow"): Promise<RuntimeSessionRecoveryResult>;
   /** Internal recovery boundary for Pi compaction failures; never exposed as session reset. */
@@ -393,6 +397,19 @@ export function createRuntimeHost(options: {
   };
 
   const TURN_END_RETRY_REASON = "runtime turn ended before Inbox consumption was observed";
+  const INBOX_UPDATE_PROMOTE_REASON = "accepted inbox_update promoted after Agent became idle";
+  const isInboxUpdateKind = (kind: unknown): boolean => kind === "inbox_update" || kind === "inbox-update";
+  const agentIsIdleForInboxScan = (agent: ManagedAgent): boolean =>
+    !agent.stopped && !agent.busy && !agent.submitting && !agent.turnInProgress && !agent.starting && Boolean(agent.session);
+  const acceptedInboxStillPending = (agent: ManagedAgent, record: DeliveryRecord): boolean => {
+    if (!agent.stateStore?.readNdjson) return true;
+    try {
+      return agent.stateStore.readNdjson<Record<string, unknown>>("inbox")
+        .some((row) => row?.message_id === record.messageId);
+    } catch {
+      return true;
+    }
+  };
 
   /**
    * Runtime acceptance acknowledges only the notification. At the safe turn
@@ -576,6 +593,7 @@ export function createRuntimeHost(options: {
         agent.retryAfterSubmit = false;
         queueMicrotask(() => { void retryPending(agent); });
       }
+      queueMicrotask(() => { void scanAndPromoteAcceptedInboxUpdates(agent); });
     }
   };
 
@@ -602,6 +620,31 @@ export function createRuntimeHost(options: {
     try { await run; } finally {
       if (agent.retryPendingInFlight === run) agent.retryPendingInFlight = null;
     }
+  };
+
+  /**
+   * After busy/submitting clears, accepted inbox_update notices have no later
+   * turn boundary. Promote each delivery id at most once to a wake.
+   */
+  const scanAndPromoteAcceptedInboxUpdates = async (agent: ManagedAgent): Promise<void> => {
+    if (!agentIsIdleForInboxScan(agent)) return;
+    reconcileExternalConsumption(agent);
+    let promoted = 0;
+    for (const record of agent.records.values()) {
+      if (record.status !== "accepted" || !isInboxUpdateKind(record.input?.kind)) continue;
+      if (agent.promotedInboxUpdateIds.has(record.deliveryId)) continue;
+      if (!acceptedInboxStillPending(agent, record)) continue;
+      agent.promotedInboxUpdateIds.add(record.deliveryId);
+      record.reason = INBOX_UPDATE_PROMOTE_REASON;
+      record.retryable = true;
+      setRecord(agent, record, "pending");
+      emit({ type: "delivery", agentId: agent.config.agentId, deliveryId: record.deliveryId,
+        messageId: record.messageId, status: "deferred", reason: INBOX_UPDATE_PROMOTE_REASON });
+      promoted += 1;
+    }
+    if (!promoted) return;
+    if (agent.retryPendingInFlight) agent.retryAfterSubmit = true;
+    await retryPending(agent);
   };
 
   const scheduleRecreate = (agent: ManagedAgent, reason: string): void => {
@@ -895,8 +938,10 @@ export function createRuntimeHost(options: {
         emit({ type: "agent-status", agentId: agent.config.agentId, status: "active", readiness: agent.readiness });
       }
       const proactive = proactivelyCompactPiAtIdle(agent, session);
-      void (proactive ?? Promise.resolve("noop" as const)).then((outcome) => {
-        if (outcome !== "failed") return retryPending(agent);
+      void (proactive ?? Promise.resolve("noop" as const)).then(async (outcome) => {
+        if (outcome === "failed") return;
+        await scanAndPromoteAcceptedInboxUpdates(agent);
+        return retryPending(agent);
       });
     } else if (event.type === "activity") {
       if (agent.turnInProgress && event.activity !== "internal") agent.turnHadAuthenticatedOutput = true;
@@ -1213,6 +1258,13 @@ export function createRuntimeHost(options: {
       };
     },
     isBusy(agentId): boolean { const agent = managed.get(agentId); return Boolean(agent?.busy || agent?.submitting || agent?.starting); },
+    async scanPendingInboxUpdates(agentId): Promise<void> {
+      const agents = agentId ? [managed.get(agentId)] : [...managed.values()];
+      for (const agent of agents) {
+        if (!agent || agent.stopped) continue;
+        await scanAndPromoteAcceptedInboxUpdates(agent);
+      }
+    },
     async resetSession(agentId): Promise<RuntimeSessionResetResult> {
       const agent = managed.get(agentId);
       if (!agent || agent.stopped) throw new RuntimeSessionResetError("unknown_agent", `unknown runtime Agent: ${agentId}`);
@@ -1481,7 +1533,8 @@ export function createRuntimeHost(options: {
           compactionMachines: new Map(), compactionRecoveryInFlight: new Set(), piOverflowCompactionFailed: new Set(),
           piProactiveCompaction: null, piProactiveCompactionGeneration: null, piProactiveCompactionSession: null,
           piProactiveCompactionFailedGeneration: null, readiness: null,
-          turnInProgress: false, turnHadFailure: false, turnHadAuthenticatedOutput: false, authFailureActive: false };
+          turnInProgress: false, turnHadFailure: false, turnHadAuthenticatedOutput: false, authFailureActive: false,
+          promotedInboxUpdateIds: new Set() };
         const startupConsumed: DeliveryRecord[] = [];
         const startupQuarantined: Array<{ record: DeliveryRecord; code: ReplayFailureCode }> = [];
         for (const record of agent.records.values()) {

--- a/src/runtime/runtime-host.ts
+++ b/src/runtime/runtime-host.ts
@@ -628,12 +628,14 @@ export function createRuntimeHost(options: {
    */
   const scanAndPromoteAcceptedInboxUpdates = async (agent: ManagedAgent): Promise<void> => {
     if (!agentIsIdleForInboxScan(agent)) return;
+    if (agent.compactionMachines.size > 0 || agent.compactionRecoveryInFlight.size > 0) return;
+    const candidates = [...agent.records.values()].filter((record) => record.status === "accepted"
+      && isInboxUpdateKind(record.input?.kind) && !agent.promotedInboxUpdateIds.has(record.deliveryId));
+    if (!candidates.length) return;
     reconcileExternalConsumption(agent);
     let promoted = 0;
-    for (const record of agent.records.values()) {
-      if (record.status !== "accepted" || !isInboxUpdateKind(record.input?.kind)) continue;
-      if (agent.promotedInboxUpdateIds.has(record.deliveryId)) continue;
-      if (!acceptedInboxStillPending(agent, record)) continue;
+    for (const record of candidates) {
+      if (agent.records.get(record.deliveryId)?.status !== "accepted") continue;
       agent.promotedInboxUpdateIds.add(record.deliveryId);
       record.reason = INBOX_UPDATE_PROMOTE_REASON;
       record.retryable = true;
@@ -938,11 +940,10 @@ export function createRuntimeHost(options: {
         emit({ type: "agent-status", agentId: agent.config.agentId, status: "active", readiness: agent.readiness });
       }
       const proactive = proactivelyCompactPiAtIdle(agent, session);
-      void (proactive ?? Promise.resolve("noop" as const)).then(async (outcome) => {
-        if (outcome === "failed") return;
-        await scanAndPromoteAcceptedInboxUpdates(agent);
-        return retryPending(agent);
+      void (proactive ?? Promise.resolve("noop" as const)).then((outcome) => {
+        if (outcome !== "failed") return retryPending(agent);
       });
+      queueMicrotask(() => { void scanAndPromoteAcceptedInboxUpdates(agent); });
     } else if (event.type === "activity") {
       if (agent.turnInProgress && event.activity !== "internal") agent.turnHadAuthenticatedOutput = true;
       emit({ type: "activity", agentId: agent.config.agentId, activity: event.activity, activityKind: event.activity });

--- a/src/runtime/runtime-host.ts
+++ b/src/runtime/runtime-host.ts
@@ -226,7 +226,17 @@ function boundedRecords(agent: ManagedAgent): DeliveryRecord[] {
   const bounded = [...active, ...terminal].slice(-MAX_DELIVERIES);
   agent.records = new Map(bounded.map((record) => [record.deliveryId, record]));
   agent.byMessage = new Map(bounded.map((record) => [record.messageId, record.deliveryId]));
+  prunePromotedInboxUpdateIds(agent);
   return bounded;
+}
+
+function prunePromotedInboxUpdateIds(agent: ManagedAgent): void {
+  if (!agent.promotedInboxUpdateIds?.size) return;
+  for (const id of agent.promotedInboxUpdateIds) {
+    if (!agent.records.has(id)) agent.promotedInboxUpdateIds.delete(id);
+  }
+  if (agent.promotedInboxUpdateIds.size <= MAX_DELIVERIES) return;
+  agent.promotedInboxUpdateIds = new Set([...agent.promotedInboxUpdateIds].slice(-MAX_DELIVERIES));
 }
 
 export function createRuntimeHost(options: {
@@ -407,7 +417,7 @@ export function createRuntimeHost(options: {
       return agent.stateStore.readNdjson<Record<string, unknown>>("inbox")
         .some((row) => row?.message_id === record.messageId);
     } catch {
-      return true;
+      return false;
     }
   };
 
@@ -635,13 +645,19 @@ export function createRuntimeHost(options: {
     reconcileExternalConsumption(agent);
     let promoted = 0;
     for (const record of candidates) {
-      if (agent.records.get(record.deliveryId)?.status !== "accepted") continue;
-      agent.promotedInboxUpdateIds.add(record.deliveryId);
-      record.reason = INBOX_UPDATE_PROMOTE_REASON;
-      record.retryable = true;
-      setRecord(agent, record, "pending");
-      emit({ type: "delivery", agentId: agent.config.agentId, deliveryId: record.deliveryId,
-        messageId: record.messageId, status: "deferred", reason: INBOX_UPDATE_PROMOTE_REASON });
+      const current = agent.records.get(record.deliveryId);
+      if (current?.status !== "accepted") continue;
+      if (!acceptedInboxStillPending(agent, current)) {
+        reconcileAbsentCanonical(agent, current);
+        continue;
+      }
+      agent.promotedInboxUpdateIds.add(current.deliveryId);
+      current.reason = INBOX_UPDATE_PROMOTE_REASON;
+      current.retryable = true;
+      const finalRecord = setRecord(agent, current, "pending");
+      if (finalRecord.status === "consumed") continue;
+      emit({ type: "delivery", agentId: agent.config.agentId, deliveryId: finalRecord.deliveryId,
+        messageId: finalRecord.messageId, status: "deferred", reason: INBOX_UPDATE_PROMOTE_REASON });
       promoted += 1;
     }
     if (!promoted) return;

--- a/test/unit/feishu/host-runtime-lifecycle.test.mjs
+++ b/test/unit/feishu/host-runtime-lifecycle.test.mjs
@@ -597,3 +597,46 @@ test("channel options disable inbound message merging (issue #88)", async () => 
     fs.rmSync(root, { recursive: true, force: true });
   }
 });
+
+test("drought reconnect scans accepted inbox_update deliveries as a second fallback", async () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "larkin-drought-inbox-scan-"));
+  const agentId = "cli_droughtScanA1";
+  const scans = [];
+  const runtimeHost = {
+    subscribe() { return () => {}; },
+    async start() {},
+    async deliver() { throw new Error("not used"); },
+    async stop() {},
+    async shutdown() {},
+    async scanPendingInboxUpdates(id) { scans.push(id ?? null); },
+  };
+  let disconnects = 0;
+  const channelPackage = {
+    createLarkChannel() {
+      return {
+        botIdentity: { openId: "ou_drought_scan", name: "DroughtScan" },
+        rawClient: null,
+        dispatcher: { register() {} },
+        on() {},
+        async connect() {},
+        async disconnect() { disconnects += 1; },
+      };
+    },
+  };
+  const agent = { agentId, name: agentId, runtime: "codex", model: "gpt", feishuAppId: agentId,
+    feishuAppSecret: "fixture-secret", feishuProfile: agentId, feishuDomain: "https://open.feishu.cn",
+    workspaceDir: path.join(root, "agents", agentId), stateDir: path.join(root, "state", "agents", agentId) };
+  const env = { LARKIN_HOME: root, LARKIN_CONFIG_DIR: root, LARKIN_SERVER_ID: "server-drought-scan",
+    LARKIN_AGENTS_CONFIG: JSON.stringify([agent]), LARKIN_INBOUND_DROUGHT_SEC: "1" };
+  const host = createHostShell({ env, runtimeHost, channelPackage, eventSourceStartDelayMs: 0 });
+  try {
+    await host.start();
+    const deadline = Date.now() + 4_000;
+    while (scans.length === 0 && Date.now() < deadline) await new Promise((resolve) => setTimeout(resolve, 25));
+    assert.deepEqual(scans, [agentId], "preventive reconnect must scan pending inbox_update deliveries");
+    assert.ok(disconnects >= 1, "drought fallback must disconnect the silent channel before scanning");
+  } finally {
+    await host.shutdown("drought inbox scan test complete");
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});

--- a/test/unit/runtime/runtime-host.test.mjs
+++ b/test/unit/runtime/runtime-host.test.mjs
@@ -1501,3 +1501,107 @@ test("issue 138: the same accepted inbox_update is not re-woken in a loop", asyn
     fs.rmSync(root, { recursive: true, force: true });
   }
 });
+
+test("issue 138: concurrent CLI poll does not emit a promoted-after-idle deferred", async () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "larkin-issue138-poll-skip-"));
+  const agentId = "cli_issue138PollSkipA1";
+  const store = createAgentStateStore(root, agentId);
+  const session = new FakeSession();
+  let releasePrompt;
+  const target = "chat:oc_issue138_poll";
+  session.prompt = async (input) => {
+    session.prompts.push(input);
+    if (session.prompts.length === 1) await new Promise((resolve) => { releasePrompt = resolve; });
+    return { status: "accepted", inputId: input.inputId };
+  };
+  session.busyInput = async (input) => {
+    session.steers.push(input);
+    const polled = store.pollInbox({ target, limit: 1 });
+    assert.deepEqual(polled.envelopes.map((row) => row.message_id), ["om_issue138_consumed_late"]);
+    return { status: "accepted", inputId: input.inputId };
+  };
+  const events = [];
+  const host = createRuntimeHost({
+    adapterFor: () => ({ id: "codex", capabilities: {}, async createSession() { return session; } }),
+    promptBuilder: new ContextPromptBuilder(),
+    stateStoreFor: () => store,
+  });
+  host.subscribe((event) => events.push(event));
+  try {
+    await host.start([{ agentId, name: agentId, runtime: "codex", model: "g", workspaceDir: path.join(root, "agents", agentId), stateDir: store.paths.root }]);
+    store.appendNdjson("inbox", { message_id: "om_issue138_owner_poll", target, content: "owner" });
+    const first = host.deliver(agentId, { message_id: "om_issue138_owner_poll", target });
+    await waitForCondition(() => session.prompts.length === 1);
+    session.emit({ type: "turn-start", turnId: "turn-poll-skip" });
+    store.pollInbox({ target, limit: 1 });
+    session.emit({ type: "turn-end", turnId: "turn-poll-skip" });
+    store.appendNdjson("inbox", { message_id: "om_issue138_consumed_late", target, content: "already polled" });
+    const late = await host.deliver(agentId, { message_id: "om_issue138_consumed_late", target });
+    assert.equal(late.status, "accepted");
+    assert.equal(session.steers[0]?.kind, "inbox_update");
+    releasePrompt();
+    assert.equal((await first).status, "accepted");
+    await host.scanPendingInboxUpdates(agentId);
+    await new Promise((resolve) => setImmediate(resolve));
+    assert.equal(session.prompts.filter((input) => input.inputId === late.deliveryId && input.kind === "wake").length, 0,
+      "a concurrently consumed Inbox row must not be promoted to a wake");
+    assert.equal(events.some((event) => event.type === "delivery" && event.deliveryId === late.deliveryId
+      && event.status === "deferred" && /promoted after Agent became idle/.test(event.reason)), false,
+      "must not emit a contradictory promoted-after-idle deferred after CLI poll consumption");
+    const lateRecord = store.readJson("runtimeDeliveries", { records: [] }).records
+      .find((record) => record.messageId === "om_issue138_consumed_late");
+    assert.equal(lateRecord?.status, "consumed");
+  } finally {
+    await host.shutdown("issue 138 poll-skip test complete");
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("issue 138: leftover inbox_update is not promoted during Pi compaction recovery", async () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "larkin-issue138-compact-skip-"));
+  const agentId = "cli_issue138CompactSkipA1";
+  const store = createAgentStateStore(root, agentId);
+  let releaseCompact;
+  class CompactingSession extends FakeSession {
+    compactCalls = 0;
+    async compact() { this.compactCalls += 1; await new Promise((resolve) => { releaseCompact = resolve; }); return {}; }
+  }
+  const session = new CompactingSession();
+  const events = [];
+  const host = createRuntimeHost({
+    adapterFor: () => ({ id: "pi", capabilities: {}, async createSession() { return session; } }),
+    promptBuilder: new ContextPromptBuilder(),
+    stateStoreFor: () => store,
+  });
+  host.subscribe((event) => events.push(event));
+  try {
+    await host.start([{ agentId, name: agentId, runtime: "pi", model: "model", workspaceDir: path.join(root, "agents", agentId), stateDir: store.paths.root }]);
+    const target = "chat:oc_issue138_compact";
+    store.appendNdjson("inbox", { message_id: "om_issue138_overflow", target, content: "overflow" });
+    const first = await host.deliver(agentId, { message_id: "om_issue138_overflow", target });
+    assert.equal(first.status, "accepted");
+    session.emit({ type: "turn-start", turnId: "turn-compact-skip" });
+    store.appendNdjson("inbox", { message_id: "om_issue138_late_compact", target, content: "late during overflow" });
+    const late = await host.deliver(agentId, { message_id: "om_issue138_late_compact", target });
+    assert.equal(late.status, "accepted");
+    assert.equal(session.steers[0]?.kind, "inbox_update");
+    session.emit({
+      type: "input-error", inputId: session.prompts[0].inputId, retryable: false, willRetry: false,
+      message: "Your input exceeds the context window of this model. Please adjust your input and try again.",
+      errorCategory: "context_window",
+    });
+    await waitForCondition(() => session.compactCalls === 1);
+    await host.scanPendingInboxUpdates(agentId);
+    assert.equal(session.prompts.filter((input) => input.inputId === late.deliveryId && input.kind === "wake").length, 0,
+      "Pi compaction recovery must not promote leftover inbox_update to a wake");
+    assert.equal(events.some((event) => event.type === "delivery" && event.deliveryId === late.deliveryId
+      && event.status === "deferred" && /promoted after Agent became idle/.test(event.reason)), false);
+    const lateRecord = store.readJson("runtimeDeliveries", { records: [] }).records
+      .find((record) => record.messageId === "om_issue138_late_compact");
+    assert.equal(lateRecord?.input?.kind, "inbox_update");
+    releaseCompact();
+  } finally {
+    await host.shutdown("issue 138 compact-skip test complete");
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});

--- a/test/unit/runtime/runtime-host.test.mjs
+++ b/test/unit/runtime/runtime-host.test.mjs
@@ -1371,3 +1371,133 @@ test("short-lived successful creations share one crash epoch and reach bounded e
   assert.ok(errors.some((message) => /recreation exhausted after 2 attempts/.test(message)), errors.join("\n"));
   await host.shutdown("test complete");
 });
+
+const waitForCondition = async (predicate, timeout = 1_000) => {
+  const deadline = Date.now() + timeout;
+  while (!predicate() && Date.now() < deadline) await new Promise((resolve) => setTimeout(resolve, 5));
+  assert.equal(Boolean(predicate()), true, "condition was not reached before timeout");
+};
+
+test("issue 138: inbox_update accepted after turn_ended while submitting stays true is promoted to a wake", async () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "larkin-issue138-promote-"));
+  const agentId = "cli_issue138PromoteA1";
+  const store = createAgentStateStore(root, agentId);
+  const session = new FakeSession();
+  let releasePrompt;
+  session.prompt = async (input) => {
+    session.prompts.push(input);
+    if (session.prompts.length === 1) await new Promise((resolve) => { releasePrompt = resolve; });
+    return { status: "accepted", inputId: input.inputId };
+  };
+  const events = [];
+  const host = createRuntimeHost({
+    adapterFor: () => ({ id: "codex", capabilities: {}, async createSession() { return session; } }),
+    promptBuilder: new ContextPromptBuilder(),
+    stateStoreFor: () => store,
+  });
+  host.subscribe((event) => events.push(event));
+  try {
+    await host.start([{ agentId, name: agentId, runtime: "codex", model: "g", workspaceDir: path.join(root, "agents", agentId), stateDir: store.paths.root }]);
+    const target = "chat:oc_issue138";
+    store.appendNdjson("inbox", { message_id: "om_issue138_first", target, content: "first" });
+    const first = host.deliver(agentId, { message_id: "om_issue138_first", target });
+    await waitForCondition(() => session.prompts.length === 1);
+    session.emit({ type: "turn-start", turnId: "turn-issue138" });
+    const polled = store.pollInbox({ target, limit: 1 });
+    assert.deepEqual(polled.envelopes.map((row) => row.message_id), ["om_issue138_first"]);
+    session.emit({ type: "turn-end", turnId: "turn-issue138" });
+    store.appendNdjson("inbox", { message_id: "om_issue138_late", target, content: "late after turn_ended" });
+    const late = await host.deliver(agentId, { message_id: "om_issue138_late", target });
+    assert.equal(late.status, "accepted");
+    assert.equal(session.steers.length, 1, "late arrival while submitting must take the busy inbox_update path");
+    assert.equal(session.steers[0].kind, "inbox_update");
+    assert.equal(session.prompts.length, 1, "no replacement wake can exist until submitting/busy clears");
+    releasePrompt();
+    assert.equal((await first).status, "accepted");
+    await waitForCondition(() => session.prompts.some((input) => input.inputId === late.deliveryId && input.kind === "wake"));
+    const promoted = session.prompts.find((input) => input.inputId === late.deliveryId);
+    assert.equal(promoted.kind, "wake");
+    assert.ok(events.some((event) => event.type === "delivery" && event.deliveryId === late.deliveryId
+      && event.status === "deferred" && /promoted after Agent became idle/.test(event.reason)));
+    const lateRecord = store.readJson("runtimeDeliveries", { records: [] }).records
+      .find((record) => record.messageId === "om_issue138_late");
+    assert.notEqual(lateRecord?.input?.kind, "inbox_update", "idle Agent must not keep an accepted inbox_update without a wake");
+  } finally {
+    await host.shutdown("issue 138 promote test complete");
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("issue 138: idle scan does not emit an extra wake when no accepted inbox_update remains", async () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "larkin-issue138-no-extra-"));
+  const agentId = "cli_issue138NoExtraA1";
+  const store = createAgentStateStore(root, agentId);
+  const session = new FakeSession();
+  const host = createRuntimeHost({
+    adapterFor: () => ({ id: "codex", capabilities: {}, async createSession() { return session; } }),
+    promptBuilder: new ContextPromptBuilder(),
+    stateStoreFor: () => store,
+  });
+  try {
+    await host.start([{ agentId, name: agentId, runtime: "codex", model: "g", workspaceDir: path.join(root, "agents", agentId), stateDir: store.paths.root }]);
+    const target = "chat:oc_issue138_idle";
+    store.appendNdjson("inbox", { message_id: "om_issue138_consumed", target, content: "only wake" });
+    const receipt = await host.deliver(agentId, { message_id: "om_issue138_consumed", target });
+    assert.equal(receipt.status, "accepted");
+    assert.equal(session.prompts.length, 1);
+    assert.equal(session.prompts[0].kind, "wake");
+    store.pollInbox({ target, limit: 1 });
+    session.emit({ type: "turn-start", turnId: "turn-consumed" });
+    session.emit({ type: "turn-end", turnId: "turn-consumed" });
+    await new Promise((resolve) => setImmediate(resolve));
+    await host.scanPendingInboxUpdates(agentId);
+    await host.scanPendingInboxUpdates(agentId);
+    assert.equal(session.prompts.length, 1, "drained Inbox must not synthesize a replacement wake");
+    assert.equal(session.steers.length, 0);
+  } finally {
+    await host.shutdown("issue 138 no-extra-wake test complete");
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("issue 138: the same accepted inbox_update is not re-woken in a loop", async () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "larkin-issue138-noloop-"));
+  const agentId = "cli_issue138NoLoopA1";
+  const store = createAgentStateStore(root, agentId);
+  const session = new FakeSession();
+  let releasePrompt;
+  session.prompt = async (input) => {
+    session.prompts.push(input);
+    if (session.prompts.length === 1) await new Promise((resolve) => { releasePrompt = resolve; });
+    return { status: "accepted", inputId: input.inputId };
+  };
+  const host = createRuntimeHost({
+    adapterFor: () => ({ id: "codex", capabilities: {}, async createSession() { return session; } }),
+    promptBuilder: new ContextPromptBuilder(),
+    stateStoreFor: () => store,
+  });
+  try {
+    await host.start([{ agentId, name: agentId, runtime: "codex", model: "g", workspaceDir: path.join(root, "agents", agentId), stateDir: store.paths.root }]);
+    const target = "chat:oc_issue138_noloop";
+    store.appendNdjson("inbox", { message_id: "om_issue138_owner", target, content: "owner" });
+    const first = host.deliver(agentId, { message_id: "om_issue138_owner", target });
+    await waitForCondition(() => session.prompts.length === 1);
+    session.emit({ type: "turn-start", turnId: "turn-noloop" });
+    store.pollInbox({ target, limit: 1 });
+    session.emit({ type: "turn-end", turnId: "turn-noloop" });
+    store.appendNdjson("inbox", { message_id: "om_issue138_stuck", target, content: "stuck update" });
+    const late = await host.deliver(agentId, { message_id: "om_issue138_stuck", target });
+    releasePrompt();
+    await first;
+    await waitForCondition(() => session.prompts.filter((input) => input.inputId === late.deliveryId).length === 1);
+    await host.scanPendingInboxUpdates(agentId);
+    await host.scanPendingInboxUpdates();
+    await host.scanPendingInboxUpdates(agentId);
+    const wakesForLate = session.prompts.filter((input) => input.inputId === late.deliveryId && input.kind === "wake");
+    assert.equal(wakesForLate.length, 1, "the same delivery id must be promoted to wake only once");
+    assert.equal(session.steers.filter((input) => input.inputId === late.deliveryId).length, 1);
+  } finally {
+    await host.shutdown("issue 138 no-loop test complete");
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});

--- a/test/unit/runtime/runtime-host.test.mjs
+++ b/test/unit/runtime/runtime-host.test.mjs
@@ -1605,3 +1605,56 @@ test("issue 138: leftover inbox_update is not promoted during Pi compaction reco
     fs.rmSync(root, { recursive: true, force: true });
   }
 });
+
+test("issue 138: reopening a terminal wake failure can be promoted again", async () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "larkin-issue138-reopen-"));
+  const agentId = "cli_issue138ReopenA1";
+  const store = createAgentStateStore(root, agentId);
+  const session = new FakeSession();
+  let releasePrompt;
+  session.prompt = async (input) => {
+    session.prompts.push(input);
+    if (session.prompts.length === 1) await new Promise((resolve) => { releasePrompt = resolve; });
+    if (input.kind === "wake" && input.inputId !== session.prompts[0]?.inputId && input.attempt === 0) {
+      return { status: "rejected", inputId: input.inputId, retryable: false, reason: "terminal fixture rejection" };
+    }
+    return { status: "accepted", inputId: input.inputId };
+  };
+  const host = createRuntimeHost({
+    adapterFor: () => ({ id: "codex", capabilities: {}, async createSession() { return session; } }),
+    promptBuilder: new ContextPromptBuilder(),
+    stateStoreFor: () => store,
+  });
+  try {
+    await host.start([{ agentId, name: agentId, runtime: "codex", model: "g", workspaceDir: path.join(root, "agents", agentId), stateDir: store.paths.root }]);
+    const target = "chat:oc_issue138_reopen";
+    store.appendNdjson("inbox", { message_id: "om_issue138_reopen_owner", target, content: "owner" });
+    const first = host.deliver(agentId, { message_id: "om_issue138_reopen_owner", target });
+    await waitForCondition(() => session.prompts.length === 1);
+    session.emit({ type: "turn-start", turnId: "turn-reopen-1" });
+    store.pollInbox({ target, limit: 1 });
+    session.emit({ type: "turn-end", turnId: "turn-reopen-1" });
+    store.appendNdjson("inbox", { message_id: "om_issue138_reopen_late", target, content: "late" });
+    const late = await host.deliver(agentId, { message_id: "om_issue138_reopen_late", target });
+    releasePrompt();
+    await first;
+    await waitForCondition(() => session.prompts.some((input) => input.inputId === late.deliveryId && input.kind === "wake"));
+    await waitForCondition(() => store.readJson("runtimeDeliveries", { records: [] }).records
+      .some((record) => record.messageId === "om_issue138_reopen_late" && record.status === "error"));
+    store.appendNdjson("inbox", { message_id: "om_issue138_reopen_owner2", target, content: "owner2" });
+    const second = host.deliver(agentId, { message_id: "om_issue138_reopen_owner2", target });
+    await waitForCondition(() => session.prompts.length >= 3);
+    session.emit({ type: "turn-start", turnId: "turn-reopen-2" });
+    session.emit({ type: "turn-end", turnId: "turn-reopen-2" });
+    const retried = await host.deliver(agentId, { message_id: "om_issue138_reopen_late", target });
+    assert.equal(retried.deliveryId, late.deliveryId);
+    await second;
+    await host.scanPendingInboxUpdates(agentId);
+    await waitForCondition(() => session.prompts.filter((input) => input.inputId === late.deliveryId && input.kind === "wake").length >= 2);
+    const retryWake = session.prompts.filter((input) => input.inputId === late.deliveryId && input.kind === "wake").at(-1);
+    assert.ok(retryWake.attempt >= 1, "reopened delivery must be promotable again after a terminal wake failure");
+  } finally {
+    await host.shutdown("issue 138 reopen-promote test complete");
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
Fixes #138.

## Root cause

`runtime-host.ts` classifies a delivery as `inbox_update` when `agent.busy || agent.submitting` is true. `turn-end` clears `busy` and emits `turn_ended`, but `submit()` can still have `submitting === true` until `prompt()` returns. A message that arrives in that window is accepted as `inbox_update` via `busyInput`. The turn that just ended will not poll it, and nothing later promotes it, so the Agent stays idle until a later external `wake`.

Drought reconnect only rebuilds the channel and does not scan this leftover ledger, so it is not a fallback today.

## Scope

- After `turn-end` and after `submitting` clears, scan accepted `inbox_update` / `inbox-update` deliveries that are still in canonical Inbox.
- Promote each matching delivery id at most once to a `wake` and retry it through the existing idle submit path.
- After drought reconnect, call the same scan as a second fallback.

## Non-goals

- #79 / #117 / #132 wake-bridge / completion notification work
- #130 interaction-layer context after a successful wake
- Production host, identity, merge, release, retag, or closing this issue

## Tests (E2, deterministic)

- `issue 138: inbox_update accepted after turn_ended while submitting stays true is promoted to a wake`
- `issue 138: idle scan does not emit an extra wake when no accepted inbox_update remains`
- `issue 138: the same accepted inbox_update is not re-woken in a loop`
- `drought reconnect scans accepted inbox_update deliveries as a second fallback`

Local results:

- `bun run typecheck` PASS
- `bun test --max-concurrency 1 test/unit/runtime/runtime-host.test.mjs` 48 pass / 0 fail
- `bun test --max-concurrency 1 test/unit/feishu/host-runtime-lifecycle.test.mjs` 13 pass / 0 fail

## Unproven

- No E4 claim: this does not prove a live Feishu client, production host, or native provider recovery of the original 24-minute hang.
- Fake session / fake channel success only proves host ledger promotion and drought wiring.
- CI on this PR head is not yet green at open time.

CI green on this PR means reviewable only. Do not merge without an explicit later authorization.