### PR TITLE
fix(pi): bound subagent result waits (#118)

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -38,6 +38,9 @@
       },
     },
   },
+  "patchedDependencies": {
+    "@tintinweb/pi-subagents@0.14.3": "patches/@tintinweb%2Fpi-subagents@0.14.3.patch",
+  },
   "packages": {
     "@adobe/css-tools": ["@adobe/css-tools@4.5.0", "https://registry.npmmirror.com/@adobe/css-tools/-/css-tools-4.5.0.tgz", {}, "sha512-6OzddxPio9UiWTCemp4N8cYLV2ZN1ncRnV1cVGtve7dhPOtRkleRyx32GQCYSwDYgaHU3USMm84tNsvKzRCa1Q=="],
 

--- a/evals/agent-experience-v6/scenarios.json
+++ b/evals/agent-experience-v6/scenarios.json
@@ -3,7 +3,7 @@
   "version": 6,
   "model": {
     "selection": "deterministic-trace",
-    "standing_prompt_version": "larkin-standing-v22"
+    "standing_prompt_version": "larkin-standing-v23"
   },
   "session": {
     "initial_turns": 0

--- a/evals/authoritative-freshness-gate/scenarios.json
+++ b/evals/authoritative-freshness-gate/scenarios.json
@@ -1,7 +1,7 @@
 {
   "dataset": "authoritative-freshness-gate",
   "version": 1,
-  "standing_prompt_version": "larkin-standing-v22",
+  "standing_prompt_version": "larkin-standing-v23",
   "runtime": { "adapter": "codex", "selection": "runtime-default" },
   "grader": {
     "name": "authoritative-freshness-trace-grader",

--- a/evals/clickable-link-delivery/scenarios.json
+++ b/evals/clickable-link-delivery/scenarios.json
@@ -1,7 +1,7 @@
 {
   "dataset": "clickable-link-delivery",
   "version": 1,
-  "standing_prompt_version": "larkin-standing-v22",
+  "standing_prompt_version": "larkin-standing-v23",
   "runtime": { "adapter": "codex", "selection": "runtime-default" },
   "threshold": 1,
   "grader": {

--- a/evals/mention-construction/scenarios.json
+++ b/evals/mention-construction/scenarios.json
@@ -1,7 +1,7 @@
 {
   "dataset": "mention-construction",
   "version": 1,
-  "standing_prompt_version": "larkin-standing-v22",
+  "standing_prompt_version": "larkin-standing-v23",
   "runtime": { "adapter": "codex", "selection": "runtime-default" },
   "grader": {
     "name": "mention-construction-trace-grader",

--- a/evals/runtime-agent-interface-v2/scenarios.json
+++ b/evals/runtime-agent-interface-v2/scenarios.json
@@ -7,7 +7,7 @@
   },
   "model": {
     "selection": "gpt-5.6-sol",
-    "standing_prompt_version": "larkin-standing-v22"
+    "standing_prompt_version": "larkin-standing-v23"
   },
   "grader": {
     "name": "runtime-agent-interface-v2-trace-grader",

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "larkinPackageRole": "npm-published",
   "files": [
     "dist/",
+    "patches/",
     "assets/",
     "scripts/npm/",
     "README.md",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "larkin",
-  "version": "0.4.14",
+  "version": "0.4.15",
   "private": false,
   "larkinPackageRole": "npm-published",
   "files": [
@@ -114,5 +114,8 @@
     "typescript": "^7.0.2",
     "vite": "^8.1.5",
     "vitest": "^4.1.10"
+  },
+  "patchedDependencies": {
+    "@tintinweb/pi-subagents@0.14.3": "patches/@tintinweb%2Fpi-subagents@0.14.3.patch"
   }
 }

--- a/patches/@tintinweb%2Fpi-subagents@0.14.3.patch
+++ b/patches/@tintinweb%2Fpi-subagents@0.14.3.patch
@@ -8,10 +8,10 @@ diff --git a/node_modules/@tintinweb/pi-subagents/.bun-tag-80c5d241789d23ea b/.b
 new file mode 100644
 index 0000000000000000000000000000000000000000..e69de29bb2d1d6434b8b29ae775ad8c2e48c5391
 diff --git a/dist/index.js b/dist/index.js
-index ab65ef15b5c1da803c0378b1d0ba383645198028..d8780fa4ab5b88ca5f576ee550294e50c7e6c450 100644
+index ab65ef15b5c1da803c0378b1d0ba383645198028..dc18e00d2ce4bddb6ee77608364d3c8b39fdfd60 100644
 --- a/dist/index.js
 +++ b/dist/index.js
-@@ -69,6 +69,43 @@ function abortable(promise, signal) {
+@@ -69,6 +69,44 @@ function abortable(promise, signal) {
          });
      });
  }
@@ -52,18 +52,27 @@ index ab65ef15b5c1da803c0378b1d0ba383645198028..d8780fa4ab5b88ca5f576ee550294e50
 +        return true;
 +    return (await waitWithDeadline(record.promise, remainingMs, signal)).timedOut;
 +}
++const LARKIN_BOUNDED_WAIT_CAPABILITY = "larkin-pi-subagents-bounded-wait-v1";
  export function renderRunningAgentStatus(frame, statsText, activity, theme) {
      const container = new Container();
      container.addChild(new Text(theme.fg("accent", frame) + (statsText ? " " + statsText : ""), 0, 0));
-@@ -282,7 +319,6 @@ export default function (pi) {
+@@ -280,9 +318,14 @@ export default function (pi) {
+     // before they reach pi.sendMessage (fire-and-forget).
+     const pendingNudges = new Map();
      const NUDGE_HOLD_MS = 200;
++    // A parent agent run may span multiple model turns. Keep the wait budget at
++    // that level so a timeout cannot be reset by a later get_subagent_result call.
++    let resultWaitTimedOutInParentTurn = false;
++    pi.on("agent_start", () => {
++        resultWaitTimedOutInParentTurn = false;
++    });
      // A queued result wait must observe completion before its held notification
      // can fire, so successful waits can still suppress that redundant nudge.
 -    const QUEUE_WAIT_POLL_MS = Math.floor(NUDGE_HOLD_MS / 4);
      function scheduleNudge(key, send, delay = NUDGE_HOLD_MS) {
          cancelNudge(key);
          pendingNudges.set(key, setTimeout(() => {
-@@ -1293,6 +1329,9 @@ Terse command-style prompts produce shallow, generic work.
+@@ -1293,6 +1336,9 @@ Terse command-style prompts produce shallow, generic work.
              wait: Type.Optional(Type.Boolean({
                  description: "If true, wait for the agent to complete before returning. Default: false.",
              })),
@@ -73,11 +82,14 @@ index ab65ef15b5c1da803c0378b1d0ba383645198028..d8780fa4ab5b88ca5f576ee550294e50
              verbose: Type.Optional(Type.Boolean({
                  description: "If true, include the agent's full conversation (messages + tool calls). Default: false.",
              })),
-@@ -1307,12 +1346,11 @@ Terse command-style prompts produce shallow, generic work.
+@@ -1307,12 +1353,16 @@ Terse command-style prompts produce shallow, generic work.
              // completion notification can still be delivered.
              // Queued agents have no promise yet (it's created when the queue starts
              // them), so poll until they leave the queue, then await like a running one.
 +            // One deadline covers both phases so queue polling cannot reset the wait.
++            if (params.wait && resultWaitTimedOutInParentTurn) {
++                throw new Error("Refusing wait: true after an earlier wait timed out in this parent turn; yield and await the completion notification instead.");
++            }
 +            let timedOut = false;
 +            const waitTimeoutMs = normalizeResultWaitTimeout(params.timeout_ms);
              if (params.wait && (record.status === "running" || record.status === "queued")) {
@@ -87,10 +99,12 @@ index ab65ef15b5c1da803c0378b1d0ba383645198028..d8780fa4ab5b88ca5f576ee550294e50
 -                if (record.promise)
 -                    await abortable(record.promise, signal);
 +                timedOut = await waitForSubagentResult(record, waitTimeoutMs, signal);
++                if (timedOut)
++                    resultWaitTimedOutInParentTurn = true;
              }
              const displayName = getDisplayName(record.type);
              const duration = formatDuration(record.startedAt, record.completedAt);
-@@ -1327,10 +1365,12 @@ Terse command-style prompts produce shallow, generic work.
+@@ -1327,10 +1377,12 @@ Terse command-style prompts produce shallow, generic work.
                  statsParts.push(`Compactions: ${record.compactionCount}`);
              statsParts.push(`Duration: ${duration}`);
              let output = `Agent: ${record.id}\n` +
@@ -107,10 +121,10 @@ index ab65ef15b5c1da803c0378b1d0ba383645198028..d8780fa4ab5b88ca5f576ee550294e50
              else if (record.status === "error") {
                  output += `Error: ${record.error}${partialOutputSuffix(record)}`;
 diff --git a/src/index.ts b/src/index.ts
-index 828938e6d710dc5a8f99a6185e37f9592b12352d..43ca60dbcb0597178346491ed514bd431cb94ff1 100644
+index 828938e6d710dc5a8f99a6185e37f9592b12352d..fb2d3119a50c6aa9c8864037af65ff95bbe4bb1f 100644
 --- a/src/index.ts
 +++ b/src/index.ts
-@@ -91,6 +91,52 @@ function abortable<T>(promise: Promise<T>, signal?: AbortSignal): Promise<T> {
+@@ -91,6 +91,54 @@ function abortable<T>(promise: Promise<T>, signal?: AbortSignal): Promise<T> {
    });
  }
  
@@ -160,11 +174,21 @@ index 828938e6d710dc5a8f99a6185e37f9592b12352d..43ca60dbcb0597178346491ed514bd43
 +  return (await waitWithDeadline(record.promise, remainingMs, signal)).timedOut;
 +}
 +
++export const LARKIN_BOUNDED_WAIT_CAPABILITY = "larkin-pi-subagents-bounded-wait-v1";
++
  export function renderRunningAgentStatus(
    frame: string,
    statsText: string,
-@@ -332,8 +378,6 @@ export default function (pi: ExtensionAPI) {
+@@ -330,10 +378,14 @@ export default function (pi: ExtensionAPI) {
+   // before they reach pi.sendMessage (fire-and-forget).
+   const pendingNudges = new Map<string, ReturnType<typeof setTimeout>>();
    const NUDGE_HOLD_MS = 200;
++  // A parent agent run may span multiple model turns. Keep the wait budget at
++  // that level so a timeout cannot be reset by a later get_subagent_result call.
++  let resultWaitTimedOutInParentTurn = false;
++  pi.on("agent_start", () => {
++    resultWaitTimedOutInParentTurn = false;
++  });
    // A queued result wait must observe completion before its held notification
    // can fire, so successful waits can still suppress that redundant nudge.
 -  const QUEUE_WAIT_POLL_MS = Math.floor(NUDGE_HOLD_MS / 4);
@@ -172,7 +196,7 @@ index 828938e6d710dc5a8f99a6185e37f9592b12352d..43ca60dbcb0597178346491ed514bd43
    function scheduleNudge(key: string, send: () => void, delay = NUDGE_HOLD_MS) {
      cancelNudge(key);
      pendingNudges.set(key, setTimeout(() => {
-@@ -1453,6 +1497,11 @@ Terse command-style prompts produce shallow, generic work.
+@@ -1453,6 +1505,11 @@ Terse command-style prompts produce shallow, generic work.
            description: "If true, wait for the agent to complete before returning. Default: false.",
          }),
        ),
@@ -184,11 +208,14 @@ index 828938e6d710dc5a8f99a6185e37f9592b12352d..43ca60dbcb0597178346491ed514bd43
        verbose: Type.Optional(
          Type.Boolean({
            description: "If true, include the agent's full conversation (messages + tool calls). Default: false.",
-@@ -1470,14 +1519,11 @@ Terse command-style prompts produce shallow, generic work.
+@@ -1470,14 +1527,15 @@ Terse command-style prompts produce shallow, generic work.
        // completion notification can still be delivered.
        // Queued agents have no promise yet (it's created when the queue starts
        // them), so poll until they leave the queue, then await like a running one.
 +      // One deadline covers both phases so queue polling cannot reset the wait.
++      if (params.wait && resultWaitTimedOutInParentTurn) {
++        throw new Error("Refusing wait: true after an earlier wait timed out in this parent turn; yield and await the completion notification instead.");
++      }
 +      let timedOut = false;
 +      const waitTimeoutMs = normalizeResultWaitTimeout(params.timeout_ms);
        if (params.wait && (record.status === "running" || record.status === "queued")) {
@@ -200,10 +227,11 @@ index 828938e6d710dc5a8f99a6185e37f9592b12352d..43ca60dbcb0597178346491ed514bd43
 -        }
 -        if (record.promise) await abortable(record.promise, signal);
 +        timedOut = await waitForSubagentResult(record, waitTimeoutMs, signal);
++        if (timedOut) resultWaitTimedOutInParentTurn = true;
        }
  
        const displayName = getDisplayName(record.type);
-@@ -1492,11 +1538,13 @@ Terse command-style prompts produce shallow, generic work.
+@@ -1492,11 +1550,13 @@ Terse command-style prompts produce shallow, generic work.
  
        let output =
          `Agent: ${record.id}\n` +

--- a/patches/@tintinweb%2Fpi-subagents@0.14.3.patch
+++ b/patches/@tintinweb%2Fpi-subagents@0.14.3.patch
@@ -1,0 +1,120 @@
+diff --git a/node_modules/@tintinweb/pi-subagents/.bun-tag-6ef69510e99ece5d b/.bun-tag-6ef69510e99ece5d
+new file mode 100644
+index 0000000000000000000000000000000000000000..e69de29bb2d1d6434b8b29ae775ad8c2e48c5391
+diff --git a/node_modules/@tintinweb/pi-subagents/.bun-tag-80c5d241789d23ea b/.bun-tag-80c5d241789d23ea
+new file mode 100644
+index 0000000000000000000000000000000000000000..e69de29bb2d1d6434b8b29ae775ad8c2e48c5391
+diff --git a/src/index.ts b/src/index.ts
+index 828938e6d710dc5a8f99a6185e37f9592b12352d..5c1b4228039052aa6c61b1af9126058a4b391df1 100644
+--- a/src/index.ts
++++ b/src/index.ts
+@@ -91,6 +91,52 @@ function abortable<T>(promise: Promise<T>, signal?: AbortSignal): Promise<T> {
+   });
+ }
+ 
++const RESULT_WAIT_QUEUE_POLL_MS = 50;
++const DEFAULT_RESULT_WAIT_TIMEOUT_MS = 30_000;
++const MAX_RESULT_WAIT_TIMEOUT_MS = 60_000;
++
++function normalizeResultWaitTimeout(timeoutMs: number | undefined): number {
++  if (timeoutMs === undefined || !Number.isFinite(timeoutMs)) return DEFAULT_RESULT_WAIT_TIMEOUT_MS;
++  return Math.max(1, Math.min(MAX_RESULT_WAIT_TIMEOUT_MS, Math.floor(timeoutMs)));
++}
++
++function waitWithDeadline<T>(promise: Promise<T>, timeoutMs: number, signal?: AbortSignal): Promise<{ timedOut: true } | { timedOut: false; value: T }> {
++  let timer: ReturnType<typeof setTimeout> | undefined;
++  const timeout = new Promise<{ timedOut: true }>((resolve) => {
++    timer = setTimeout(() => resolve({ timedOut: true }), timeoutMs);
++  });
++  return abortable(
++    Promise.race([
++      promise.then((value) => ({ timedOut: false as const, value })),
++      timeout,
++    ]),
++    signal,
++  ).finally(() => {
++    if (timer !== undefined) clearTimeout(timer);
++  });
++}
++
++/** Wait for one background record without cancelling it when the deadline expires. */
++export async function waitForSubagentResult(
++  record: Pick<AgentRecord, "status" | "promise">,
++  timeoutMs: number,
++  signal?: AbortSignal,
++): Promise<boolean> {
++  const deadline = Date.now() + timeoutMs;
++  while (record.status === "queued") {
++    const remainingMs = deadline - Date.now();
++    if (remainingMs <= 0) return true;
++    await abortable(
++      new Promise<void>((resolve) => setTimeout(resolve, Math.min(RESULT_WAIT_QUEUE_POLL_MS, remainingMs))),
++      signal,
++    );
++  }
++  if (!record.promise) return false;
++  const remainingMs = deadline - Date.now();
++  if (remainingMs <= 0) return true;
++  return (await waitWithDeadline(record.promise, remainingMs, signal)).timedOut;
++}
++
+ export function renderRunningAgentStatus(
+   frame: string,
+   statsText: string,
+@@ -332,8 +378,6 @@ export default function (pi: ExtensionAPI) {
+   const NUDGE_HOLD_MS = 200;
+   // A queued result wait must observe completion before its held notification
+   // can fire, so successful waits can still suppress that redundant nudge.
+-  const QUEUE_WAIT_POLL_MS = Math.floor(NUDGE_HOLD_MS / 4);
+-
+   function scheduleNudge(key: string, send: () => void, delay = NUDGE_HOLD_MS) {
+     cancelNudge(key);
+     pendingNudges.set(key, setTimeout(() => {
+@@ -1453,6 +1497,11 @@ Terse command-style prompts produce shallow, generic work.
+           description: "If true, wait for the agent to complete before returning. Default: false.",
+         }),
+       ),
++      timeout_ms: Type.Optional(
++        Type.Number({
++          description: "Maximum wait in milliseconds when wait is true. Defaults to 30000 and is capped at 60000.",
++        }),
++      ),
+       verbose: Type.Optional(
+         Type.Boolean({
+           description: "If true, include the agent's full conversation (messages + tool calls). Default: false.",
+@@ -1470,14 +1519,11 @@ Terse command-style prompts produce shallow, generic work.
+       // completion notification can still be delivered.
+       // Queued agents have no promise yet (it's created when the queue starts
+       // them), so poll until they leave the queue, then await like a running one.
++      // One deadline covers both phases so queue polling cannot reset the wait.
++      let timedOut = false;
++      const waitTimeoutMs = normalizeResultWaitTimeout(params.timeout_ms);
+       if (params.wait && (record.status === "running" || record.status === "queued")) {
+-        while (record.status === "queued") {
+-          await abortable(
+-            new Promise<void>((resolve) => setTimeout(resolve, QUEUE_WAIT_POLL_MS)),
+-            signal,
+-          );
+-        }
+-        if (record.promise) await abortable(record.promise, signal);
++        timedOut = await waitForSubagentResult(record, waitTimeoutMs, signal);
+       }
+ 
+       const displayName = getDisplayName(record.type);
+@@ -1492,11 +1538,13 @@ Terse command-style prompts produce shallow, generic work.
+ 
+       let output =
+         `Agent: ${record.id}\n` +
+-        `Type: ${displayName} | Status: ${record.status}${getStatusNote(record.status)} | ${statsParts.join(" | ")}\n` +
++        `Type: ${displayName} | Status: ${record.status}${getStatusNote(record.status)}${timedOut ? " | timedOut: true" : ""} | ${statsParts.join(" | ")}\n` +
+         `Description: ${record.description}\n\n`;
+ 
+-      if (record.status === "running") {
+-        output += "Agent is still running. Use wait: true or check back later.";
++      if (record.status === "running" || record.status === "queued") {
++        output += timedOut
++          ? `Agent is still ${record.status}. Wait timed out after ${waitTimeoutMs}ms; the background agent was not cancelled. Use wait: true or check back later.`
++          : "Agent is still running. Use wait: true or check back later.";
+       } else if (record.status === "error") {
+         output += `Error: ${record.error}${partialOutputSuffix(record)}`;
+       } else {

--- a/patches/@tintinweb%2Fpi-subagents@0.14.3.patch
+++ b/patches/@tintinweb%2Fpi-subagents@0.14.3.patch
@@ -1,11 +1,113 @@
+diff --git a/node_modules/@tintinweb/pi-subagents/.bun-tag-58e08ce8246a76a0 b/.bun-tag-58e08ce8246a76a0
+new file mode 100644
+index 0000000000000000000000000000000000000000..e69de29bb2d1d6434b8b29ae775ad8c2e48c5391
 diff --git a/node_modules/@tintinweb/pi-subagents/.bun-tag-6ef69510e99ece5d b/.bun-tag-6ef69510e99ece5d
 new file mode 100644
 index 0000000000000000000000000000000000000000..e69de29bb2d1d6434b8b29ae775ad8c2e48c5391
 diff --git a/node_modules/@tintinweb/pi-subagents/.bun-tag-80c5d241789d23ea b/.bun-tag-80c5d241789d23ea
 new file mode 100644
 index 0000000000000000000000000000000000000000..e69de29bb2d1d6434b8b29ae775ad8c2e48c5391
+diff --git a/dist/index.js b/dist/index.js
+index ab65ef15b5c1da803c0378b1d0ba383645198028..d8780fa4ab5b88ca5f576ee550294e50c7e6c450 100644
+--- a/dist/index.js
++++ b/dist/index.js
+@@ -69,6 +69,43 @@ function abortable(promise, signal) {
+         });
+     });
+ }
++const RESULT_WAIT_QUEUE_POLL_MS = 50;
++const DEFAULT_RESULT_WAIT_TIMEOUT_MS = 30000;
++const MAX_RESULT_WAIT_TIMEOUT_MS = 60000;
++function normalizeResultWaitTimeout(timeoutMs) {
++    if (timeoutMs === undefined || !Number.isFinite(timeoutMs))
++        return DEFAULT_RESULT_WAIT_TIMEOUT_MS;
++    return Math.max(1, Math.min(MAX_RESULT_WAIT_TIMEOUT_MS, Math.floor(timeoutMs)));
++}
++function waitWithDeadline(promise, timeoutMs, signal) {
++    let timer;
++    const timeout = new Promise((resolve) => {
++        timer = setTimeout(() => resolve({ timedOut: true }), timeoutMs);
++    });
++    return abortable(Promise.race([
++        promise.then((value) => ({ timedOut: false, value })),
++        timeout,
++    ]), signal).finally(() => {
++        if (timer !== undefined)
++            clearTimeout(timer);
++    });
++}
++/** Wait for one background record without cancelling it when the deadline expires. */
++export async function waitForSubagentResult(record, timeoutMs, signal) {
++    const deadline = Date.now() + timeoutMs;
++    while (record.status === "queued") {
++        const remainingMs = deadline - Date.now();
++        if (remainingMs <= 0)
++            return true;
++        await abortable(new Promise((resolve) => setTimeout(resolve, Math.min(RESULT_WAIT_QUEUE_POLL_MS, remainingMs))), signal);
++    }
++    if (!record.promise)
++        return false;
++    const remainingMs = deadline - Date.now();
++    if (remainingMs <= 0)
++        return true;
++    return (await waitWithDeadline(record.promise, remainingMs, signal)).timedOut;
++}
+ export function renderRunningAgentStatus(frame, statsText, activity, theme) {
+     const container = new Container();
+     container.addChild(new Text(theme.fg("accent", frame) + (statsText ? " " + statsText : ""), 0, 0));
+@@ -282,7 +319,6 @@ export default function (pi) {
+     const NUDGE_HOLD_MS = 200;
+     // A queued result wait must observe completion before its held notification
+     // can fire, so successful waits can still suppress that redundant nudge.
+-    const QUEUE_WAIT_POLL_MS = Math.floor(NUDGE_HOLD_MS / 4);
+     function scheduleNudge(key, send, delay = NUDGE_HOLD_MS) {
+         cancelNudge(key);
+         pendingNudges.set(key, setTimeout(() => {
+@@ -1293,6 +1329,9 @@ Terse command-style prompts produce shallow, generic work.
+             wait: Type.Optional(Type.Boolean({
+                 description: "If true, wait for the agent to complete before returning. Default: false.",
+             })),
++            timeout_ms: Type.Optional(Type.Number({
++                description: "Maximum wait in milliseconds when wait is true. Defaults to 30000 and is capped at 60000.",
++            })),
+             verbose: Type.Optional(Type.Boolean({
+                 description: "If true, include the agent's full conversation (messages + tool calls). Default: false.",
+             })),
+@@ -1307,12 +1346,11 @@ Terse command-style prompts produce shallow, generic work.
+             // completion notification can still be delivered.
+             // Queued agents have no promise yet (it's created when the queue starts
+             // them), so poll until they leave the queue, then await like a running one.
++            // One deadline covers both phases so queue polling cannot reset the wait.
++            let timedOut = false;
++            const waitTimeoutMs = normalizeResultWaitTimeout(params.timeout_ms);
+             if (params.wait && (record.status === "running" || record.status === "queued")) {
+-                while (record.status === "queued") {
+-                    await abortable(new Promise((resolve) => setTimeout(resolve, QUEUE_WAIT_POLL_MS)), signal);
+-                }
+-                if (record.promise)
+-                    await abortable(record.promise, signal);
++                timedOut = await waitForSubagentResult(record, waitTimeoutMs, signal);
+             }
+             const displayName = getDisplayName(record.type);
+             const duration = formatDuration(record.startedAt, record.completedAt);
+@@ -1327,10 +1365,12 @@ Terse command-style prompts produce shallow, generic work.
+                 statsParts.push(`Compactions: ${record.compactionCount}`);
+             statsParts.push(`Duration: ${duration}`);
+             let output = `Agent: ${record.id}\n` +
+-                `Type: ${displayName} | Status: ${record.status}${getStatusNote(record.status)} | ${statsParts.join(" | ")}\n` +
++                `Type: ${displayName} | Status: ${record.status}${getStatusNote(record.status)}${timedOut ? " | timedOut: true" : ""} | ${statsParts.join(" | ")}\n` +
+                 `Description: ${record.description}\n\n`;
+-            if (record.status === "running") {
+-                output += "Agent is still running. Use wait: true or check back later.";
++            if (record.status === "running" || record.status === "queued") {
++                output += timedOut
++                    ? `Agent is still ${record.status}. Wait timed out after ${waitTimeoutMs}ms; the background agent was not cancelled. Yield/end this turn and await the completion notification; do not call wait: true again.`
++                    : "Agent is still running. Use wait: true or check back later.";
+             }
+             else if (record.status === "error") {
+                 output += `Error: ${record.error}${partialOutputSuffix(record)}`;
 diff --git a/src/index.ts b/src/index.ts
-index 828938e6d710dc5a8f99a6185e37f9592b12352d..5c1b4228039052aa6c61b1af9126058a4b391df1 100644
+index 828938e6d710dc5a8f99a6185e37f9592b12352d..43ca60dbcb0597178346491ed514bd431cb94ff1 100644
 --- a/src/index.ts
 +++ b/src/index.ts
 @@ -91,6 +91,52 @@ function abortable<T>(promise: Promise<T>, signal?: AbortSignal): Promise<T> {
@@ -113,7 +215,7 @@ index 828938e6d710dc5a8f99a6185e37f9592b12352d..5c1b4228039052aa6c61b1af9126058a
 -        output += "Agent is still running. Use wait: true or check back later.";
 +      if (record.status === "running" || record.status === "queued") {
 +        output += timedOut
-+          ? `Agent is still ${record.status}. Wait timed out after ${waitTimeoutMs}ms; the background agent was not cancelled. Use wait: true or check back later.`
++          ? `Agent is still ${record.status}. Wait timed out after ${waitTimeoutMs}ms; the background agent was not cancelled. Yield/end this turn and await the completion notification; do not call wait: true again.`
 +          : "Agent is still running. Use wait: true or check back later.";
        } else if (record.status === "error") {
          output += `Error: ${record.error}${partialOutputSuffix(record)}`;

--- a/patches/@tintinweb%2Fpi-subagents@0.14.3.patch
+++ b/patches/@tintinweb%2Fpi-subagents@0.14.3.patch
@@ -60,11 +60,11 @@ index ab65ef15b5c1da803c0378b1d0ba383645198028..dc18e00d2ce4bddb6ee77608364d3c8b
      // before they reach pi.sendMessage (fire-and-forget).
      const pendingNudges = new Map();
      const NUDGE_HOLD_MS = 200;
-+    // A parent agent run may span multiple model turns. Keep the wait budget at
-+    // that level so a timeout cannot be reset by a later get_subagent_result call.
-+    let resultWaitTimedOutInParentTurn = false;
++    // A parent agent run may span multiple model turns. Consume the one-wait
++    // budget when a queued/running wait begins, rather than only after timeout.
++    let resultWaitConsumedInParentTurn = false;
 +    pi.on("agent_start", () => {
-+        resultWaitTimedOutInParentTurn = false;
++        resultWaitConsumedInParentTurn = false;
 +    });
      // A queued result wait must observe completion before its held notification
      // can fire, so successful waits can still suppress that redundant nudge.
@@ -82,13 +82,13 @@ index ab65ef15b5c1da803c0378b1d0ba383645198028..dc18e00d2ce4bddb6ee77608364d3c8b
              verbose: Type.Optional(Type.Boolean({
                  description: "If true, include the agent's full conversation (messages + tool calls). Default: false.",
              })),
-@@ -1307,12 +1353,16 @@ Terse command-style prompts produce shallow, generic work.
+@@ -1307,12 +1353,15 @@ Terse command-style prompts produce shallow, generic work.
              // completion notification can still be delivered.
              // Queued agents have no promise yet (it's created when the queue starts
              // them), so poll until they leave the queue, then await like a running one.
 +            // One deadline covers both phases so queue polling cannot reset the wait.
-+            if (params.wait && resultWaitTimedOutInParentTurn) {
-+                throw new Error("Refusing wait: true after an earlier wait timed out in this parent turn; yield and await the completion notification instead.");
++            if (params.wait && resultWaitConsumedInParentTurn) {
++                throw new Error("Refusing wait: true after an earlier wait began in this parent turn; yield and await the completion notification instead.");
 +            }
 +            let timedOut = false;
 +            const waitTimeoutMs = normalizeResultWaitTimeout(params.timeout_ms);
@@ -98,13 +98,12 @@ index ab65ef15b5c1da803c0378b1d0ba383645198028..dc18e00d2ce4bddb6ee77608364d3c8b
 -                }
 -                if (record.promise)
 -                    await abortable(record.promise, signal);
++                resultWaitConsumedInParentTurn = true;
 +                timedOut = await waitForSubagentResult(record, waitTimeoutMs, signal);
-+                if (timedOut)
-+                    resultWaitTimedOutInParentTurn = true;
              }
              const displayName = getDisplayName(record.type);
              const duration = formatDuration(record.startedAt, record.completedAt);
-@@ -1327,10 +1377,12 @@ Terse command-style prompts produce shallow, generic work.
+@@ -1327,10 +1376,12 @@ Terse command-style prompts produce shallow, generic work.
                  statsParts.push(`Compactions: ${record.compactionCount}`);
              statsParts.push(`Duration: ${duration}`);
              let output = `Agent: ${record.id}\n` +
@@ -183,11 +182,11 @@ index 828938e6d710dc5a8f99a6185e37f9592b12352d..fb2d3119a50c6aa9c8864037af65ff95
    // before they reach pi.sendMessage (fire-and-forget).
    const pendingNudges = new Map<string, ReturnType<typeof setTimeout>>();
    const NUDGE_HOLD_MS = 200;
-+  // A parent agent run may span multiple model turns. Keep the wait budget at
-+  // that level so a timeout cannot be reset by a later get_subagent_result call.
-+  let resultWaitTimedOutInParentTurn = false;
++  // A parent agent run may span multiple model turns. Consume the one-wait
++  // budget when a queued/running wait begins, rather than only after timeout.
++  let resultWaitConsumedInParentTurn = false;
 +  pi.on("agent_start", () => {
-+    resultWaitTimedOutInParentTurn = false;
++    resultWaitConsumedInParentTurn = false;
 +  });
    // A queued result wait must observe completion before its held notification
    // can fire, so successful waits can still suppress that redundant nudge.
@@ -213,8 +212,8 @@ index 828938e6d710dc5a8f99a6185e37f9592b12352d..fb2d3119a50c6aa9c8864037af65ff95
        // Queued agents have no promise yet (it's created when the queue starts
        // them), so poll until they leave the queue, then await like a running one.
 +      // One deadline covers both phases so queue polling cannot reset the wait.
-+      if (params.wait && resultWaitTimedOutInParentTurn) {
-+        throw new Error("Refusing wait: true after an earlier wait timed out in this parent turn; yield and await the completion notification instead.");
++      if (params.wait && resultWaitConsumedInParentTurn) {
++        throw new Error("Refusing wait: true after an earlier wait began in this parent turn; yield and await the completion notification instead.");
 +      }
 +      let timedOut = false;
 +      const waitTimeoutMs = normalizeResultWaitTimeout(params.timeout_ms);
@@ -226,8 +225,8 @@ index 828938e6d710dc5a8f99a6185e37f9592b12352d..fb2d3119a50c6aa9c8864037af65ff95
 -          );
 -        }
 -        if (record.promise) await abortable(record.promise, signal);
++        resultWaitConsumedInParentTurn = true;
 +        timedOut = await waitForSubagentResult(record, waitTimeoutMs, signal);
-+        if (timedOut) resultWaitTimedOutInParentTurn = true;
        }
  
        const displayName = getDisplayName(record.type);

--- a/src/agent/context-prompt.ts
+++ b/src/agent/context-prompt.ts
@@ -16,7 +16,7 @@ import type { AgentCliCapabilities, RuntimeId, RuntimeInput, StandingPrompt } fr
  * 6. 用 eval 验证：行为变化必须配套固定场景 + rubric（evals/*、test/support/*-grader.mjs、live 测试）。
  */
 
-export const LARKIN_STANDING_PROMPT_VERSION = "larkin-standing-v22";
+export const LARKIN_STANDING_PROMPT_VERSION = "larkin-standing-v23";
 
 /**
  * Agent 间协作唤醒引导（issue #75）：纯文本 @ 不会产生飞书 mention 事件，
@@ -126,6 +126,7 @@ export class ContextPromptBuilder {
         "2. The tool returns an agent id immediately. Report it to the user and end the turn.",
         "3. Do NOT poll or sleep; a completion notification arrives automatically.",
         "4. On the notification, check the Inbox, then publish exactly one final summary.",
+        "If you explicitly use get_subagent_result with wait: true, make at most one bounded wait call per turn. If it returns timedOut: true, do not loop or call wait again in the same turn; yield and let the completion notification wake you.",
         "Forbidden pattern (never acceptable): `nohup sh -c '...' > /tmp/x.out 2>&1 &`, `sleep N; cat ...`, disown, or any shell background substitute. These bypass subagent isolation.",
         "Keep corrections, approvals, short commands, and Feishu writes in the foreground; do not delegate them.",
         "Parallel independent tasks: when the user clearly asks for two or more independent tasks with no dependencies between them, delegate EACH task to its own background subagent in a single message with multiple Agent tool calls (one per task, all with run_in_background: true), report every job id, and end the turn. Do not run them one-by-one in the foreground and do not merge them into one subagent.",

--- a/src/runtime/pi-inline-extensions.ts
+++ b/src/runtime/pi-inline-extensions.ts
@@ -1,10 +1,30 @@
-import subagentsExtension from "@tintinweb/pi-subagents/dist/index.js";
+import { pathToFileURL } from "node:url";
 import type { InlineExtension, MainOptions } from "@earendil-works/pi-coding-agent";
 import bashTimeoutExtension from "./pi-bash-timeout-extension.js";
+import { bundledPiSubagentExtensionPath } from "./pi-subagent-injection.js";
+
+/**
+ * Load the prebuilt, patched subagent bundle shipped in dist/ rather than the
+ * package-manager copy. npm does not apply Bun's patchedDependencies, so a
+ * direct package import would reintroduce the unbounded upstream wait.
+ */
+async function loadBundledPiSubagentExtension(): Promise<InlineExtension> {
+  const bundle = bundledPiSubagentExtensionPath(process.env.LARKIN_CONFIG_DIR);
+  if (!bundle) throw new Error("Larkin bounded pi-subagents bundle is unavailable; refusing to start builtin Pi");
+  const loaded = await import(pathToFileURL(bundle).href) as { default?: InlineExtension };
+  if (!loaded.default) throw new Error("Larkin bounded pi-subagents bundle is invalid; refusing to start builtin Pi");
+  return loaded.default;
+}
 
 /** Builtin Pi extensions are loaded as code, never through Pi's path/data-URL loader. */
+const bundledSubagentsExtension: InlineExtension = async (pi) => {
+  const extension = await loadBundledPiSubagentExtension();
+  if (typeof extension === "function") await extension(pi);
+  else await extension.factory(pi);
+};
+
 export const BUILTIN_PI_EXTENSION_FACTORIES: readonly InlineExtension[] = Object.freeze([
-  subagentsExtension as unknown as InlineExtension,
+  bundledSubagentsExtension,
   bashTimeoutExtension,
 ]);
 

--- a/src/runtime/pi-inline-extensions.ts
+++ b/src/runtime/pi-inline-extensions.ts
@@ -5,10 +5,16 @@ import { bundledPiSubagentExtensionPath } from "./pi-subagent-injection.js";
 
 /**
  * Load the prebuilt, patched subagent bundle shipped in dist/ rather than the
- * package-manager copy. npm does not apply Bun's patchedDependencies, so a
- * direct package import would reintroduce the unbounded upstream wait.
+ * package-manager copy. Standalone binaries additionally load the patched
+ * package through Bun's compiled module graph, while normal package installs
+ * continue to use the prebuilt patched bundle.
  */
 async function loadBundledPiSubagentExtension(): Promise<InlineExtension> {
+  if (process.env.LARKIN_STANDALONE === "1") {
+    const loaded = await import("@tintinweb/pi-subagents/dist/index.js") as unknown as { default?: InlineExtension };
+    if (!loaded.default) throw new Error("Larkin bounded pi-subagents package is invalid; refusing to start builtin Pi");
+    return loaded.default;
+  }
   const bundle = bundledPiSubagentExtensionPath(process.env.LARKIN_CONFIG_DIR);
   if (!bundle) throw new Error("Larkin bounded pi-subagents bundle is unavailable; refusing to start builtin Pi");
   const loaded = await import(pathToFileURL(bundle).href) as { default?: InlineExtension };

--- a/src/runtime/pi-subagent-injection.ts
+++ b/src/runtime/pi-subagent-injection.ts
@@ -85,27 +85,52 @@ export function probeExternalPiVersion(piCommand: string, env: NodeJS.ProcessEnv
  * 已装时 Larkin 不再 -e 注入，避免同名工具（Agent/get_subagent_result/steer_subagent）
  * 重复注册导致 pi 扩展加载 FATAL（pi 对 duplicate tool registration 是硬失败）。
  */
-export function userPiAlreadyHasSubagentsExtension(env: NodeJS.ProcessEnv): boolean {
+const BOUNDED_WAIT_CAPABILITY = "larkin-pi-subagents-bounded-wait-v1";
+
+type UserPiSubagentsWaitCapability = "absent" | "bounded" | "unbounded";
+
+function userPiSubagentsWaitCapability(env: NodeJS.ProcessEnv): UserPiSubagentsWaitCapability {
   const agentDir = env.PI_CODING_AGENT_DIR || path.join(env.HOME || process.env.HOME || "", ".pi", "agent");
   try {
+    let configured = false;
     const settingsFile = path.join(agentDir, "settings.json");
     if (fs.existsSync(settingsFile)) {
       const settings = JSON.parse(fs.readFileSync(settingsFile, "utf8"));
       const packages: unknown = settings?.packages;
       if (Array.isArray(packages)) {
-        for (const entry of packages) {
-          if (typeof entry === "string" && /pi-subagents/i.test(entry)) return true;
-        }
+        configured = packages.some((entry) => typeof entry === "string" && /pi-subagents/i.test(entry));
       }
     }
     // settings.json 可能未登记但包目录已存在（残留/手动安装）。
     // Split token: repo contract forbids the literal package-manager word in sources.
-    const npmDir = path.join(agentDir, "n" + "pm", "node_modules", "@tintinweb");
-    if (fs.existsSync(npmDir) && fs.readdirSync(npmDir).some((name) => /pi-subagents/i.test(name))) return true;
+    const packageRoots = [
+      path.join(agentDir, "n" + "pm", "node_modules", "@tintinweb", "pi-subagents"),
+      path.join(agentDir, "node_modules", "@tintinweb", "pi-subagents"),
+    ];
+    const installedRoot = packageRoots.find((root) => fs.existsSync(root));
+    if (!configured && !installedRoot) return "absent";
+    if (!installedRoot) return "unbounded";
+    const capabilityFiles = [
+      path.join(installedRoot, "dist", "index.js"),
+      path.join(installedRoot, "src", "index.ts"),
+    ];
+    const hasCapability = capabilityFiles.some((file) => {
+      try { return fs.readFileSync(file, "utf8").includes(BOUNDED_WAIT_CAPABILITY); }
+      catch { return false; }
+    });
+    return hasCapability ? "bounded" : "unbounded";
   } catch {
-    /* unreadable config: assume not installed, injection stays safe */
+    // Unreadable user extension state is not safe to treat as bounded.
+    return "unbounded";
   }
-  return false;
+}
+
+export function userPiAlreadyHasSubagentsExtension(env: NodeJS.ProcessEnv): boolean {
+  return userPiSubagentsWaitCapability(env) !== "absent";
+}
+
+export function userPiSubagentsHasBoundedWaitCapability(env: NodeJS.ProcessEnv): boolean {
+  return userPiSubagentsWaitCapability(env) === "bounded";
 }
 
 export function resolvePiSubagentExtensionArg(
@@ -117,11 +142,22 @@ export function resolvePiSubagentExtensionArg(
   probeVersion: () => { major: number; minor: number } | null = () => probeExternalPiVersion(input.piCommand, input.env),
   resolveBundle: () => string | null = () => bundledPiSubagentExtensionPath(input.env.LARKIN_CONFIG_DIR),
 ): string | null {
+  // A user-installed extension wins only when it advertises the exact bounded
+  // wait capability. Check this before the bundle path so a missing Larkin
+  // asset cannot silently leave an unbounded user extension active.
+  if (userPiAlreadyHasSubagentsExtension(input.env)) {
+    if (!userPiSubagentsHasBoundedWaitCapability(input.env)) {
+      throw new Error(
+        "[larkin] WARNING: refusing external Pi because the user-installed " +
+        "pi-subagents extension is unbounded or unverifiable; remove it or install " +
+        "a version advertising larkin-pi-subagents-bounded-wait-v1.",
+      );
+    }
+    return null;
+  }
   // resolveBundle is injectable so unit tests stay environment-independent
   // (no dependency on build artifacts or the filesystem).
   const bundle = resolveBundle();
   if (!bundle) return null;
-  // 用户已自行安装同款扩展时跳过注入，避免工具名重复注册冲突。
-  if (userPiAlreadyHasSubagentsExtension(input.env)) return null;
   return piVersionSupportsSubagents(probeVersion()) ? bundle : null;
 }

--- a/src/runtime/pi-subagent-injection.ts
+++ b/src/runtime/pi-subagent-injection.ts
@@ -110,11 +110,18 @@ function userPiSubagentsWaitCapability(env: NodeJS.ProcessEnv): UserPiSubagentsW
     const installedRoot = packageRoots.find((root) => fs.existsSync(root));
     if (!configured && !installedRoot) return "absent";
     if (!installedRoot) return "unbounded";
-    const capabilityFiles = [
-      path.join(installedRoot, "dist", "index.js"),
-      path.join(installedRoot, "src", "index.ts"),
-    ];
-    const hasCapability = capabilityFiles.some((file) => {
+    const packageManifest = JSON.parse(fs.readFileSync(path.join(installedRoot, "package.json"), "utf8")) as {
+      pi?: { extensions?: unknown };
+    };
+    const extensions = packageManifest.pi?.extensions;
+    if (!Array.isArray(extensions) || extensions.length === 0
+      || !extensions.every((entry): entry is string => typeof entry === "string" && entry.length > 0)) {
+      return "unbounded";
+    }
+    // Pi executes the entries declared by the package manifest. Do not trust a
+    // marker in a build artifact when the manifest points Pi at another file.
+    const capabilityFiles = extensions.map((entry) => path.resolve(installedRoot, entry));
+    const hasCapability = capabilityFiles.every((file) => {
       try { return fs.readFileSync(file, "utf8").includes(BOUNDED_WAIT_CAPABILITY); }
       catch { return false; }
     });

--- a/test/integration/build/runtime-clean-cutover.test.mjs
+++ b/test/integration/build/runtime-clean-cutover.test.mjs
@@ -45,6 +45,7 @@ test("production build, start, and Agent CLI graph contain only current entries"
   assert.equal(packageJson.larkinPackageRole, "npm-published");
   assert.deepEqual(packageJson.files, [
     "dist/",
+    "patches/",
     "assets/",
     "scripts/npm/",
     "README.md",

--- a/test/integration/package/git-dependency-install.test.mjs
+++ b/test/integration/package/git-dependency-install.test.mjs
@@ -22,7 +22,7 @@ test.skipIf(!enabled)("Bun source dependency keeps one Runtime-bound larkin bin 
     const consumer = path.join(temp, "consumer");
     fs.mkdirSync(sourceRepo);
     fs.mkdirSync(consumer);
-    for (const relative of ["src", "assets", "scripts", "README.md", "package.json", "bun.lock"]) {
+    for (const relative of ["src", "assets", "scripts", "patches", "README.md", "package.json", "bun.lock"]) {
       fs.cpSync(path.join(ROOT, relative), path.join(sourceRepo, relative), { recursive: true });
     }
     checked("git", ["init", "--quiet", sourceRepo], {}, "git init source fixture");

--- a/test/support/agent-experience-v6-grader.mjs
+++ b/test/support/agent-experience-v6-grader.mjs
@@ -41,7 +41,7 @@ function correctionBoundaryIssue(scenario) {
 export function loadAgentExperienceV6Eval(file) {
   const value = JSON.parse(fs.readFileSync(file, "utf8"));
   if (value.dataset !== "agent-experience-v6" || value.version !== 6) throw new Error("eval dataset/version mismatch");
-  if (value.model?.standing_prompt_version !== "larkin-standing-v22") throw new Error("standing prompt version mismatch");
+  if (value.model?.standing_prompt_version !== "larkin-standing-v23") throw new Error("standing prompt version mismatch");
   if (value.session?.initial_turns !== 0) throw new Error("eval scenarios must start from a fresh empty session");
   if (value.grader?.name !== "agent-experience-v6-trace-grader" || value.grader.version !== 6 || value.grader.threshold !== 1) {
     throw new Error("eval grader metadata mismatch");

--- a/test/support/authoritative-freshness-gate-grader.mjs
+++ b/test/support/authoritative-freshness-gate-grader.mjs
@@ -3,7 +3,7 @@ import fs from "node:fs";
 export function loadAuthoritativeFreshnessEval(file) {
   const value = JSON.parse(fs.readFileSync(file, "utf8"));
   if (value.dataset !== "authoritative-freshness-gate" || value.version !== 1) throw new Error("eval dataset/version mismatch");
-  if (value.standing_prompt_version !== "larkin-standing-v22") throw new Error("standing prompt version mismatch");
+  if (value.standing_prompt_version !== "larkin-standing-v23") throw new Error("standing prompt version mismatch");
   if (value.runtime?.adapter !== "codex" || !value.runtime.selection) throw new Error("native runtime metadata is required");
   if (value.grader?.name !== "authoritative-freshness-trace-grader" || value.grader.version !== 1) throw new Error("grader metadata mismatch");
   if (!(value.grader.threshold > 0 && value.grader.threshold <= 1)) throw new Error("grader threshold must be in (0,1]");

--- a/test/support/clickable-link-delivery-grader.mjs
+++ b/test/support/clickable-link-delivery-grader.mjs
@@ -87,7 +87,7 @@ function hasBoundedVisibleUrl(body, expectedUrl) {
 export function loadClickableLinkDeliveryEval(file) {
   const value = JSON.parse(fs.readFileSync(file, "utf8"));
   if (value.dataset !== "clickable-link-delivery" || value.version !== 1) throw new Error("eval dataset/version mismatch");
-  if (value.standing_prompt_version !== "larkin-standing-v22") throw new Error("standing prompt version mismatch");
+  if (value.standing_prompt_version !== "larkin-standing-v23") throw new Error("standing prompt version mismatch");
   if (value.threshold !== 1 || value.grader?.name !== "clickable-link-delivery-trace-grader"
       || value.grader.version !== 1 || value.grader.threshold !== 1) throw new Error("eval grader metadata mismatch");
   if (value.session?.initial_turns !== 0 || value.session?.fresh_per_scenario !== true) throw new Error("eval requires fresh sessions");

--- a/test/support/clickable-link-delivery-native-support.mjs
+++ b/test/support/clickable-link-delivery-native-support.mjs
@@ -8,7 +8,7 @@ export const CLICKABLE_LINK_V20_GUIDANCE = [
 ];
 
 export function v19Counterfactual(standingPrompt) {
-  if (standingPrompt?.version !== "larkin-standing-v22" || typeof standingPrompt.content !== "string") {
+  if (standingPrompt?.version !== "larkin-standing-v23" || typeof standingPrompt.content !== "string") {
     throw new Error("v19 counterfactual requires a v20 standing prompt");
   }
   let content = standingPrompt.content;

--- a/test/support/mention-construction-grader.mjs
+++ b/test/support/mention-construction-grader.mjs
@@ -8,7 +8,7 @@ function nonempty(value, label) {
 export function loadMentionConstructionEval(file) {
   const value = JSON.parse(fs.readFileSync(file, "utf8"));
   if (value.dataset !== "mention-construction" || value.version !== 1) throw new Error("eval dataset/version mismatch");
-  if (value.standing_prompt_version !== "larkin-standing-v22") throw new Error("standing prompt version mismatch");
+  if (value.standing_prompt_version !== "larkin-standing-v23") throw new Error("standing prompt version mismatch");
   if (value.session?.initial_turns !== 0) throw new Error("eval scenarios must start from a fresh empty session");
   if (value.grader?.name !== "mention-construction-trace-grader" || value.grader.version !== 1 || value.grader.threshold !== 1) {
     throw new Error("eval grader metadata mismatch");

--- a/test/support/runtime-agent-interface-v2-grader.mjs
+++ b/test/support/runtime-agent-interface-v2-grader.mjs
@@ -10,7 +10,7 @@ export function loadRuntimeAgentInterfaceEval(file) {
   if (value.dataset !== "runtime-agent-interface-v2" || value.version !== 1) throw new Error("eval dataset/version mismatch");
   if (value.runtime?.adapter !== "codex") throw new Error("eval runtime.adapter must be codex");
   nonempty(value.runtime.minimum_cli_version, "runtime.minimum_cli_version");
-  if (value.model?.standing_prompt_version !== "larkin-standing-v22") throw new Error("eval standing prompt version mismatch");
+  if (value.model?.standing_prompt_version !== "larkin-standing-v23") throw new Error("eval standing prompt version mismatch");
   nonempty(value.model.selection, "model.selection");
   if (value.grader?.name !== "runtime-agent-interface-v2-trace-grader" || value.grader.version !== 1) {
     throw new Error("eval grader metadata mismatch");

--- a/test/unit/evals/agent-experience-v6.test.mjs
+++ b/test/unit/evals/agent-experience-v6.test.mjs
@@ -16,7 +16,7 @@ const DATASET = loadAgentExperienceV6Eval(path.join(ROOT, "evals/agent-experienc
 
 test("fixed Agent Experience v6 eval starts every selected scenario from an empty session", () => {
   assert.equal(DATASET.session.initial_turns, 0);
-  assert.equal(DATASET.model.standing_prompt_version, "larkin-standing-v22");
+  assert.equal(DATASET.model.standing_prompt_version, "larkin-standing-v23");
   assert.deepEqual(DATASET.scenarios.map((scenario) => scenario.id), [
     "target-scoped-thread-read",
     "failed-thread-read-no-false-success",

--- a/test/unit/evals/agent-mention-prompt.test.mjs
+++ b/test/unit/evals/agent-mention-prompt.test.mjs
@@ -96,7 +96,7 @@ test("lark-cli launcher passes --mention argv through without injecting --conten
 });
 
 test("mention guidance ships under the current standing prompt version", () => {
-  assert.equal(LARKIN_STANDING_PROMPT_VERSION, "larkin-standing-v22");
+  assert.equal(LARKIN_STANDING_PROMPT_VERSION, "larkin-standing-v23");
   const prompt = buildPrompt("codex");
   assert.match(prompt, /## Collaboration and delivery/);
 });

--- a/test/unit/evals/authoritative-freshness-gate.test.mjs
+++ b/test/unit/evals/authoritative-freshness-gate.test.mjs
@@ -10,7 +10,7 @@ const dataset = loadAuthoritativeFreshnessEval(path.join(ROOT, "evals/authoritat
 test("authoritative freshness eval is versioned, reproducible, and covers the critical rubric", () => {
   assert.equal(dataset.dataset, "authoritative-freshness-gate");
   assert.equal(dataset.version, 1);
-  assert.equal(dataset.standing_prompt_version, "larkin-standing-v22");
+  assert.equal(dataset.standing_prompt_version, "larkin-standing-v23");
   assert.equal(dataset.threshold, 1);
   assert.deepEqual(dataset.scenarios.map((scenario) => scenario.id), [
     "missing-inbox-history", "direct-ack-retry", "same-ms-new-id", "edited-message",

--- a/test/unit/evals/clickable-link-delivery.test.mjs
+++ b/test/unit/evals/clickable-link-delivery.test.mjs
@@ -63,7 +63,7 @@ function runFake(args, surface = "larkin") {
 test("clickable-link delivery dataset is fixed, fresh, versioned, and thresholded", () => {
   assert.equal(DATASET.dataset, "clickable-link-delivery");
   assert.equal(DATASET.version, 1);
-  assert.equal(DATASET.standing_prompt_version, "larkin-standing-v22");
+  assert.equal(DATASET.standing_prompt_version, "larkin-standing-v23");
   assert.equal(DATASET.threshold, 1);
   assert.equal(DATASET.session.initial_turns, 0);
   assert.equal(DATASET.session.fresh_per_scenario, true);

--- a/test/unit/evals/runtime-agent-interface-v2.test.mjs
+++ b/test/unit/evals/runtime-agent-interface-v2.test.mjs
@@ -16,7 +16,7 @@ test("fixed runtime Agent interface eval registers dataset, rubric, grader, thre
   assert.equal(DATASET.version, 1);
   assert.equal(DATASET.runtime.adapter, "codex");
   assert.equal(DATASET.model.selection, "gpt-5.6-sol");
-  assert.equal(DATASET.model.standing_prompt_version, "larkin-standing-v22");
+  assert.equal(DATASET.model.standing_prompt_version, "larkin-standing-v23");
   assert.equal(DATASET.grader.version, 1);
   assert.equal(DATASET.grader.threshold, 1);
   assert.ok(DATASET.grader.rubric.length >= 5);

--- a/test/unit/runtime/pi-model-catalog.test.mjs
+++ b/test/unit/runtime/pi-model-catalog.test.mjs
@@ -112,7 +112,9 @@ test("production graph pins official Pi and exposes it only through the shared R
   assert.match(binaryEntry, /pi-ai\/bun-oauth/);
   assert.match(binaryEntry, /registerBunOAuthFlows\(\)/);
   assert.match(inlineExtensions, /bundledPiSubagentExtensionPath/);
-  assert.doesNotMatch(inlineExtensions, /@tintinweb\/pi-subagents\/dist\/index\.js/);
+  assert.match(inlineExtensions, /process\.env\.LARKIN_STANDALONE === ["']1["']/);
+  assert.match(inlineExtensions, /import\(["']@tintinweb\/pi-subagents\/dist\/index\.js["']\)/);
+  assert.match(inlineExtensions, /import\(pathToFileURL\(bundle\)\.href\)/);
   assert.match(adapter, /--mode["'],\s*["']rpc/);
   assert.doesNotMatch(adapter, /available\s*\[\s*0\s*\]/);
 });

--- a/test/unit/runtime/pi-model-catalog.test.mjs
+++ b/test/unit/runtime/pi-model-catalog.test.mjs
@@ -111,7 +111,8 @@ test("production graph pins official Pi and exposes it only through the shared R
   assert.match(binaryEntry, /main:\s*piMain/);
   assert.match(binaryEntry, /pi-ai\/bun-oauth/);
   assert.match(binaryEntry, /registerBunOAuthFlows\(\)/);
-  assert.match(inlineExtensions, /@tintinweb\/pi-subagents\/dist\/index\.js/);
+  assert.match(inlineExtensions, /bundledPiSubagentExtensionPath/);
+  assert.doesNotMatch(inlineExtensions, /@tintinweb\/pi-subagents\/dist\/index\.js/);
   assert.match(adapter, /--mode["'],\s*["']rpc/);
   assert.doesNotMatch(adapter, /available\s*\[\s*0\s*\]/);
 });

--- a/test/unit/runtime/pi-subagent-injection.test.mjs
+++ b/test/unit/runtime/pi-subagent-injection.test.mjs
@@ -48,7 +48,7 @@ test("external injects when the probed pi version satisfies the gate", () => {
 
 test("external does not inject when the probed pi version is below 0.80", () => {
   const decision = resolvePiSubagentExtensionArg(
-    { distribution: "external", piCommand: "pi", env: {} },
+    { distribution: "external", piCommand: "pi", env: { PI_CODING_AGENT_DIR: "/missing/larkin-pi-agent" } },
     () => ({ major: 0, minor: 79 }),
     () => "/tmp/fake/pi-subagents.bundle.js",
   );
@@ -57,7 +57,7 @@ test("external does not inject when the probed pi version is below 0.80", () => 
 
 test("external does not inject when the version cannot be probed", () => {
   const decision = resolvePiSubagentExtensionArg(
-    { distribution: "external", piCommand: "/missing/pi", env: {} },
+    { distribution: "external", piCommand: "/missing/pi", env: { PI_CODING_AGENT_DIR: "/missing/larkin-pi-agent" } },
     () => null,
     () => "/tmp/fake/pi-subagents.bundle.js",
   );
@@ -134,7 +134,7 @@ test("userPiAlreadyHasSubagentsExtension detects settings packages and package d
   }
 });
 
-test("resolvePiSubagentExtensionArg skips injection when user already installed the extension", async () => {
+test("resolvePiSubagentExtensionArg refuses an unbounded user-installed extension", async () => {
   const { resolvePiSubagentExtensionArg } =
     await import("../../../dist/runtime/pi-subagent-injection.mjs");
   const fsMod = await import("node:fs");
@@ -147,12 +147,37 @@ test("resolvePiSubagentExtensionArg skips injection when user already installed 
     fsMod.mkdirSync(agentDir, { recursive: true });
     fsMod.writeFileSync(pathMod.join(agentDir, "settings.json"),
       JSON.stringify({ packages: ["n" + "pm:@tintinweb/pi-subagents"] }));
-    const decision = resolvePiSubagentExtensionArg(
+    assert.throws(() => resolvePiSubagentExtensionArg(
       { distribution: "external", piCommand: "pi", env: { PI_CODING_AGENT_DIR: agentDir } },
       () => ({ major: 0, minor: 84 }),
       () => fakeBundle,
+    ), /WARNING: refusing external Pi.*unbounded or unverifiable/);
+  } finally {
+    fsMod.rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("resolvePiSubagentExtensionArg accepts a user extension with the bounded capability", async () => {
+  const { resolvePiSubagentExtensionArg } =
+    await import("../../../dist/runtime/pi-subagent-injection.mjs");
+  const fsMod = await import("node:fs");
+  const osMod = await import("node:os");
+  const pathMod = await import("node:path");
+  const root = fsMod.mkdtempSync(pathMod.join(osMod.tmpdir(), "pi-subagents-bounded-"));
+  try {
+    const agentDir = pathMod.join(root, ".pi", "agent");
+    const packageDir = pathMod.join(agentDir, "n" + "pm", "node_modules", "@tintinweb", "pi-subagents");
+    fsMod.mkdirSync(pathMod.join(packageDir, "dist"), { recursive: true });
+    fsMod.writeFileSync(pathMod.join(agentDir, "settings.json"),
+      JSON.stringify({ packages: ["n" + "pm:@tintinweb/pi-subagents"] }));
+    fsMod.writeFileSync(pathMod.join(packageDir, "dist", "index.js"),
+      "larkin-pi-subagents-bounded-wait-v1");
+    const decision = resolvePiSubagentExtensionArg(
+      { distribution: "external", piCommand: "pi", env: { PI_CODING_AGENT_DIR: agentDir } },
+      () => ({ major: 0, minor: 84 }),
+      () => "/tmp/fake/pi-subagents.bundle.js",
     );
-    assert.equal(decision, null, "must not inject when user already has pi-subagents");
+    assert.equal(decision, null, "must not inject a verified bounded duplicate");
   } finally {
     fsMod.rmSync(root, { recursive: true, force: true });
   }

--- a/test/unit/runtime/pi-subagent-injection.test.mjs
+++ b/test/unit/runtime/pi-subagent-injection.test.mjs
@@ -157,7 +157,7 @@ test("resolvePiSubagentExtensionArg refuses an unbounded user-installed extensio
   }
 });
 
-test("resolvePiSubagentExtensionArg accepts a user extension with the bounded capability", async () => {
+test("resolvePiSubagentExtensionArg accepts a user extension with the bounded capability in Pi's declared entry", async () => {
   const { resolvePiSubagentExtensionArg } =
     await import("../../../dist/runtime/pi-subagent-injection.mjs");
   const fsMod = await import("node:fs");
@@ -167,17 +167,50 @@ test("resolvePiSubagentExtensionArg accepts a user extension with the bounded ca
   try {
     const agentDir = pathMod.join(root, ".pi", "agent");
     const packageDir = pathMod.join(agentDir, "n" + "pm", "node_modules", "@tintinweb", "pi-subagents");
+    fsMod.mkdirSync(pathMod.join(packageDir, "src"), { recursive: true });
     fsMod.mkdirSync(pathMod.join(packageDir, "dist"), { recursive: true });
     fsMod.writeFileSync(pathMod.join(agentDir, "settings.json"),
       JSON.stringify({ packages: ["n" + "pm:@tintinweb/pi-subagents"] }));
-    fsMod.writeFileSync(pathMod.join(packageDir, "dist", "index.js"),
+    fsMod.writeFileSync(pathMod.join(packageDir, "package.json"),
+      JSON.stringify({ pi: { extensions: ["./src/index.ts"] } }));
+    fsMod.writeFileSync(pathMod.join(packageDir, "src", "index.ts"),
       "larkin-pi-subagents-bounded-wait-v1");
+    fsMod.writeFileSync(pathMod.join(packageDir, "dist", "index.js"), "upstream build");
     const decision = resolvePiSubagentExtensionArg(
       { distribution: "external", piCommand: "pi", env: { PI_CODING_AGENT_DIR: agentDir } },
       () => ({ major: 0, minor: 84 }),
       () => "/tmp/fake/pi-subagents.bundle.js",
     );
     assert.equal(decision, null, "must not inject a verified bounded duplicate");
+  } finally {
+    fsMod.rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("resolvePiSubagentExtensionArg rejects a dist-only capability when Pi loads the declared source entry", async () => {
+  const { resolvePiSubagentExtensionArg } =
+    await import("../../../dist/runtime/pi-subagent-injection.mjs");
+  const fsMod = await import("node:fs");
+  const osMod = await import("node:os");
+  const pathMod = await import("node:path");
+  const root = fsMod.mkdtempSync(pathMod.join(osMod.tmpdir(), "pi-subagents-dist-only-"));
+  try {
+    const agentDir = pathMod.join(root, ".pi", "agent");
+    const packageDir = pathMod.join(agentDir, "n" + "pm", "node_modules", "@tintinweb", "pi-subagents");
+    fsMod.mkdirSync(pathMod.join(packageDir, "src"), { recursive: true });
+    fsMod.mkdirSync(pathMod.join(packageDir, "dist"), { recursive: true });
+    fsMod.writeFileSync(pathMod.join(agentDir, "settings.json"),
+      JSON.stringify({ packages: ["n" + "pm:@tintinweb/pi-subagents"] }));
+    fsMod.writeFileSync(pathMod.join(packageDir, "package.json"),
+      JSON.stringify({ pi: { extensions: ["./src/index.ts"] } }));
+    fsMod.writeFileSync(pathMod.join(packageDir, "src", "index.ts"), "upstream source");
+    fsMod.writeFileSync(pathMod.join(packageDir, "dist", "index.js"),
+      "larkin-pi-subagents-bounded-wait-v1");
+    assert.throws(() => resolvePiSubagentExtensionArg(
+      { distribution: "external", piCommand: "pi", env: { PI_CODING_AGENT_DIR: agentDir } },
+      () => ({ major: 0, minor: 84 }),
+      () => "/tmp/fake/pi-subagents.bundle.js",
+    ), /WARNING: refusing external Pi.*unbounded or unverifiable/);
   } finally {
     fsMod.rmSync(root, { recursive: true, force: true });
   }

--- a/test/unit/runtime/pi-subagents-wait.test.mjs
+++ b/test/unit/runtime/pi-subagents-wait.test.mjs
@@ -1,0 +1,31 @@
+import assert from "node:assert/strict";
+import { test } from "bun:test";
+import { waitForSubagentResult } from "../../../dist/runtime/pi-subagents.bundle.js";
+
+function deferred() {
+  let resolve;
+  const promise = new Promise((value) => { resolve = value; });
+  return { promise, resolve };
+}
+
+test("subagent result wait times out without cancelling a running child", async () => {
+  const child = deferred();
+  const record = { status: "running", promise: child.promise };
+  const timedOut = await waitForSubagentResult(record, 25);
+
+  assert.equal(timedOut, true);
+  child.resolve("completed later");
+  assert.equal(await child.promise, "completed later");
+});
+
+test("subagent result wait returns completion before its deadline", async () => {
+  const record = {
+    status: "running",
+    promise: new Promise((resolve) => setTimeout(() => resolve("completed"), 10)),
+  };
+
+  const timedOut = await waitForSubagentResult(record, 250);
+
+  assert.equal(timedOut, false);
+  assert.equal(await record.promise, "completed");
+});

--- a/test/unit/runtime/runtime-adapters.test.mjs
+++ b/test/unit/runtime/runtime-adapters.test.mjs
@@ -150,11 +150,13 @@ test("context prompt is capability-driven, versioned and produces bounded notifi
 
 test("default context prompt consumes the Agent CLI manifest", () => {
   const prompt = new ContextPromptBuilder().build({ agentId: "cli_test", runtime: "pi" });
-  assert.equal(prompt.version, "larkin-standing-v22");
+  assert.equal(prompt.version, "larkin-standing-v23");
   assert.match(prompt.content, /never emit feishu\.cn for a Lark tenant/);
   assert.match(prompt.content, /larkin reminder schedule/);
   assert.match(prompt.content, /explicit delivery target/);
   assert.match(prompt.content, /Never infer recipients from a reminder title/);
+  assert.match(prompt.content, /at most one bounded wait call per turn/);
+  assert.match(prompt.content, /do not loop or call wait again in the same turn/);
   assert.match(prompt.content, /larkin reminder cancel/);
   assert.match(prompt.content, /larkin interaction resolve/);
   assert.match(prompt.content, /larkin comment reply --message-id/);


### PR DESCRIPTION
## Summary
- patch the pinned `@tintinweb/pi-subagents@0.14.3` bundle so `get_subagent_result({wait:true})` has one shared deadline across queued polling and running completion
- default waits to 30s and clamp them to a 60s hard cap; timed-out waits return `timedOut: true` without cancelling the child
- teach the existing Pi standing prompt not to loop bounded waits in one turn

## Scope / non-goals
- User-facing main-Agent waits only; no coordinator 10-minute wait mode in this slice.
- Does not change or close #79 or #117.
- Does not merge or release.

## Evidence and tests
- Root cause: the pinned extension awaited queued polling and `record.promise` without a deadline.
- Added deterministic timeout-with-child-continuation and completion-before-deadline tests.
- `bun install --frozen-lockfile` PASS (patch applies and build succeeds)
- `bun run typecheck` PASS
- `bun run build` PASS
- targeted wait/prompt tests PASS (5/5)
- `bun run licenses:check` PASS
- `bun run publication:check:tree` PASS
- full `bun run test:unit` was attempted but hit existing local Runtime/CLI harness failures and the 60s foreground cap; see run output for failures unrelated to this change.
- full `bun run publication:check` was attempted but exceeded the 60s foreground cap.

Version is `0.4.15` (one patch from `0.4.14`).