### PR TITLE
fix(comment): allow follow-up replies via body-hash delivery identity

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "larkin",
-  "version": "0.4.11",
+  "version": "0.4.12",
   "private": false,
   "larkinPackageRole": "npm-published",
   "files": [

--- a/src/app/cli.ts
+++ b/src/app/cli.ts
@@ -92,7 +92,7 @@ Reset replaces one idle, zero-backlog Runtime session. Recover is an explicit op
        larkin pi-auth logout <provider> [--agent <App ID>]
 Show non-sensitive official Pi credential metadata or remove one target provider credential.`,
   comment: `Usage: larkin comment reply --message-id <doc_comment_message_id> --text '<reply>' --json
-Reply once, as the Runtime-bound Bot, to the exact cloud-document comment locator supplied by canonical Inbox.`,
+Reply as the Runtime-bound Bot to the exact cloud-document comment locator supplied by canonical Inbox. Retrying the same body is idempotent; a different body appends a follow-up reply to the same comment.`,
   telemetry: `Usage: larkin telemetry <status|export|import|flush>
 Inspect the durable local trace queue, move an offline bundle, or upload queued OTLP traces.`,
 };

--- a/src/app/lark-cli.ts
+++ b/src/app/lark-cli.ts
@@ -338,10 +338,13 @@ function runCommentReply(
       const prior = state.document_comment_replies[ledgerKey]
         ?? (legacy?.digest === digest ? legacy : undefined);
       if (prior?.status === "sent") return "sent";
-      if (prior?.status === "sending") return "ambiguous";
+      const messageEntries = Object.entries(state.document_comment_replies)
+        .filter(([key]) => key === input.messageId || key.startsWith(`${input.messageId}::`));
+      if (messageEntries.some(([, entry]) => entry.status === "sending")) return "ambiguous";
       state.document_comment_replies[ledgerKey] = { digest, status: "sending", updated_at: new Date().toISOString() };
-      const keys = Object.keys(state.document_comment_replies);
-      for (const stale of keys.slice(0, Math.max(0, keys.length - 512))) delete state.document_comment_replies[stale];
+      const terminalKeys = Object.keys(state.document_comment_replies)
+        .filter((key) => state.document_comment_replies![key]?.status !== "sending");
+      for (const stale of terminalKeys.slice(0, Math.max(0, terminalKeys.length - 512))) delete state.document_comment_replies[stale];
       return "ready";
     },
   );

--- a/src/app/lark-cli.ts
+++ b/src/app/lark-cli.ts
@@ -330,14 +330,16 @@ function runCommentReply(
   if (!target) throw new Error("comment reply 无法从当前 Agent Inbox 绑定文档评论 locator；先 poll 该消息且不得跨 Agent/评论回复");
   if (!store.inboxTargetIsFresh(targetKey!)) throw new Error("comment reply 需要先 poll 当前 document-comment target 的最新 Inbox 消息");
   const digest = createHash("sha256").update(input.text).digest("hex");
-  const claim = store.mutateJson<CommentReplyLedger, "ready" | "sent" | "ambiguous" | "conflict">(
+  const ledgerKey = `${input.messageId}::${digest}`;
+  const claim = store.mutateJson<CommentReplyLedger, "ready" | "sent" | "ambiguous">(
     "freshnessState", { version: 1, cursors: {} }, (state) => {
       state.document_comment_replies ??= {};
-      const prior = state.document_comment_replies[input.messageId];
-      if (prior?.status === "sent" && prior.digest === digest) return "sent";
-      if (prior?.status === "sending" && prior.digest === digest) return "ambiguous";
-      if (prior && prior.status !== "failed" && prior.digest !== digest) return "conflict";
-      state.document_comment_replies[input.messageId] = { digest, status: "sending", updated_at: new Date().toISOString() };
+      const legacy = state.document_comment_replies[input.messageId];
+      const prior = state.document_comment_replies[ledgerKey]
+        ?? (legacy?.digest === digest ? legacy : undefined);
+      if (prior?.status === "sent") return "sent";
+      if (prior?.status === "sending") return "ambiguous";
+      state.document_comment_replies[ledgerKey] = { digest, status: "sending", updated_at: new Date().toISOString() };
       const keys = Object.keys(state.document_comment_replies);
       for (const stale of keys.slice(0, Math.max(0, keys.length - 512))) delete state.document_comment_replies[stale];
       return "ready";
@@ -347,8 +349,7 @@ function runCommentReply(
     io.stdout(`${JSON.stringify({ ok: true, identity: "bot", committed: true, duplicate: true, target: targetKey })}\n`);
     return 0;
   }
-  if (claim === "ambiguous") throw new Error("comment reply 上次调用结果不明确，已 fail-closed 以避免重复评论；请由用户检查原评论线程");
-  if (claim === "conflict") throw new Error("comment reply 已为同一 Inbox 消息提交不同正文，拒绝覆盖或重复发送");
+  if (claim === "ambiguous") throw new Error("comment reply 上次调用结果不明确，已 fail-closed 以避免重复评论；请勿改写正文重试，请由用户检查原评论线程");
   const nativeArgs = target.topLevel
     ? [
         "drive", "file.comments", "create_v2",
@@ -375,7 +376,7 @@ function runCommentReply(
   if (terminalStatus) {
     store.mutateJson<CommentReplyLedger, void>("freshnessState", { version: 1, cursors: {} }, (state) => {
       state.document_comment_replies ??= {};
-      state.document_comment_replies[input.messageId] = {
+      state.document_comment_replies[ledgerKey] = {
         digest,
         status: terminalStatus,
         updated_at: new Date().toISOString(),

--- a/test/unit/app/lark-cli-launcher.test.mjs
+++ b/test/unit/app/lark-cli-launcher.test.mjs
@@ -1,4 +1,5 @@
 import assert from "node:assert/strict";
+import { createHash } from "node:crypto";
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
@@ -77,7 +78,7 @@ test("launcher classifies protected writes, removed drafts, bypasses, and observ
   ]).kind, "passthrough", "native help remains observational even for unsupported write flags");
 });
 
-test("document comment reply is bound to a polled Inbox locator, Bot identity, exact route, and local idempotency ledger", () => {
+test("document comment reply uses body-hash delivery identity for same-locator follow-ups", () => {
   const f = fixture();
   try {
     const messageId = `doc_comment_${"a".repeat(32)}`;
@@ -108,12 +109,17 @@ test("document comment reply is bound to a polled Inbox locator, Bot identity, e
     assert.equal(duplicate.code, 0);
     assert.match(duplicate.stdout, /"duplicate":true/);
     assert.equal(f.calls.length, 1, "committed reply must not reach the provider twice");
-    assert.equal(f.run(["comment", "reply", "--message-id", messageId, "--text", "changed", "--json"]).code, 2);
-    assert.equal(f.calls.length, 1);
+    const changed = f.run(["comment", "reply", "--message-id", messageId, "--text", "changed", "--json"]);
+    assert.equal(changed.code, 0, changed.stderr);
+    assert.equal(f.calls.length, 2, "a different body appends a follow-up on the same locator");
+    assert.equal(f.calls[1].args.includes("--idempotency-key"), false);
+    const ledger = f.store.readJson("freshnessState", {}).document_comment_replies;
+    assert.equal(Object.keys(ledger).length, 2);
+    assert.ok(Object.keys(ledger).every((key) => key.startsWith(`${messageId}::`)));
   } finally { fs.rmSync(f.root, { recursive: true, force: true }); }
 });
 
-test("whole-document Inbox locators select the explicit top-level fallback and reject guessed messages", () => {
+test("whole-document Inbox locators route same-locator follow-ups through create_v2", () => {
   const f = fixture();
   try {
     const messageId = `doc_comment_${"b".repeat(32)}`;
@@ -131,8 +137,17 @@ test("whole-document Inbox locators select the explicit top-level fallback and r
       reply_elements: [{ type: "text", text: "answer" }],
     });
     assert.equal(native[native.indexOf("--as") + 1], "bot");
+    const followUp = f.run(["comment", "reply", "--message-id", messageId, "--text", "follow-up"]);
+    assert.equal(followUp.code, 0, followUp.stderr);
+    assert.equal(f.calls.length, 2);
+    const followUpNative = f.calls[1].args.slice(1);
+    assert.deepEqual(JSON.parse(followUpNative[followUpNative.indexOf("--data") + 1]), {
+      file_type: "sheet",
+      reply_elements: [{ type: "text", text: "follow-up" }],
+    });
+    assert.equal(followUpNative.includes("--idempotency-key"), false);
     assert.equal(f.run(["comment", "reply", "--message-id", `doc_comment_${"c".repeat(32)}`, "--text", "answer"]).code, 2);
-    assert.equal(f.calls.length, 1);
+    assert.equal(f.calls.length, 2);
   } finally { fs.rmSync(f.root, { recursive: true, force: true }); }
 });
 
@@ -152,11 +167,17 @@ test("document comment reply retains ambiguous native outcomes as sending and re
       f.store.pollInbox({ target, limit: 1 });
       f.setWriteResult(result);
       assert.notEqual(f.run(["comment", "reply", "--message-id", messageId, "--text", "answer"]).code, 0);
-      assert.equal(f.store.readJson("freshnessState", {}).document_comment_replies[messageId].status, "sending");
+      const ledger = f.store.readJson("freshnessState", {}).document_comment_replies;
+      assert.equal(Object.values(ledger)[0].status, "sending");
+      assert.ok(Object.keys(ledger)[0].startsWith(`${messageId}::`));
       const retry = f.run(["comment", "reply", "--message-id", messageId, "--text", "answer"]);
       assert.equal(retry.code, 2);
       assert.match(retry.stderr, /结果不明确/);
-      assert.equal(f.calls.length, 1, "ambiguous outcome must never resend");
+      assert.equal(f.calls.length, 1, "ambiguous outcome must never resend same body");
+      f.setWriteResult({ status: 0, signal: null, output: [], pid: 1, stdout: "{}\n", stderr: "", error: undefined });
+      const completion = f.run(["comment", "reply", "--message-id", messageId, "--text", "completion"]);
+      assert.equal(completion.code, 0, completion.stderr);
+      assert.equal(f.calls.length, 2, "a different body remains a separate delivery identity");
     } finally { fs.rmSync(f.root, { recursive: true, force: true }); }
   }
 
@@ -170,10 +191,51 @@ test("document comment reply retains ambiguous native outcomes as sending and re
       ok: false, error: { code: 1069302, message: "provider rejected" },
     }), error: undefined });
     assert.equal(rejected.run(["comment", "reply", "--message-id", messageId, "--text", "answer"]).code, 7);
-    assert.equal(rejected.store.readJson("freshnessState", {}).document_comment_replies[messageId].status, "failed");
+    const rejectedLedger = rejected.store.readJson("freshnessState", {}).document_comment_replies;
+    assert.equal(Object.values(rejectedLedger)[0].status, "failed");
     assert.equal(rejected.run(["comment", "reply", "--message-id", messageId, "--text", "answer"]).code, 7);
     assert.equal(rejected.calls.length, 2, "definitive provider rejection may be retried");
   } finally { fs.rmSync(rejected.root, { recursive: true, force: true }); }
+});
+
+test("comment reply rejects synthetic idempotency keys without invoking the provider", () => {
+  const f = fixture();
+  try {
+    const messageId = `doc_comment_${"f".repeat(32)}`;
+    const target = "document-comment:docx:doc_tokenF:comment_F:in-thread";
+    f.store.appendInboxOnce({ message_id: messageId, target, kind: "document_comment", content: "question" });
+    f.store.pollInbox({ target, limit: 1 });
+    const result = f.run(["comment", "reply", "--message-id", messageId, "--text", "answer", "--idempotency-key", "legacy-key"]);
+    assert.equal(result.code, 2);
+    assert.match(result.stderr, /不支持参数 --idempotency-key/);
+    assert.equal(f.calls.length, 0);
+    assert.equal(f.store.readJson("freshnessState", {}).document_comment_replies, undefined);
+  } finally { fs.rmSync(f.root, { recursive: true, force: true }); }
+});
+
+test("legacy bare message-id ledger entries migrate by same digest and allow follow-ups", () => {
+  const f = fixture();
+  try {
+    const messageId = `doc_comment_${"7".repeat(32)}`;
+    const target = "document-comment:docx:doc_tokenG:comment_G:in-thread";
+    const text = "legacy answer";
+    f.store.appendInboxOnce({ message_id: messageId, target, kind: "document_comment", content: "question" });
+    f.store.pollInbox({ target, limit: 1 });
+    f.store.writeJson("freshnessState", { version: 1, cursors: {}, document_comment_replies: {
+      [messageId]: { digest: createHash("sha256").update(text).digest("hex"), status: "sent", updated_at: new Date().toISOString() },
+    }});
+    const duplicate = f.run(["comment", "reply", "--message-id", messageId, "--text", text]);
+    assert.equal(duplicate.code, 0, duplicate.stderr);
+    assert.match(duplicate.stdout, /"duplicate":true/);
+    assert.equal(f.calls.length, 0);
+    f.setWriteResult({ status: 0, signal: null, output: [], pid: 1, stdout: "{}\n", stderr: "", error: undefined });
+    const followUp = f.run(["comment", "reply", "--message-id", messageId, "--text", "new answer"]);
+    assert.equal(followUp.code, 0, followUp.stderr);
+    assert.equal(f.calls.length, 1);
+    const ledger = f.store.readJson("freshnessState", {}).document_comment_replies;
+    assert.equal(ledger[messageId].status, "sent");
+    assert.equal(Object.keys(ledger).length, 2);
+  } finally { fs.rmSync(f.root, { recursive: true, force: true }); }
 });
 
 test("guarded writes probe with locked Bot identity before preserving provider write bytes", () => {

--- a/test/unit/app/lark-cli-launcher.test.mjs
+++ b/test/unit/app/lark-cli-launcher.test.mjs
@@ -174,10 +174,11 @@ test("document comment reply retains ambiguous native outcomes as sending and re
       assert.equal(retry.code, 2);
       assert.match(retry.stderr, /结果不明确/);
       assert.equal(f.calls.length, 1, "ambiguous outcome must never resend same body");
-      f.setWriteResult({ status: 0, signal: null, output: [], pid: 1, stdout: "{}\n", stderr: "", error: undefined });
-      const completion = f.run(["comment", "reply", "--message-id", messageId, "--text", "completion"]);
-      assert.equal(completion.code, 0, completion.stderr);
-      assert.equal(f.calls.length, 2, "a different body remains a separate delivery identity");
+      const changed = f.run(["comment", "reply", "--message-id", messageId, "--text", "changed"]);
+      assert.equal(changed.code, 2);
+      assert.match(changed.stderr, /请勿改写正文重试/);
+      assert.match(changed.stderr, /检查原评论线程/);
+      assert.equal(f.calls.length, 1, "an unresolved body blocks changed-body retries before the provider");
     } finally { fs.rmSync(f.root, { recursive: true, force: true }); }
   }
 
@@ -195,6 +196,8 @@ test("document comment reply retains ambiguous native outcomes as sending and re
     assert.equal(Object.values(rejectedLedger)[0].status, "failed");
     assert.equal(rejected.run(["comment", "reply", "--message-id", messageId, "--text", "answer"]).code, 7);
     assert.equal(rejected.calls.length, 2, "definitive provider rejection may be retried");
+    assert.equal(rejected.run(["comment", "reply", "--message-id", messageId, "--text", "changed"]).code, 7);
+    assert.equal(rejected.calls.length, 3, "a changed body is allowed once all prior identities are terminal");
   } finally { fs.rmSync(rejected.root, { recursive: true, force: true }); }
 });
 

--- a/test/unit/feishu/host-document-comment.test.mjs
+++ b/test/unit/feishu/host-document-comment.test.mjs
@@ -227,10 +227,10 @@ test("document comment Mock workflow traces safe rejection, pending replay, Inbo
       { LARKIN_CONFIG_DIR: root, LARKIN_AGENT_ID: agentId }, cliDependencies);
     assert.equal(code, 0, output.stderr);
     assert.equal(nativeCalls.length, 1, "fixture must exercise the real locator-bound reply path once without Feishu I/O");
-    const rejectedReply = runLarkCli(["comment", "reply", "--message-id", envelope.message_id, "--text", "FORBIDDEN_CHANGED_BODY", "--json"],
+    const followUp = runLarkCli(["comment", "reply", "--message-id", envelope.message_id, "--text", "FORBIDDEN_CHANGED_BODY", "--json"],
       { LARKIN_CONFIG_DIR: root, LARKIN_AGENT_ID: agentId }, cliDependencies);
-    assert.equal(rejectedReply, 2);
-    assert.equal(nativeCalls.length, 1, "local reply rejection must not perform another Feishu write");
+    assert.equal(followUp, 0, output.stderr);
+    assert.equal(nativeCalls.length, 2, "a different body appends a follow-up on the same locator");
     telemetry.runtimeEvent(agentId, { type: "turn-end" });
     await telemetry.shutdown();
 
@@ -251,8 +251,8 @@ test("document comment Mock workflow traces safe rejection, pending replay, Inbo
     const replies = spans.filter((span) => span.name === "document.comment.reply");
     assert.equal(replies.length, 2);
     assert.ok(replies.every((reply) => reply.parentSpanId === turn.spanId));
-    assert.deepEqual(replies.map((reply) => reply.attributes.find((attribute) => attribute.key === "larkin.operation.outcome")?.value?.stringValue).sort(), ["error", "success"]);
-    assert.equal(replies.filter((reply) => reply.status.code === 2).length, 1);
+    assert.deepEqual(replies.map((reply) => reply.attributes.find((attribute) => attribute.key === "larkin.operation.outcome")?.value?.stringValue).sort(), ["success", "success"]);
+    assert.equal(replies.filter((reply) => reply.status.code === 2).length, 0);
     const serialized = JSON.stringify(records);
     for (const forbidden of ["doc_private_token", "comment_private", "reply_private", "ou_recovery_human", "FORBIDDEN_PROVIDER_ERROR",
       "FORBIDDEN_REPLY_BODY", "FORBIDDEN_CHANGED_BODY", "/fixed/", stateDir]) assert.equal(serialized.includes(forbidden), false, forbidden);


### PR DESCRIPTION
## Summary

Implements Fable 5 Option C (body-hash delivery identity) for #143. `comment reply` now supports acknowledgement-then-completion follow-ups on the same bound document comment locator without adding a caller-visible or native idempotency flag.

Root cause: `runCommentReply` keyed the existing fail-closed local ledger only by Inbox `messageId`, so any different body was rejected even though the official Drive comment commands have no idempotency parameter.

## Changes

- Ledger identity is `messageId::sha256(text)`.
- Same body after `sent` returns `duplicate: true` without a provider call.
- Same body after an ambiguous `sending` result remains fail-closed; callers are told not to reword and retry before checking the thread.
- Different bodies append separate replies on the same bound locator.
- Legacy bare `messageId` entries are read for same-digest compatibility; terminal state is written under the new key.
- `--idempotency-key` is rejected for `comment reply`; it is never included in native Drive argv.
- Native routes remain only `drive file.comment.replys create` and `drive file.comments create_v2`.
- Package version bumps `0.4.11` → `0.4.12` once.

## Scope / non-goals

- No standing-prompt or eval change; no prompt-version bump.
- No merge, release, retag, issue close, second Larkin runtime, production Larkin edit, or live Feishu write.
- No change to document-comment locator binding, freshness gate, subscription policy, or telemetry span name.

## Tests

Added/updated fake-sink and Host coverage for:

- same-locator acknowledgement plus different-body completion;
- same-body duplicate and ambiguous fail-closed behavior;
- ambiguous same body not blocking a different-body completion;
- definitive provider rejection retry;
- rejection of `--idempotency-key` with no provider call;
- legacy ledger fallback;
- top-level `create_v2` follow-ups;
- Host telemetry for two successful comment replies.

Passed:

- `bun test --max-concurrency 1 test/unit/app/lark-cli-launcher.test.mjs test/unit/feishu/host-document-comment.test.mjs` — 34 pass
- `bun run build`
- `bun run licenses:check`
- `bun run publication:check:tree`
- `git diff --check`

`bun run test` was attempted but exceeded the 60-second local execution limit and exposed unrelated baseline process-marker/internal-entry failures; the targeted issue suites are green. `bun run publication:check` likewise exceeded that local limit. Hosted CI remains the review gate.

## Unproven

No live Feishu write was performed. Fake sinks prove argv/ledger behavior only; they do not prove Feishu provider append semantics or client visibility. No pass-rate improvement claim is made.

## Review boundary

PR #144 is updated in place and is intentionally not merged. Merge remains subject to a later authorized Codex 5.6 sol high pass.