### PR TITLE
fix(setup): tenant-correct Lark vs Feishu accounts/open hosts

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,8 @@ Feishu clients do not reliably render Markdown links such as `[label](URL)` as c
 
 ## Setup and configuration
 
+Feishu (https://open.feishu.cn) and Lark (https://open.larksuite.com) are different platforms; `larkin setup` must be told which brand with `--tenant feishu|lark` or the interactive prompt before the authorization QR, and must never emit a `feishu.cn` host for a Lark tenant.
+
 During setup, a new Agent is offered Pi first, followed by Codex and Claude Code. Provider keys are stored only in the selected Agent's private provider directory, not in the ordinary Agent config. Setup also discovers every API-key and OAuth/subscription login exposed by the pinned official Pi registry and delegates those flows to Pi.
 
 Use `larkin pi-auth status` or `larkin pi-auth logout <provider>` to manage Pi auth. The builtin Pi runtime loads Larkin's two supported extensions inline: background subagents and the 60-second foreground bash timeout guard are enabled without writing extension files or arguments. A compatible external Pi installation keeps the existing explicit `-e` extension path.

--- a/evals/agent-experience-v6/scenarios.json
+++ b/evals/agent-experience-v6/scenarios.json
@@ -3,7 +3,7 @@
   "version": 6,
   "model": {
     "selection": "deterministic-trace",
-    "standing_prompt_version": "larkin-standing-v20"
+    "standing_prompt_version": "larkin-standing-v21"
   },
   "session": {
     "initial_turns": 0

--- a/evals/authoritative-freshness-gate/scenarios.json
+++ b/evals/authoritative-freshness-gate/scenarios.json
@@ -1,7 +1,7 @@
 {
   "dataset": "authoritative-freshness-gate",
   "version": 1,
-  "standing_prompt_version": "larkin-standing-v20",
+  "standing_prompt_version": "larkin-standing-v21",
   "runtime": { "adapter": "codex", "selection": "runtime-default" },
   "grader": {
     "name": "authoritative-freshness-trace-grader",

--- a/evals/clickable-link-delivery/scenarios.json
+++ b/evals/clickable-link-delivery/scenarios.json
@@ -1,7 +1,7 @@
 {
   "dataset": "clickable-link-delivery",
   "version": 1,
-  "standing_prompt_version": "larkin-standing-v20",
+  "standing_prompt_version": "larkin-standing-v21",
   "runtime": { "adapter": "codex", "selection": "runtime-default" },
   "threshold": 1,
   "grader": {

--- a/evals/mention-construction/scenarios.json
+++ b/evals/mention-construction/scenarios.json
@@ -1,7 +1,7 @@
 {
   "dataset": "mention-construction",
   "version": 1,
-  "standing_prompt_version": "larkin-standing-v20",
+  "standing_prompt_version": "larkin-standing-v21",
   "runtime": { "adapter": "codex", "selection": "runtime-default" },
   "grader": {
     "name": "mention-construction-trace-grader",

--- a/evals/runtime-agent-interface-v2/scenarios.json
+++ b/evals/runtime-agent-interface-v2/scenarios.json
@@ -7,7 +7,7 @@
   },
   "model": {
     "selection": "gpt-5.6-sol",
-    "standing_prompt_version": "larkin-standing-v20"
+    "standing_prompt_version": "larkin-standing-v21"
   },
   "grader": {
     "name": "runtime-agent-interface-v2-trace-grader",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "larkin",
-  "version": "0.4.8",
+  "version": "0.4.9",
   "private": false,
   "larkinPackageRole": "npm-published",
   "files": [

--- a/src/agent/context-prompt.ts
+++ b/src/agent/context-prompt.ts
@@ -16,7 +16,7 @@ import type { AgentCliCapabilities, RuntimeId, RuntimeInput, StandingPrompt } fr
  * 6. 用 eval 验证：行为变化必须配套固定场景 + rubric（evals/*、test/support/*-grader.mjs、live 测试）。
  */
 
-export const LARKIN_STANDING_PROMPT_VERSION = "larkin-standing-v20";
+export const LARKIN_STANDING_PROMPT_VERSION = "larkin-standing-v21";
 
 /**
  * Agent 间协作唤醒引导（issue #75）：纯文本 @ 不会产生飞书 mention 事件，
@@ -139,6 +139,7 @@ export class ContextPromptBuilder {
       "## Feishu IM command map",
       "",
       `Use only the Larkin-owned \`${executable}\` command for Feishu. Bot identity, private configuration, and freshness are Runtime-bound; the wrapper delegates to the unmodified global official CLI. Use \`${executable} <command> --help\`, never invoke bare \`lark-cli\`, and never pass \`--agent\`, \`--as user\`, \`--profile\`, or \`--config-dir\`. If a command reports a missing scope, relay that error unchanged and ask the user to authorize it; do not bypass the scope boundary.`,
+      "If a platform URL must be shown, use the current Agent tenant host; never emit feishu.cn for a Lark tenant.",
       `Use the exact Inbox target for history reads. For \`thread:<chat_id>:<thread_id>\`, run \`${executable} im +threads-messages-list --thread <thread_id> --order desc --page-size 10 --no-reactions --json\`. For \`chat:<chat_id>\`, run \`${executable} im +chat-messages-list --chat-id <chat_id> --order desc --page-size 10 --no-reactions --json\`.`,
       "Successful history response messages are always at `data.messages`. Never use a chat-wide fallback for a thread target, never merge stderr with `2>&1` before parsing JSON, and never truncate structured output before parsing it.",
       "If the scoped history read fails or its schema is invalid, fail visibly. Do not reuse remembered or hard-coded text to make the task appear successful.",

--- a/src/app/cli.ts
+++ b/src/app/cli.ts
@@ -54,8 +54,8 @@ if (runtimeAgentAuthority && command === "comment") routes.comment = ["lark-cli"
 const commandHelp: Record<string, string> = {
   start: `Usage: larkin start [--agent <App ID> | --agents <App ID,...>]
 Start one foreground supervisor for the daemon and local dashboard, or reuse it.`,
-  setup: `Usage: larkin setup [--runtime <builtin-pi|external-pi|codex|claude>] [--provider <id> --api-key <key>]
-Run setup to create or connect a bot, configure its Agent, and attach it. Interactive terminals keep the guided flow; Agent-driven (non-TTY) runs default to builtin-pi and need --provider/--api-key (or --runtime external-pi).`,
+  setup: `Usage: larkin setup [--tenant feishu|lark] [--runtime <builtin-pi|external-pi|codex|claude>] [--provider <id> --api-key <key>]
+Run setup to create or connect a bot, configure its Agent, and attach it. Choose Feishu or Lark before the authorization QR (--tenant; default feishu). Interactive terminals keep the guided flow; Agent-driven (non-TTY) runs default to builtin-pi and need --provider/--api-key (or --runtime external-pi).`,
   status: `Usage: larkin status [--json]
 Show Agent configuration, bot identity, credentials, and connection status. Use --json for readiness automation.`,
   agents: `Usage: larkin agents [--json]

--- a/src/app/runtime-agent-config.ts
+++ b/src/app/runtime-agent-config.ts
@@ -17,10 +17,15 @@ import { internalCommandSpec } from "./internal-command.js";
 import {
   assertAgentWorkspaceBound, larkChannelSourceConfigPath, larkChannelWorkspaceConfigPath, managedLarkCliEnv,
 } from "./agent-lark-cli-workspace.js";
+import {
+  accountTenantFromOpenHost,
+  openPlatformHost,
+  type OpenPlatformHost,
+} from "../feishu/platform-hosts.js";
 
 export interface RuntimeAgentConfig extends HydratedAgent {
   feishuAppSecret: string;
-  feishuDomain: "https://open.feishu.cn" | "https://open.larksuite.com";
+  feishuDomain: OpenPlatformHost;
   credentialRevision: string;
 }
 
@@ -157,7 +162,7 @@ export function hydrateRuntimeAgent(configDir: string, agent: HydratedAgent): Ru
   return {
     ...agent,
     feishuAppSecret: credential.appSecret,
-    feishuDomain: credential.tenant === "lark" ? "https://open.larksuite.com" : "https://open.feishu.cn",
+    feishuDomain: openPlatformHost(credential.tenant),
     credentialRevision,
   };
 }
@@ -266,7 +271,7 @@ export function installRuntimeCommandShims(agent: Pick<RuntimeAgentConfig, "stat
   return commandDir;
 }
 
-function sourceProjection(agent: RuntimeAgentConfig, env: NodeJS.ProcessEnv): Record<string, unknown> {
+export function sourceProjection(agent: RuntimeAgentConfig, env: NodeJS.ProcessEnv): Record<string, unknown> {
   const configDir = path.resolve(env.LARKIN_CONFIG_DIR || "");
   if (!configDir) throw new Error("LARKIN_CONFIG_DIR required for lark-channel source projection");
   const provider = internalCommandSpec("lark-channel-secret", [], {
@@ -278,7 +283,7 @@ function sourceProjection(agent: RuntimeAgentConfig, env: NodeJS.ProcessEnv): Re
     accounts: { app: {
       id: agent.feishuAppId,
       secret: { source: "exec", provider: "larkin-bot-credential", id: agent.feishuAppId },
-      tenant: agent.feishuDomain === "https://open.larksuite.com" ? "lark" : "feishu",
+      tenant: accountTenantFromOpenHost(agent.feishuDomain),
     } },
     secrets: { providers: { "larkin-bot-credential": {
       source: "exec", command: provider.command, args: provider.args,
@@ -292,7 +297,7 @@ function sourceProjection(agent: RuntimeAgentConfig, env: NodeJS.ProcessEnv): Re
   };
 }
 
-function validateSourceProjection(file: string, agent: Pick<RuntimeAgentConfig, "agentId" | "feishuAppId" | "credentialRevision">): void {
+function validateSourceProjection(file: string, agent: Pick<RuntimeAgentConfig, "agentId" | "feishuAppId" | "credentialRevision" | "feishuDomain">): void {
   const snapshot = captureProfileSnapshot(file);
   if (!snapshot) throw new Error(`Agent ${agent.agentId} lark-channel source projection missing`);
   const root = snapshot.value as Record<string, any>;
@@ -309,6 +314,9 @@ function validateSourceProjection(file: string, agent: Pick<RuntimeAgentConfig, 
   }
   if (JSON.stringify(snapshot.value).includes("appSecret")) throw new Error("lark-channel source projection 不得包含 plaintext secret 字段");
   if (root.credentialRevision !== agent.credentialRevision) throw new Error(`Agent ${agent.agentId} lark-channel credential revision mismatch`);
+  if (app?.tenant !== accountTenantFromOpenHost(agent.feishuDomain)) {
+    throw new Error(`Agent ${agent.agentId} lark-channel source projection tenant mismatch`);
+  }
 }
 
 export function syncAgentProfile(

--- a/src/app/setup.ts
+++ b/src/app/setup.ts
@@ -85,6 +85,11 @@ Options:
   --base-url <url>                      custom 端点（provider=custom 时必填；也可覆盖 preset 默认端点）
   --model <id>                          模型 ID；默认取 provider 预设。不同 runtime 的模型可用
                                           \`larkin model\` 查看 / 切换
+  --tenant feishu|lark                  授权二维码之前选择品牌。默认 feishu（accounts.feishu.cn /
+                                          https://open.feishu.cn）。Lark 用 --tenant lark
+                                          （accounts.larksuite.com / https://open.larksuite.com）。
+                                          交互式未指定时会先询问。飞书与 Lark 是不同平台，
+                                          Lark 租户不得使用 feishu.cn 主机。
 
 setup handles browser authorization, permission grants, credential storage, Agent configuration,
 and target-only hot attach. Each Agent is identified by its bot App ID: selecting the same bot reuses
@@ -153,6 +158,11 @@ export async function main(): Promise<void> {
     if (normalizedRuntime.distribution) registerArgs.push("--pi-distribution", normalizedRuntime.distribution);
   }
   registerArgs.push("--comment-subscription", OPT.commentSubscription);
+  if (has("--tenant")) {
+    const tenant = flag("--tenant");
+    if (tenant !== "feishu" && tenant !== "lark") die("--tenant 只支持 feishu 或 lark");
+    registerArgs.push("--tenant", tenant === "lark" ? "lark" : "feishu");
+  }
   for (const name of ["--provider", "--api-key", "--base-url", "--model"] as const) {
     const value = flag(name);
     if (value) registerArgs.push(name, value);

--- a/src/feishu/host-shell.ts
+++ b/src/feishu/host-shell.ts
@@ -37,6 +37,7 @@ import {
 } from "./document-comment.js";
 import type { CommentEvent, CommentTarget, FetchedComment } from "@larksuite/channel";
 import type { TelemetryRuntime } from "../platform/telemetry-tracing.js";
+import { isOpenPlatformHost, requireOpenDomain } from "./platform-hosts.js";
 
 interface ConfiguredAgent {
   agentId: string;
@@ -216,7 +217,7 @@ function loadAgents(
       }
     }
     if (!testEventSource && (typeof candidate.feishuAppSecret !== "string" || !candidate.feishuAppSecret.trim()
-      || !["https://open.feishu.cn", "https://open.larksuite.com"].includes(String(candidate.feishuDomain)))) {
+      || !isOpenPlatformHost(candidate.feishuDomain))) {
       throw new Error(`LARKIN_AGENTS_CONFIG Agent ${id} 缺少有效 channel 凭证/domain`);
     }
     const expectedWorkspace = path.join(larkinHome, "agents", id);
@@ -791,7 +792,7 @@ export function createHostShell({
     const channel = createLarkChannel({
       appId: agent.feishuAppId,
       appSecret: agent.feishuAppSecret,
-      domain: agent.feishuDomain || "https://open.feishu.cn",
+      domain: requireOpenDomain(agent.feishuDomain),
       source: "larkin",
       policy: { dmMode: "open", requireMention: false, respondToMentionAll: true },
       // issue #88：关闭 SDK 的防抖批量合并（默认 600ms），逐条投递，
@@ -898,7 +899,7 @@ export function createHostShell({
       const channel = createLarkChannel({
         appId: agent.feishuAppId,
         appSecret: agent.feishuAppSecret,
-        domain: agent.feishuDomain || "https://open.feishu.cn",
+        domain: requireOpenDomain(agent.feishuDomain),
         source: "larkin",
         policy: { dmMode: "open", requireMention: false, respondToMentionAll: true },
         // issue #88：关闭 SDK 的防抖批量合并（默认 600ms），逐条投递，

--- a/src/feishu/platform-hosts.ts
+++ b/src/feishu/platform-hosts.ts
@@ -1,0 +1,50 @@
+// Official Feishu vs Lark hosts from @larksuite/cli ResolveEndpoints
+// (open / accounts / applink) plus Open-host docs and console paths.
+// Do not add larkoffice.com or any unofficial host.
+
+export type LarkinTenant = "feishu" | "lark";
+
+export const PLATFORM_HOSTS = {
+  feishu: {
+    open: "https://open.feishu.cn",
+    accounts: "https://accounts.feishu.cn",
+    applink: "https://applink.feishu.cn",
+    docs: "https://open.feishu.cn/document",
+    console: "https://open.feishu.cn/app",
+  },
+  lark: {
+    open: "https://open.larksuite.com",
+    accounts: "https://accounts.larksuite.com",
+    applink: "https://applink.larksuite.com",
+    docs: "https://open.larksuite.com/document",
+    console: "https://open.larksuite.com/app",
+  },
+} as const;
+
+export type OpenPlatformHost = typeof PLATFORM_HOSTS[LarkinTenant]["open"];
+
+export function parseLarkinTenant(value: unknown): LarkinTenant | null {
+  return value === "feishu" || value === "lark" ? value : null;
+}
+
+export function openPlatformHost(tenant: LarkinTenant): OpenPlatformHost {
+  return PLATFORM_HOSTS[tenant].open;
+}
+
+export function registerAppAccountsHost(tenant: LarkinTenant): string {
+  // node-sdk registerApp.domain / larkDomain interpolate https://${host}
+  return new URL(PLATFORM_HOSTS[tenant].accounts).host;
+}
+
+export function isOpenPlatformHost(value: unknown): value is OpenPlatformHost {
+  return value === PLATFORM_HOSTS.feishu.open || value === PLATFORM_HOSTS.lark.open;
+}
+
+export function requireOpenDomain(value: unknown): OpenPlatformHost {
+  if (isOpenPlatformHost(value)) return value;
+  throw new Error("missing or invalid Open Platform domain");
+}
+
+export function accountTenantFromOpenHost(domain: OpenPlatformHost): LarkinTenant {
+  return domain === PLATFORM_HOSTS.lark.open ? "lark" : "feishu";
+}

--- a/src/setup/bot-register.ts
+++ b/src/setup/bot-register.ts
@@ -37,6 +37,12 @@ import {
   type DocumentCommentSubscriptionCapability,
   type DocumentCommentSubscriptionDimension,
 } from "../platform/callback-capability.js";
+import {
+  openPlatformHost,
+  parseLarkinTenant,
+  registerAppAccountsHost,
+  type LarkinTenant,
+} from "../feishu/platform-hosts.js";
 // qrcode-terminal does not publish TypeScript declarations.
 // @ts-expect-error bundled CommonJS dependency
 import qrcodePackage from "qrcode-terminal";
@@ -55,6 +61,8 @@ interface StoredCredential {
 
 type RegisterApp = (options: {
   source: string;
+  domain?: string;
+  larkDomain?: string;
   addons: {
     scopes: { tenant: string[] };
     events: { items: { tenant: string[] } };
@@ -269,6 +277,42 @@ export async function applyDocumentCommentSubscription(input: {
   }
 }
 
+async function resolveSelectedTenant(): Promise<LarkinTenant> {
+  const raw = flag("--tenant");
+  if (raw !== undefined) {
+    const parsed = parseLarkinTenant(raw);
+    if (parsed === "feishu" || parsed === "lark") return parsed;
+    die("--tenant 只支持 feishu 或 lark");
+  }
+  if (process.stdin.isTTY && process.stdout.isTTY && !testFixture) {
+    const questioner = terminalSetupQuestioner();
+    try {
+      const answer = (await questioner.ask(
+        "选择平台（授权二维码必须对应正确品牌；lark-cli --domain 是业务域，品牌是 feishu|lark）：\n"
+        + "  1. 中国飞书 Feishu（accounts.feishu.cn / https://open.feishu.cn）\n"
+        + "  2. International Lark（accounts.larksuite.com / https://open.larksuite.com）\n> ",
+      )).trim();
+      if (answer === "1" || /^feishu$/i.test(answer)) return "feishu";
+      if (answer === "2" || /^lark$/i.test(answer)) return "lark";
+      die("必须选择 1/feishu 或 2/lark；未开始授权");
+    } finally { questioner.close?.(); }
+  }
+  return "feishu";
+}
+
+function persistTenant(selected: LarkinTenant, userInfo: RegistrationResult["user_info"]): LarkinTenant {
+  const brand = userInfo?.tenant_brand;
+  if (brand === undefined || brand === null || brand === "") return selected;
+  const observed = parseLarkinTenant(brand);
+  if (observed !== "feishu" && observed !== "lark") {
+    die("授权返回的租户品牌非法；未执行凭证同步、文件写入或 Agent 绑定");
+  }
+  if (observed !== selected) {
+    die(`授权返回的租户 ${observed} 与预先选择的 ${selected} 不一致；未执行凭证同步、文件写入或 Agent 绑定`);
+  }
+  return selected;
+}
+
 function botVerificationRetryable(result: { status: number | null; stdout?: unknown; stderr?: unknown }): boolean {
   const text = `${typeof result.stdout === "string" ? result.stdout : ""}\n${typeof result.stderr === "string" ? result.stderr : ""}`;
   return /\binvalid_client\b|specified app does not exist|EAI_AGAIN|ENOTFOUND|ECONNREFUSED|ECONNRESET|ETIMEDOUT|fetch failed|temporary network|too many requests|\b(?:429|502|503|504)\b/i.test(text);
@@ -412,7 +456,7 @@ async function fetchBotInfoViaHttp(appId: string, tenant: "feishu" | "lark" | un
     credential = JSON.parse(fs.readFileSync(path.join(ensureSecureBotsDir(), `${appId}.json`), "utf8")) as { appSecret?: unknown };
   } catch { return null; }
   if (typeof credential.appSecret !== "string" || !credential.appSecret) return null;
-  const base = tenant === "lark" ? "https://open.larksuite.com" : "https://open.feishu.cn";
+  const base = openPlatformHost(tenant === "lark" ? "lark" : "feishu");
   try {
     const tokenResponse = await fetch(`${base}/open-apis/auth/v3/tenant_access_token/internal`, {
       method: "POST",
@@ -457,7 +501,10 @@ if (has("--help") || has("-h")) {
   say(`setup 内部机器人注册阶段
 
 用法:
-  bun bot-register.mjs --auto
+  bun bot-register.mjs --auto [--tenant feishu|lark]
+
+--tenant 在授权二维码之前选择品牌。默认 feishu（accounts.feishu.cn）；
+Lark 必须用 --tenant lark 或交互选择，授权主机是 accounts.larksuite.com。
 
 完成后自动：按返回 appId 判定新旧 → 同步并校验 lark-cli bot 凭证 →
   原子写 bots/<appId>.json（0600）→ 绑定 Agent。`);
@@ -479,7 +526,8 @@ if (argv.some((arg) => arg === "--app-id" || arg.startsWith("--app-id="))) {
   die("不支持 --app-id；机器人必须在飞书（Lark）网页中选择");
 }
 if (!autoSelect) die("setup 注册阶段必须由交互式选择流程启动");
-say("[setup 1/5] 在网页选择已有机器人或创建新机器人");
+const selectedTenant = await resolveSelectedTenant();
+say(`[setup 1/5] 在${selectedTenant === "lark" ? " International Lark" : "中国飞书 Feishu"}网页选择已有机器人或创建新机器人`);
 if (commentSubscription === "application") {
   say(`! 已显式选择 ${commentSubscription} 维度评论订阅：一旦平台状态验证为已订阅，Bot 可见文档中实际送达的每条支持评论都会进入 Inbox 并唤醒 Agent，不要求 @Bot。`);
   say("! setup 将通过官方 lark-cli 的结构化 API 请求创建该订阅，并以只读 subscription_status 二次核验；不会从意图或事件配置推断订阅已生效。");
@@ -516,6 +564,8 @@ let pollingCount = 0;
 
 const result = await registerApp({
   source: "larkin",
+  domain: registerAppAccountsHost(selectedTenant),
+  larkDomain: registerAppAccountsHost("lark"),
   addons: {
     scopes: { tenant: TENANT_SCOPES },
     events: { items: { tenant: TENANT_EVENTS } },
@@ -538,10 +588,9 @@ if (typeof rawId !== "string" || !APP_ID.test(rawId)) die("授权返回的 App I
 if (typeof rawSecret !== "string" || rawSecret.length === 0) die("授权完成但未取得有效凭证；未执行凭证同步、文件写入或 Agent 绑定");
 const id = rawId as string;
 const secret = rawSecret as string;
+const tenant = persistTenant(selectedTenant, userInfo);
 const botsDir = ensureSecureBotsDir();
 say(`[setup 3/5] 正在按 App ID ${id} 刷新凭证并配置 Agent`);
-
-const tenant = userInfo?.tenant_brand === "lark" ? "lark" : "feishu";
 const botFile = path.join(botsDir, `${id}.json`);
 const prior: StoredCredential = (() => {
   try { return JSON.parse(fs.readFileSync(botFile, "utf8")) as StoredCredential; }

--- a/src/setup/grant-scopes.ts
+++ b/src/setup/grant-scopes.ts
@@ -9,6 +9,8 @@ import { registerApp as channelRegisterApp } from "@larksuite/channel";
 import { markSetupCapabilitiesRequested } from "../platform/callback-capability.js";
 import * as larkinConfig from "../platform/config.js";
 import { managedOfficialLarkCli } from "../app/agent-lark-cli-workspace.js";
+import { loadValidatedBotCredential } from "./run-credential-preflight.js";
+import { parseLarkinTenant, registerAppAccountsHost, type LarkinTenant } from "../feishu/platform-hosts.js";
 // qrcode-terminal does not publish TypeScript declarations.
 // @ts-expect-error bundled CommonJS dependency
 import qrcodePackage from "qrcode-terminal";
@@ -27,7 +29,7 @@ interface GrantOptions {
   source: string;
   appId: string;
   addons: { scopes: { tenant: string[] }; events: { items: { tenant: string[] } }; callbacks: { items: string[] } };
-  domain?: "lark";
+  domain?: string;
   onQRCodeReady(info: { url: string; expireIn: number }): void;
   onStatusChange(info: { status: string }): void;
 }
@@ -64,7 +66,18 @@ const APP_ID = selected.agentId;
 if (explicitAppId && explicitAppId !== selected.feishuAppId) throw new Error("--app-id 必须等于所选 Agent 的 App ID");
 if (!/^cli_[A-Za-z0-9]+$/.test(APP_ID)) throw new Error(`无效飞书（Lark） App ID：${APP_ID}`);
 const SEND_TO = flag("--send-to", "");
-const TENANT = flag("--tenant", "feishu");
+const explicitTenant = argv.includes("--tenant") ? flag("--tenant", "") : "";
+if (argv.includes("--tenant") && !parseLarkinTenant(explicitTenant)) {
+  throw new Error("--tenant 只支持 feishu 或 lark");
+}
+function storedCredentialTenant(): LarkinTenant {
+  try {
+    return loadValidatedBotCredential(path.join(config.larkinHome, "bots"), APP_ID).tenant;
+  } catch {
+    return "feishu";
+  }
+}
+const TENANT = parseLarkinTenant(explicitTenant) ?? storedCredentialTenant();
 const WAIT_MIN = Number(flag("--wait-min", "9"));
 const URL_FILE = flag("--url-file", "");
 
@@ -129,8 +142,8 @@ export async function main(): Promise<void> {
       sendUrlToChat(info.url, minutes);
     },
     onStatusChange: (info) => log(`[grant] 状态: ${info.status}`),
+    domain: registerAppAccountsHost(TENANT),
   };
-  if (TENANT === "lark") options.domain = "lark";
 
   let result: { client_id?: string } | null;
   try { result = await registerApp(options); }

--- a/test/integration/build/production-boundary.test.mjs
+++ b/test/integration/build/production-boundary.test.mjs
@@ -72,7 +72,10 @@ test("grant-scopes selects only explicit App ID, explicit --agent App ID, or act
     });
     let result = run([]);
     assert.equal(result.status, 0, result.stderr);
-    assert.equal(JSON.parse(fs.readFileSync(marker, "utf8")).appId, app);
+    const defaultGrant = JSON.parse(fs.readFileSync(marker, "utf8"));
+    assert.equal(defaultGrant.appId, app);
+    assert.equal(defaultGrant.domain, "accounts.feishu.cn");
+    assert.notEqual(defaultGrant.domain, "lark");
     const updatedCredential = JSON.parse(fs.readFileSync(path.join(root, "bots", `${app}.json`), "utf8"));
     const commentCapability = updatedCredential.capabilities.documentCommentEvent;
     assert.deepEqual({ status: commentCapability.status, event: commentCapability.event, scope: commentCapability.scope }, {

--- a/test/support/agent-experience-v6-grader.mjs
+++ b/test/support/agent-experience-v6-grader.mjs
@@ -41,7 +41,7 @@ function correctionBoundaryIssue(scenario) {
 export function loadAgentExperienceV6Eval(file) {
   const value = JSON.parse(fs.readFileSync(file, "utf8"));
   if (value.dataset !== "agent-experience-v6" || value.version !== 6) throw new Error("eval dataset/version mismatch");
-  if (value.model?.standing_prompt_version !== "larkin-standing-v20") throw new Error("standing prompt version mismatch");
+  if (value.model?.standing_prompt_version !== "larkin-standing-v21") throw new Error("standing prompt version mismatch");
   if (value.session?.initial_turns !== 0) throw new Error("eval scenarios must start from a fresh empty session");
   if (value.grader?.name !== "agent-experience-v6-trace-grader" || value.grader.version !== 6 || value.grader.threshold !== 1) {
     throw new Error("eval grader metadata mismatch");

--- a/test/support/authoritative-freshness-gate-grader.mjs
+++ b/test/support/authoritative-freshness-gate-grader.mjs
@@ -3,7 +3,7 @@ import fs from "node:fs";
 export function loadAuthoritativeFreshnessEval(file) {
   const value = JSON.parse(fs.readFileSync(file, "utf8"));
   if (value.dataset !== "authoritative-freshness-gate" || value.version !== 1) throw new Error("eval dataset/version mismatch");
-  if (value.standing_prompt_version !== "larkin-standing-v20") throw new Error("standing prompt version mismatch");
+  if (value.standing_prompt_version !== "larkin-standing-v21") throw new Error("standing prompt version mismatch");
   if (value.runtime?.adapter !== "codex" || !value.runtime.selection) throw new Error("native runtime metadata is required");
   if (value.grader?.name !== "authoritative-freshness-trace-grader" || value.grader.version !== 1) throw new Error("grader metadata mismatch");
   if (!(value.grader.threshold > 0 && value.grader.threshold <= 1)) throw new Error("grader threshold must be in (0,1]");

--- a/test/support/clickable-link-delivery-grader.mjs
+++ b/test/support/clickable-link-delivery-grader.mjs
@@ -87,7 +87,7 @@ function hasBoundedVisibleUrl(body, expectedUrl) {
 export function loadClickableLinkDeliveryEval(file) {
   const value = JSON.parse(fs.readFileSync(file, "utf8"));
   if (value.dataset !== "clickable-link-delivery" || value.version !== 1) throw new Error("eval dataset/version mismatch");
-  if (value.standing_prompt_version !== "larkin-standing-v20") throw new Error("standing prompt version mismatch");
+  if (value.standing_prompt_version !== "larkin-standing-v21") throw new Error("standing prompt version mismatch");
   if (value.threshold !== 1 || value.grader?.name !== "clickable-link-delivery-trace-grader"
       || value.grader.version !== 1 || value.grader.threshold !== 1) throw new Error("eval grader metadata mismatch");
   if (value.session?.initial_turns !== 0 || value.session?.fresh_per_scenario !== true) throw new Error("eval requires fresh sessions");

--- a/test/support/clickable-link-delivery-native-support.mjs
+++ b/test/support/clickable-link-delivery-native-support.mjs
@@ -8,7 +8,7 @@ export const CLICKABLE_LINK_V20_GUIDANCE = [
 ];
 
 export function v19Counterfactual(standingPrompt) {
-  if (standingPrompt?.version !== "larkin-standing-v20" || typeof standingPrompt.content !== "string") {
+  if (standingPrompt?.version !== "larkin-standing-v21" || typeof standingPrompt.content !== "string") {
     throw new Error("v19 counterfactual requires a v20 standing prompt");
   }
   let content = standingPrompt.content;

--- a/test/support/mention-construction-grader.mjs
+++ b/test/support/mention-construction-grader.mjs
@@ -8,7 +8,7 @@ function nonempty(value, label) {
 export function loadMentionConstructionEval(file) {
   const value = JSON.parse(fs.readFileSync(file, "utf8"));
   if (value.dataset !== "mention-construction" || value.version !== 1) throw new Error("eval dataset/version mismatch");
-  if (value.standing_prompt_version !== "larkin-standing-v20") throw new Error("standing prompt version mismatch");
+  if (value.standing_prompt_version !== "larkin-standing-v21") throw new Error("standing prompt version mismatch");
   if (value.session?.initial_turns !== 0) throw new Error("eval scenarios must start from a fresh empty session");
   if (value.grader?.name !== "mention-construction-trace-grader" || value.grader.version !== 1 || value.grader.threshold !== 1) {
     throw new Error("eval grader metadata mismatch");

--- a/test/support/runtime-agent-interface-v2-grader.mjs
+++ b/test/support/runtime-agent-interface-v2-grader.mjs
@@ -10,7 +10,7 @@ export function loadRuntimeAgentInterfaceEval(file) {
   if (value.dataset !== "runtime-agent-interface-v2" || value.version !== 1) throw new Error("eval dataset/version mismatch");
   if (value.runtime?.adapter !== "codex") throw new Error("eval runtime.adapter must be codex");
   nonempty(value.runtime.minimum_cli_version, "runtime.minimum_cli_version");
-  if (value.model?.standing_prompt_version !== "larkin-standing-v20") throw new Error("eval standing prompt version mismatch");
+  if (value.model?.standing_prompt_version !== "larkin-standing-v21") throw new Error("eval standing prompt version mismatch");
   nonempty(value.model.selection, "model.selection");
   if (value.grader?.name !== "runtime-agent-interface-v2-trace-grader" || value.grader.version !== 1) {
     throw new Error("eval grader metadata mismatch");

--- a/test/unit/app/runtime-agent-config-tenant.test.mjs
+++ b/test/unit/app/runtime-agent-config-tenant.test.mjs
@@ -1,0 +1,47 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { fileURLToPath, pathToFileURL } from "node:url";
+import { test } from "bun:test";
+
+const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../../..");
+const runtime = await import(pathToFileURL(path.join(ROOT, "dist/app/runtime-agent-config.mjs")).href);
+
+function writeAgent(root, { appId, tenant }) {
+  fs.mkdirSync(path.join(root, "bots"), { recursive: true, mode: 0o700 });
+  fs.writeFileSync(path.join(root, "bots", `${appId}.json`), `${JSON.stringify({
+    appId, appSecret: "fixture-secret", tenant,
+  })}\n`, { mode: 0o600 });
+  return {
+    name: appId,
+    agentId: appId,
+    feishuAppId: appId,
+    feishuProfile: appId,
+    runtime: "codex",
+    model: "gpt",
+    workspaceDir: path.join(root, "agents", appId),
+    stateDir: path.join(root, "state", "agents", appId),
+    larkConfigDir: path.join(root, "state", "agents", appId, "lark-cli-config"),
+  };
+}
+
+test("hydrateRuntimeAgent and sourceProjection stay tenant-correct", () => {
+  const temp = fs.mkdtempSync(path.join(os.tmpdir(), "larkin-runtime-tenant-"));
+  try {
+    const larkAgent = writeAgent(temp, { appId: "cli_runtimeLarkA1", tenant: "lark" });
+    const hydratedLark = runtime.hydrateRuntimeAgent(temp, larkAgent);
+    assert.equal(hydratedLark.feishuDomain, "https://open.larksuite.com");
+    const larkProjection = JSON.stringify(runtime.sourceProjection(hydratedLark, { LARKIN_CONFIG_DIR: temp }));
+    assert.match(larkProjection, /"tenant":"lark"/);
+    assert.match(larkProjection, /open\.larksuite\.com|lark/);
+    assert.doesNotMatch(larkProjection, /feishu\.cn/);
+
+    const feishuAgent = writeAgent(temp, { appId: "cli_runtimeFeishuB2", tenant: "feishu" });
+    const hydratedFeishu = runtime.hydrateRuntimeAgent(temp, feishuAgent);
+    assert.equal(hydratedFeishu.feishuDomain, "https://open.feishu.cn");
+    const feishuProjection = JSON.stringify(runtime.sourceProjection(hydratedFeishu, { LARKIN_CONFIG_DIR: temp }));
+    assert.match(feishuProjection, /"tenant":"feishu"/);
+    assert.doesNotMatch(feishuProjection, /larksuite\.com/);
+  } finally { fs.rmSync(temp, { recursive: true, force: true }); }
+});

--- a/test/unit/evals/agent-experience-v6.test.mjs
+++ b/test/unit/evals/agent-experience-v6.test.mjs
@@ -16,7 +16,7 @@ const DATASET = loadAgentExperienceV6Eval(path.join(ROOT, "evals/agent-experienc
 
 test("fixed Agent Experience v6 eval starts every selected scenario from an empty session", () => {
   assert.equal(DATASET.session.initial_turns, 0);
-  assert.equal(DATASET.model.standing_prompt_version, "larkin-standing-v20");
+  assert.equal(DATASET.model.standing_prompt_version, "larkin-standing-v21");
   assert.deepEqual(DATASET.scenarios.map((scenario) => scenario.id), [
     "target-scoped-thread-read",
     "failed-thread-read-no-false-success",

--- a/test/unit/evals/agent-mention-prompt.test.mjs
+++ b/test/unit/evals/agent-mention-prompt.test.mjs
@@ -96,7 +96,7 @@ test("lark-cli launcher passes --mention argv through without injecting --conten
 });
 
 test("mention guidance ships under the current standing prompt version", () => {
-  assert.equal(LARKIN_STANDING_PROMPT_VERSION, "larkin-standing-v20");
+  assert.equal(LARKIN_STANDING_PROMPT_VERSION, "larkin-standing-v21");
   const prompt = buildPrompt("codex");
   assert.match(prompt, /## Collaboration and delivery/);
 });

--- a/test/unit/evals/authoritative-freshness-gate.test.mjs
+++ b/test/unit/evals/authoritative-freshness-gate.test.mjs
@@ -10,7 +10,7 @@ const dataset = loadAuthoritativeFreshnessEval(path.join(ROOT, "evals/authoritat
 test("authoritative freshness eval is versioned, reproducible, and covers the critical rubric", () => {
   assert.equal(dataset.dataset, "authoritative-freshness-gate");
   assert.equal(dataset.version, 1);
-  assert.equal(dataset.standing_prompt_version, "larkin-standing-v20");
+  assert.equal(dataset.standing_prompt_version, "larkin-standing-v21");
   assert.equal(dataset.threshold, 1);
   assert.deepEqual(dataset.scenarios.map((scenario) => scenario.id), [
     "missing-inbox-history", "direct-ack-retry", "same-ms-new-id", "edited-message",

--- a/test/unit/evals/clickable-link-delivery.test.mjs
+++ b/test/unit/evals/clickable-link-delivery.test.mjs
@@ -63,7 +63,7 @@ function runFake(args, surface = "larkin") {
 test("clickable-link delivery dataset is fixed, fresh, versioned, and thresholded", () => {
   assert.equal(DATASET.dataset, "clickable-link-delivery");
   assert.equal(DATASET.version, 1);
-  assert.equal(DATASET.standing_prompt_version, "larkin-standing-v20");
+  assert.equal(DATASET.standing_prompt_version, "larkin-standing-v21");
   assert.equal(DATASET.threshold, 1);
   assert.equal(DATASET.session.initial_turns, 0);
   assert.equal(DATASET.session.fresh_per_scenario, true);

--- a/test/unit/evals/runtime-agent-interface-v2.test.mjs
+++ b/test/unit/evals/runtime-agent-interface-v2.test.mjs
@@ -16,7 +16,7 @@ test("fixed runtime Agent interface eval registers dataset, rubric, grader, thre
   assert.equal(DATASET.version, 1);
   assert.equal(DATASET.runtime.adapter, "codex");
   assert.equal(DATASET.model.selection, "gpt-5.6-sol");
-  assert.equal(DATASET.model.standing_prompt_version, "larkin-standing-v20");
+  assert.equal(DATASET.model.standing_prompt_version, "larkin-standing-v21");
   assert.equal(DATASET.grader.version, 1);
   assert.equal(DATASET.grader.threshold, 1);
   assert.ok(DATASET.grader.rubric.length >= 5);

--- a/test/unit/feishu/host-shell-domain.test.mjs
+++ b/test/unit/feishu/host-shell-domain.test.mjs
@@ -1,0 +1,89 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { fileURLToPath, pathToFileURL } from "node:url";
+import { test } from "bun:test";
+
+const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../../..");
+const { createHostShell } = await import(pathToFileURL(path.join(ROOT, "dist/feishu/host-shell.mjs")).href);
+const { requireOpenDomain } = await import(pathToFileURL(path.join(ROOT, "dist/feishu/platform-hosts.mjs")).href);
+
+function agentConfig(root, id, domain) {
+  return {
+    agentId: id, name: id, runtime: "codex", model: "gpt", feishuAppId: id,
+    feishuAppSecret: "fixture-secret", feishuProfile: id, feishuDomain: domain,
+    workspaceDir: path.join(root, "agents", id), stateDir: path.join(root, "state", "agents", id),
+    larkConfigDir: path.join(root, "lark-cli-config"),
+  };
+}
+
+test("Lark agent createLarkChannel uses open.larksuite.com and never open.feishu.cn", async () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "larkin-host-lark-domain-"));
+  const agentId = "cli_hostLarkDomainA1";
+  const captured = [];
+  const runtimeHost = {
+    subscribe() { return () => {}; },
+    async start() {},
+    async deliver() { throw new Error("not used"); },
+    async stop() {},
+    async shutdown() {},
+  };
+  const channelPackage = {
+    createLarkChannel(options) {
+      captured.push(options);
+      return {
+        botIdentity: { openId: "ou_lark", name: "Lark" },
+        rawClient: null,
+        dispatcher: { register() {} },
+        on() {},
+        async connect() {},
+        async disconnect() {},
+      };
+    },
+  };
+  const agent = agentConfig(root, agentId, "https://open.larksuite.com");
+  const host = createHostShell({
+    env: {
+      LARKIN_HOME: root, LARKIN_CONFIG_DIR: root, LARKIN_SERVER_ID: "server-lark-domain",
+      LARKIN_AGENTS_CONFIG: JSON.stringify([agent]), LARKIN_INBOUND_DROUGHT_SEC: "0",
+    },
+    runtimeHost, channelPackage, eventSourceStartDelayMs: 0,
+  });
+  try {
+    host.start();
+    const deadline = Date.now() + 2_000;
+    while (captured.length === 0 && Date.now() < deadline) await new Promise((resolve) => setTimeout(resolve, 5));
+    assert.equal(captured.length > 0, true);
+    assert.equal(captured[0].domain, "https://open.larksuite.com");
+    assert.notEqual(captured[0].domain, "https://open.feishu.cn");
+    assert.doesNotMatch(JSON.stringify(captured[0]), /feishu\.cn/);
+  } finally {
+    await host.shutdown("lark domain test complete");
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("missing feishuDomain throws and does not default to China", () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "larkin-host-missing-domain-"));
+  try {
+    const agentId = "cli_hostMissingDomainA1";
+    const agent = agentConfig(root, agentId, undefined);
+    delete agent.feishuDomain;
+    assert.throws(() => createHostShell({
+      env: {
+        LARKIN_HOME: root, LARKIN_CONFIG_DIR: root, LARKIN_SERVER_ID: "server-missing-domain",
+        LARKIN_AGENTS_CONFIG: JSON.stringify([agent]),
+      },
+      runtimeHost: {
+        subscribe() { return () => {}; },
+        async start() {}, async deliver() {}, async stop() {}, async shutdown() {},
+      },
+      channelPackage: {
+        createLarkChannel() { throw new Error("createLarkChannel must not run without a domain"); },
+      },
+    }), /缺少有效 channel 凭证\/domain/);
+    assert.throws(() => requireOpenDomain(undefined), /missing or invalid Open Platform domain/);
+    assert.throws(() => requireOpenDomain(""), /missing or invalid Open Platform domain/);
+  } finally { fs.rmSync(root, { recursive: true, force: true }); }
+});

--- a/test/unit/feishu/platform-hosts.test.mjs
+++ b/test/unit/feishu/platform-hosts.test.mjs
@@ -1,0 +1,43 @@
+import assert from "node:assert/strict";
+import path from "node:path";
+import { fileURLToPath, pathToFileURL } from "node:url";
+import { test } from "bun:test";
+
+const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../../..");
+const hosts = await import(pathToFileURL(path.join(ROOT, "dist/feishu/platform-hosts.mjs")).href);
+
+test("open and accounts hosts match official Feishu vs Lark ResolveEndpoints", () => {
+  assert.equal(hosts.openPlatformHost("lark"), "https://open.larksuite.com");
+  assert.equal(hosts.openPlatformHost("feishu"), "https://open.feishu.cn");
+  assert.equal(hosts.registerAppAccountsHost("lark"), "accounts.larksuite.com");
+  assert.equal(hosts.registerAppAccountsHost("feishu"), "accounts.feishu.cn");
+});
+
+test("Lark helper outputs never contain feishu.cn and Feishu outputs never contain larksuite.com", () => {
+  const larkValues = [
+    hosts.openPlatformHost("lark"),
+    hosts.registerAppAccountsHost("lark"),
+    hosts.PLATFORM_HOSTS.lark.accounts,
+    hosts.PLATFORM_HOSTS.lark.applink,
+    hosts.PLATFORM_HOSTS.lark.docs,
+    hosts.PLATFORM_HOSTS.lark.console,
+  ];
+  const feishuValues = [
+    hosts.openPlatformHost("feishu"),
+    hosts.registerAppAccountsHost("feishu"),
+    hosts.PLATFORM_HOSTS.feishu.accounts,
+    hosts.PLATFORM_HOSTS.feishu.applink,
+    hosts.PLATFORM_HOSTS.feishu.docs,
+    hosts.PLATFORM_HOSTS.feishu.console,
+  ];
+  for (const value of larkValues) assert.doesNotMatch(value, /feishu\.cn/);
+  for (const value of feishuValues) assert.doesNotMatch(value, /larksuite\.com/);
+});
+
+test("requireOpenDomain accepts only official Open hosts and fail-closes otherwise", () => {
+  assert.equal(hosts.requireOpenDomain("https://open.larksuite.com"), "https://open.larksuite.com");
+  assert.equal(hosts.requireOpenDomain("https://open.feishu.cn"), "https://open.feishu.cn");
+  assert.throws(() => hosts.requireOpenDomain(undefined), /missing or invalid Open Platform domain/);
+  assert.throws(() => hosts.requireOpenDomain("https://open.larkoffice.com"), /missing or invalid Open Platform domain/);
+  assert.throws(() => hosts.requireOpenDomain("lark"), /missing or invalid Open Platform domain/);
+});

--- a/test/unit/runtime/runtime-adapters.test.mjs
+++ b/test/unit/runtime/runtime-adapters.test.mjs
@@ -146,7 +146,8 @@ test("context prompt is capability-driven, versioned and produces bounded notifi
 
 test("default context prompt consumes the Agent CLI manifest", () => {
   const prompt = new ContextPromptBuilder().build({ agentId: "cli_test", runtime: "pi" });
-  assert.equal(prompt.version, "larkin-standing-v20");
+  assert.equal(prompt.version, "larkin-standing-v21");
+  assert.match(prompt.content, /never emit feishu\.cn for a Lark tenant/);
   assert.match(prompt.content, /larkin reminder schedule/);
   assert.match(prompt.content, /larkin reminder cancel/);
   assert.match(prompt.content, /larkin interaction resolve/);

--- a/test/unit/setup/bot-register-tenant-urls.test.mjs
+++ b/test/unit/setup/bot-register-tenant-urls.test.mjs
@@ -1,0 +1,103 @@
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { test } from "bun:test";
+
+const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../../..");
+const ENTRY = path.join(ROOT, "dist/setup/bot-register.mjs");
+
+function runRegister({ tenantArgs = [], userInfo = { tenant_brand: "feishu" }, clientId = "not-an-app-id" } = {}) {
+  const temp = fs.mkdtempSync(path.join(os.tmpdir(), "larkin-bot-register-tenant-"));
+  const configDir = path.join(temp, "config");
+  fs.mkdirSync(configDir, { recursive: true, mode: 0o700 });
+  const marker = path.join(temp, "register.json");
+  const qrMarker = path.join(temp, "qr.txt");
+  const fixture = path.join(temp, "fixture.cjs");
+  fs.writeFileSync(fixture, `const fs = require("node:fs");
+module.exports = {
+  registerApp: async (opts) => {
+    fs.writeFileSync(process.env.REGISTER_MARKER, JSON.stringify({
+      domain: opts.domain,
+      larkDomain: opts.larkDomain,
+    }));
+    const url = "https://" + opts.domain + "/oauth/v1/app/registration?code=fixture";
+    fs.writeFileSync(process.env.QR_MARKER, url);
+    opts.onQRCodeReady({ url, expireIn: 60 });
+    return {
+      client_id: ${JSON.stringify(clientId)},
+      client_secret: "fixture-secret",
+      user_info: ${JSON.stringify(userInfo)},
+    };
+  },
+  qrcode: { generate() {} },
+  spawnSync() { return { status: 1, stdout: "", stderr: "blocked" }; },
+};
+`);
+  const result = spawnSync(process.execPath, [ENTRY, "--auto", ...tenantArgs], {
+    cwd: ROOT,
+    encoding: "utf8",
+    env: {
+      ...process.env,
+      HOME: path.join(temp, "home"),
+      LARKIN_HOME: configDir,
+      LARKIN_CONFIG_DIR: configDir,
+      LARKSUITE_CLI_CONFIG_DIR: path.join(temp, "lark-cli"),
+      LARKIN_TEST_BOT_REGISTER_MODULE: fixture,
+      REGISTER_MARKER: marker,
+      QR_MARKER: qrMarker,
+    },
+  });
+  return { temp, configDir, marker, qrMarker, result };
+}
+
+test("--tenant lark passes official Lark accounts hosts and the QR URL has no feishu.cn", () => {
+  const { temp, marker, qrMarker, result } = runRegister({
+    tenantArgs: ["--tenant", "lark"],
+    userInfo: { tenant_brand: "lark" },
+  });
+  try {
+    assert.notEqual(result.status, 0);
+    const opts = JSON.parse(fs.readFileSync(marker, "utf8"));
+    assert.equal(opts.domain, "accounts.larksuite.com");
+    assert.equal(opts.larkDomain, "accounts.larksuite.com");
+    const url = fs.readFileSync(qrMarker, "utf8");
+    assert.match(url, /accounts\.larksuite\.com/);
+    assert.doesNotMatch(url, /feishu\.cn/);
+    assert.doesNotMatch(JSON.stringify(opts), /feishu\.cn/);
+  } finally { fs.rmSync(temp, { recursive: true, force: true }); }
+});
+
+test("default and --tenant feishu stay on official China accounts hosts", () => {
+  for (const tenantArgs of [[], ["--tenant", "feishu"]]) {
+    const { temp, marker, qrMarker, result } = runRegister({ tenantArgs });
+    try {
+      assert.notEqual(result.status, 0);
+      const opts = JSON.parse(fs.readFileSync(marker, "utf8"));
+      assert.equal(opts.domain, "accounts.feishu.cn");
+      assert.equal(opts.larkDomain, "accounts.larksuite.com");
+      const url = fs.readFileSync(qrMarker, "utf8");
+      assert.match(url, /accounts\.feishu\.cn/);
+      assert.doesNotMatch(url, /larksuite\.com/);
+    } finally { fs.rmSync(temp, { recursive: true, force: true }); }
+  }
+});
+
+test("conflicting user_info.tenant_brand fails closed without writing credentials", () => {
+  const { temp, configDir, result } = runRegister({
+    tenantArgs: ["--tenant", "lark"],
+    userInfo: { tenant_brand: "feishu", open_id: "ou_conflict" },
+    clientId: "cli_conflictTenantA1",
+  });
+  try {
+    assert.notEqual(result.status, 0, result.stderr);
+    assert.match(result.stderr, /不一致|未执行凭证/);
+    assert.equal(fs.existsSync(path.join(configDir, "bots", "cli_conflictTenantA1.json")), false);
+    const botsDir = path.join(configDir, "bots");
+    if (fs.existsSync(botsDir)) {
+      assert.deepEqual(fs.readdirSync(botsDir).filter((name) => name.endsWith(".json")), []);
+    }
+  } finally { fs.rmSync(temp, { recursive: true, force: true }); }
+});

--- a/test/unit/setup/grant-scopes-tenant-urls.test.mjs
+++ b/test/unit/setup/grant-scopes-tenant-urls.test.mjs
@@ -1,0 +1,89 @@
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { test } from "bun:test";
+
+const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../../..");
+const ENTRY = path.join(ROOT, "dist/setup/grant-scopes.mjs");
+
+function runGrant({ tenant = "feishu", extraArgs = [] } = {}) {
+  const temp = fs.mkdtempSync(path.join(os.tmpdir(), "larkin-grant-tenant-"));
+  const root = path.join(temp, "root");
+  const app = "cli_grantTenantA1";
+  fs.mkdirSync(root, { recursive: true, mode: 0o700 });
+  fs.writeFileSync(path.join(root, "config.json"), JSON.stringify({
+    version: 3, serverId: "server-grant-tenant", activeAgent: app,
+    agents: { [app]: { runtime: "codex", model: "gpt" } },
+  }), { mode: 0o600 });
+  fs.mkdirSync(path.join(root, "bots"), { mode: 0o700 });
+  fs.writeFileSync(path.join(root, "bots", `${app}.json`), JSON.stringify({
+    appId: app, appSecret: "fixture-secret", tenant,
+  }), { mode: 0o600 });
+  const marker = path.join(temp, "register.json");
+  const fixture = path.join(temp, "fixture.cjs");
+  fs.writeFileSync(fixture, `const fs = require("node:fs");
+module.exports = {
+  registerApp: async (opts) => {
+    fs.writeFileSync(process.env.REGISTER_MARKER, JSON.stringify({
+      appId: opts.appId,
+      domain: opts.domain,
+    }));
+    opts.onQRCodeReady({ url: "https://" + opts.domain + "/oauth/grant", expireIn: 60 });
+    return { client_id: opts.appId };
+  },
+  qrcode: { generate() {} },
+  managedOfficialCli: () => ({ command: { command: "/verified/official-lark-cli", argsPrefix: [], version: "1.0.80" }, env: {} }),
+  spawnSync() { return { status: 0, stdout: "{}", stderr: "" }; },
+};
+`);
+  const result = spawnSync(process.execPath, [ENTRY, "--wait-min", "1", ...extraArgs], {
+    cwd: ROOT,
+    encoding: "utf8",
+    env: {
+      ...process.env,
+      HOME: path.join(temp, "home"),
+      LARKIN_HOME: root,
+      LARKIN_CONFIG_DIR: root,
+      LARKSUITE_CLI_CONFIG_DIR: path.join(temp, "lark-cli"),
+      LARKIN_TEST_GRANT_SCOPES_MODULE: fixture,
+      REGISTER_MARKER: marker,
+      LARKIN_AGENT_ID: undefined,
+    },
+  });
+  return { temp, marker, result };
+}
+
+test("stored Lark credential without --tenant uses accounts.larksuite.com, not brand token lark", () => {
+  const { temp, marker, result } = runGrant({ tenant: "lark" });
+  try {
+    assert.equal(result.status, 0, result.stderr);
+    const opts = JSON.parse(fs.readFileSync(marker, "utf8"));
+    assert.equal(opts.domain, "accounts.larksuite.com");
+    assert.notEqual(opts.domain, "lark");
+    assert.notEqual(opts.domain, "accounts.feishu.cn");
+    assert.doesNotMatch(JSON.stringify(opts), /feishu\.cn/);
+  } finally { fs.rmSync(temp, { recursive: true, force: true }); }
+});
+
+test("explicit --tenant lark uses the official Lark accounts host", () => {
+  const { temp, marker, result } = runGrant({ tenant: "feishu", extraArgs: ["--tenant", "lark"] });
+  try {
+    assert.equal(result.status, 0, result.stderr);
+    const opts = JSON.parse(fs.readFileSync(marker, "utf8"));
+    assert.equal(opts.domain, "accounts.larksuite.com");
+    assert.doesNotMatch(JSON.stringify(opts), /feishu\.cn/);
+  } finally { fs.rmSync(temp, { recursive: true, force: true }); }
+});
+
+test("Feishu credential / default still uses accounts.feishu.cn", () => {
+  const { temp, marker, result } = runGrant({ tenant: "feishu" });
+  try {
+    assert.equal(result.status, 0, result.stderr);
+    const opts = JSON.parse(fs.readFileSync(marker, "utf8"));
+    assert.equal(opts.domain, "accounts.feishu.cn");
+    assert.doesNotMatch(JSON.stringify(opts), /larksuite\.com/);
+  } finally { fs.rmSync(temp, { recursive: true, force: true }); }
+});


### PR DESCRIPTION
## Summary

Fixes the China-default authorization/open-host path that blocks International Lark tenants from finishing setup. Grounded in official `@larksuite/cli` `ResolveEndpoints` (open / accounts / applink on `feishu.cn` vs `larksuite.com`). Official `lark-cli --domain` is a **business** domain (`im`, `drive`, …); brand is `--brand feishu|lark`. Larkin bind already projects `accounts.app.tenant`. This PR only makes the first user-visible `registerApp` URL and later grant/runtime hosts match that brand.

Does **not** close #140. Waiting for review; no merge/release.

## Root cause (E1)

`@larksuiteoapi/node-sdk` `registerApp` starts at `https://${domain ?? "accounts.feishu.cn"}` and only switches polling after `user_info.tenant_brand === "lark"`. Larkin never passed a Lark accounts host, so the first QR/link was always China.

Secondary: `grant-scopes` sent `domain: "lark"`, which the SDK interpolates as `https://lark/...`.

Tertiary: `host-shell` `createLarkChannel` fail-opened missing `feishuDomain` to `https://open.feishu.cn`.

## Scope

- Shared official host table: `src/feishu/platform-hosts.ts` (open / accounts / applink / docs / console). No `larkoffice.com`.
- `bot-register`: ask or require tenant **before** `registerApp`; pass `domain=<accounts host>` and `larkDomain=accounts.larksuite.com`. Default remains `feishu`. Conflict between preselected tenant and `user_info.tenant_brand` fails closed with **no credential write**.
- `grant-scopes`: default tenant from stored credential; always pass accounts **host**, never brand token `"lark"`.
- `host-shell`: `requireOpenDomain`, no `|| open.feishu.cn` fail-open.
- `runtime-agent-config`: hydrate/projection via `openPlatformHost`; Lark Open host cannot project as `feishu`.
- Setup help + one README sentence + one standing-prompt sentence: never emit `feishu.cn` for a Lark tenant.
- Version `0.4.8` → `0.4.9` (required patch increment before merge). Standing prompt `v20` → `v21` is contract hygiene for that one sentence.

## Non-goals

- No merge / release / retag / close issue.
- No production rebind, no second Runtime, no bot identity / credential / process change.
- Do not migrate existing China Feishu Agents to Lark.
- Do not call `lark-cli config init --brand`.
- Do not claim Miaoda/`apps` / `larkoffice.com` compatibility.

## Tests (E2)

Claim proved: **Lark-tenant setup/grant/runtime payloads do not contain `feishu.cn`; Feishu-tenant payloads still use official China hosts.**

- `test/unit/feishu/platform-hosts.test.mjs`
- `test/unit/setup/bot-register-tenant-urls.test.mjs` (including conflict → no credential write)
- `test/unit/setup/grant-scopes-tenant-urls.test.mjs`
- `test/unit/app/runtime-agent-config-tenant.test.mjs`
- `test/unit/feishu/host-shell-domain.test.mjs`
- Existing Feishu fixtures kept as regression (`production-boundary` now also asserts `opts.domain === accounts.feishu.cn`)

Local results (clean env): typecheck PASS; 12/12 new tenant tests; production-boundary + host-runtime-lifecycle 28/28; setup-cli + eval version contracts 25/25.

## Unproven (no E4)

- No overseas company walkthrough. **Do not claim setup now works for overseas employees.**
- Unknown whether some Lark tenants still redirect from `accounts.feishu.cn`.
- Unknown whether `registerApp` addons/confirm page on Lark is feature-complete vs Feishu.
- Standing-prompt v21 is an explicit contract line only; no E3 behavior-eval pass-rate claim.
- Fake-sink / fixture URLs are not client clickability evidence.

## Version

`package.json` `0.4.9`. Merge still requires explicit authorization; this PR does not merge or release.