### PR TITLE
fix(setup): use official /page/cli for International Lark QR

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "larkin",
-  "version": "0.4.10",
+  "version": "0.4.11",
   "private": false,
   "larkinPackageRole": "npm-published",
   "files": [

--- a/src/app/setup.ts
+++ b/src/app/setup.ts
@@ -85,11 +85,10 @@ Options:
   --base-url <url>                      custom 端点（provider=custom 时必填；也可覆盖 preset 默认端点）
   --model <id>                          模型 ID；默认取 provider 预设。不同 runtime 的模型可用
                                           \`larkin model\` 查看 / 切换
-  --tenant feishu|lark                  授权二维码之前选择品牌。默认 feishu（accounts.feishu.cn /
-                                          https://open.feishu.cn）。Lark 用 --tenant lark
-                                          （accounts.larksuite.com / https://open.larksuite.com）。
-                                          交互式未指定时会先询问。飞书与 Lark 是不同平台，
-                                          Lark 租户不得使用 feishu.cn 主机。
+  --from-cli-profile <name>            可选：复用已有官方 lark-cli profile（需 LARKIN_SETUP_APP_SECRET）
+  --tenant feishu|lark                  授权二维码之前选择品牌。默认 feishu（扫码 /page/launcher）。
+                                          Lark 用 --tenant lark：扫码 /page/cli，完成后凭证回传，
+                                          不要打开 /page/launcher。交互式未指定时会先询问。
 
 setup handles browser authorization, permission grants, credential storage, Agent configuration,
 and target-only hot attach. Each Agent is identified by its bot App ID: selecting the same bot reuses
@@ -163,11 +162,12 @@ export async function main(): Promise<void> {
     if (tenant !== "feishu" && tenant !== "lark") die("--tenant 只支持 feishu 或 lark");
     registerArgs.push("--tenant", tenant === "lark" ? "lark" : "feishu");
   }
-  for (const name of ["--provider", "--api-key", "--base-url", "--model"] as const) {
+  for (const name of ["--provider", "--api-key", "--base-url", "--model", "--from-cli-profile"] as const) {
     const value = flag(name);
     if (value) registerArgs.push(name, value);
   }
   const result = await runForeground("bot-register", registerArgs);
+  delete process.env.LARKIN_SETUP_APP_SECRET;
   if (result.code !== 0) die("机器人授权或 Agent 配置未完成");
 
   let agentId: string | undefined;

--- a/src/setup/bot-register.ts
+++ b/src/setup/bot-register.ts
@@ -43,6 +43,7 @@ import {
   registerAppAccountsHost,
   type LarkinTenant,
 } from "../feishu/platform-hosts.js";
+import { authorizationUrlFailureMessage, presentAuthorizationUrl } from "./setup-authorization-url.js";
 // qrcode-terminal does not publish TypeScript declarations.
 // @ts-expect-error bundled CommonJS dependency
 import qrcodePackage from "qrcode-terminal";
@@ -63,7 +64,7 @@ type RegisterApp = (options: {
   source: string;
   domain?: string;
   larkDomain?: string;
-  addons: {
+  addons?: {
     scopes: { tenant: string[] };
     events: { items: { tenant: string[] } };
     callbacks: { items: string[] };
@@ -79,6 +80,7 @@ const testFixture = process.env.LARKIN_TEST_BOT_REGISTER_MODULE
     spawnSync?: typeof systemSpawnSync;
     syncAgentProfile?: typeof syncAgentProfile;
     resolveOfficialLarkCli?: typeof resolveOfficialLarkCli;
+    spawn?: typeof systemSpawn;
     wait?: (milliseconds: number) => Promise<void>;
   }
   : null;
@@ -503,8 +505,10 @@ if (has("--help") || has("-h")) {
 用法:
   bun bot-register.mjs --auto [--tenant feishu|lark]
 
---tenant 在授权二维码之前选择品牌。默认 feishu（accounts.feishu.cn）；
-Lark 必须用 --tenant lark 或交互选择，授权主机是 accounts.larksuite.com。
+--tenant 在授权二维码之前选择品牌。默认 feishu（accounts.feishu.cn /page/launcher）。
+Lark 必须用 --tenant lark：授权二维码是官方 /page/cli（begin 仍走飞书 accounts，
+打开 open.larksuite.com），不要打开 /page/launcher（ack 10074 / 链接已失效）。
+扫码完成后凭证回传，无需手抄 App Secret。
 
 完成后自动：按返回 appId 判定新旧 → 同步并校验 lark-cli bot 凭证 →
   原子写 bots/<appId>.json（0600）→ 绑定 Agent。`);
@@ -523,10 +527,12 @@ if (resultFile && (path.dirname(resultFile) !== path.resolve(CFG_DIR) || !/^\.se
   die("--result-file 必须是配置根目录内的 .setup-result-<pid>.json");
 }
 if (argv.some((arg) => arg === "--app-id" || arg.startsWith("--app-id="))) {
-  die("不支持 --app-id；机器人必须在飞书（Lark）网页中选择");
+  die("不支持 --app-id；机器人必须在飞书（Lark）网页中选择。已有官方 lark-cli profile 时用 --from-cli-profile");
 }
+const fromCliProfile = flag("--from-cli-profile") || "";
+if (fromCliProfile && !/^[A-Za-z0-9._-]{1,64}$/.test(fromCliProfile)) die("--from-cli-profile 非法");
 if (!autoSelect) die("setup 注册阶段必须由交互式选择流程启动");
-const selectedTenant = await resolveSelectedTenant();
+let selectedTenant = await resolveSelectedTenant();
 say(`[setup 1/5] 在${selectedTenant === "lark" ? " International Lark" : "中国飞书 Feishu"}网页选择已有机器人或创建新机器人`);
 if (commentSubscription === "application") {
   say(`! 已显式选择 ${commentSubscription} 维度评论订阅：一旦平台状态验证为已订阅，Bot 可见文档中实际送达的每条支持评论都会进入 Inbox 并唤醒 Agent，不要求 @Bot。`);
@@ -560,28 +566,79 @@ const TENANT_SCOPES = [
   "docs:document.comment:create",
 ];
 const TENANT_EVENTS = ["im.message.receive_v1", "im.message.message_read_v1", "drive.notice.comment_add_v1"];
+const LARKIN_REGISTER_ADDONS = {
+  scopes: { tenant: TENANT_SCOPES },
+  events: { items: { tenant: TENANT_EVENTS } },
+  callbacks: { items: ["card.action.trigger"] },
+};
 let pollingCount = 0;
 
-const result = await registerApp({
-  source: "larkin",
-  domain: registerAppAccountsHost(selectedTenant),
-  larkDomain: registerAppAccountsHost("lark"),
-  addons: {
-    scopes: { tenant: TENANT_SCOPES },
-    events: { items: { tenant: TENANT_EVENTS } },
-    callbacks: { items: ["card.action.trigger"] },
-  },
-  onQRCodeReady: ({ url, expireIn }) => {
-    qrcode.generate(url, { small: true }, (code: string) => say(code));
-    say(`\n打开以下链接（或扫码），${Math.round(expireIn / 60)} 分钟内有效：\n\n  ${url}\n\n[setup 2/5] 等待飞书（Lark）网页完成授权并回传凭证…`);
-    say(openBrowser(url) ? "[setup] 已在默认浏览器打开授权页" : "[setup] 未能自动打开浏览器，请手动打开上面的链接");
-  },
-  onStatusChange: ({ status, interval }) => {
-    if (status === "domain_switched") say("[setup] 已切换到 Lark 域名");
-    if (status === "slow_down") say(`[setup] 飞书（Lark）要求降低轮询频率，${interval || "稍后"}秒后继续`);
-    if (status === "polling" && ++pollingCount % 12 === 0) say(`[setup] 仍在等待飞书（Lark）回传凭证（约 ${pollingCount / 12} 分钟）…`);
-  },
-}).catch(() => die("网页授权失败；未执行凭证同步、文件写入或 Agent 绑定，请重试 setup"));
+const presentUrl = (url: string, expireIn: number): void => {
+  qrcode.generate(url, { small: true }, (code: string) => say(code));
+  say(`\n打开以下链接（或扫码），${Math.round(expireIn / 60)} 分钟内有效：\n\n  ${url}\n\n[setup 2/5] 等待飞书（Lark）网页完成授权并回传凭证…`);
+  say(openBrowser(url) ? "[setup] 已在默认浏览器打开授权页" : "[setup] 未能自动打开浏览器，请手动打开上面的链接");
+};
+
+const importedSecret = typeof process.env.LARKIN_SETUP_APP_SECRET === "string"
+  ? process.env.LARKIN_SETUP_APP_SECRET.trim() : "";
+delete process.env.LARKIN_SETUP_APP_SECRET;
+let result: RegistrationResult | null = null;
+if (fromCliProfile) {
+  if (!importedSecret) die("--from-cli-profile 需要环境变量 LARKIN_SETUP_APP_SECRET（App Secret 不进 argv）");
+  const official = officialCliForProfile(process.env);
+  const listed = spawnSync(official.command, [...official.argsPrefix, "profile", "list"], { encoding: "utf8", env: process.env });
+  let profiles: Array<{ name?: unknown; appId?: unknown; brand?: unknown }> = [];
+  try { profiles = JSON.parse(listed.stdout || "[]") as Array<{ name?: unknown; appId?: unknown; brand?: unknown }>; }
+  catch { die("读取 lark-cli profile list 失败"); }
+  const matched = profiles.find((profile) => profile.name === fromCliProfile);
+  if (matched == null || typeof matched.appId !== "string" || !APP_ID.test(matched.appId)) {
+    die(`找不到 lark-cli profile ${fromCliProfile}`);
+  } else {
+    const brand = matched.brand === "lark" || matched.brand === "feishu" ? matched.brand : selectedTenant;
+    selectedTenant = brand;
+    result = { client_id: matched.appId, client_secret: importedSecret, user_info: { tenant_brand: brand } };
+    say(`[setup 1/5] 复用官方 lark-cli profile ${fromCliProfile} → ${matched.appId}`);
+  }
+} else if (selectedTenant === "lark") {
+  // Official lark-cli always begins on Feishu accounts, then presents
+  // open.larksuite.com/page/cli. Beginning on Lark accounts yields /page/launcher
+  // codes that open.larksuite.com ack rejects with 10074.
+  say("[setup 1/5] Lark 租户走官方 /page/cli 扫码授权；扫码完成后凭证回传，不要打开 /page/launcher");
+  const official = officialCliForProfile(process.env);
+  result = await registerApp({
+    source: "larkin",
+    domain: registerAppAccountsHost("feishu"),
+    larkDomain: registerAppAccountsHost("lark"),
+    addons: LARKIN_REGISTER_ADDONS,
+    onQRCodeReady: ({ url, expireIn }) => {
+      const presented = presentAuthorizationUrl(url, { tenant: "lark", larkCliVersion: official.version });
+      if (/\/page\/launcher(?:\?|$)/.test(presented)) {
+        throw new Error("Lark 租户拒绝把 /page/launcher 交给浏览器");
+      }
+      presentUrl(presented, expireIn);
+    },
+    onStatusChange: ({ status, interval }) => {
+      if (status === "domain_switched") say("[setup] 已切换到 Lark 域名");
+      if (status === "slow_down") say(`[setup] 飞书（Lark）要求降低轮询频率，${interval || "稍后"}秒后继续`);
+      if (status === "polling" && ++pollingCount % 12 === 0) say(`[setup] 仍在等待飞书（Lark）回传凭证（约 ${pollingCount / 12} 分钟）…`);
+    },
+  }).catch((error: unknown) => die(authorizationUrlFailureMessage(error)));
+} else {
+  result = await registerApp({
+    source: "larkin",
+    domain: registerAppAccountsHost(selectedTenant),
+    larkDomain: registerAppAccountsHost("lark"),
+    addons: LARKIN_REGISTER_ADDONS,
+    onQRCodeReady: ({ url, expireIn }) => {
+      presentUrl(url, expireIn);
+    },
+    onStatusChange: ({ status, interval }) => {
+      if (status === "domain_switched") say("[setup] 已切换到 Lark 域名");
+      if (status === "slow_down") say(`[setup] 飞书（Lark）要求降低轮询频率，${interval || "稍后"}秒后继续`);
+      if (status === "polling" && ++pollingCount % 12 === 0) say(`[setup] 仍在等待飞书（Lark）回传凭证（约 ${pollingCount / 12} 分钟）…`);
+    },
+  }).catch((error: unknown) => die(authorizationUrlFailureMessage(error)));
+}
 
 const { client_id: rawId, client_secret: rawSecret, user_info: userInfo } = result || {};
 if (typeof rawId !== "string" || !APP_ID.test(rawId)) die("授权返回的 App ID 格式非法；未执行凭证同步、文件写入或 Agent 绑定");

--- a/src/setup/setup-authorization-url.ts
+++ b/src/setup/setup-authorization-url.ts
@@ -1,0 +1,53 @@
+import { openPlatformHost, type LarkinTenant } from "../feishu/platform-hosts.js";
+
+export interface OfficialCliSetupUrlInput {
+  tenant: LarkinTenant;
+  userCode: string;
+  larkCliVersion: string;
+}
+
+// Official lark-cli presents /page/cli. node-sdk registerApp returns /page/launcher,
+// which open.larksuite.com ack rejects with 10074 ("链接已失效") for Lark tenants.
+export function officialCliSetupUrl(input: OfficialCliSetupUrlInput): string {
+  const userCode = input.userCode.trim();
+  if (!/^[A-Z0-9]{4}-[A-Z0-9]{4}$/.test(userCode)) throw new Error("setup user_code 格式非法");
+  const version = input.larkCliVersion.trim();
+  if (!/^\d+\.\d+\.\d+$/.test(version)) throw new Error("lark-cli version 格式非法");
+  const url = new URL(`${openPlatformHost(input.tenant)}/page/cli`);
+  url.searchParams.set("user_code", userCode);
+  url.searchParams.set("lpv", version);
+  url.searchParams.set("ocv", version);
+  url.searchParams.set("from", "cli");
+  return url.toString();
+}
+
+export function presentAuthorizationUrl(
+  rawUrl: string,
+  input: { tenant: LarkinTenant; larkCliVersion: string },
+): string {
+  let parsed: URL;
+  try { parsed = new URL(rawUrl); } catch { throw new Error("授权 URL 非法"); }
+  const userCode = parsed.searchParams.get("user_code") || "";
+  // Feishu China still authorizes on /page/launcher. Only International Lark
+  // must leave launcher (open.larksuite.com ack 10074 / 链接已失效).
+  if (input.tenant === "lark" && parsed.pathname === "/page/launcher") {
+    if (!userCode) throw new Error("Lark 租户拒绝把 /page/launcher 交给浏览器");
+    const presented = new URL(officialCliSetupUrl({ tenant: "lark", userCode, larkCliVersion: input.larkCliVersion }));
+    // node-sdk registerApp encodes scopes/events/callbacks only on the landing URL
+    // (`addons=`). Keep that payload when rewriting launcher → /page/cli so Lark
+    // still requests the same Larkin addons Feishu already sends.
+    const addons = parsed.searchParams.get("addons");
+    if (addons) presented.searchParams.set("addons", addons);
+    return presented.toString();
+  }
+  return parsed.toString();
+}
+
+export function authorizationUrlFailureMessage(error: unknown): string {
+  const message = error instanceof Error ? error.message : String(error);
+  const code = error && typeof error === "object" && "code" in error ? String((error as { code?: unknown }).code) : "";
+  const description = error && typeof error === "object" && "description" in error
+    ? String((error as { description?: unknown }).description) : "";
+  const detail = [code, description, message].filter(Boolean).join(": ");
+  return `网页授权失败（${detail || "unknown"}）；未执行凭证同步、文件写入或 Agent 绑定。Lark 租户不要使用 /page/launcher（ack 10074 / 链接已失效），应走官方 lark-cli 的 /page/cli。`;
+}

--- a/src/setup/setup-bind.ts
+++ b/src/setup/setup-bind.ts
@@ -10,7 +10,6 @@ import { fileURLToPath } from "node:url";
 import { isWindows } from "../platform/secure-metadata.js";
 import { TargetRootLayout } from "../platform/root-layout.js";
 import { planSingleRootBinding, type StoredConfig } from "./setup-binding.js";
-import { discoverPiModelCatalog } from "../runtime/pi-model-catalog.js";
 import { configureBuiltinPiProviderModel, type BuiltinPiProviderSetupSelection } from "../runtime/pi-provider-config.js";
 import { terminalSetupQuestioner, type OfficialPiAuthSelection, type SetupAgentChoice } from "./setup-agent-choice.js";
 import {
@@ -22,6 +21,7 @@ import {
 } from "../runtime/pi-official-auth.js";
 import * as larkinConfigImport from "../platform/config.js";
 import { resolveOfficialLarkCli } from "../app/official-lark-cli.js";
+import { loadValidatedBotCredential } from "./run-credential-preflight.js";
 
 interface RuntimeModel {
   id: string;
@@ -135,20 +135,50 @@ function openAuthUrl(url: string): boolean {
   return result.status === 0;
 }
 
-function listProfiles(): Profile[] {
-  const result = larkJson(["profile", "list"]);
-  if (!result.ok || !Array.isArray(result.json)) {
-    die("读取 lark-cli profile 失败；未修改 Agent 配置，请检查隔离 profile 后重试 setup");
+function listProfilesFromEnv(env: NodeJS.ProcessEnv): Profile[] {
+  const official = resolveOfficialLarkCli({ env });
+  const result = spawnSync(official.command, [...official.argsPrefix, "profile", "list"], { encoding: "utf8", env });
+  try {
+    const parsed = JSON.parse(result.stdout || "[]") as unknown;
+    return Array.isArray(parsed) ? parsed as Profile[] : [];
+  } catch {
+    return [];
   }
-  return result.json as Profile[];
+}
+
+function listProfiles(): Profile[] {
+  const isolated = listProfilesFromEnv(larkEnv());
+  const globalEnv = { ...process.env };
+  delete globalEnv.LARKSUITE_CLI_CONFIG_DIR;
+  const global = listProfilesFromEnv(globalEnv);
+  const seen = new Set<string>();
+  const merged: Profile[] = [];
+  for (const profile of [...isolated, ...global]) {
+    const key = `${String(profile.name || "")}\0${String(profile.appId || "")}`;
+    if (seen.has(key)) continue;
+    seen.add(key);
+    merged.push(profile);
+  }
+  return merged;
+}
+
+function resolveProfile(requested: string, profiles: Profile[]): Profile | undefined {
+  return profiles.find((profile) => profile.name === requested)
+    || profiles.find((profile) => profile.appId === requested);
 }
 
 async function pickProfile(): Promise<Profile> {
-  if (options.profile) {
-    if (!APP_ID.test(options.profile)) die(`profile ${options.profile} 不是合法 App ID`);
+  if (options.profile && APP_ID.test(options.profile)) {
     return { name: options.profile, appId: options.profile, active: true };
   }
   const profiles = listProfiles();
+  if (options.profile) {
+    const matched = resolveProfile(options.profile, profiles);
+    if (matched && typeof matched.appId === "string" && APP_ID.test(matched.appId)) {
+      return { name: String(matched.name || matched.appId), appId: matched.appId, active: matched.active };
+    }
+    die(`找不到 lark-cli profile ${options.profile}（可用名字或 App ID，不要求名字等于 App ID）`);
+  }
   if (profiles.length === 0) die("lark-cli 里还没有 bot profile。请运行 larkin setup 创建或连接机器人");
 
   say("\n可复用的飞书（Lark）机器人（lark-cli profiles）：");
@@ -158,7 +188,19 @@ async function pickProfile(): Promise<Profile> {
   const answer = await ask(`选择 profile（回车=${activeIndex + 1}）: `);
   const selected = answer === "" ? activeIndex : Number(answer) - 1;
   if (!(selected >= 0 && selected < profiles.length)) die("无效的 profile 选择");
-  return profiles[selected]!;
+  const picked = profiles[selected]!;
+  if (typeof picked.appId !== "string" || !APP_ID.test(picked.appId)) {
+    die(`profile ${picked.name || "?"} 没有合法 App ID`);
+  }
+  return picked;
+}
+
+function requireUsableBotCredential(appId: string): void {
+  try {
+    loadValidatedBotCredential(path.join(CFG_DIR, "bots"), appId);
+  } catch {
+    die(`没有可用的 bot 凭证 ${appId}（bots/${appId}.json）；未修改 Agent 配置，请先运行 larkin setup 完成扫码授权`);
+  }
 }
 
 function verifyBot(profile: Profile): unknown[] {
@@ -271,9 +313,11 @@ export async function main(): Promise<void> {
 
   say("=== larkin 多 Agent onboarding ===");
   const profile = await pickProfile();
-  if (typeof profile?.appId !== "string" || !APP_ID.test(profile.appId) || profile.name !== profile.appId) {
-    die("profile name 与合法 App ID 必须完全一致；未修改 Agent 配置，请重新运行 larkin setup 刷新 profile");
+  if (typeof profile.appId !== "string" || !APP_ID.test(profile.appId)) {
+    die(`profile ${profile.name || "?"} 没有合法 App ID；未修改 Agent 配置`);
   }
+  say(`使用 profile ${profile.name} → App ID ${profile.appId}`);
+  requireUsableBotCredential(profile.appId);
   if (!options.profile) verifyBot(profile);
 
   const requestedAgent = options.agent || profile.appId;
@@ -287,15 +331,11 @@ export async function main(): Promise<void> {
   const selectedModel = selection?.runtime === "pi" && selection.distribution === "builtin" ? selection.model : undefined;
   const targetModelId = selectedModel || (prior?.runtime === runtime ? prior.model : defaultModel);
   let runtimeModels = larkinConfig.loadRuntimeModels()[runtime];
-  if (runtime === "pi" && piDistribution === "builtin") {
-    runtimeModels = [{ id: targetModelId, supportedReasoningEfforts: [] }];
-  } else if (runtime === "pi") {
-    const piCatalog = await discoverPiModelCatalog({
-      cwd: layout.workspaceDir(profile.appId),
-      ...(process.env.PI_CODING_AGENT_DIR ? { agentDir: process.env.PI_CODING_AGENT_DIR } : {}),
-    });
-    const effective = piCatalog.models.find((model) => model.id === piCatalog.effectiveModel);
-    runtimeModels = [{ id: "default", supportedReasoningEfforts: effective?.supportedReasoningEfforts || [] }, ...piCatalog.models];
+  if (runtime === "pi") {
+    const preservedEffort = prior?.runtime === "pi" && typeof prior.effort === "string" && prior.effort.trim()
+      ? [prior.effort]
+      : [];
+    runtimeModels = [{ id: targetModelId, supportedReasoningEfforts: preservedEffort }];
   }
   const targetModel = runtimeModels.find((model) => model.id === targetModelId);
   if (!targetModel) die(`目标模型 ${runtime}/${targetModelId} 不在 runtime 模型目录中；未修改 Agent 配置`);
@@ -304,7 +344,7 @@ export async function main(): Promise<void> {
     profile,
     requestedAgent,
     runtime: selection?.runtime || options.runtime,
-    ...(selection?.runtime === "pi" ? { piDistribution: selection.distribution } : {}),
+    ...(runtime === "pi" && piDistribution ? { piDistribution } : {}),
     ...(selectedModel ? { model: selectedModel } : {}),
     defaultModel,
     supportedReasoningEfforts: targetModel!.supportedReasoningEfforts || [],

--- a/src/setup/setup-official-cli-register.ts
+++ b/src/setup/setup-official-cli-register.ts
@@ -1,0 +1,84 @@
+import { spawn as systemSpawn, type ChildProcess } from "node:child_process";
+import type { OfficialLarkCliCommand } from "../app/official-lark-cli.js";
+import type { LarkinTenant } from "../feishu/platform-hosts.js";
+
+export interface OfficialCliInitResult {
+  appId: string;
+  authorizationUrl: string;
+  brand: LarkinTenant;
+}
+
+const APP_ID = /^cli_[A-Za-z0-9]+$/;
+const SETUP_URL = /https:\/\/open\.(?:larksuite\.com|feishu\.cn)\/page\/cli\?[^\s]+/;
+
+export function parseOfficialCliAuthorizationUrl(text: string): string | null {
+  return text.match(SETUP_URL)?.[0] ?? null;
+}
+
+export function parseOfficialCliInitOutput(text: string): OfficialCliInitResult {
+  const authorizationUrl = parseOfficialCliAuthorizationUrl(text);
+  const appId = text.match(/App ID:\s*(cli_[A-Za-z0-9]+)/)?.[1]
+    || text.match(/"appId"\s*:\s*"(cli_[A-Za-z0-9]+)"/)?.[1];
+  const brand = text.match(/"brand"\s*:\s*"(lark|feishu)"/)?.[1] as LarkinTenant | undefined;
+  if (!authorizationUrl) throw new Error("官方 lark-cli init 未返回 /page/cli 授权链接");
+  if (!appId || !APP_ID.test(appId)) throw new Error("官方 lark-cli init 未返回合法 App ID");
+  if (brand !== "lark" && brand !== "feishu") throw new Error("官方 lark-cli init 未返回合法 brand");
+  return { appId, authorizationUrl, brand };
+}
+
+export function officialCliInitArgs(tenant: LarkinTenant, profileName: string): string[] {
+  if (!/^[A-Za-z0-9._-]{1,64}$/.test(profileName)) throw new Error("lark-cli profile name 非法");
+  return ["config", "init", "--new", "--brand", tenant, "--name", profileName];
+}
+
+export async function runOfficialCliAppInit(input: {
+  tenant: LarkinTenant;
+  official: OfficialLarkCliCommand;
+  profileName: string;
+  env: NodeJS.ProcessEnv;
+  onAuthorizationUrl: (url: string) => void;
+  spawnImpl?: typeof systemSpawn;
+  signal?: AbortSignal;
+  onChild?: (child: ChildProcess | null) => void;
+}): Promise<OfficialCliInitResult> {
+  const args = [...input.official.argsPrefix, ...officialCliInitArgs(input.tenant, input.profileName)];
+  const child = (input.spawnImpl ?? systemSpawn)(input.official.command, args, {
+    env: input.env,
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+  input.onChild?.(child);
+  let output = "";
+  let presented = false;
+  const consume = (chunk: Buffer | string): void => {
+    output += String(chunk);
+    if (presented) return;
+    const url = parseOfficialCliAuthorizationUrl(output);
+    if (!url) return;
+    presented = true;
+    input.onAuthorizationUrl(url);
+  };
+  child.stdout?.on("data", consume);
+  child.stderr?.on("data", consume);
+  const abort = (): void => {
+    child.kill("SIGTERM");
+    const killTimer = setTimeout(() => {
+      if (child.exitCode === null && child.signalCode === null) child.kill("SIGKILL");
+    }, 1_000);
+    killTimer.unref?.();
+  };
+  if (input.signal?.aborted) abort();
+  else input.signal?.addEventListener("abort", abort, { once: true });
+  try {
+    const status = await new Promise<number | null>((resolve, reject) => {
+      child.once("error", reject);
+      child.once("exit", (code) => resolve(code));
+    });
+    if (input.signal?.aborted) throw new Error("官方 lark-cli init 已取消");
+    const parsed = parseOfficialCliInitOutput(output);
+    if (status !== 0) throw new Error(`官方 lark-cli init 失败（exit=${status ?? "none"}）`);
+    return parsed;
+  } finally {
+    input.signal?.removeEventListener("abort", abort);
+    input.onChild?.(null);
+  }
+}

--- a/test/integration/app/strict-production-cutover.test.mjs
+++ b/test/integration/app/strict-production-cutover.test.mjs
@@ -64,7 +64,9 @@ test("bot credential verification pins lark-cli identity explicitly to bot", () 
   assert.match(register, /\[\.\.\.official\.argsPrefix, "im", "\+chat-list", "--as", "bot"\]/);
   assert.match(register, /synchronizeAgentProfile\(agent/);
   assert.match(bind, /\["--profile", profile\.name, "im", "\+chat-list", "--as", "bot", "--json"\]/);
-  assert.match(bind, /profile\.name !== profile\.appId/);
+  assert.match(bind, /不要求名字等于 App ID/);
+  assert.doesNotMatch(bind, /profile\.name !== profile\.appId/);
+  assert.match(bind, /loadValidatedBotCredential/);
 });
 
 test("run fails closed for missing or malformed App-ID bot credentials before daemon spawn", () => {

--- a/test/integration/setup/setup-cli.test.mjs
+++ b/test/integration/setup/setup-cli.test.mjs
@@ -267,6 +267,14 @@ assert.match(setupSource, /acquireProcessLock\(path\.join\(CFG_DIR, "setup\.lock
 assert.match(setupSource, /process\.on\("exit", releaseMutationLock\)/);
 assert.match(setupSource, /!OPT\.start[\s\S]*releaseMutationLock\(\)/);
 assert.match(setupSource, /requestAgentUpsert\(\{ larkinHome: CFG_DIR, agentId: selectedAgentId \}\)/);
+{
+  const registerChild = setupSource.indexOf('runForeground("bot-register"');
+  const scrubSecret = setupSource.indexOf("delete process.env.LARKIN_SETUP_APP_SECRET");
+  const upsert = setupSource.indexOf("requestAgentUpsert({ larkinHome: CFG_DIR, agentId: selectedAgentId })");
+  const startRun = setupSource.indexOf('runForeground("run"');
+  assert.equal(registerChild >= 0 && scrubSecret > registerChild, true, "setup must scrub App Secret after bot-register");
+  assert.equal(scrubSecret < upsert && scrubSecret < startRun, true, "App Secret must not reach daemon upsert or supervisor start");
+}
 assert.doesNotMatch(setupSource, /stopDaemonForReload|terminateOwnedProcess|dashboard\.mjs/);
 assert.doesNotMatch(setupSource, /\bpreviousAgentId\b|\binferRunningAgents\b|workspace-service|reconcileAgentWorkspace/);
 assert.doesNotMatch(setupSource, /flag\("--app-id"\)|OPT\.appId/);

--- a/test/integration/setup/setup-single-root.test.mjs
+++ b/test/integration/setup/setup-single-root.test.mjs
@@ -180,10 +180,20 @@ else console.log(JSON.stringify({ ok: true, identity: "bot", data: { chats: [] }
 `, { mode: 0o755 });
 }
 
+function writeBotCredential(root, appId = APP) {
+  const botsDir = path.join(root, "bots");
+  fs.mkdirSync(botsDir, { recursive: true, mode: 0o700 });
+  fs.chmodSync(botsDir, 0o700);
+  fs.writeFileSync(path.join(botsDir, `${appId}.json`), `${JSON.stringify({
+    appId, appSecret: "secret-value", tenant: "feishu",
+  }, null, 2)}\n`, { mode: 0o600 });
+}
+
 function runFreshSetupWithRuntime(runtime) {
   const root = fs.mkdtempSync(path.join(os.tmpdir(), "larkin-setup-runtime-"));
   const binDir = path.join(root, "bin");
   writeStubLarkCli(binDir);
+  writeBotCredential(root);
   const result = spawnSync(process.execPath, [
     path.join(ROOT, "dist/setup/setup-bind.mjs"), "--profile", APP, "--agent", APP, "--runtime", runtime, "--yes",
   ], {
@@ -216,6 +226,7 @@ test("real setup-bind integration rewrites v3 config without a workspace symlink
     assert.equal(fs.existsSync(BUILT), true, "setup-binding build artifact must exist before integration");
     const binDir = path.join(root, "bin");
     writeStubLarkCli(binDir);
+    writeBotCredential(root);
     fs.writeFileSync(path.join(root, "config.json"), JSON.stringify(twoAgentConfig(), null, 2) + "\n", { mode: 0o600 });
     const result = spawnSync(process.execPath, [
       path.join(ROOT, "dist/setup/setup-bind.mjs"), "--profile", APP, "--agent", APP, "--yes",

--- a/test/unit/setup/bot-register-tenant-urls.test.mjs
+++ b/test/unit/setup/bot-register-tenant-urls.test.mjs
@@ -8,20 +8,40 @@ import { test } from "bun:test";
 
 const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../../..");
 const ENTRY = path.join(ROOT, "dist/setup/bot-register.mjs");
+const EXPECTED_TENANT_EVENTS = ["im.message.receive_v1", "im.message.message_read_v1", "drive.notice.comment_add_v1"];
+const EXPECTED_CALLBACKS = ["card.action.trigger"];
 
-function runRegister({ tenantArgs = [], userInfo = { tenant_brand: "feishu" }, clientId = "not-an-app-id" } = {}) {
+function assertLarkinRegisterAddons(addons) {
+  assert.equal(addons == null, false);
+  assert.deepEqual(addons.events.items.tenant, EXPECTED_TENANT_EVENTS);
+  assert.deepEqual(addons.callbacks.items, EXPECTED_CALLBACKS);
+  for (const scope of ["im:message", "im:message:send_as_bot", "drive:drive", "docs:document.comment:create", "docs:document.comment:read"]) {
+    assert.equal(addons.scopes.tenant.includes(scope), true, `missing tenant scope ${scope}`);
+  }
+}
+
+function runRegister({
+  tenantArgs = [],
+  userInfo = { tenant_brand: "feishu" },
+  clientId = "not-an-app-id",
+  extraEnv = {},
+  fixtureExtra = "",
+} = {}) {
   const temp = fs.mkdtempSync(path.join(os.tmpdir(), "larkin-bot-register-tenant-"));
   const configDir = path.join(temp, "config");
   fs.mkdirSync(configDir, { recursive: true, mode: 0o700 });
   const marker = path.join(temp, "register.json");
   const qrMarker = path.join(temp, "qr.txt");
+  const initMarker = path.join(temp, "init.json");
   const fixture = path.join(temp, "fixture.cjs");
   fs.writeFileSync(fixture, `const fs = require("node:fs");
+const { EventEmitter } = require("node:events");
 module.exports = {
   registerApp: async (opts) => {
     fs.writeFileSync(process.env.REGISTER_MARKER, JSON.stringify({
       domain: opts.domain,
       larkDomain: opts.larkDomain,
+      addons: opts.addons ?? null,
     }));
     const url = "https://" + opts.domain + "/oauth/v1/app/registration?code=fixture";
     fs.writeFileSync(process.env.QR_MARKER, url);
@@ -33,7 +53,9 @@ module.exports = {
     };
   },
   qrcode: { generate() {} },
+  resolveOfficialLarkCli() { throw new Error("official cli blocked in tenant url test"); },
   spawnSync() { return { status: 1, stdout: "", stderr: "blocked" }; },
+  ${fixtureExtra}
 };
 `);
   const result = spawnSync(process.execPath, [ENTRY, "--auto", ...tenantArgs], {
@@ -48,25 +70,75 @@ module.exports = {
       LARKIN_TEST_BOT_REGISTER_MODULE: fixture,
       REGISTER_MARKER: marker,
       QR_MARKER: qrMarker,
+      INIT_MARKER: initMarker,
+      ...extraEnv,
     },
   });
-  return { temp, configDir, marker, qrMarker, result };
+  return { temp, configDir, marker, qrMarker, initMarker, result };
 }
 
-test("--tenant lark passes official Lark accounts hosts and the QR URL has no feishu.cn", () => {
-  const { temp, marker, qrMarker, result } = runRegister({
+test("--tenant lark bootstraps Feishu accounts and presents /page/cli, not launcher", () => {
+  const fixtureExtra = `
+  resolveOfficialLarkCli() { return { command: "lark-cli", argsPrefix: [], version: "1.0.87" }; },
+  registerApp: async (opts) => {
+    fs.writeFileSync(process.env.REGISTER_MARKER, JSON.stringify({
+      domain: opts.domain,
+      larkDomain: opts.larkDomain,
+      addons: opts.addons ?? null,
+    }));
+    const url = "https://open.feishu.cn/page/launcher?user_code=YKDY-TZ7Q&from=sdk&addons=H4sI";
+    fs.writeFileSync(process.env.QR_MARKER, url);
+    opts.onQRCodeReady({ url, expireIn: 60 });
+    return {
+      client_id: "cli_aa0e2efcc0b89e14",
+      client_secret: "fixture-secret",
+      user_info: { tenant_brand: "lark" },
+    };
+  },
+`;
+  const { temp, marker, result } = runRegister({
     tenantArgs: ["--tenant", "lark"],
     userInfo: { tenant_brand: "lark" },
+    fixtureExtra,
   });
   try {
-    assert.notEqual(result.status, 0);
+    assert.notEqual(result.status, 0, result.stderr);
     const opts = JSON.parse(fs.readFileSync(marker, "utf8"));
-    assert.equal(opts.domain, "accounts.larksuite.com");
+    assert.equal(opts.domain, "accounts.feishu.cn");
     assert.equal(opts.larkDomain, "accounts.larksuite.com");
-    const url = fs.readFileSync(qrMarker, "utf8");
-    assert.match(url, /accounts\.larksuite\.com/);
-    assert.doesNotMatch(url, /feishu\.cn/);
-    assert.doesNotMatch(JSON.stringify(opts), /feishu\.cn/);
+    assertLarkinRegisterAddons(opts.addons);
+    const text = `${result.stdout}\n${result.stderr}`;
+    assert.match(text, /https:\/\/open\.larksuite\.com\/page\/cli\?user_code=YKDY-TZ7Q/);
+    assert.match(text, /from=cli/);
+    assert.match(text, /[?&]addons=H4sI/);
+    assert.doesNotMatch(text, /open\.larksuite\.com\/page\/launcher/);
+    assert.doesNotMatch(text, /LARKIN_SETUP_APP_SECRET/);
+  } finally { fs.rmSync(temp, { recursive: true, force: true }); }
+});
+
+test("--from-cli-profile binds without opening /page/launcher", () => {
+  const fixtureExtra = `
+  resolveOfficialLarkCli() { return { command: "lark-cli", argsPrefix: [], version: "1.0.87" }; },
+  spawnSync(command, args) {
+    if (args.includes("profile") && args.includes("list")) {
+      return { status: 0, stdout: JSON.stringify([{ name: "aisa", appId: "cli_aa0e2efcc0b89e14", brand: "lark" }]), stderr: "" };
+    }
+    return { status: 1, stdout: "", stderr: "blocked" };
+  },
+`;
+  const { temp, configDir, marker, qrMarker, result } = runRegister({
+    tenantArgs: ["--tenant", "lark", "--from-cli-profile", "aisa"],
+    extraEnv: { LARKIN_SETUP_APP_SECRET: "fixture-from-profile-secret" },
+    fixtureExtra,
+  });
+  try {
+    assert.notEqual(result.status, 0, result.stderr);
+    assert.equal(fs.existsSync(marker), false);
+    assert.equal(fs.existsSync(qrMarker), false);
+    const text = `${result.stdout}\n${result.stderr}`;
+    assert.match(text, /复用官方 lark-cli profile aisa/);
+    assert.doesNotMatch(text, /page\/launcher|page\/cli/);
+    assert.equal(fs.existsSync(path.join(configDir, "bots", "cli_aa0e2efcc0b89e14.json")), true);
   } finally { fs.rmSync(temp, { recursive: true, force: true }); }
 });
 
@@ -78,6 +150,7 @@ test("default and --tenant feishu stay on official China accounts hosts", () => 
       const opts = JSON.parse(fs.readFileSync(marker, "utf8"));
       assert.equal(opts.domain, "accounts.feishu.cn");
       assert.equal(opts.larkDomain, "accounts.larksuite.com");
+      assertLarkinRegisterAddons(opts.addons);
       const url = fs.readFileSync(qrMarker, "utf8");
       assert.match(url, /accounts\.feishu\.cn/);
       assert.doesNotMatch(url, /larksuite\.com/);
@@ -87,8 +160,8 @@ test("default and --tenant feishu stay on official China accounts hosts", () => 
 
 test("conflicting user_info.tenant_brand fails closed without writing credentials", () => {
   const { temp, configDir, result } = runRegister({
-    tenantArgs: ["--tenant", "lark"],
-    userInfo: { tenant_brand: "feishu", open_id: "ou_conflict" },
+    tenantArgs: ["--tenant", "feishu"],
+    userInfo: { tenant_brand: "lark", open_id: "ou_conflict" },
     clientId: "cli_conflictTenantA1",
   });
   try {

--- a/test/unit/setup/bot-register-typescript.test.mjs
+++ b/test/unit/setup/bot-register-typescript.test.mjs
@@ -67,7 +67,9 @@ test("registration publishes the credential before binding, then verifies the bo
     "comment subscription reconciliation must keep the credential heartbeat event loop live");
   assert.match(source, /synchronizeAgentProfile\([\s\S]*\{ forceRebind: true \}\)/,
     "new setup credentials must explicitly force one authoritative rebind");
-  assert.doesNotMatch(source, /config["', ]+init/);
+  assert.match(source, /presentAuthorizationUrl/);
+  assert.match(source, /page\/cli/);
+  assert.match(source, /--from-cli-profile/);
   assert.match(source, /mode: 0o700/);
   assert.match(source, /mode: 0o600, flag: "wx"/);
   assert.match(source, /JSON\.stringify\(\{ \.\.\.raw, runtime: "pi", model: validated\.model, authCompleted: true, readinessCompleted: true \}\)/,

--- a/test/unit/setup/setup-authorization-url.test.mjs
+++ b/test/unit/setup/setup-authorization-url.test.mjs
@@ -1,0 +1,96 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath, pathToFileURL } from "node:url";
+import { test } from "bun:test";
+
+const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../../..");
+const mod = await import(pathToFileURL(path.join(ROOT, "dist/setup/setup-authorization-url.mjs")).href);
+const cli = await import(pathToFileURL(path.join(ROOT, "dist/setup/setup-official-cli-register.mjs")).href);
+
+test("official CLI setup URL stays on the Lark open host and uses /page/cli", () => {
+  const url = mod.officialCliSetupUrl({ tenant: "lark", userCode: "AB12-CD34", larkCliVersion: "1.0.87" });
+  assert.equal(url, "https://open.larksuite.com/page/cli?user_code=AB12-CD34&lpv=1.0.87&ocv=1.0.87&from=cli");
+  assert.doesNotMatch(url, /page\/launcher|feishu\.cn|addons=/);
+});
+
+test("presentAuthorizationUrl rewrites the broken Lark launcher to /page/cli", () => {
+  const raw = "https://open.larksuite.com/page/launcher?user_code=YKDY-TZ7Q&from=sdk&source=node-sdk%2Flarkin&tp=sdk&addons=H4sI";
+  const presented = mod.presentAuthorizationUrl(raw, { tenant: "lark", larkCliVersion: "1.0.87" });
+  const parsed = new URL(presented);
+  assert.equal(parsed.origin + parsed.pathname, "https://open.larksuite.com/page/cli");
+  assert.equal(parsed.searchParams.get("user_code"), "YKDY-TZ7Q");
+  assert.equal(parsed.searchParams.get("from"), "cli");
+  assert.equal(parsed.searchParams.get("lpv"), "1.0.87");
+  assert.equal(parsed.searchParams.get("ocv"), "1.0.87");
+  assert.equal(parsed.searchParams.get("addons"), "H4sI");
+  assert.doesNotMatch(presented, /page\/launcher/);
+});
+
+test("presentAuthorizationUrl rejects a launcher-only Lark URL", () => {
+  assert.throws(
+    () => mod.presentAuthorizationUrl("https://open.larksuite.com/page/launcher?from=sdk", {
+      tenant: "lark",
+      larkCliVersion: "1.0.87",
+    }),
+    /Lark 租户拒绝把 \/page\/launcher 交给浏览器/,
+  );
+});
+
+test("presentAuthorizationUrl leaves Feishu launcher URLs unchanged", () => {
+  const raw = "https://open.feishu.cn/page/launcher?user_code=AB12-CD34&from=sdk&source=node-sdk%2Flarkin&tp=sdk&addons=H4sI";
+  const presented = mod.presentAuthorizationUrl(raw, { tenant: "feishu", larkCliVersion: "1.0.87" });
+  assert.equal(presented, raw);
+  assert.match(presented, /open\.feishu\.cn\/page\/launcher/);
+  assert.doesNotMatch(presented, /page\/cli|larksuite\.com/);
+});
+
+test("authorization failure message names launcher ack 10074", () => {
+  const message = mod.authorizationUrlFailureMessage({ code: "10074", message: "ack failed", description: "链接已失效" });
+  assert.match(message, /10074/);
+  assert.match(message, /page\/cli/);
+  assert.match(message, /page\/launcher/);
+});
+
+test("official lark-cli init parser requires /page/cli and an App ID", () => {
+  const parsed = cli.parseOfficialCliInitOutput([
+    "打开以下链接配置应用:",
+    "  https://open.larksuite.com/page/cli?user_code=E8G6-ZK7L&lpv=1.0.87&ocv=1.0.87&from=cli",
+    'OK: 应用配置成功! App ID: cli_aa0e2efcc0b89e14',
+    '{"appId":"cli_aa0e2efcc0b89e14","appSecret":"****","brand":"lark"}',
+  ].join("\n"));
+  assert.equal(parsed.appId, "cli_aa0e2efcc0b89e14");
+  assert.equal(parsed.brand, "lark");
+  assert.match(parsed.authorizationUrl, /\/page\/cli\?user_code=E8G6-ZK7L/);
+  assert.deepEqual(cli.officialCliInitArgs("lark", "larkin-setup-1"), [
+    "config", "init", "--new", "--brand", "lark", "--name", "larkin-setup-1",
+  ]);
+  assert.throws(() => cli.parseOfficialCliInitOutput("https://open.larksuite.com/page/launcher?user_code=AAAA-BBBB"), /\/page\/cli/);
+  assert.throws(() => cli.parseOfficialCliInitOutput("App ID: cli_aa0e2efcc0b89e14\nhttps://open.larksuite.com/page/launcher?user_code=AAAA-BBBB"), /\/page\/cli/);
+  assert.throws(() => cli.parseOfficialCliInitOutput([
+    "https://open.larksuite.com/page/cli?user_code=E8G6-ZK7L&lpv=1.0.87&ocv=1.0.87&from=cli",
+    "App ID: cli_aa0e2efcc0b89e14",
+  ].join("\n")), /brand/);
+});
+
+test("bot-register wires Lark to /page/cli QR and keeps Feishu on launcher registerApp", () => {
+  const shippedRegister = fs.readFileSync(path.join(ROOT, "dist/setup/bot-register.mjs"), "utf8");
+  const larkStart = shippedRegister.indexOf('else if (selectedTenant === "lark")');
+  const larkCall = shippedRegister.indexOf("result = await registerApp({", larkStart);
+  const feishuCall = shippedRegister.indexOf("result = await registerApp({", larkCall + 1);
+  assert.notEqual(larkStart, -1);
+  assert.notEqual(larkCall, -1);
+  assert.notEqual(feishuCall, -1);
+  const larkBranch = shippedRegister.slice(larkStart, feishuCall);
+  const feishuBranch = shippedRegister.slice(feishuCall, feishuCall + 1600);
+  assert.match(larkBranch, /presentAuthorizationUrl/);
+  assert.match(larkBranch, /registerAppAccountsHost\("feishu"\)/);
+  assert.match(larkBranch, /page\/cli/);
+  assert.match(larkBranch, /addons: LARKIN_REGISTER_ADDONS/);
+  assert.doesNotMatch(larkBranch, /runOfficialCliAppInit|LARKIN_SETUP_APP_SECRET/);
+  assert.doesNotMatch(larkBranch, /presentUrl\([^)]*launcher/);
+  assert.match(feishuBranch, /registerApp\(/);
+  assert.match(feishuBranch, /addons: LARKIN_REGISTER_ADDONS/);
+  assert.match(feishuBranch, /presentUrl\(url, expireIn\)/);
+  assert.doesNotMatch(feishuBranch, /presentAuthorizationUrl|page\/cli/);
+});

--- a/test/unit/setup/setup-bind-typescript.test.mjs
+++ b/test/unit/setup/setup-bind-typescript.test.mjs
@@ -11,26 +11,54 @@ const SOURCE = path.join(ROOT, "src/setup/setup-bind.ts");
 const BUILT = path.join(ROOT, "dist/setup/setup-bind.mjs");
 const ENTRY = path.join(ROOT, "dist/setup/setup-bind.mjs");
 const APP = "cli_setupBindA1";
+const NAMED_APP = "cli_namedProfileA1";
 
-function writeLarkCliStub(binDir) {
+function writeOfficialLarkCliStub(root, profiles = [{ name: APP, appId: APP, active: true }]) {
+  const pkg = path.join(root, "official-cli");
+  const binDir = path.join(pkg, "bin");
   fs.mkdirSync(binDir, { recursive: true });
+  fs.writeFileSync(path.join(pkg, "package.json"), JSON.stringify({
+    name: "@larksuite/cli",
+    version: "1.0.87",
+    bin: { "lark-cli": "bin/lark-cli" },
+  }));
   fs.writeFileSync(path.join(binDir, "lark-cli"), `#!/usr/bin/env bun
 const args = process.argv.slice(2);
-if (args[0] === "profile" && args[1] === "list") {
-  console.log(JSON.stringify([{ name: ${JSON.stringify(APP)}, appId: ${JSON.stringify(APP)}, active: true }]));
-} else if (process.env.FAIL_BOT_VERIFY === "1") {
-  console.log(JSON.stringify({ ok: false, identity: "bot" }));
-  process.exitCode = 1;
-} else {
-  console.log(JSON.stringify({ ok: true, identity: "bot", data: { chats: [] } }));
+if (args[0] === "--version") {
+  console.log("1.0.87");
+  process.exit(0);
 }
+if (args[0] === "config" && args[1] === "bind" && args[2] === "--help") {
+  console.log("Usage: config bind --source lark-channel --identity bot-only");
+  process.exit(0);
+}
+if (args[0] === "profile" && args[1] === "list") {
+  console.log(JSON.stringify(${JSON.stringify(profiles)}));
+  process.exit(0);
+}
+if (process.env.FAIL_BOT_VERIFY === "1") {
+  console.log(JSON.stringify({ ok: false, identity: "bot" }));
+  process.exit(1);
+}
+console.log(JSON.stringify({ ok: true, identity: "bot", data: { chats: [] } }));
 `, { mode: 0o755 });
+  return binDir;
 }
 
-function runBind(root, extraEnv = {}) {
-  const binDir = path.join(root, "bin");
-  writeLarkCliStub(binDir);
-  return spawnSync(process.execPath, [ENTRY, "--profile", APP, "--agent", APP, "--runtime", "codex", "--yes"], {
+function writeCredential(root, appId = APP) {
+  const botsDir = path.join(root, "bots");
+  fs.mkdirSync(botsDir, { recursive: true, mode: 0o700 });
+  fs.chmodSync(botsDir, 0o700);
+  fs.writeFileSync(path.join(botsDir, `${appId}.json`), `${JSON.stringify({
+    appId,
+    appSecret: "secret-value",
+    tenant: "feishu",
+  }, null, 2)}\n`, { mode: 0o600 });
+}
+
+function runBind(root, extraEnv = {}, args = ["--profile", APP, "--agent", APP, "--runtime", "codex", "--yes"]) {
+  const binDir = writeOfficialLarkCliStub(root);
+  return spawnSync(process.execPath, [ENTRY, ...args], {
     cwd: ROOT,
     encoding: "utf8",
     env: {
@@ -46,10 +74,15 @@ function runBind(root, extraEnv = {}) {
 test("setup-bind is strict TypeScript compiled to its direct runtime entry", () => {
   assert.equal(fs.existsSync(SOURCE), true);
   assert.equal(fs.existsSync(BUILT), true);
+  const source = fs.readFileSync(SOURCE, "utf8");
   const entry = fs.readFileSync(ENTRY, "utf8");
   assert.match(entry, /^#!\/usr\/bin\/env bun/);
   assert.match(entry, /spawnSync|commitSetupConfig|fabricateAttachment|planSingleRootBinding/);
   assert.doesNotMatch(entry, /packages\/larkin-shell|fork\/feishu/);
+  assert.doesNotMatch(source, /profile\.name !== profile\.appId/);
+  assert.match(source, /不要求名字等于 App ID/);
+  assert.match(source, /loadValidatedBotCredential/);
+  assert.match(source, /preservedEffort/);
 });
 
 test("explicit App-ID setup-bind no longer depends on a legacy profile verification", () => {
@@ -58,6 +91,7 @@ test("explicit App-ID setup-bind no longer depends on a legacy profile verificat
     const configFile = path.join(root, "config.json");
     const before = `${JSON.stringify({ version: 3, serverId: "server-existing", activeAgent: null, agents: {} }, null, 2)}\n`;
     fs.writeFileSync(configFile, before, { mode: 0o600 });
+    writeCredential(root);
     const result = runBind(root, { FAIL_BOT_VERIFY: "1" });
     assert.equal(result.status, 0, result.stdout + result.stderr);
     assert.notEqual(fs.readFileSync(configFile, "utf8"), before);
@@ -67,9 +101,111 @@ test("explicit App-ID setup-bind no longer depends on a legacy profile verificat
   }
 });
 
+test("named lark-cli profile binds by App ID without requiring name === appId", () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "larkin-setup-bind-named-profile-"));
+  try {
+    const configFile = path.join(root, "config.json");
+    fs.writeFileSync(configFile, `${JSON.stringify({ version: 3, serverId: "server-existing", activeAgent: null, agents: {} }, null, 2)}\n`, { mode: 0o600 });
+    writeCredential(root, NAMED_APP);
+    const binDir = writeOfficialLarkCliStub(root, [{ name: "aisa", appId: NAMED_APP, active: true }]);
+    const result = spawnSync(process.execPath, [ENTRY, "--profile", "aisa", "--agent", NAMED_APP, "--runtime", "codex", "--yes"], {
+      cwd: ROOT,
+      encoding: "utf8",
+      env: {
+        ...process.env,
+        HOME: path.join(root, "home"),
+        LARKIN_CONFIG_DIR: root,
+        PATH: `${binDir}${path.delimiter}${process.env.PATH}`,
+      },
+    });
+    assert.equal(result.status, 0, result.stdout + result.stderr);
+    assert.match(result.stdout, /profile aisa → App ID cli_namedProfileA1/);
+    const stored = JSON.parse(fs.readFileSync(configFile, "utf8"));
+    assert.equal(stored.agents[NAMED_APP].runtime, "codex");
+    assert.deepEqual(Object.keys(stored.agents), [NAMED_APP]);
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("named-profile bind fails closed without bots/<appId>.json", () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "larkin-setup-bind-missing-cred-"));
+  try {
+    const configFile = path.join(root, "config.json");
+    const before = `${JSON.stringify({ version: 3, serverId: "server-existing", activeAgent: null, agents: {} }, null, 2)}\n`;
+    fs.writeFileSync(configFile, before, { mode: 0o600 });
+    const binDir = writeOfficialLarkCliStub(root, [{ name: "aisa", appId: NAMED_APP, active: true }]);
+    const result = spawnSync(process.execPath, [ENTRY, "--profile", "aisa", "--agent", NAMED_APP, "--runtime", "codex", "--yes"], {
+      cwd: ROOT,
+      encoding: "utf8",
+      env: {
+        ...process.env,
+        HOME: path.join(root, "home"),
+        LARKIN_CONFIG_DIR: root,
+        PATH: `${binDir}${path.delimiter}${process.env.PATH}`,
+      },
+    });
+    assert.notEqual(result.status, 0, result.stdout + result.stderr);
+    assert.match(`${result.stdout}\n${result.stderr}`, /没有可用的 bot 凭证/);
+    assert.equal(fs.readFileSync(configFile, "utf8"), before);
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("Pi rebind keeps a previously stored effort without spawning pi catalog", () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "larkin-setup-bind-pi-effort-"));
+  try {
+    const configFile = path.join(root, "config.json");
+    fs.writeFileSync(configFile, `${JSON.stringify({
+      version: 4,
+      serverId: "server-existing",
+      mentionPolicy: "require",
+      activeAgent: APP,
+      agents: {
+        [APP]: { runtime: "pi", model: "openai/gpt-5", effort: "high" },
+      },
+    }, null, 2)}\n`, { mode: 0o600 });
+    writeCredential(root);
+    const result = runBind(root, {}, ["--profile", APP, "--agent", APP, "--runtime", "pi", "--yes"]);
+    assert.equal(result.status, 0, result.stdout + result.stderr);
+    const stored = JSON.parse(fs.readFileSync(configFile, "utf8"));
+    assert.equal(stored.agents[APP].runtime, "pi");
+    assert.equal(stored.agents[APP].effort, "high");
+    assert.doesNotMatch(`${result.stdout}\n${result.stderr}`, /--mode rpc|discoverPiModelCatalog/);
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("switching a Codex agent to Pi does not carry Codex effort into the Pi catalog", () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "larkin-setup-bind-codex-to-pi-effort-"));
+  try {
+    const configFile = path.join(root, "config.json");
+    fs.writeFileSync(configFile, `${JSON.stringify({
+      version: 4,
+      serverId: "server-existing",
+      mentionPolicy: "require",
+      activeAgent: APP,
+      agents: {
+        [APP]: { runtime: "codex", model: "gpt-5.6-sol", effort: "high" },
+      },
+    }, null, 2)}\n`, { mode: 0o600 });
+    writeCredential(root);
+    const result = runBind(root, {}, ["--profile", APP, "--agent", APP, "--runtime", "pi", "--yes"]);
+    assert.equal(result.status, 0, result.stdout + result.stderr);
+    const stored = JSON.parse(fs.readFileSync(configFile, "utf8"));
+    assert.equal(stored.agents[APP].runtime, "pi");
+    assert.equal(Object.hasOwn(stored.agents[APP], "effort"), false);
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});
+
 test("successful binding writes one stable 0600 runner attachment and no workspace symlink", () => {
   const root = fs.mkdtempSync(path.join(os.tmpdir(), "larkin-setup-bind-attachment-"));
   try {
+    writeCredential(root);
     const first = runBind(root);
     assert.equal(first.status, 0, first.stderr || first.stdout);
     const stored = JSON.parse(fs.readFileSync(path.join(root, "config.json"), "utf8"));


### PR DESCRIPTION
## Summary
International Lark setup presented `/page/launcher`, which Aisa/SG ack rejects with HTTP 400 code 10074 (`链接已失效`).

This keeps the interactive QR path, but:
- begins the grant on Feishu accounts
- presents `https://open.larksuite.com/page/cli?...&from=cli` (never `/page/launcher`)
- copies the SDK `addons=` payload onto that URL so Lark still requests the same scopes/events/`card.action.trigger` as Feishu
- polls credentials back (no copy-secret as the main path)
- binds named lark-cli profiles without requiring `name === App ID`
- fails closed without `bots/<appId>.json`
- preserves Pi `effort` on rebind
- scrubs `LARKIN_SETUP_APP_SECRET` before daemon start

Feishu China stays on `registerApp` + `/page/launcher` + addons.

Bumps `0.4.10` → `0.4.11` because `v0.4.10` is already tagged at `89ff707`.

## Test plan
- [x] `bun test` tenant-url / setup-bind / cutover (twice)
- [x] `bun run test` (typecheck + build + frontend + unit + integration + e2e)
- [x] Codex 5.6 sol high + cursor-agent Fable 5: `VERDICT: SHIP`
- [x] `bun run publication:check:tree` (twice)
- [ ] CI `source-checks`