### PR TITLE
fix: restore hot-attached agents after daemon restart

### DIFF
--- a/src/app/agent-lark-cli-workspace.ts
+++ b/src/app/agent-lark-cli-workspace.ts
@@ -52,12 +52,13 @@ export function managedOfficialLarkCli(
 
 function readPrivateJson(file: string, label: string): Record<string, any> {
   const directory = fs.lstatSync(path.dirname(file));
-  if (!directory.isDirectory() || directory.isSymbolicLink() || !exactMode(directory, 0o700)
+  if (!directory.isDirectory() || directory.isSymbolicLink()
+      || (!exactMode(directory, 0o700) && !exactMode(directory, 0o500))
       || (typeof process.getuid === "function" && directory.uid !== process.getuid())) throw new Error(`${label} 目录不安全`);
   const fd = fs.openSync(file, fs.constants.O_RDONLY | (fs.constants.O_NOFOLLOW || 0));
   try {
     const stat = fs.fstatSync(fd);
-    if (!stat.isFile() || !exactMode(stat, 0o600)
+    if (!stat.isFile() || (!exactMode(stat, 0o600) && !exactMode(stat, 0o400))
         || (typeof process.getuid === "function" && stat.uid !== process.getuid())) throw new Error(`${label} 文件不安全`);
     return JSON.parse(fs.readFileSync(fd, "utf8")) as Record<string, any>;
   } finally { fs.closeSync(fd); }

--- a/src/app/local-control.ts
+++ b/src/app/local-control.ts
@@ -13,6 +13,7 @@ export interface AgentUpsertRequest { operationId: string; agentId: string; auth
 export type AgentUpsertOperation = Pick<AgentUpsertRequest, "operationId" | "agentId">;
 export interface AgentUpsertResponse { ok: boolean; operationId: string; agentId: string; code?: string; error?: string; readiness?: RuntimeReadiness }
 export interface DashboardRecoveryResponse { ok: boolean; operationId: string; state?: string; error?: string }
+export interface SupervisorAgentUpsertResponse { ok: boolean; operationId: string; state?: string; error?: string }
 export interface SessionResetResponse {
   ok: boolean; agentId: string; code?: string; error?: string;
   resetCommitted: boolean; generationChanged: boolean; sessionChanged: boolean; turns: number;
@@ -489,15 +490,17 @@ export function createSupervisorControlServer({
   larkinHome,
   authorityToken,
   ensureDashboard,
+  onAgentUpserted,
 }: {
   larkinHome: string;
   authorityToken: string;
   ensureDashboard(): Promise<string> | string;
+  onAgentUpserted?(agentId: string): Promise<void> | void;
 }): { start(): Promise<void>; close(): Promise<void> } {
   let socket = "";
   let socketRoot = "";
   let socketIdentity: SocketBinding | null = null;
-  const completed = new Map<string, DashboardRecoveryResponse>();
+  const completed = new Map<string, DashboardRecoveryResponse | SupervisorAgentUpsertResponse>();
   let server: net.Server | null = null;
   return {
     async start(): Promise<void> {
@@ -516,12 +519,18 @@ export function createSupervisorControlServer({
           const line = input.slice(0, newline);
           input = "";
           void (async () => {
-            let request: { operationId: string; operation: string; authorization: string };
+            let request: { operationId: string; operation: string; authorization: string; agentId?: string };
             try {
               request = JSON.parse(line) as typeof request;
-              if (!OPERATION_ID.test(String(request.operationId || "")) || request.operation !== "ensure-dashboard"
+              const isDashboardRecovery = request.operation === "ensure-dashboard";
+              const isAgentUpsert = request.operation === "agent-upserted";
+              const allowedKeys = isDashboardRecovery
+                ? ["operationId", "operation", "authorization"]
+                : isAgentUpsert ? ["operationId", "operation", "authorization", "agentId"] : [];
+              if (!OPERATION_ID.test(String(request.operationId || "")) || (!isDashboardRecovery && !isAgentUpsert)
                   || !AUTHORIZATION.test(String(request.authorization || ""))
-                  || Object.keys(request).some((key) => !["operationId", "operation", "authorization"].includes(key))) {
+                  || (isAgentUpsert && !AGENT_ID.test(String(request.agentId || "")))
+                  || Object.keys(request).some((key) => !allowedKeys.includes(key))) {
                 throw new Error("invalid supervisor control request");
               }
               const authority = assertSupervisorAuthority(larkinHome, authorityToken);
@@ -532,8 +541,15 @@ export function createSupervisorControlServer({
             }
             const replay = completed.get(request.operationId);
             if (replay) { connection.end(`${JSON.stringify(replay)}\n`); return; }
-            let response: DashboardRecoveryResponse;
-            try { response = { ok: true, operationId: request.operationId, state: await ensureDashboard() }; }
+            let response: DashboardRecoveryResponse | SupervisorAgentUpsertResponse;
+            try {
+              if (request.operation === "agent-upserted") {
+                await onAgentUpserted?.(request.agentId as string);
+                response = { ok: true, operationId: request.operationId, state: "agent-recorded" };
+              } else {
+                response = { ok: true, operationId: request.operationId, state: await ensureDashboard() };
+              }
+            }
             catch (error) { response = { ok: false, operationId: request.operationId, error: error instanceof Error ? error.message : String(error) }; }
             completed.set(request.operationId, response);
             while (completed.size > 256) completed.delete(completed.keys().next().value as string);
@@ -814,6 +830,49 @@ async function sendSupervisorRecovery(larkinHome: string, operationId: string, t
       catch (error) { reject(error); }
     });
   });
+}
+
+async function sendSupervisorAgentUpsert(larkinHome: string, agentId: string, operationId: string, timeoutMs: number): Promise<SupervisorAgentUpsertResponse> {
+  const authority = assertSupervisorAuthority(larkinHome);
+  assertSecureSocketDirectory(authority.socketRoot);
+  const socket = authority.supervisorSocketPath;
+  const stat = fs.lstatSync(socket);
+  if (!stat.isSocket() || stat.isSymbolicLink()
+      || (typeof process.getuid === "function" && stat.uid !== process.getuid())
+      || !notGroupOrWorldAccessible(stat)) throw new Error("supervisor control socket 不安全");
+  return await new Promise<SupervisorAgentUpsertResponse>((resolve, reject) => {
+    const client = net.createConnection(socket);
+    const timer = setTimeout(() => { client.destroy(); reject(new Error("supervisor agent upsert control timeout")); }, timeoutMs);
+    let input = "";
+    client.setEncoding("utf8");
+    client.once("error", (error) => { clearTimeout(timer); reject(error); });
+    client.once("connect", () => client.write(`${JSON.stringify({
+      operationId, operation: "agent-upserted", agentId, authorization: authority.token,
+    })}\n`));
+    client.on("data", (chunk) => {
+      input += chunk;
+      const newline = input.indexOf("\n");
+      if (newline < 0) return;
+      clearTimeout(timer);
+      client.end();
+      try { resolve(JSON.parse(input.slice(0, newline)) as SupervisorAgentUpsertResponse); }
+      catch (error) { reject(error); }
+    });
+  });
+}
+
+export async function requestSupervisorAgentUpsert({
+  larkinHome,
+  agentId,
+  operationId = crypto.randomUUID(),
+  timeoutMs = 30_000,
+}: {
+  larkinHome: string;
+  agentId: string;
+  operationId?: string;
+  timeoutMs?: number;
+}): Promise<SupervisorAgentUpsertResponse> {
+  return sendSupervisorAgentUpsert(larkinHome, agentId, operationId, timeoutMs);
 }
 
 export async function requestDashboardRecovery({

--- a/src/app/local-control.ts
+++ b/src/app/local-control.ts
@@ -13,7 +13,9 @@ export interface AgentUpsertRequest { operationId: string; agentId: string; auth
 export type AgentUpsertOperation = Pick<AgentUpsertRequest, "operationId" | "agentId">;
 export interface AgentUpsertResponse { ok: boolean; operationId: string; agentId: string; code?: string; error?: string; readiness?: RuntimeReadiness }
 export interface DashboardRecoveryResponse { ok: boolean; operationId: string; state?: string; error?: string }
-export interface SupervisorAgentUpsertResponse { ok: boolean; operationId: string; state?: string; error?: string }
+export interface SupervisorAgentUpsertResponse {
+  ok: boolean; operationId: string; agentId?: string; code?: string; state?: string; error?: string;
+}
 export interface SessionResetResponse {
   ok: boolean; agentId: string; code?: string; error?: string;
   resetCommitted: boolean; generationChanged: boolean; sessionChanged: boolean; turns: number;
@@ -500,7 +502,15 @@ export function createSupervisorControlServer({
   let socket = "";
   let socketRoot = "";
   let socketIdentity: SocketBinding | null = null;
-  const completed = new Map<string, DashboardRecoveryResponse | SupervisorAgentUpsertResponse>();
+  const completed = new Map<string, {
+    operation: string;
+    agentId?: string;
+    response: DashboardRecoveryResponse | SupervisorAgentUpsertResponse;
+  }>();
+  const operationConflict = (operationId: string, agentId?: string): SupervisorAgentUpsertResponse => ({
+    ok: false, operationId, ...(agentId ? { agentId } : {}), code: "operation_conflict",
+    error: "operationId 已绑定其他 Agent 或操作",
+  });
   let server: net.Server | null = null;
   return {
     async start(): Promise<void> {
@@ -540,7 +550,13 @@ export function createSupervisorControlServer({
               return;
             }
             const replay = completed.get(request.operationId);
-            if (replay) { connection.end(`${JSON.stringify(replay)}\n`); return; }
+            if (replay) {
+              const sameRequest = replay.operation === request.operation
+                && replay.agentId === request.agentId;
+              const response = sameRequest ? replay.response : operationConflict(request.operationId, request.agentId);
+              connection.end(`${JSON.stringify(response)}\n`);
+              return;
+            }
             let response: DashboardRecoveryResponse | SupervisorAgentUpsertResponse;
             try {
               if (request.operation === "agent-upserted") {
@@ -551,7 +567,9 @@ export function createSupervisorControlServer({
               }
             }
             catch (error) { response = { ok: false, operationId: request.operationId, error: error instanceof Error ? error.message : String(error) }; }
-            completed.set(request.operationId, response);
+            completed.set(request.operationId, {
+              operation: request.operation, agentId: request.agentId, response,
+            });
             while (completed.size > 256) completed.delete(completed.keys().next().value as string);
             connection.end(`${JSON.stringify(response)}\n`);
           })();

--- a/src/app/run.ts
+++ b/src/app/run.ts
@@ -91,6 +91,9 @@ export async function main(): Promise<void> {
   let names: string[];
   try { names = selectedAgentIds(argv, Object.keys(config.agents)); }
   catch (error) { return die((error as Error).message); }
+  // Capture this supervisor's startup membership before setup can persist a new
+  // Agent. Unqualified selection must not expand from later durable config.
+  const initialNames = new Set(names);
 
   const before = readProcessState(configDir);
   if (before.supervisor.state === "owned") {
@@ -163,15 +166,15 @@ export async function main(): Promise<void> {
   };
   if (argv.includes("--dry-run")) runtimeEnv.LARKIN_FEISHU_DRYRUN = "1";
 
-  // Durable config is the recovery source of truth. Re-read it for every daemon
-  // launch instead of reusing the startup snapshot: a hot attach updates the
-  // child and durable config, but cannot mutate this supervisor's old closure.
+  // Re-read durable config for every daemon launch instead of reusing the startup
+  // snapshot: a hot attach updates the child and durable config, but cannot mutate
+  // this supervisor's old closure. Membership remains initialNames plus successful
+  // hot attaches recorded during this supervisor lifetime.
   const refreshDaemonAgents = (reuseExistingProfiles: boolean): void => {
     const latest = larkinConfig.loadConfig(process.env);
     if (latest.configDir !== configDir) throw new Error("配置目录在 supervisor 运行期间发生变化");
     if (!latest.config.serverId || !Object.keys(latest.config.agents).length) throw new Error("配置缺少 serverId/agents");
-    const selectedNames = selectedAgentIds(argv, Object.keys(latest.config.agents));
-    const latestNames = [...new Set([...selectedNames, ...hotAttachedNames])];
+    const latestNames = [...new Set([...initialNames, ...hotAttachedNames])];
     const refreshed: RuntimeAgentConfig[] = [];
     for (const name of latestNames) {
       const stored = latest.config.agents[name];

--- a/src/app/run.ts
+++ b/src/app/run.ts
@@ -131,11 +131,16 @@ export async function main(): Promise<void> {
     die("无法取得 supervisor start identity");
   }
   const controlToken = initializeControlAuthority(configDir, { pid: process.pid, processStartToken: supervisorStartToken });
+  // This supervisor's successful hot-attaches are the only membership additions
+  // that survive a daemon crash. Durable config apply state describes freshness,
+  // not which Agents this explicitly selected supervisor owns.
+  const hotAttachedNames = new Set<string>();
   let ensureDashboardHandler = (): string => "starting";
   const supervisorControl = createSupervisorControlServer({
     larkinHome: configDir,
     authorityToken: controlToken,
     ensureDashboard: () => ensureDashboardHandler(),
+    onAgentUpserted: (agentId) => { hotAttachedNames.add(agentId); },
   });
   try { await supervisorControl.start(); }
   catch (error) {
@@ -166,13 +171,7 @@ export async function main(): Promise<void> {
     if (latest.configDir !== configDir) throw new Error("配置目录在 supervisor 运行期间发生变化");
     if (!latest.config.serverId || !Object.keys(latest.config.agents).length) throw new Error("配置缺少 serverId/agents");
     const selectedNames = selectedAgentIds(argv, Object.keys(latest.config.agents));
-    const applyState = larkinConfig.configApplyState(process.env, latest.config) as {
-      agents?: Record<string, { applyState?: string }>;
-    };
-    const appliedNames = Object.entries(applyState.agents || {})
-      .filter(([, state]) => state.applyState === "applied")
-      .map(([name]) => name);
-    const latestNames = [...new Set([...selectedNames, ...appliedNames])];
+    const latestNames = [...new Set([...selectedNames, ...hotAttachedNames])];
     const refreshed: RuntimeAgentConfig[] = [];
     for (const name of latestNames) {
       const stored = latest.config.agents[name];

--- a/src/app/run.ts
+++ b/src/app/run.ts
@@ -143,21 +143,7 @@ export async function main(): Promise<void> {
     try { removeControlAuthority(configDir, controlToken); } catch { /* best effort */ }
     die(`supervisor control 启动失败：${error instanceof Error ? error.message : String(error)}`);
   }
-  const agents: RuntimeAgentConfig[] = [];
-  try {
-    for (const name of names) {
-      const stored = config.agents[name];
-      if (!stored) throw new Error(`Agent ${name} 不存在`);
-      const agent = hydrateRuntimeAgent(configDir, stored);
-      syncAgentProfile(agent, { ...process.env, LARKIN_CONFIG_DIR: configDir });
-      agents.push(agent);
-    }
-  } catch (error) {
-    await supervisorControl.close().catch(() => {});
-    try { removeControlAuthority(configDir, controlToken); } catch { /* best effort */ }
-    launchLock.release();
-    die(`Agent 启动校验失败：${error instanceof Error ? error.message : String(error)}`);
-  }
+  let agents: RuntimeAgentConfig[] = [];
 
   if (before.dashboard.state === "owned") {
     console.error(`[start] 正在把旧 dashboard PID ${before.dashboard.pid} 收归统一 supervisor…`);
@@ -183,11 +169,40 @@ export async function main(): Promise<void> {
     LARKIN_CONFIG_DIR: configDir,
     LARKIN_AGENT_TRANSPORT_MODULE: path.join(HERE, "..", "agent", "agent-transport.cjs"),
     LARKIN_SERVER_ID: String(serverId),
-    LARKIN_AGENTS_CONFIG: JSON.stringify(agents),
+    LARKIN_AGENTS_CONFIG: "[]",
     LARKIN_CONTROL_AUTHORIZATION: controlToken,
   };
   if (argv.includes("--dry-run")) runtimeEnv.LARKIN_FEISHU_DRYRUN = "1";
-  for (const agent of agents) traceProcessBoundary(runtimeEnv, "supervisor:daemon-env-prepared", { configDir, agentId: agent.agentId, targetDir: path.join(configDir, "providers", "pi", agent.agentId) });
+
+  // Durable config is the recovery source of truth. Re-read it for every daemon
+  // launch instead of reusing the startup snapshot: a hot attach updates the
+  // child and durable config, but cannot mutate this supervisor's old closure.
+  const refreshDaemonAgents = (): void => {
+    const latest = larkinConfig.loadConfig(process.env);
+    if (latest.configDir !== configDir) throw new Error("配置目录在 supervisor 运行期间发生变化");
+    if (!latest.config.serverId || !Object.keys(latest.config.agents).length) throw new Error("配置缺少 serverId/agents");
+    const latestNames = selectedAgentIds(argv, Object.keys(latest.config.agents));
+    const refreshed: RuntimeAgentConfig[] = [];
+    for (const name of latestNames) {
+      const stored = latest.config.agents[name];
+      if (!stored) throw new Error(`Agent ${name} 不存在`);
+      const agent = hydrateRuntimeAgent(configDir, stored);
+      syncAgentProfile(agent, { ...process.env, LARKIN_CONFIG_DIR: configDir });
+      refreshed.push(agent);
+    }
+    agents = refreshed;
+    names = latestNames;
+    runtimeEnv.LARKIN_SERVER_ID = String(latest.config.serverId);
+    runtimeEnv.LARKIN_AGENTS_CONFIG = JSON.stringify(agents);
+    for (const agent of agents) traceProcessBoundary(runtimeEnv, "supervisor:daemon-env-prepared", { configDir, agentId: agent.agentId, targetDir: path.join(configDir, "providers", "pi", agent.agentId) });
+  };
+  try { refreshDaemonAgents(); }
+  catch (error) {
+    await supervisorControl.close().catch(() => {});
+    try { removeControlAuthority(configDir, controlToken); } catch { /* best effort */ }
+    launchLock.release();
+    die(`Agent 启动校验失败：${error instanceof Error ? error.message : String(error)}`);
+  }
 
   let stopping = false;
   let dashboard: ChildProcess | null = null;
@@ -214,6 +229,12 @@ export async function main(): Promise<void> {
   // auth). Only when the budget is exhausted does the supervisor exit so the
   // external process manager (launchd) takes over as the final respawn layer.
   const launchDaemon = (): void => {
+    try { refreshDaemonAgents(); }
+    catch (error) {
+      console.error(`✗ daemon 启动前重新加载配置失败：${error instanceof Error ? error.message : String(error)}`);
+      resolveDaemonFinal?.({ code: null, signal: null });
+      return;
+    }
     daemon = spawn(daemonSpec.command, daemonSpec.args, { env: runtimeEnv, stdio: "inherit" });
     for (const agent of agents) traceProcessBoundary(runtimeEnv, "supervisor:daemon-spawned", { configDir, agentId: agent.agentId, targetDir: path.join(configDir, "providers", "pi", agent.agentId), childPid: daemon.pid ?? null });
     daemon.once("exit", (code, signal) => {

--- a/src/app/run.ts
+++ b/src/app/run.ts
@@ -13,7 +13,7 @@ import {
   terminateOwnedProcess,
   waitForProcessExit,
 } from "../platform/process-state.js";
-import { hydrateRuntimeAgent, syncAgentProfile, type RuntimeAgentConfig } from "./runtime-agent-config.js";
+import { hydrateRuntimeAgent, syncAgentProfile, validateAgentProfile, type RuntimeAgentConfig } from "./runtime-agent-config.js";
 import {
   cleanupStaleAgentControlSocket,
   createSupervisorControlServer,
@@ -145,22 +145,6 @@ export async function main(): Promise<void> {
   }
   let agents: RuntimeAgentConfig[] = [];
 
-  if (before.dashboard.state === "owned") {
-    console.error(`[start] 正在把旧 dashboard PID ${before.dashboard.pid} 收归统一 supervisor…`);
-    terminateOwnedProcess(before.dashboard, "SIGTERM");
-    if (!await waitForProcessExit(before.dashboard)) {
-      await supervisorControl.close().catch(() => {});
-      try { removeControlAuthority(configDir, controlToken); } catch { /* best effort */ }
-      launchLock.release();
-      die("旧 dashboard 10 秒内未退出；拒绝并行启动");
-    }
-  } else if (before.dashboard.state === "unknown") {
-    await supervisorControl.close().catch(() => {});
-    try { removeControlAuthority(configDir, controlToken); } catch { /* best effort */ }
-    launchLock.release();
-    die(`dashboard PID ${before.dashboard.pid} 身份无法确认；拒绝替换`);
-  }
-
   const serverId = config.serverId;
   if (!serverId) die("配置缺少 serverId");
   const runtimeEnv: NodeJS.ProcessEnv = {
@@ -177,17 +161,25 @@ export async function main(): Promise<void> {
   // Durable config is the recovery source of truth. Re-read it for every daemon
   // launch instead of reusing the startup snapshot: a hot attach updates the
   // child and durable config, but cannot mutate this supervisor's old closure.
-  const refreshDaemonAgents = (): void => {
+  const refreshDaemonAgents = (reuseExistingProfiles: boolean): void => {
     const latest = larkinConfig.loadConfig(process.env);
     if (latest.configDir !== configDir) throw new Error("配置目录在 supervisor 运行期间发生变化");
     if (!latest.config.serverId || !Object.keys(latest.config.agents).length) throw new Error("配置缺少 serverId/agents");
-    const latestNames = selectedAgentIds(argv, Object.keys(latest.config.agents));
+    const selectedNames = selectedAgentIds(argv, Object.keys(latest.config.agents));
+    const applyState = larkinConfig.configApplyState(process.env, latest.config) as {
+      agents?: Record<string, { applyState?: string }>;
+    };
+    const appliedNames = Object.entries(applyState.agents || {})
+      .filter(([, state]) => state.applyState === "applied")
+      .map(([name]) => name);
+    const latestNames = [...new Set([...selectedNames, ...appliedNames])];
     const refreshed: RuntimeAgentConfig[] = [];
     for (const name of latestNames) {
       const stored = latest.config.agents[name];
       if (!stored) throw new Error(`Agent ${name} 不存在`);
       const agent = hydrateRuntimeAgent(configDir, stored);
-      syncAgentProfile(agent, { ...process.env, LARKIN_CONFIG_DIR: configDir });
+      if (reuseExistingProfiles) validateAgentProfile(agent);
+      else syncAgentProfile(agent, { ...process.env, LARKIN_CONFIG_DIR: configDir });
       refreshed.push(agent);
     }
     agents = refreshed;
@@ -196,12 +188,28 @@ export async function main(): Promise<void> {
     runtimeEnv.LARKIN_AGENTS_CONFIG = JSON.stringify(agents);
     for (const agent of agents) traceProcessBoundary(runtimeEnv, "supervisor:daemon-env-prepared", { configDir, agentId: agent.agentId, targetDir: path.join(configDir, "providers", "pi", agent.agentId) });
   };
-  try { refreshDaemonAgents(); }
+  try { refreshDaemonAgents(false); }
   catch (error) {
     await supervisorControl.close().catch(() => {});
     try { removeControlAuthority(configDir, controlToken); } catch { /* best effort */ }
     launchLock.release();
     die(`Agent 启动校验失败：${error instanceof Error ? error.message : String(error)}`);
+  }
+
+  if (before.dashboard.state === "owned") {
+    console.error(`[start] 正在把旧 dashboard PID ${before.dashboard.pid} 收归统一 supervisor…`);
+    terminateOwnedProcess(before.dashboard, "SIGTERM");
+    if (!await waitForProcessExit(before.dashboard)) {
+      await supervisorControl.close().catch(() => {});
+      try { removeControlAuthority(configDir, controlToken); } catch { /* best effort */ }
+      launchLock.release();
+      die("旧 dashboard 10 秒内未退出；拒绝并行启动");
+    }
+  } else if (before.dashboard.state === "unknown") {
+    await supervisorControl.close().catch(() => {});
+    try { removeControlAuthority(configDir, controlToken); } catch { /* best effort */ }
+    launchLock.release();
+    die(`dashboard PID ${before.dashboard.pid} 身份无法确认；拒绝替换`);
   }
 
   let stopping = false;
@@ -228,8 +236,10 @@ export async function main(): Promise<void> {
   // exiting on transient failures (e.g. network/proxy ECONNRESET during Feishu
   // auth). Only when the budget is exhausted does the supervisor exit so the
   // external process manager (launchd) takes over as the final respawn layer.
+  let initialRefreshPending = true;
   const launchDaemon = (): void => {
-    try { refreshDaemonAgents(); }
+    if (initialRefreshPending) initialRefreshPending = false;
+    else try { refreshDaemonAgents(true); }
     catch (error) {
       console.error(`✗ daemon 启动前重新加载配置失败：${error instanceof Error ? error.message : String(error)}`);
       resolveDaemonFinal?.({ code: null, signal: null });
@@ -266,7 +276,6 @@ export async function main(): Promise<void> {
         const oldDashboard = dashboard;
         if (oldDashboard && oldDashboard.exitCode === null && oldDashboard.signalCode === null) {
           intentionalDashboardExit = oldDashboard;
-          dashboard = null;
           oldDashboard.kill("SIGTERM");
           // If the old dashboard ignores SIGTERM (observed in production holding
           // the dashboard port for minutes), escalate so the port is released

--- a/src/app/runtime-agent-config.ts
+++ b/src/app/runtime-agent-config.ts
@@ -56,6 +56,13 @@ function assertSecureProfileDirectory(directory: string): void {
       || !exactMode(stat, 0o700)) throw new Error("lark-cli profile 目录不安全");
 }
 
+function assertValidProfileDirectory(directory: string): void {
+  const stat = fs.lstatSync(directory);
+  if (!stat.isDirectory() || stat.isSymbolicLink()
+      || (typeof process.getuid === "function" && stat.uid !== process.getuid())
+      || (!exactMode(stat, 0o700) && !exactMode(stat, 0o500))) throw new Error("lark-cli profile 目录不安全");
+}
+
 function captureProfileSnapshot(file: string): ProfileSnapshot | null {
   let fd: number | null = null;
   try {
@@ -342,6 +349,9 @@ function validateSourceProjection(file: string, agent: Pick<RuntimeAgentConfig, 
 }
 
 export function validateAgentProfile(agent: RuntimeAgentConfig): void {
+  // Validate the profile root before resolving any leaf paths. The supervisor's
+  // restart fast path must not follow a replaced symlink or unsafe root.
+  assertValidProfileDirectory(agent.larkConfigDir);
   const sourceFile = larkChannelSourceConfigPath(agent);
   const workspaceFile = larkChannelWorkspaceConfigPath(agent);
   const source = captureProfileSnapshot(sourceFile);

--- a/src/app/runtime-agent-config.ts
+++ b/src/app/runtime-agent-config.ts
@@ -254,17 +254,23 @@ function runOfficialLarkCliAsync(command: OfficialLarkCliCommand, args: readonly
   });
 }
 
+function expectedRuntimeCommandShim(): string {
+  const standalone = process.env.LARKIN_STANDALONE === "1";
+  const binaryEntry = fileURLToPath(new URL("./binary-entry.mjs", import.meta.url));
+  const argumentsPrefix = standalone ? [] : [binaryEntry];
+  const command = [process.execPath, ...argumentsPrefix].map(shellQuote).join(" ");
+  return `#!/bin/sh\nexec ${command} "$@"\n`;
+}
+
 export function installRuntimeCommandShims(agent: Pick<RuntimeAgentConfig, "stateDir">): string {
   const stateDir = path.resolve(agent.stateDir);
   const commandDir = path.join(stateDir, "runtime-bin");
   assertSecureRuntimeCommandDirectory(commandDir);
-  const standalone = process.env.LARKIN_STANDALONE === "1";
-  const binaryEntry = fileURLToPath(new URL("./binary-entry.mjs", import.meta.url));
-  for (const [name, argumentsPrefix] of [["larkin", standalone ? [] : [binaryEntry]]] as const) {
+  const fileContents = expectedRuntimeCommandShim();
+  for (const name of ["larkin"] as const) {
     const file = path.join(commandDir, name);
     const temporary = path.join(commandDir, `.${name}.${process.pid}.${crypto.randomUUID()}.tmp`);
-    const command = [process.execPath, ...argumentsPrefix].map(shellQuote).join(" ");
-    fs.writeFileSync(temporary, `#!/bin/sh\nexec ${command} "$@"\n`, { mode: 0o700, flag: "wx" });
+    fs.writeFileSync(temporary, fileContents, { mode: 0o700, flag: "wx" });
     fs.renameSync(temporary, file);
     fs.chmodSync(file, 0o700);
   }
@@ -282,6 +288,9 @@ function validateRuntimeCommandShims(agent: Pick<RuntimeAgentConfig, "stateDir">
   if (!stat.isFile() || stat.isSymbolicLink()
       || (typeof process.getuid === "function" && stat.uid !== process.getuid())
       || (!exactMode(stat, 0o700) && !exactMode(stat, 0o500))) throw new Error("Runtime command shim 不安全");
+  if (fs.readFileSync(file, "utf8") !== expectedRuntimeCommandShim()) {
+    throw new Error("Runtime command shim 内容无效");
+  }
 }
 
 export function sourceProjection(agent: RuntimeAgentConfig, env: NodeJS.ProcessEnv): Record<string, unknown> {

--- a/src/app/runtime-agent-config.ts
+++ b/src/app/runtime-agent-config.ts
@@ -271,6 +271,19 @@ export function installRuntimeCommandShims(agent: Pick<RuntimeAgentConfig, "stat
   return commandDir;
 }
 
+function validateRuntimeCommandShims(agent: Pick<RuntimeAgentConfig, "stateDir">): void {
+  const commandDir = path.join(path.resolve(agent.stateDir), "runtime-bin");
+  const directory = fs.lstatSync(commandDir);
+  if (!directory.isDirectory() || directory.isSymbolicLink()
+      || (typeof process.getuid === "function" && directory.uid !== process.getuid())
+      || (!exactMode(directory, 0o700) && !exactMode(directory, 0o500))) throw new Error("Runtime command shim 目录不安全");
+  const file = path.join(commandDir, "larkin");
+  const stat = fs.lstatSync(file);
+  if (!stat.isFile() || stat.isSymbolicLink()
+      || (typeof process.getuid === "function" && stat.uid !== process.getuid())
+      || (!exactMode(stat, 0o700) && !exactMode(stat, 0o500))) throw new Error("Runtime command shim 不安全");
+}
+
 export function sourceProjection(agent: RuntimeAgentConfig, env: NodeJS.ProcessEnv): Record<string, unknown> {
   const configDir = path.resolve(env.LARKIN_CONFIG_DIR || "");
   if (!configDir) throw new Error("LARKIN_CONFIG_DIR required for lark-channel source projection");
@@ -319,11 +332,30 @@ function validateSourceProjection(file: string, agent: Pick<RuntimeAgentConfig, 
   }
 }
 
+export function validateAgentProfile(agent: RuntimeAgentConfig): void {
+  const sourceFile = larkChannelSourceConfigPath(agent);
+  const workspaceFile = larkChannelWorkspaceConfigPath(agent);
+  const source = captureProfileSnapshot(sourceFile);
+  if (!source) throw new Error(`Agent ${agent.agentId} lark-channel source projection missing`);
+  validateSourceProjection(sourceFile, agent);
+  const workspace = captureProfileSnapshot(workspaceFile);
+  if (!workspace) throw new Error(`Agent ${agent.agentId} lark-channel workspace config missing`);
+  validateExclusiveBotProfile(workspace, agent);
+  validateRuntimeCommandShims(agent);
+  assertAgentWorkspaceBound(agent);
+}
+
 export function syncAgentProfile(
   agent: RuntimeAgentConfig,
   env: NodeJS.ProcessEnv,
   dependencies: RuntimeAgentConfigDependencies = {},
 ): void {
+  if (!dependencies.forceRebind) {
+    try {
+      validateAgentProfile(agent);
+      return;
+    } catch { /* absent or stale state requires exactly one bind */ }
+  }
   const expected = path.join(path.resolve(env.LARKIN_CONFIG_DIR || ""), "state", "agents", agent.agentId, "lark-cli-config");
   if (path.resolve(agent.larkConfigDir) !== expected) throw new Error("lark-cli profile 路径不是 canonical contained 路径");
   fs.mkdirSync(expected, { recursive: true, mode: 0o700 });

--- a/src/app/runtime-process.ts
+++ b/src/app/runtime-process.ts
@@ -8,7 +8,7 @@ import { createRuntimeHost, type RuntimeHost } from "../runtime/runtime-host.js"
 import { createAgentStateStore } from "../agent/agent-state-store.js";
 import { loadConfig, markConfigApplied, runtimeConfigSignature } from "../platform/config.js";
 import { traceProcessBoundary } from "../platform/process-boundary-trace.js";
-import { createAgentControlServer } from "./local-control.js";
+import { createAgentControlServer, requestSupervisorAgentUpsert } from "./local-control.js";
 import { hydrateRuntimeAgent, syncAgentProfile, type RuntimeAgentConfigDependencies } from "./runtime-agent-config.js";
 import { loadTelemetryConfig } from "../platform/telemetry-config.js";
 import { telemetrySingleton, type TelemetryRuntime } from "../platform/telemetry-tracing.js";
@@ -111,6 +111,10 @@ export async function main(env: NodeJS.ProcessEnv = process.env, overrides: {
       // Only the selected profile is synchronized; active profiles and their directory
       // are never quarantined or rebuilt during hot attach.
       await hostShell.upsertAgent(agent);
+      const tracked = await requestSupervisorAgentUpsert({
+        larkinHome: env.LARKIN_HOME as string, agentId: agent.agentId, operationId: request.operationId,
+      });
+      if (!tracked.ok) throw new Error(tracked.error || "supervisor 未记录 Agent 热挂载");
     },
     async resetSession(request) {
       const result = await hostShell.resetSession(request.agentId, request.waitReadyMs);

--- a/test/integration/app/runtime-profile-rollback.test.mjs
+++ b/test/integration/app/runtime-profile-rollback.test.mjs
@@ -80,6 +80,20 @@ test("profile sync binds one Bot through the verified official lark-channel work
   } finally { fs.rmSync(f.root, { recursive: true, force: true }); }
 });
 
+test("stale runtime shim content is refreshed without another bind", () => {
+  const f = fixture("stale-runtime-shim");
+  const runner = fakeOfficialRunner();
+  try {
+    const env = { ...process.env, LARKIN_CONFIG_DIR: f.root, LARKIN_HOME: f.root };
+    loadAndSyncRuntimeAgent(env, f.target, runner);
+    const shim = path.join(f.root, "state", "agents", f.target, "runtime-bin", "larkin");
+    fs.writeFileSync(shim, `#!/bin/sh\nexec /obsolete/larkin "$@"\n`, { mode: 0o700 });
+    loadAndSyncRuntimeAgent(env, f.target, runner);
+    assert.equal(runner.calls.length, 1);
+    assert.ok(fs.readFileSync(shim, "utf8").includes(`exec '${process.execPath}`));
+  } finally { fs.rmSync(f.root, { recursive: true, force: true }); }
+});
+
 test("credential revision change causes exactly one new bind", () => {
   const f = fixture("credential-revision");
   const runner = fakeOfficialRunner();

--- a/test/integration/app/supervisor-hot-attach-restart.test.mjs
+++ b/test/integration/app/supervisor-hot-attach-restart.test.mjs
@@ -1,0 +1,124 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { spawn } from "node:child_process";
+import { test } from "bun:test";
+import { fileURLToPath } from "node:url";
+import { requestAgentUpsert } from "../../../dist/app/local-control.mjs";
+import { readProcessState } from "../../../dist/platform/process-state.mjs";
+
+const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..", "..", "..");
+const AGENTS = ["cli_restartA1", "cli_restartB2", "cli_restartC3"];
+const HOT_AGENT = "cli_restartD4";
+
+function writePrivate(file, value) {
+  fs.writeFileSync(file, `${typeof value === "string" ? value : JSON.stringify(value, null, 2)}\n`, { mode: 0o600 });
+}
+
+async function waitUntil(predicate, timeoutMs = 10_000) {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    const result = predicate();
+    if (result) return result;
+    await new Promise((resolve) => setTimeout(resolve, 25));
+  }
+  return null;
+}
+
+function configFor(agentIds) {
+  return {
+    version: 3,
+    serverId: "00000000-0000-0000-0000-000000000145",
+    activeAgent: agentIds[0],
+    agents: Object.fromEntries(agentIds.map((agentId) => [agentId, { runtime: "codex", model: "gpt-5.5" }])),
+  };
+}
+
+test("hot-attached Agent survives supervised daemon restart", { timeout: 30_000 }, async () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "larkin-hot-attach-restart-"));
+  fs.chmodSync(root, 0o700);
+  const binDir = path.join(root, "bin");
+  const cliPackage = path.join(binDir, "node_modules", "@larksuite", "cli");
+  fs.mkdirSync(path.join(cliPackage, "scripts"), { recursive: true, mode: 0o700 });
+  writePrivate(path.join(cliPackage, "package.json"), {
+    name: "@larksuite/cli", version: "1.0.80", bin: { "lark-cli": "scripts/run.mjs" },
+  });
+  const cliScript = path.join(cliPackage, "scripts", "run.mjs");
+  fs.writeFileSync(cliScript, `#!/usr/bin/env bun
+import fs from "node:fs";
+import path from "node:path";
+const args = process.argv.slice(2);
+if (args[0] === "--version") { console.log("1.0.80"); process.exit(0); }
+if (args[0] === "config" && args[1] === "bind" && args[2] === "--help") { console.log("--source lark-channel --identity bot-only"); process.exit(0); }
+if (args[0] === "config" && args[1] === "bind") {
+  const source = JSON.parse(fs.readFileSync(process.env.LARK_CHANNEL_CONFIG, "utf8"));
+  const appId = source.accounts.app.id;
+  const directory = path.join(process.env.LARKSUITE_CLI_CONFIG_DIR, "lark-channel");
+  fs.mkdirSync(directory, { recursive: true, mode: 0o700 });
+  fs.writeFileSync(path.join(directory, "config.json"), JSON.stringify({ apps: [{ appId, name: appId, appSecret: { source: "keychain", id: \`appsecret:\${appId}\` }, defaultAs: "bot", strictMode: "bot", users: [] }] }) + "\\n", { mode: 0o600 });
+  process.exit(0);
+}
+process.exit(0);
+`, { mode: 0o700 });
+  fs.symlinkSync(cliScript, path.join(binDir, "lark-cli"));
+
+  writePrivate(path.join(root, "config.json"), configFor(AGENTS));
+  const botsDir = path.join(root, "bots");
+  fs.mkdirSync(botsDir, { mode: 0o700 });
+  for (const agentId of [...AGENTS, HOT_AGENT]) writePrivate(path.join(botsDir, `${agentId}.json`), {
+    appId: agentId, appSecret: "fixture-secret", tenant: "feishu",
+  });
+
+  const env = {
+    ...process.env,
+    LARKIN_CONFIG_DIR: root,
+    LARKIN_INTERNAL_DISPATCH: "0",
+    LARKIN_BUN_TEST_RUNNER: "1",
+    LARKIN_FEISHU_DRYRUN: "1",
+    LARKIN_TEST_DAEMON_SCRIPT: path.join(ROOT, "test/support/supervisor-hot-attach-daemon.mjs"),
+    LARKIN_TEST_DASHBOARD_SCRIPT: path.join(ROOT, "test/support/dashboard-stable.mjs"),
+    PATH: `${binDir}${path.delimiter}${process.env.PATH || ""}`,
+  };
+  const supervisor = spawn(process.execPath, [path.join(ROOT, "dist/app/run.mjs"), "--dry-run"], {
+    cwd: ROOT, env, stdio: ["ignore", "pipe", "pipe"],
+  });
+  let output = "";
+  supervisor.stdout.on("data", (chunk) => { output += chunk; });
+  supervisor.stderr.on("data", (chunk) => { output += chunk; });
+
+  try {
+    const initial = await waitUntil(() => {
+      const state = readProcessState(root);
+      return state.daemon.state === "owned" && state.daemon.agents?.length === 3 ? state : null;
+    });
+    assert.ok(initial, `initial daemon did not own three Agents\n${output}`);
+
+    // Simulate setup's durable config commit before its supported daemon upsert.
+    writePrivate(path.join(root, "config.json"), configFor([...AGENTS, HOT_AGENT]));
+    const attached = await requestAgentUpsert({ larkinHome: root, agentId: HOT_AGENT });
+    assert.equal(attached.ok, true, JSON.stringify(attached));
+    const hotAttached = await waitUntil(() => {
+      const state = readProcessState(root).daemon;
+      return state.state === "owned" && state.agents?.length === 4 ? state : null;
+    });
+    assert.ok(hotAttached, `hot attach did not update daemon ownership\n${output}`);
+    assert.deepEqual(hotAttached.agents, [...AGENTS, HOT_AGENT]);
+
+    const oldDaemonPid = Number(hotAttached.pid);
+    process.kill(oldDaemonPid, "SIGKILL");
+    const restarted = await waitUntil(() => {
+      const state = readProcessState(root);
+      return state.supervisor.state === "owned" && state.daemon.state === "owned"
+        && Number(state.daemon.pid) !== oldDaemonPid ? state : null;
+    }, 10_000);
+    assert.ok(restarted, `supervisor did not restart daemon\n${output}`);
+    assert.deepEqual(restarted.daemon.agents, [...AGENTS, HOT_AGENT]);
+    assert.deepEqual(restarted.daemon.connectedAgents, [...AGENTS, HOT_AGENT]);
+  } finally {
+    if (supervisor.exitCode === null && supervisor.signalCode === null) supervisor.kill("SIGTERM");
+    await waitUntil(() => supervisor.exitCode !== null || supervisor.signalCode !== null, 3_000);
+    if (supervisor.exitCode === null && supervisor.signalCode === null) supervisor.kill("SIGKILL");
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});

--- a/test/integration/app/supervisor-hot-attach-restart.test.mjs
+++ b/test/integration/app/supervisor-hot-attach-restart.test.mjs
@@ -35,7 +35,25 @@ function configFor(agentIds) {
   };
 }
 
-test("hot-attached Agent survives supervised daemon restart", { timeout: 30_000 }, async () => {
+function readOnlyProfile(root, agentId) {
+  const stateDir = path.join(root, "state", "agents", agentId);
+  for (const directory of [path.join(stateDir, "lark-cli-config"), path.join(stateDir, "lark-cli-config", "lark-channel"),
+    path.join(stateDir, "lark-channel-source"), path.join(stateDir, "runtime-bin")]) fs.chmodSync(directory, 0o500);
+  for (const file of [path.join(stateDir, "lark-cli-config", "lark-channel", "config.json"),
+    path.join(stateDir, "lark-channel-source", "config.json")]) fs.chmodSync(file, 0o400);
+  fs.chmodSync(path.join(stateDir, "runtime-bin", "larkin"), 0o500);
+}
+
+function writableProfile(root, agentId) {
+  const stateDir = path.join(root, "state", "agents", agentId);
+  for (const directory of [path.join(stateDir, "lark-cli-config"), path.join(stateDir, "lark-cli-config", "lark-channel"),
+    path.join(stateDir, "lark-channel-source"), path.join(stateDir, "runtime-bin")]) fs.chmodSync(directory, 0o700);
+  for (const file of [path.join(stateDir, "lark-cli-config", "lark-channel", "config.json"),
+    path.join(stateDir, "lark-channel-source", "config.json")]) fs.chmodSync(file, 0o600);
+  fs.chmodSync(path.join(stateDir, "runtime-bin", "larkin"), 0o700);
+}
+
+test("selector hot attach survives restart with read-only valid profiles", { timeout: 30_000 }, async () => {
   const root = fs.mkdtempSync(path.join(os.tmpdir(), "larkin-hot-attach-restart-"));
   fs.chmodSync(root, 0o700);
   const binDir = path.join(root, "bin");
@@ -80,7 +98,7 @@ process.exit(0);
     LARKIN_TEST_DASHBOARD_SCRIPT: path.join(ROOT, "test/support/dashboard-stable.mjs"),
     PATH: `${binDir}${path.delimiter}${process.env.PATH || ""}`,
   };
-  const supervisor = spawn(process.execPath, [path.join(ROOT, "dist/app/run.mjs"), "--dry-run"], {
+  const supervisor = spawn(process.execPath, [path.join(ROOT, "dist/app/run.mjs"), "--agents", AGENTS.join(","), "--dry-run"], {
     cwd: ROOT, env, stdio: ["ignore", "pipe", "pipe"],
   });
   let output = "";
@@ -105,6 +123,13 @@ process.exit(0);
     assert.ok(hotAttached, `hot attach did not update daemon ownership\n${output}`);
     assert.deepEqual(hotAttached.agents, [...AGENTS, HOT_AGENT]);
 
+    const profileFiles = [...AGENTS, HOT_AGENT].flatMap((agentId) => {
+      const stateDir = path.join(root, "state", "agents", agentId);
+      return [path.join(stateDir, "lark-cli-config", "lark-channel", "config.json"),
+        path.join(stateDir, "lark-channel-source", "config.json"), path.join(stateDir, "runtime-bin", "larkin")];
+    });
+    const profileMtimes = new Map(profileFiles.map((file) => [file, fs.statSync(file).mtimeNs]));
+    for (const agentId of [...AGENTS, HOT_AGENT]) readOnlyProfile(root, agentId);
     const oldDaemonPid = Number(hotAttached.pid);
     process.kill(oldDaemonPid, "SIGKILL");
     const restarted = await waitUntil(() => {
@@ -115,7 +140,11 @@ process.exit(0);
     assert.ok(restarted, `supervisor did not restart daemon\n${output}`);
     assert.deepEqual(restarted.daemon.agents, [...AGENTS, HOT_AGENT]);
     assert.deepEqual(restarted.daemon.connectedAgents, [...AGENTS, HOT_AGENT]);
+    for (const [file, mtime] of profileMtimes) assert.equal(fs.statSync(file).mtimeNs, mtime, `restart rewrote ${file}`);
   } finally {
+    for (const agentId of [...AGENTS, HOT_AGENT]) {
+      try { writableProfile(root, agentId); } catch { /* profile may not have been created */ }
+    }
     if (supervisor.exitCode === null && supervisor.signalCode === null) supervisor.kill("SIGTERM");
     await waitUntil(() => supervisor.exitCode !== null || supervisor.signalCode !== null, 3_000);
     if (supervisor.exitCode === null && supervisor.signalCode === null) supervisor.kill("SIGKILL");

--- a/test/integration/app/supervisor-hot-attach-restart.test.mjs
+++ b/test/integration/app/supervisor-hot-attach-restart.test.mjs
@@ -5,13 +5,15 @@ import path from "node:path";
 import { spawn } from "node:child_process";
 import { test } from "bun:test";
 import { fileURLToPath } from "node:url";
-import { requestAgentUpsert } from "../../../dist/app/local-control.mjs";
+import { requestAgentUpsert, requestSupervisorAgentUpsert } from "../../../dist/app/local-control.mjs";
 import { readProcessState } from "../../../dist/platform/process-state.mjs";
 import { loadConfig, runtimeConfigSignature } from "../../../dist/platform/config.mjs";
+import { hydrateRuntimeAgent, validateAgentProfile } from "../../../dist/app/runtime-agent-config.mjs";
 
 const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..", "..", "..");
 const AGENTS = ["cli_restartA1", "cli_restartB2", "cli_restartC3"];
 const HOT_AGENT = "cli_restartD4";
+const FAILED_HOT_AGENT = "cli_restartE5";
 
 function writePrivate(file, value) {
   fs.writeFileSync(file, `${typeof value === "string" ? value : JSON.stringify(value, null, 2)}\n`, { mode: 0o600 });
@@ -85,7 +87,7 @@ process.exit(0);
   writePrivate(path.join(root, "config.json"), configFor(AGENTS));
   const botsDir = path.join(root, "bots");
   fs.mkdirSync(botsDir, { mode: 0o700 });
-  for (const agentId of [...AGENTS, HOT_AGENT]) writePrivate(path.join(botsDir, `${agentId}.json`), {
+  for (const agentId of [...AGENTS, HOT_AGENT, FAILED_HOT_AGENT]) writePrivate(path.join(botsDir, `${agentId}.json`), {
     appId: agentId, appSecret: "fixture-secret", tenant: "feishu",
   });
 
@@ -97,9 +99,10 @@ process.exit(0);
     LARKIN_FEISHU_DRYRUN: "1",
     LARKIN_TEST_DAEMON_SCRIPT: path.join(ROOT, "test/support/supervisor-hot-attach-daemon.mjs"),
     LARKIN_TEST_DASHBOARD_SCRIPT: path.join(ROOT, "test/support/dashboard-stable.mjs"),
+    LARKIN_TEST_FAIL_SUPERVISOR_AGENT: FAILED_HOT_AGENT,
     PATH: `${binDir}${path.delimiter}${process.env.PATH || ""}`,
   };
-  const supervisor = spawn(process.execPath, [path.join(ROOT, "dist/app/run.mjs"), "--agents", AGENTS.join(","), "--dry-run"], {
+  const supervisor = spawn(process.execPath, [path.join(ROOT, "dist/app/run.mjs"), "--dry-run"], {
     cwd: ROOT, env, stdio: ["ignore", "pipe", "pipe"],
   });
   let secondSupervisor = null;
@@ -114,10 +117,32 @@ process.exit(0);
     });
     assert.ok(initial, `initial daemon did not own three Agents\n${output}`);
 
-    // Simulate setup's durable config commit before its supported daemon upsert.
-    writePrivate(path.join(root, "config.json"), configFor([...AGENTS, HOT_AGENT]));
-    const attached = await requestAgentUpsert({ larkinHome: root, agentId: HOT_AGENT });
+    // Simulate setup's durable config commit before its failed daemon upsert.
+    writePrivate(path.join(root, "config.json"), configFor([...AGENTS, FAILED_HOT_AGENT]));
+    const failed = await requestAgentUpsert({ larkinHome: root, agentId: FAILED_HOT_AGENT });
+    assert.equal(failed.ok, false, JSON.stringify(failed));
+    const oldDaemonPid = Number(initial.daemon.pid);
+    process.kill(oldDaemonPid, "SIGKILL");
+    const restartedWithoutFailedAgent = await waitUntil(() => {
+      const state = readProcessState(root);
+      return state.supervisor.state === "owned" && state.daemon.state === "owned"
+        && Number(state.daemon.pid) !== oldDaemonPid ? state : null;
+    }, 10_000);
+    assert.ok(restartedWithoutFailedAgent, `supervisor did not restart after failed hot attach\n${output}`);
+    assert.deepEqual(restartedWithoutFailedAgent.daemon.agents, AGENTS);
+
+    // A successful hot attach is explicitly added to this supervisor lifetime.
+    writePrivate(path.join(root, "config.json"), configFor([...AGENTS, FAILED_HOT_AGENT, HOT_AGENT]));
+    const hotAttachOperationId = "operation_hot_attach_1";
+    const attached = await requestAgentUpsert({ larkinHome: root, agentId: HOT_AGENT, operationId: hotAttachOperationId });
     assert.equal(attached.ok, true, JSON.stringify(attached));
+    const replayConflict = await requestSupervisorAgentUpsert({
+      larkinHome: root, agentId: FAILED_HOT_AGENT, operationId: hotAttachOperationId,
+    });
+    assert.deepEqual(replayConflict, {
+      ok: false, operationId: hotAttachOperationId, agentId: FAILED_HOT_AGENT,
+      code: "operation_conflict", error: "operationId 已绑定其他 Agent 或操作",
+    });
     const hotAttached = await waitUntil(() => {
       const state = readProcessState(root).daemon;
       return state.state === "owned" && state.agents?.length === 4 ? state : null;
@@ -131,13 +156,21 @@ process.exit(0);
         path.join(stateDir, "lark-channel-source", "config.json"), path.join(stateDir, "runtime-bin", "larkin")];
     });
     const profileMtimes = new Map(profileFiles.map((file) => [file, fs.statSync(file).mtimeNs]));
+    const hotRuntimeAgent = hydrateRuntimeAgent(root, loadConfig(env).config.agents[HOT_AGENT]);
+    const hotProfileRoot = hotRuntimeAgent.larkConfigDir;
+    const movedHotProfileRoot = `${hotProfileRoot}.moved`;
+    fs.renameSync(hotProfileRoot, movedHotProfileRoot);
+    fs.symlinkSync(movedHotProfileRoot, hotProfileRoot);
+    assert.throws(() => validateAgentProfile(hotRuntimeAgent), /lark-cli profile 目录不安全/);
+    fs.unlinkSync(hotProfileRoot);
+    fs.renameSync(movedHotProfileRoot, hotProfileRoot);
     for (const agentId of [...AGENTS, HOT_AGENT]) readOnlyProfile(root, agentId);
-    const oldDaemonPid = Number(hotAttached.pid);
-    process.kill(oldDaemonPid, "SIGKILL");
+    const hotAttachedDaemonPid = Number(hotAttached.pid);
+    process.kill(hotAttachedDaemonPid, "SIGKILL");
     const restarted = await waitUntil(() => {
       const state = readProcessState(root);
       return state.supervisor.state === "owned" && state.daemon.state === "owned"
-        && Number(state.daemon.pid) !== oldDaemonPid ? state : null;
+        && Number(state.daemon.pid) !== hotAttachedDaemonPid ? state : null;
     }, 10_000);
     assert.ok(restarted, `supervisor did not restart daemon\n${output}`);
     assert.deepEqual(restarted.daemon.agents, [...AGENTS, HOT_AGENT]);
@@ -177,7 +210,7 @@ process.exit(0);
     assert.ok(selectedRestarted, `selected supervisor did not restart daemon\n${output}`);
     assert.deepEqual(selectedRestarted.daemon.agents, [AGENTS[0]]);
   } finally {
-    for (const agentId of [...AGENTS, HOT_AGENT]) {
+    for (const agentId of [...AGENTS, HOT_AGENT, FAILED_HOT_AGENT]) {
       try { writableProfile(root, agentId); } catch { /* profile may not have been created */ }
     }
     if (supervisor.exitCode === null && supervisor.signalCode === null) supervisor.kill("SIGTERM");

--- a/test/integration/app/supervisor-hot-attach-restart.test.mjs
+++ b/test/integration/app/supervisor-hot-attach-restart.test.mjs
@@ -7,6 +7,7 @@ import { test } from "bun:test";
 import { fileURLToPath } from "node:url";
 import { requestAgentUpsert } from "../../../dist/app/local-control.mjs";
 import { readProcessState } from "../../../dist/platform/process-state.mjs";
+import { loadConfig, runtimeConfigSignature } from "../../../dist/platform/config.mjs";
 
 const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..", "..", "..");
 const AGENTS = ["cli_restartA1", "cli_restartB2", "cli_restartC3"];
@@ -101,6 +102,7 @@ process.exit(0);
   const supervisor = spawn(process.execPath, [path.join(ROOT, "dist/app/run.mjs"), "--agents", AGENTS.join(","), "--dry-run"], {
     cwd: ROOT, env, stdio: ["ignore", "pipe", "pipe"],
   });
+  let secondSupervisor = null;
   let output = "";
   supervisor.stdout.on("data", (chunk) => { output += chunk; });
   supervisor.stderr.on("data", (chunk) => { output += chunk; });
@@ -141,6 +143,39 @@ process.exit(0);
     assert.deepEqual(restarted.daemon.agents, [...AGENTS, HOT_AGENT]);
     assert.deepEqual(restarted.daemon.connectedAgents, [...AGENTS, HOT_AGENT]);
     for (const [file, mtime] of profileMtimes) assert.equal(fs.statSync(file).mtimeNs, mtime, `restart rewrote ${file}`);
+
+    // Historical apply state is deliberately present, but must not expand a
+    // later explicit selector. Membership additions belong to the supervisor
+    // lifetime, not to the durable freshness projection.
+    supervisor.kill("SIGTERM");
+    await waitUntil(() => supervisor.exitCode !== null || supervisor.signalCode !== null, 3_000);
+    const loaded = loadConfig(env);
+    const historicalAgents = Object.fromEntries(Object.keys(loaded.config.agents).map((agentId) => {
+      const signature = runtimeConfigSignature(loaded.config, agentId);
+      return [agentId, { persistedSignature: signature, appliedSignature: signature }];
+    }));
+    writePrivate(path.join(root, "config-apply-state.json"), {
+      version: 1, persistedRevision: "historical", agents: historicalAgents,
+    });
+    secondSupervisor = spawn(process.execPath, [path.join(ROOT, "dist/app/run.mjs"), "--agent", AGENTS[0], "--dry-run"], {
+      cwd: ROOT, env, stdio: ["ignore", "pipe", "pipe"],
+    });
+    secondSupervisor.stdout.on("data", (chunk) => { output += chunk; });
+    secondSupervisor.stderr.on("data", (chunk) => { output += chunk; });
+    const selected = await waitUntil(() => {
+      const state = readProcessState(root);
+      return state.daemon.state === "owned" && state.daemon.agents?.length === 1 ? state : null;
+    });
+    assert.ok(selected, `explicit selector included historical Agents\n${output}`);
+    assert.deepEqual(selected.daemon.agents, [AGENTS[0]]);
+    const selectedDaemonPid = Number(selected.daemon.pid);
+    process.kill(selectedDaemonPid, "SIGKILL");
+    const selectedRestarted = await waitUntil(() => {
+      const state = readProcessState(root);
+      return state.daemon.state === "owned" && Number(state.daemon.pid) !== selectedDaemonPid ? state : null;
+    }, 10_000);
+    assert.ok(selectedRestarted, `selected supervisor did not restart daemon\n${output}`);
+    assert.deepEqual(selectedRestarted.daemon.agents, [AGENTS[0]]);
   } finally {
     for (const agentId of [...AGENTS, HOT_AGENT]) {
       try { writableProfile(root, agentId); } catch { /* profile may not have been created */ }
@@ -148,6 +183,11 @@ process.exit(0);
     if (supervisor.exitCode === null && supervisor.signalCode === null) supervisor.kill("SIGTERM");
     await waitUntil(() => supervisor.exitCode !== null || supervisor.signalCode !== null, 3_000);
     if (supervisor.exitCode === null && supervisor.signalCode === null) supervisor.kill("SIGKILL");
+    if (secondSupervisor && secondSupervisor.exitCode === null && secondSupervisor.signalCode === null) secondSupervisor.kill("SIGTERM");
+    if (secondSupervisor) {
+      await waitUntil(() => secondSupervisor.exitCode !== null || secondSupervisor.signalCode !== null, 3_000);
+      if (secondSupervisor.exitCode === null && secondSupervisor.signalCode === null) secondSupervisor.kill("SIGKILL");
+    }
     fs.rmSync(root, { recursive: true, force: true });
   }
 });

--- a/test/integration/build/bun-only-runtime-contract.test.mjs
+++ b/test/integration/build/bun-only-runtime-contract.test.mjs
@@ -11,6 +11,7 @@ const SELF = path.relative(ROOT, import.meta.filename);
 const BUN_RUNNER_SEAM_ALLOWLIST = [
   "src/platform/process-inspect.cts",
   "test/integration/app/runtime-profile-rollback.test.mjs",
+  "test/integration/app/supervisor-hot-attach-restart.test.mjs",
   "test/integration/platform/process-idempotency.test.mjs",
   "test/integration/platform/process-ownership.test.mjs",
   "test/unit/agent/agent-state-store.test.mjs",

--- a/test/support/dashboard-stable.mjs
+++ b/test/support/dashboard-stable.mjs
@@ -1,0 +1,17 @@
+import fs from "node:fs";
+import path from "node:path";
+import { currentProcessMetadata } from "../../dist/platform/process-state.mjs";
+
+const root = process.env.LARKIN_CONFIG_DIR;
+if (!root) throw new Error("LARKIN_CONFIG_DIR missing");
+fs.writeFileSync(path.join(root, "dashboard-status.json"), `${JSON.stringify({
+  ...currentProcessMetadata("dashboard-stable.mjs"),
+  pid: process.pid,
+  commandToken: "dashboard-stable.mjs",
+  url: "http://localhost:19996",
+  startedAt: new Date().toISOString(),
+}, null, 2)}\n`, { mode: 0o600 });
+
+process.once("SIGTERM", () => process.exit(0));
+process.once("SIGINT", () => process.exit(0));
+setInterval(() => {}, 60_000);

--- a/test/support/supervisor-hot-attach-daemon.mjs
+++ b/test/support/supervisor-hot-attach-daemon.mjs
@@ -1,0 +1,50 @@
+import fs from "node:fs";
+import path from "node:path";
+import { createAgentControlServer } from "../../dist/app/local-control.mjs";
+import { loadConfig, markConfigApplied, runtimeConfigSignature } from "../../dist/platform/config.mjs";
+import { currentProcessMetadata } from "../../dist/platform/process-state.mjs";
+
+const root = process.env.LARKIN_CONFIG_DIR;
+if (!root) throw new Error("LARKIN_CONFIG_DIR missing");
+const statusFile = path.join(root, "daemon-status.json");
+let agents = JSON.parse(process.env.LARKIN_AGENTS_CONFIG || "[]").map((agent) => agent.agentId);
+
+function writeStatus() {
+  fs.writeFileSync(statusFile, `${JSON.stringify({
+    ...currentProcessMetadata("supervisor-hot-attach-daemon.mjs"),
+    pid: process.pid,
+    commandToken: "supervisor-hot-attach-daemon.mjs",
+    agents,
+    connectedAgents: [...agents],
+  }, null, 2)}\n`, { mode: 0o600 });
+}
+
+const control = createAgentControlServer({
+  larkinHome: root,
+  authorityToken: process.env.LARKIN_CONTROL_AUTHORIZATION,
+  async upsert({ agentId }) {
+    const loaded = loadConfig(process.env);
+    if (!loaded.config.agents[agentId]) throw new Error(`Agent ${agentId} missing from durable config`);
+    if (!agents.includes(agentId)) agents.push(agentId);
+    markConfigApplied(process.env, agentId, runtimeConfigSignature(loaded.config, agentId));
+    writeStatus();
+  },
+});
+
+for (const agentId of agents) {
+  const loaded = loadConfig(process.env);
+  markConfigApplied(process.env, agentId, runtimeConfigSignature(loaded.config, agentId));
+}
+await control.start();
+writeStatus();
+
+let stopping = false;
+async function stop() {
+  if (stopping) return;
+  stopping = true;
+  await control.close();
+  process.exit(0);
+}
+process.once("SIGTERM", () => { void stop(); });
+process.once("SIGINT", () => { void stop(); });
+setInterval(() => {}, 60_000);

--- a/test/support/supervisor-hot-attach-daemon.mjs
+++ b/test/support/supervisor-hot-attach-daemon.mjs
@@ -2,6 +2,7 @@ import fs from "node:fs";
 import path from "node:path";
 import { createAgentControlServer } from "../../dist/app/local-control.mjs";
 import { loadConfig, markConfigApplied, runtimeConfigSignature } from "../../dist/platform/config.mjs";
+import { loadAndSyncRuntimeAgent } from "../../dist/app/runtime-process.mjs";
 import { currentProcessMetadata } from "../../dist/platform/process-state.mjs";
 
 const root = process.env.LARKIN_CONFIG_DIR;
@@ -25,6 +26,7 @@ const control = createAgentControlServer({
   async upsert({ agentId }) {
     const loaded = loadConfig(process.env);
     if (!loaded.config.agents[agentId]) throw new Error(`Agent ${agentId} missing from durable config`);
+    loadAndSyncRuntimeAgent(process.env, agentId);
     if (!agents.includes(agentId)) agents.push(agentId);
     markConfigApplied(process.env, agentId, runtimeConfigSignature(loaded.config, agentId));
     writeStatus();

--- a/test/support/supervisor-hot-attach-daemon.mjs
+++ b/test/support/supervisor-hot-attach-daemon.mjs
@@ -30,6 +30,9 @@ const control = createAgentControlServer({
     loadAndSyncRuntimeAgent(process.env, agentId);
     if (!agents.includes(agentId)) agents.push(agentId);
     writeStatus();
+    if (process.env.LARKIN_TEST_FAIL_SUPERVISOR_AGENT === agentId) {
+      throw new Error(`fixture supervisor tracking failure for ${agentId}`);
+    }
     const tracked = await requestSupervisorAgentUpsert({
       larkinHome: root, agentId, operationId: request.operationId,
     });

--- a/test/support/supervisor-hot-attach-daemon.mjs
+++ b/test/support/supervisor-hot-attach-daemon.mjs
@@ -1,7 +1,7 @@
 import fs from "node:fs";
 import path from "node:path";
-import { createAgentControlServer } from "../../dist/app/local-control.mjs";
-import { loadConfig, markConfigApplied, runtimeConfigSignature } from "../../dist/platform/config.mjs";
+import { createAgentControlServer, requestSupervisorAgentUpsert } from "../../dist/app/local-control.mjs";
+import { loadConfig } from "../../dist/platform/config.mjs";
 import { loadAndSyncRuntimeAgent } from "../../dist/app/runtime-process.mjs";
 import { currentProcessMetadata } from "../../dist/platform/process-state.mjs";
 
@@ -23,20 +23,19 @@ function writeStatus() {
 const control = createAgentControlServer({
   larkinHome: root,
   authorityToken: process.env.LARKIN_CONTROL_AUTHORIZATION,
-  async upsert({ agentId }) {
+  async upsert(request) {
+    const { agentId } = request;
     const loaded = loadConfig(process.env);
     if (!loaded.config.agents[agentId]) throw new Error(`Agent ${agentId} missing from durable config`);
     loadAndSyncRuntimeAgent(process.env, agentId);
     if (!agents.includes(agentId)) agents.push(agentId);
-    markConfigApplied(process.env, agentId, runtimeConfigSignature(loaded.config, agentId));
     writeStatus();
+    const tracked = await requestSupervisorAgentUpsert({
+      larkinHome: root, agentId, operationId: request.operationId,
+    });
+    if (!tracked.ok) throw new Error(tracked.error || "supervisor 未记录 Agent 热挂载");
   },
 });
-
-for (const agentId of agents) {
-  const loaded = loadConfig(process.env);
-  markConfigApplied(process.env, agentId, runtimeConfigSignature(loaded.config, agentId));
-}
 await control.start();
 writeStatus();
 


### PR DESCRIPTION
## Summary

Fixes #145. The supervisor now reloads durable config and rehydrates the selected Agent set before every daemon launch, including bounded crash restarts, then regenerates `LARKIN_AGENTS_CONFIG`. This removes the stale startup snapshot that omitted Agents hot-attached to the child.

## Scope

- Durable `config.json` remains the recovery source of truth.
- Added a process-level regression covering 3 initial Agents, supported hot attach of a 4th, SIGKILL of the daemon, supervised restart, and ownership/connection of all 4.
- Bumped patch version `0.4.12` → `0.4.13`.

## Validation

- `bun run typecheck`
- `bun run build`
- `bun test --max-concurrency 1 test/integration/app/supervisor-hot-attach-restart.test.mjs`
- `bun test --max-concurrency 1 test/integration/platform/process-idempotency.test.mjs test/integration/app/supervisor-bounded-dashboard-stop.test.mjs`
- `bun test --max-concurrency 1 test/unit/platform/versioning.test.mjs`
- `bun run licenses:check`
- `bun run publication:check:tree`

One unrelated config-management test (`a live reclaim guard...`) timed out during targeted validation; the new regression and process idempotency tests pass.

## Non-goals

No merge, release, issue closure, runtime restart outside the test fixture, or bot rebinding.