### PR TITLE
fix(runtime): orphan wake for disappeared Pi subagents

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "larkin",
-  "version": "0.4.18",
+  "version": "0.4.19",
   "private": false,
   "larkinPackageRole": "npm-published",
   "files": [

--- a/scripts/build.mjs
+++ b/scripts/build.mjs
@@ -248,6 +248,27 @@ function bundlePiBashTimeoutExtension(outFile) {
   return true;
 }
 
+function bundlePiSubagentRecordWatchdogExtension(outFile) {
+  const entry = path.join(ROOT, "src", "runtime", "pi-subagent-record-watchdog.ts");
+  if (!fs.existsSync(entry)) {
+    process.stderr.write(`[build] pi-subagent-record-watchdog extension entry missing: ${entry}\n`);
+    process.exitCode = 1;
+    return false;
+  }
+  const result = spawnSync("bun", ["build", entry, "--outfile", outFile, "--external", "@earendil-works/pi-*", "--target", "bun"], {
+    cwd: ROOT,
+    encoding: "utf8",
+  });
+  if (result.error || result.status !== 0) {
+    process.stderr.write(result.stderr || result.stdout || `[build] pi-subagent-record-watchdog bundle failed: ${result.error?.message || result.status}\n`);
+    process.exitCode = 1;
+    return false;
+  }
+  process.stderr.write(result.stderr || result.stdout || "");
+  console.error(`[build] pi-subagent-record-watchdog bundle → ${path.relative(process.cwd(), outFile) || outFile}`);
+  return true;
+}
+
 function buildDashboardWeb(outDir) {
   const viteEnv = { ...process.env, LARKIN_DASHBOARD_OUT_DIR: outDir, NODE_DISABLE_COMPILE_CACHE: "1" };
   delete viteEnv.NODE_COMPILE_CACHE;
@@ -315,6 +336,7 @@ try {
   if (!buildDashboardWeb(path.join(outputStage, "dashboard", "web"))) throw new CompilationFailed();
   if (!bundlePiSubagentExtension(path.join(outputStage, "runtime", "pi-subagents.bundle.js"))) throw new CompilationFailed();
   if (!bundlePiBashTimeoutExtension(path.join(outputStage, "runtime", "pi-bash-timeout.bundle.js"))) throw new CompilationFailed();
+  if (!bundlePiSubagentRecordWatchdogExtension(path.join(outputStage, "runtime", "pi-subagent-record-watchdog.bundle.js"))) throw new CompilationFailed();
 
   // Materialize the whole graph before touching the active dist tree. Failed builds
   // preserve the prior output; successful builds replace it wholesale, removing stale files.

--- a/scripts/release/standalone-entry.ts
+++ b/scripts/release/standalone-entry.ts
@@ -7,6 +7,7 @@ import piDarkTheme from "../../node_modules/@earendil-works/pi-coding-agent/dist
 import piLightTheme from "../../node_modules/@earendil-works/pi-coding-agent/dist/modes/interactive/theme/light.json" with { type: "text" };
 import piSubagentsBundle from "../../dist/runtime/pi-subagents.bundle.js" with { type: "text" };
 import piBashTimeoutBundle from "../../dist/runtime/pi-bash-timeout.bundle.js" with { type: "text" };
+import piSubagentRecordWatchdogBundle from "../../dist/runtime/pi-subagent-record-watchdog.bundle.js" with { type: "text" };
 import { main } from "../../dist/app/binary-entry.mjs";
 
 const encoder = new TextEncoder();
@@ -23,6 +24,7 @@ globalThis.__LARKIN_EMBEDDED_BUILTIN_PI_ASSETS__ = Object.freeze({
 });
 globalThis.__LARKIN_EMBEDDED_PI_SUBAGENTS_BUNDLE__ = piSubagentsBundle;
 globalThis.__LARKIN_EMBEDDED_PI_BASH_TIMEOUT_BUNDLE__ = piBashTimeoutBundle;
+globalThis.__LARKIN_EMBEDDED_PI_SUBAGENT_RECORD_WATCHDOG_BUNDLE__ = piSubagentRecordWatchdogBundle;
 process.env.LARKIN_STANDALONE = "1";
 // Bun preserves the wrapper entry at argv[1]; the public binary contract is argv[1] = first user argument.
 process.argv.splice(1, 1);

--- a/src/runtime/pi-inline-extensions.ts
+++ b/src/runtime/pi-inline-extensions.ts
@@ -2,6 +2,7 @@ import { pathToFileURL } from "node:url";
 import type { InlineExtension, MainOptions } from "@earendil-works/pi-coding-agent";
 import bashTimeoutExtension from "./pi-bash-timeout-extension.js";
 import { bundledPiSubagentExtensionPath } from "./pi-subagent-injection.js";
+import piSubagentRecordWatchdog from "./pi-subagent-record-watchdog.js";
 
 /**
  * Load the prebuilt, patched subagent bundle shipped in dist/ rather than the
@@ -32,6 +33,7 @@ const bundledSubagentsExtension: InlineExtension = async (pi) => {
 export const BUILTIN_PI_EXTENSION_FACTORIES: readonly InlineExtension[] = Object.freeze([
   bundledSubagentsExtension,
   bashTimeoutExtension,
+  piSubagentRecordWatchdog,
 ]);
 
 type PiMain = (args: string[], options?: MainOptions) => Promise<void>;

--- a/src/runtime/pi-inline-extensions.ts
+++ b/src/runtime/pi-inline-extensions.ts
@@ -30,10 +30,13 @@ const bundledSubagentsExtension: InlineExtension = async (pi) => {
   else await extension.factory(pi);
 };
 
+// Watchdog must register session_shutdown before the bundled subagent extension
+// so the final sweep can still read AgentManager.getRecord and bridge consumed
+// terminals before manager teardown.
 export const BUILTIN_PI_EXTENSION_FACTORIES: readonly InlineExtension[] = Object.freeze([
+  piSubagentRecordWatchdog,
   bundledSubagentsExtension,
   bashTimeoutExtension,
-  piSubagentRecordWatchdog,
 ]);
 
 type PiMain = (args: string[], options?: MainOptions) => Promise<void>;

--- a/src/runtime/pi-subagent-ledger.ts
+++ b/src/runtime/pi-subagent-ledger.ts
@@ -3,6 +3,7 @@ import path from "node:path";
 import crypto from "node:crypto";
 
 export const PI_SUBAGENT_LEDGER_FILENAME = "pi-subagent-ledger.json";
+export const PI_SUBAGENT_RECORD_DIRNAME = "pi-subagent-records";
 export const PI_SUBAGENT_LEDGER_VERSION = 1 as const;
 
 export type DispatchedSubagentStatus =
@@ -13,14 +14,18 @@ export type DispatchedSubagentStatus =
   | "timed_out"
   | "orphaned";
 
+export type DispatchedSubagentWakeState = "pending" | "acknowledged";
+
 export interface DispatchedSubagentRecord {
   taskId: string;
   status: DispatchedSubagentStatus;
   dispatchedAt: number;
   lastActivityAt: number;
   outputFile?: string;
+  recordFile?: string;
   reason?: string;
   wakeKey?: string;
+  wakeState?: DispatchedSubagentWakeState;
   notifiedAt?: number;
 }
 
@@ -74,7 +79,7 @@ export function getDispatchedSubagent(
 
 export function noteDispatchedSubagent(
   ledger: DispatchedSubagentLedger,
-  input: { taskId: string; outputFile?: string; now?: number },
+  input: { taskId: string; outputFile?: string; recordFile?: string; now?: number },
 ): DispatchedSubagentLedger {
   const now = input.now ?? Date.now();
   const existing = getDispatchedSubagent(ledger, input.taskId);
@@ -84,6 +89,7 @@ export function noteDispatchedSubagent(
       ...existing,
       lastActivityAt: now,
       ...(input.outputFile ? { outputFile: input.outputFile } : {}),
+      ...(input.recordFile ? { recordFile: input.recordFile } : {}),
     });
   }
   return appendTask(ledger, {
@@ -92,6 +98,7 @@ export function noteDispatchedSubagent(
     dispatchedAt: now,
     lastActivityAt: now,
     ...(input.outputFile ? { outputFile: input.outputFile } : {}),
+    ...(input.recordFile ? { recordFile: input.recordFile } : {}),
   });
 }
 
@@ -113,7 +120,6 @@ export function noteDispatchedSubagentTerminal(
     return replaceTask(ledger, {
       ...existing,
       lastActivityAt: now,
-      notifiedAt: existing.notifiedAt ?? now,
       ...(input.outputFile && !existing.outputFile ? { outputFile: input.outputFile } : {}),
     });
   }
@@ -122,9 +128,10 @@ export function noteDispatchedSubagentTerminal(
     status,
     dispatchedAt: existing?.dispatchedAt ?? now,
     lastActivityAt: now,
-    notifiedAt: now,
+    wakeState: existing?.wakeState ?? "pending",
     ...(existing?.outputFile || input.outputFile
       ? { outputFile: input.outputFile ?? existing?.outputFile } : {}),
+    ...(existing?.recordFile ? { recordFile: existing.recordFile } : {}),
     ...(input.reason ? { reason: input.reason } : existing?.reason ? { reason: existing.reason } : {}),
     ...(input.wakeKey ? { wakeKey: input.wakeKey } : existing?.wakeKey ? { wakeKey: existing.wakeKey } : {}),
   };
@@ -160,9 +167,10 @@ export function markDispatchedSubagentOrphaned(
     lastActivityAt: existing?.lastActivityAt ?? now,
     reason: input.reason,
     wakeKey: input.taskId,
-    notifiedAt: now,
+    wakeState: "pending",
     ...(input.outputFile || existing?.outputFile
       ? { outputFile: input.outputFile ?? existing?.outputFile } : {}),
+    ...(existing?.recordFile ? { recordFile: existing.recordFile } : {}),
   };
   return {
     ledger: existing ? replaceTask(ledger, record) : appendTask(ledger, record),
@@ -179,12 +187,22 @@ export function reconcileDispatchedSubagents(
   let next = ledger;
   for (const task of ledger.tasks) {
     if (isTerminalDispatchedSubagentStatus(task.status)) continue;
-    const presence = input.forceMissing ? "absent" : (input.probe?.(refreshActivityFromOutput(task, now)) ?? "present");
+    const current = getDispatchedSubagent(next, task.taskId) ?? task;
+    const refreshed = refreshActivityFromOutput(current, now);
+    if (refreshed.lastActivityAt !== current.lastActivityAt) {
+      next = noteDispatchedSubagentActivity(next, {
+        taskId: current.taskId,
+        outputFile: refreshed.outputFile,
+        now: refreshed.lastActivityAt,
+      });
+    }
+    const probed = getDispatchedSubagent(next, current.taskId) ?? refreshed;
+    const presence = input.forceMissing ? "absent" : (input.probe?.(probed) ?? "present");
     if (presence !== "absent") continue;
     const marked = markDispatchedSubagentOrphaned(next, {
-      taskId: task.taskId,
+      taskId: current.taskId,
       reason: input.missingReason ?? (input.forceMissing ? "pi session gone" : "pi record missing"),
-      outputFile: task.outputFile,
+      outputFile: current.outputFile,
       now,
     });
     next = marked.ledger;
@@ -193,14 +211,100 @@ export function reconcileDispatchedSubagents(
   return { ledger: next, orphaned };
 }
 
-export function probePiSubagentOutputRecord(record: DispatchedSubagentRecord): PiSubagentRecordPresence {
-  if (!record.outputFile) return "present";
+export function noteDispatchedSubagentWakeAcknowledged(
+  ledger: DispatchedSubagentLedger,
+  input: { completionKey: string; now?: number },
+): DispatchedSubagentLedger {
+  const now = input.now ?? Date.now();
+  let next = ledger;
+  for (const taskId of taskIdsFromCompletionKey(input.completionKey)) {
+    const existing = getDispatchedSubagent(next, taskId);
+    if (!existing || !isTerminalDispatchedSubagentStatus(existing.status)) continue;
+    if (existing.wakeState === "acknowledged") continue;
+    next = replaceTask(next, { ...existing, wakeState: "acknowledged", notifiedAt: now });
+  }
+  return next;
+}
+
+export function undeliveredTerminalWakeKeys(ledger: DispatchedSubagentLedger): string[] {
+  const seen = new Set<string>();
+  const keys: string[] = [];
+  for (const task of ledger.tasks) {
+    if (!needsTerminalWake(task)) continue;
+    const key = task.wakeKey ?? task.taskId;
+    if (seen.has(key)) continue;
+    seen.add(key);
+    keys.push(key);
+  }
+  return keys;
+}
+
+/** Probe the Pi task record sidecar. A leftover transcript is never presence. */
+export function probePiSubagentRecord(record: DispatchedSubagentRecord): PiSubagentRecordPresence {
+  if (!record.recordFile) return "absent";
   try {
-    fs.accessSync(record.outputFile);
+    fs.accessSync(record.recordFile);
     return "present";
   } catch {
     return "absent";
   }
+}
+
+/** @deprecated Use probePiSubagentRecord. Transcript leftovers are not presence. */
+export function probePiSubagentOutputRecord(record: DispatchedSubagentRecord): PiSubagentRecordPresence {
+  return probePiSubagentRecord(record);
+}
+
+export function dispatchedSubagentRecordDir(stateDir: string): string {
+  return path.join(stateDir, PI_SUBAGENT_RECORD_DIRNAME);
+}
+
+export function dispatchedSubagentRecordFile(stateDir: string, taskId: string): string {
+  return path.join(dispatchedSubagentRecordDir(stateDir), taskId);
+}
+
+export function writeDispatchedSubagentRecordFile(stateDir: string | undefined, taskId: string): string | undefined {
+  if (!stateDir || !taskId) return undefined;
+  const dir = dispatchedSubagentRecordDir(stateDir);
+  fs.mkdirSync(dir, { recursive: true, mode: 0o700 });
+  const file = dispatchedSubagentRecordFile(stateDir, taskId);
+  const existing = (() => { try { return fs.lstatSync(file); } catch { return null; } })();
+  if (existing?.isSymbolicLink()) throw new Error("subagent record file must not be a symlink");
+  fs.writeFileSync(file, `${JSON.stringify({ taskId })}\n`, { mode: 0o600 });
+  fs.chmodSync(file, 0o600);
+  return file;
+}
+
+export function sweepAbsentPiSubagentRecordFiles(
+  recordDir: string,
+  getRecord: (taskId: string) => unknown,
+): string[] {
+  let names: string[];
+  try {
+    names = fs.readdirSync(recordDir);
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") return [];
+    throw error;
+  }
+  const removed: string[] = [];
+  for (const name of names) {
+    if (!name || name.startsWith(".")) continue;
+    const file = path.join(recordDir, name);
+    try {
+      const stat = fs.lstatSync(file);
+      if (stat.isSymbolicLink() || !stat.isFile()) continue;
+    } catch {
+      continue;
+    }
+    if (getRecord(name) != null) continue;
+    try {
+      fs.unlinkSync(file);
+      removed.push(name);
+    } catch {
+      // Best-effort: the next sweep retries.
+    }
+  }
+  return removed;
 }
 
 export function ledgerFilePath(stateDir: string | undefined): string | null {
@@ -283,7 +387,16 @@ function isPersistedTask(value: unknown): value is DispatchedSubagentRecord {
     && typeof record.status === "string"
     && ["dispatched", "completed", "failed", "cancelled", "timed_out", "orphaned"].includes(record.status)
     && Number.isFinite(record.dispatchedAt)
-    && Number.isFinite(record.lastActivityAt);
+    && Number.isFinite(record.lastActivityAt)
+    && (record.recordFile === undefined || (typeof record.recordFile === "string" && record.recordFile.length > 0))
+    && (record.wakeState === undefined || record.wakeState === "pending" || record.wakeState === "acknowledged");
+}
+
+function needsTerminalWake(task: DispatchedSubagentRecord): boolean {
+  if (!isTerminalDispatchedSubagentStatus(task.status)) return false;
+  if (task.wakeState === "acknowledged") return false;
+  if (task.wakeState === "pending") return true;
+  return task.notifiedAt == null;
 }
 
 function appendTask(ledger: DispatchedSubagentLedger, record: DispatchedSubagentRecord): DispatchedSubagentLedger {

--- a/src/runtime/pi-subagent-ledger.ts
+++ b/src/runtime/pi-subagent-ledger.ts
@@ -1,0 +1,330 @@
+import fs from "node:fs";
+import path from "node:path";
+import crypto from "node:crypto";
+
+export const PI_SUBAGENT_LEDGER_FILENAME = "pi-subagent-ledger.json";
+export const PI_SUBAGENT_LEDGER_VERSION = 1 as const;
+
+export type DispatchedSubagentStatus =
+  | "dispatched"
+  | "completed"
+  | "failed"
+  | "cancelled"
+  | "timed_out"
+  | "orphaned";
+
+export interface DispatchedSubagentRecord {
+  taskId: string;
+  status: DispatchedSubagentStatus;
+  dispatchedAt: number;
+  lastActivityAt: number;
+  outputFile?: string;
+  reason?: string;
+  wakeKey?: string;
+  notifiedAt?: number;
+}
+
+export interface DispatchedSubagentLedger {
+  version: typeof PI_SUBAGENT_LEDGER_VERSION;
+  tasks: DispatchedSubagentRecord[];
+}
+
+export type PiSubagentRecordPresence = "present" | "absent";
+
+export interface ReconcileDispatchedSubagentsInput {
+  probe?: (record: DispatchedSubagentRecord) => PiSubagentRecordPresence;
+  forceMissing?: boolean;
+  now?: number;
+  missingReason?: string;
+}
+
+export interface ReconcileDispatchedSubagentsResult {
+  ledger: DispatchedSubagentLedger;
+  orphaned: DispatchedSubagentRecord[];
+}
+
+const TERMINAL_STATUSES = new Set<DispatchedSubagentStatus>([
+  "completed",
+  "failed",
+  "cancelled",
+  "timed_out",
+  "orphaned",
+]);
+
+const MAX_LEDGER_TASKS = 2048;
+
+export function emptyDispatchedSubagentLedger(): DispatchedSubagentLedger {
+  return { version: PI_SUBAGENT_LEDGER_VERSION, tasks: [] };
+}
+
+export function isTerminalDispatchedSubagentStatus(status: DispatchedSubagentStatus): boolean {
+  return TERMINAL_STATUSES.has(status);
+}
+
+export function taskIdsFromCompletionKey(completionKey: string): string[] {
+  return completionKey.split("|").map((part) => part.trim()).filter(Boolean);
+}
+
+export function getDispatchedSubagent(
+  ledger: DispatchedSubagentLedger,
+  taskId: string,
+): DispatchedSubagentRecord | null {
+  return ledger.tasks.find((task) => task.taskId === taskId) ?? null;
+}
+
+export function noteDispatchedSubagent(
+  ledger: DispatchedSubagentLedger,
+  input: { taskId: string; outputFile?: string; now?: number },
+): DispatchedSubagentLedger {
+  const now = input.now ?? Date.now();
+  const existing = getDispatchedSubagent(ledger, input.taskId);
+  if (existing) {
+    if (isTerminalDispatchedSubagentStatus(existing.status)) return ledger;
+    return replaceTask(ledger, {
+      ...existing,
+      lastActivityAt: now,
+      ...(input.outputFile ? { outputFile: input.outputFile } : {}),
+    });
+  }
+  return appendTask(ledger, {
+    taskId: input.taskId,
+    status: "dispatched",
+    dispatchedAt: now,
+    lastActivityAt: now,
+    ...(input.outputFile ? { outputFile: input.outputFile } : {}),
+  });
+}
+
+export function noteDispatchedSubagentTerminal(
+  ledger: DispatchedSubagentLedger,
+  input: {
+    taskId: string;
+    status?: Exclude<DispatchedSubagentStatus, "dispatched">;
+    outputFile?: string;
+    reason?: string;
+    wakeKey?: string;
+    now?: number;
+  },
+): DispatchedSubagentLedger {
+  const now = input.now ?? Date.now();
+  const status = input.status ?? "completed";
+  const existing = getDispatchedSubagent(ledger, input.taskId);
+  if (existing && isTerminalDispatchedSubagentStatus(existing.status)) {
+    return replaceTask(ledger, {
+      ...existing,
+      lastActivityAt: now,
+      notifiedAt: existing.notifiedAt ?? now,
+      ...(input.outputFile && !existing.outputFile ? { outputFile: input.outputFile } : {}),
+    });
+  }
+  const next: DispatchedSubagentRecord = {
+    taskId: input.taskId,
+    status,
+    dispatchedAt: existing?.dispatchedAt ?? now,
+    lastActivityAt: now,
+    notifiedAt: now,
+    ...(existing?.outputFile || input.outputFile
+      ? { outputFile: input.outputFile ?? existing?.outputFile } : {}),
+    ...(input.reason ? { reason: input.reason } : existing?.reason ? { reason: existing.reason } : {}),
+    ...(input.wakeKey ? { wakeKey: input.wakeKey } : existing?.wakeKey ? { wakeKey: existing.wakeKey } : {}),
+  };
+  return existing ? replaceTask(ledger, next) : appendTask(ledger, next);
+}
+
+export function noteDispatchedSubagentActivity(
+  ledger: DispatchedSubagentLedger,
+  input: { taskId: string; outputFile?: string; now?: number },
+): DispatchedSubagentLedger {
+  const existing = getDispatchedSubagent(ledger, input.taskId);
+  if (!existing || isTerminalDispatchedSubagentStatus(existing.status)) return ledger;
+  return replaceTask(ledger, {
+    ...existing,
+    lastActivityAt: input.now ?? Date.now(),
+    ...(input.outputFile ? { outputFile: input.outputFile } : {}),
+  });
+}
+
+export function markDispatchedSubagentOrphaned(
+  ledger: DispatchedSubagentLedger,
+  input: { taskId: string; reason: string; outputFile?: string; now?: number },
+): { ledger: DispatchedSubagentLedger; record: DispatchedSubagentRecord | null } {
+  const existing = getDispatchedSubagent(ledger, input.taskId);
+  if (existing && isTerminalDispatchedSubagentStatus(existing.status)) {
+    return { ledger, record: null };
+  }
+  const now = input.now ?? Date.now();
+  const record: DispatchedSubagentRecord = {
+    taskId: input.taskId,
+    status: "orphaned",
+    dispatchedAt: existing?.dispatchedAt ?? now,
+    lastActivityAt: existing?.lastActivityAt ?? now,
+    reason: input.reason,
+    wakeKey: input.taskId,
+    notifiedAt: now,
+    ...(input.outputFile || existing?.outputFile
+      ? { outputFile: input.outputFile ?? existing?.outputFile } : {}),
+  };
+  return {
+    ledger: existing ? replaceTask(ledger, record) : appendTask(ledger, record),
+    record,
+  };
+}
+
+export function reconcileDispatchedSubagents(
+  ledger: DispatchedSubagentLedger,
+  input: ReconcileDispatchedSubagentsInput = {},
+): ReconcileDispatchedSubagentsResult {
+  const now = input.now ?? Date.now();
+  const orphaned: DispatchedSubagentRecord[] = [];
+  let next = ledger;
+  for (const task of ledger.tasks) {
+    if (isTerminalDispatchedSubagentStatus(task.status)) continue;
+    const presence = input.forceMissing ? "absent" : (input.probe?.(refreshActivityFromOutput(task, now)) ?? "present");
+    if (presence !== "absent") continue;
+    const marked = markDispatchedSubagentOrphaned(next, {
+      taskId: task.taskId,
+      reason: input.missingReason ?? (input.forceMissing ? "pi session gone" : "pi record missing"),
+      outputFile: task.outputFile,
+      now,
+    });
+    next = marked.ledger;
+    if (marked.record) orphaned.push(marked.record);
+  }
+  return { ledger: next, orphaned };
+}
+
+export function probePiSubagentOutputRecord(record: DispatchedSubagentRecord): PiSubagentRecordPresence {
+  if (!record.outputFile) return "present";
+  try {
+    fs.accessSync(record.outputFile);
+    return "present";
+  } catch {
+    return "absent";
+  }
+}
+
+export function ledgerFilePath(stateDir: string | undefined): string | null {
+  return stateDir ? path.join(stateDir, PI_SUBAGENT_LEDGER_FILENAME) : null;
+}
+
+export function readDispatchedSubagentLedger(file: string | null): DispatchedSubagentLedger {
+  if (!file) return emptyDispatchedSubagentLedger();
+  try {
+    const stat = fs.lstatSync(file);
+    if (stat.isSymbolicLink() || !stat.isFile()) throw new Error("subagent ledger is not a regular file");
+    const parsed = JSON.parse(fs.readFileSync(file, "utf8")) as Partial<DispatchedSubagentLedger>;
+    return normalizeLedger(parsed);
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") return emptyDispatchedSubagentLedger();
+    throw error;
+  }
+}
+
+export function writeDispatchedSubagentLedger(file: string | null, ledger: DispatchedSubagentLedger): void {
+  if (!file) return;
+  fs.mkdirSync(path.dirname(file), { recursive: true, mode: 0o700 });
+  const existing = (() => { try { return fs.lstatSync(file); } catch { return null; } })();
+  if (existing?.isSymbolicLink()) throw new Error("subagent ledger must not be a symlink");
+  const temporary = path.join(path.dirname(file), `.${path.basename(file)}.${process.pid}.${crypto.randomUUID()}.tmp`);
+  fs.writeFileSync(temporary, `${JSON.stringify(normalizeLedger(ledger), null, 2)}\n`, { mode: 0o600 });
+  fs.renameSync(temporary, file);
+  fs.chmodSync(file, 0o600);
+}
+
+export function extractBackgroundPiSubagentDispatch(event: {
+  toolName?: unknown;
+  args?: unknown;
+  result?: unknown;
+  isError?: unknown;
+}): { taskId: string; outputFile?: string } | null {
+  if (event.isError === true) return null;
+  if (String(event.toolName || "") !== "Agent") return null;
+  const args = asRecord(event.args);
+  const resultText = collectResultText(event.result);
+  const details = asRecord(asRecord(event.result)?.details);
+  const backgroundByArgs = args?.run_in_background === true;
+  const backgroundByResult = /Agent (?:started|queued) in background/i.test(resultText);
+  if (!backgroundByArgs && !backgroundByResult) return null;
+  const taskId = firstNonEmpty(
+    stringValue(details?.agentId),
+    stringValue(details?.id),
+    matchCapture(resultText, /Agent ID:\s*(\S+)/i),
+  );
+  if (!taskId) return null;
+  const outputFile = firstNonEmpty(
+    stringValue(details?.outputFile),
+    matchCapture(resultText, /Output file:\s*(\S+)/i),
+  );
+  return outputFile ? { taskId, outputFile } : { taskId };
+}
+
+function refreshActivityFromOutput(task: DispatchedSubagentRecord, now: number): DispatchedSubagentRecord {
+  if (!task.outputFile) return task;
+  try {
+    const mtimeMs = fs.statSync(task.outputFile).mtimeMs;
+    if (Number.isFinite(mtimeMs) && mtimeMs > task.lastActivityAt) {
+      return { ...task, lastActivityAt: Math.min(now, Math.floor(mtimeMs)) };
+    }
+  } catch {
+    // Missing output files are handled by the probe, not activity refresh.
+  }
+  return task;
+}
+
+function normalizeLedger(value: Partial<DispatchedSubagentLedger> | null | undefined): DispatchedSubagentLedger {
+  const tasks = Array.isArray(value?.tasks) ? value.tasks.filter(isPersistedTask) : [];
+  return { version: PI_SUBAGENT_LEDGER_VERSION, tasks: tasks.slice(-MAX_LEDGER_TASKS) };
+}
+
+function isPersistedTask(value: unknown): value is DispatchedSubagentRecord {
+  if (!value || typeof value !== "object") return false;
+  const record = value as Partial<DispatchedSubagentRecord>;
+  return typeof record.taskId === "string" && record.taskId.length > 0
+    && typeof record.status === "string"
+    && ["dispatched", "completed", "failed", "cancelled", "timed_out", "orphaned"].includes(record.status)
+    && Number.isFinite(record.dispatchedAt)
+    && Number.isFinite(record.lastActivityAt);
+}
+
+function appendTask(ledger: DispatchedSubagentLedger, record: DispatchedSubagentRecord): DispatchedSubagentLedger {
+  return normalizeLedger({ version: PI_SUBAGENT_LEDGER_VERSION, tasks: [...ledger.tasks, record] });
+}
+
+function replaceTask(ledger: DispatchedSubagentLedger, record: DispatchedSubagentRecord): DispatchedSubagentLedger {
+  return {
+    version: PI_SUBAGENT_LEDGER_VERSION,
+    tasks: ledger.tasks.map((task) => task.taskId === record.taskId ? record : task),
+  };
+}
+
+function asRecord(value: unknown): Record<string, unknown> | null {
+  return value && typeof value === "object" && !Array.isArray(value) ? value as Record<string, unknown> : null;
+}
+
+function stringValue(value: unknown): string | null {
+  return typeof value === "string" && value.trim() ? value.trim() : null;
+}
+
+function firstNonEmpty(...values: Array<string | null | undefined>): string | null {
+  return values.find((value): value is string => Boolean(value)) ?? null;
+}
+
+function matchCapture(text: string, pattern: RegExp): string | null {
+  const match = pattern.exec(text);
+  return match?.[1] ? match[1].trim() : null;
+}
+
+function collectResultText(result: unknown): string {
+  if (typeof result === "string") return result;
+  const record = asRecord(result);
+  if (!record) return "";
+  if (typeof record.content === "string") return record.content;
+  if (Array.isArray(record.content)) {
+    return record.content.map((part) => {
+      if (typeof part === "string") return part;
+      const item = asRecord(part);
+      return typeof item?.text === "string" ? item.text : "";
+    }).join("\n");
+  }
+  return typeof record.text === "string" ? record.text : "";
+}

--- a/src/runtime/pi-subagent-ledger.ts
+++ b/src/runtime/pi-subagent-ledger.ts
@@ -6,6 +6,7 @@ export const PI_SUBAGENT_LEDGER_FILENAME = "pi-subagent-ledger.json";
 export const PI_SUBAGENT_RECORD_DIRNAME = "pi-subagent-records";
 export const PI_SUBAGENT_LEDGER_VERSION = 1 as const;
 export const PI_SUBAGENT_SESSION_OWNER_ENV = "LARKIN_PI_SESSION_OWNER";
+export const PI_SUBAGENT_TERMINAL_NOTIFICATION_GRACE_MS = 30_000;
 
 export type DispatchedSubagentStatus =
   | "dispatched"
@@ -35,7 +36,7 @@ export interface DispatchedSubagentLedger {
   tasks: DispatchedSubagentRecord[];
 }
 
-export type PiSubagentRecordPresence = "present" | "absent" | "consumed";
+export type PiSubagentRecordPresence = "present" | "absent" | "consumed" | "terminal";
 
 export type ConsumedPiSubagentTerminalStatus = Exclude<DispatchedSubagentStatus, "dispatched" | "orphaned">;
 
@@ -54,6 +55,7 @@ export interface ReconcileDispatchedSubagentsInput {
 export interface ReconcileDispatchedSubagentsResult {
   ledger: DispatchedSubagentLedger;
   orphaned: DispatchedSubagentRecord[];
+  terminals: DispatchedSubagentRecord[];
 }
 
 const TERMINAL_STATUSES = new Set<DispatchedSubagentStatus>([
@@ -192,6 +194,7 @@ export function reconcileDispatchedSubagents(
 ): ReconcileDispatchedSubagentsResult {
   const now = input.now ?? Date.now();
   const orphaned: DispatchedSubagentRecord[] = [];
+  const terminals: DispatchedSubagentRecord[] = [];
   let next = ledger;
   for (const task of ledger.tasks) {
     if (isTerminalDispatchedSubagentStatus(task.status)) continue;
@@ -207,7 +210,7 @@ export function reconcileDispatchedSubagents(
     const probed = getDispatchedSubagent(next, current.taskId) ?? refreshed;
     const probedPresence = input.probe?.(probed);
     const presence = input.forceMissing
-      ? (probedPresence === "consumed" ? "consumed" : "absent")
+      ? (probedPresence === "consumed" || probedPresence === "terminal" ? probedPresence : "absent")
       : (probedPresence ?? "present");
     if (presence === "consumed") {
       next = noteConsumedDispatchedSubagent(next, {
@@ -217,6 +220,19 @@ export function reconcileDispatchedSubagents(
         now,
       });
       retireConsumedPiSubagentRecord(current.recordFile);
+      continue;
+    }
+    if (presence === "terminal") {
+      if (!input.forceMissing && !hasTerminalNotificationGraceElapsed(current.recordFile, now)) continue;
+      next = noteDispatchedSubagentTerminal(next, {
+        taskId: current.taskId,
+        status: readPersistedPiSubagentTerminal(current.recordFile)?.status ?? "completed",
+        outputFile: current.outputFile,
+        wakeKey: current.taskId,
+        now,
+      });
+      const advanced = getDispatchedSubagent(next, current.taskId);
+      if (advanced) terminals.push(advanced);
       continue;
     }
     if (presence !== "absent") continue;
@@ -229,7 +245,7 @@ export function reconcileDispatchedSubagents(
     next = marked.ledger;
     if (marked.record) orphaned.push(marked.record);
   }
-  return { ledger: next, orphaned };
+  return { ledger: next, orphaned, terminals };
 }
 
 export function noteDispatchedSubagentWakeAcknowledged(
@@ -350,6 +366,7 @@ export function probePiSubagentRecord(record: DispatchedSubagentRecord): PiSubag
     const stat = fs.lstatSync(record.recordFile);
     if (stat.isSymbolicLink() || !stat.isFile()) return "absent";
     if (readConsumedPiSubagentTerminal(record.recordFile)) return "consumed";
+    if (readPersistedPiSubagentTerminal(record.recordFile)) return "terminal";
     return "present";
   } catch {
     return "absent";
@@ -532,6 +549,16 @@ function writePiSubagentTerminalFile(
     ...(owner ? { owner } : {}),
   })}\n`, { mode: 0o600 });
   fs.chmodSync(file, 0o600);
+}
+
+function hasTerminalNotificationGraceElapsed(file: string | undefined, now: number): boolean {
+  if (!file) return true;
+  try {
+    const mtimeMs = fs.statSync(file).mtimeMs;
+    return Number.isFinite(mtimeMs) && now - mtimeMs >= PI_SUBAGENT_TERMINAL_NOTIFICATION_GRACE_MS;
+  } catch {
+    return true;
+  }
 }
 
 function refreshActivityFromOutput(task: DispatchedSubagentRecord, now: number): DispatchedSubagentRecord {

--- a/src/runtime/pi-subagent-ledger.ts
+++ b/src/runtime/pi-subagent-ledger.ts
@@ -378,6 +378,11 @@ export function probePiSubagentOutputRecord(record: DispatchedSubagentRecord): P
   return probePiSubagentRecord(record);
 }
 
+/** Same implicit root the Pi adapter uses when `stateDir` is omitted. */
+export function effectivePiStateDir(input: { workspaceDir: string; stateDir?: string }): string {
+  return input.stateDir ?? path.join(input.workspaceDir, ".larkin");
+}
+
 export function dispatchedSubagentRecordDir(stateDir: string): string {
   return path.join(stateDir, PI_SUBAGENT_RECORD_DIRNAME);
 }
@@ -433,6 +438,8 @@ export function sweepAbsentPiSubagentRecordFiles(
     const record = getRecord(name);
     if (isTerminalPiSubagentRecord(record)) {
       try {
+        // Unchanged terminal payloads must not be rewritten: mtime is the
+        // 30s lost-notification grace clock while Pi still holds the record.
         writePersistedPiSubagentTerminal(file, {
           taskId: name,
           status: ledgerStatusFromPiSubagentRecord(record),
@@ -542,12 +549,20 @@ function writePiSubagentTerminalFile(
   const existing = (() => { try { return fs.lstatSync(file); } catch { return null; } })();
   if (existing?.isSymbolicLink()) throw new Error("subagent record file must not be a symlink");
   const owner = readPiSubagentRecordOwner(file);
-  fs.writeFileSync(file, `${JSON.stringify({
+  const payload = `${JSON.stringify({
     taskId: input.taskId,
     ...(resultConsumed ? { resultConsumed: true } : {}),
     status: input.status,
     ...(owner ? { owner } : {}),
-  })}\n`, { mode: 0o600 });
+  })}\n`;
+  if (existing?.isFile()) {
+    try {
+      if (fs.readFileSync(file, "utf8") === payload) return;
+    } catch {
+      // Rewrite if the existing sidecar cannot be compared.
+    }
+  }
+  fs.writeFileSync(file, payload, { mode: 0o600 });
   fs.chmodSync(file, 0o600);
 }
 

--- a/src/runtime/pi-subagent-ledger.ts
+++ b/src/runtime/pi-subagent-ledger.ts
@@ -5,6 +5,7 @@ import crypto from "node:crypto";
 export const PI_SUBAGENT_LEDGER_FILENAME = "pi-subagent-ledger.json";
 export const PI_SUBAGENT_RECORD_DIRNAME = "pi-subagent-records";
 export const PI_SUBAGENT_LEDGER_VERSION = 1 as const;
+export const PI_SUBAGENT_SESSION_OWNER_ENV = "LARKIN_PI_SESSION_OWNER";
 
 export type DispatchedSubagentStatus =
   | "dispatched"
@@ -215,6 +216,7 @@ export function reconcileDispatchedSubagents(
         outputFile: current.outputFile,
         now,
       });
+      retireConsumedPiSubagentRecord(current.recordFile);
       continue;
     }
     if (presence !== "absent") continue;
@@ -291,7 +293,8 @@ export function ledgerStatusFromPiSubagentRecord(record: unknown): ConsumedPiSub
     ? String((record as { status?: unknown }).status || "").trim().toLowerCase()
     : "";
   if (status === "error") return "failed";
-  if (status === "aborted" || status === "stopped") return "cancelled";
+  if (status === "aborted") return "timed_out";
+  if (status === "stopped") return "cancelled";
   if (status === "steered") return "timed_out";
   return "completed";
 }
@@ -324,12 +327,24 @@ export function writeConsumedPiSubagentTerminal(
 ): void {
   const existing = (() => { try { return fs.lstatSync(file); } catch { return null; } })();
   if (existing?.isSymbolicLink()) throw new Error("subagent record file must not be a symlink");
+  const owner = readPiSubagentRecordOwner(file);
   fs.writeFileSync(file, `${JSON.stringify({
     taskId: input.taskId,
     resultConsumed: true,
     status: input.status,
+    ...(owner ? { owner } : {}),
   })}\n`, { mode: 0o600 });
   fs.chmodSync(file, 0o600);
+}
+
+export function retireConsumedPiSubagentRecord(file: string | undefined): boolean {
+  if (!file || !readConsumedPiSubagentTerminal(file)) return false;
+  try {
+    fs.unlinkSync(file);
+    return true;
+  } catch {
+    return false;
+  }
 }
 
 /** Probe the Pi task record sidecar. A leftover transcript is never presence. */
@@ -358,14 +373,22 @@ export function dispatchedSubagentRecordFile(stateDir: string, taskId: string): 
   return path.join(dispatchedSubagentRecordDir(stateDir), taskId);
 }
 
-export function writeDispatchedSubagentRecordFile(stateDir: string | undefined, taskId: string): string | undefined {
+export function writeDispatchedSubagentRecordFile(
+  stateDir: string | undefined,
+  taskId: string,
+  owner?: string,
+): string | undefined {
   if (!stateDir || !taskId) return undefined;
   const dir = dispatchedSubagentRecordDir(stateDir);
   fs.mkdirSync(dir, { recursive: true, mode: 0o700 });
   const file = dispatchedSubagentRecordFile(stateDir, taskId);
   const existing = (() => { try { return fs.lstatSync(file); } catch { return null; } })();
   if (existing?.isSymbolicLink()) throw new Error("subagent record file must not be a symlink");
-  fs.writeFileSync(file, `${JSON.stringify({ taskId })}\n`, { mode: 0o600 });
+  const normalizedOwner = typeof owner === "string" && owner.trim() ? owner.trim() : undefined;
+  fs.writeFileSync(file, `${JSON.stringify({
+    taskId,
+    ...(normalizedOwner ? { owner: normalizedOwner } : {}),
+  })}\n`, { mode: 0o600 });
   fs.chmodSync(file, 0o600);
   return file;
 }
@@ -373,6 +396,7 @@ export function writeDispatchedSubagentRecordFile(stateDir: string | undefined, 
 export function sweepAbsentPiSubagentRecordFiles(
   recordDir: string,
   getRecord: (taskId: string) => unknown,
+  options?: { owner?: string },
 ): string[] {
   let names: string[];
   try {
@@ -391,6 +415,8 @@ export function sweepAbsentPiSubagentRecordFiles(
     } catch {
       continue;
     }
+    const owner = typeof options?.owner === "string" && options.owner.trim() ? options.owner.trim() : undefined;
+    if (owner && readPiSubagentRecordOwner(file) !== owner) continue;
     const record = getRecord(name);
     if (isConsumedTerminalPiSubagentRecord(record)) {
       try {
@@ -485,7 +511,31 @@ function refreshActivityFromOutput(task: DispatchedSubagentRecord, now: number):
 
 function normalizeLedger(value: Partial<DispatchedSubagentLedger> | null | undefined): DispatchedSubagentLedger {
   const tasks = Array.isArray(value?.tasks) ? value.tasks.filter(isPersistedTask) : [];
-  return { version: PI_SUBAGENT_LEDGER_VERSION, tasks: tasks.slice(-MAX_LEDGER_TASKS) };
+  return { version: PI_SUBAGENT_LEDGER_VERSION, tasks: capLedgerTasks(tasks) };
+}
+
+function isAcknowledgedTerminalTask(task: DispatchedSubagentRecord): boolean {
+  return isTerminalDispatchedSubagentStatus(task.status) && task.wakeState === "acknowledged";
+}
+
+function capLedgerTasks(tasks: DispatchedSubagentRecord[]): DispatchedSubagentRecord[] {
+  if (tasks.length <= MAX_LEDGER_TASKS) return tasks;
+  const overflow = tasks.length - MAX_LEDGER_TASKS;
+  const evict = new Set<number>();
+  for (let index = 0; index < tasks.length && evict.size < overflow; index += 1) {
+    if (isAcknowledgedTerminalTask(tasks[index]!)) evict.add(index);
+  }
+  if (evict.size === 0) return tasks;
+  return tasks.filter((_, index) => !evict.has(index));
+}
+
+function readPiSubagentRecordOwner(file: string): string | undefined {
+  try {
+    const parsed = JSON.parse(fs.readFileSync(file, "utf8")) as { owner?: unknown };
+    return typeof parsed?.owner === "string" && parsed.owner.trim() ? parsed.owner.trim() : undefined;
+  } catch {
+    return undefined;
+  }
 }
 
 function isPersistedTask(value: unknown): value is DispatchedSubagentRecord {

--- a/src/runtime/pi-subagent-ledger.ts
+++ b/src/runtime/pi-subagent-ledger.ts
@@ -34,7 +34,14 @@ export interface DispatchedSubagentLedger {
   tasks: DispatchedSubagentRecord[];
 }
 
-export type PiSubagentRecordPresence = "present" | "absent";
+export type PiSubagentRecordPresence = "present" | "absent" | "consumed";
+
+export type ConsumedPiSubagentTerminalStatus = Exclude<DispatchedSubagentStatus, "dispatched" | "orphaned">;
+
+export interface ConsumedPiSubagentTerminal {
+  taskId: string;
+  status: ConsumedPiSubagentTerminalStatus;
+}
 
 export interface ReconcileDispatchedSubagentsInput {
   probe?: (record: DispatchedSubagentRecord) => PiSubagentRecordPresence;
@@ -197,7 +204,19 @@ export function reconcileDispatchedSubagents(
       });
     }
     const probed = getDispatchedSubagent(next, current.taskId) ?? refreshed;
-    const presence = input.forceMissing ? "absent" : (input.probe?.(probed) ?? "present");
+    const probedPresence = input.probe?.(probed);
+    const presence = input.forceMissing
+      ? (probedPresence === "consumed" ? "consumed" : "absent")
+      : (probedPresence ?? "present");
+    if (presence === "consumed") {
+      next = noteConsumedDispatchedSubagent(next, {
+        taskId: current.taskId,
+        status: readConsumedPiSubagentTerminal(current.recordFile)?.status ?? "completed",
+        outputFile: current.outputFile,
+        now,
+      });
+      continue;
+    }
     if (presence !== "absent") continue;
     const marked = markDispatchedSubagentOrphaned(next, {
       taskId: current.taskId,
@@ -239,11 +258,87 @@ export function undeliveredTerminalWakeKeys(ledger: DispatchedSubagentLedger): s
   return keys;
 }
 
+export function noteConsumedDispatchedSubagent(
+  ledger: DispatchedSubagentLedger,
+  input: {
+    taskId: string;
+    status?: ConsumedPiSubagentTerminalStatus;
+    outputFile?: string;
+    now?: number;
+  },
+): DispatchedSubagentLedger {
+  const now = input.now ?? Date.now();
+  const next = noteDispatchedSubagentTerminal(ledger, {
+    taskId: input.taskId,
+    status: input.status ?? "completed",
+    outputFile: input.outputFile,
+    wakeKey: input.taskId,
+    now,
+  });
+  return noteDispatchedSubagentWakeAcknowledged(next, { completionKey: input.taskId, now });
+}
+
+export function isConsumedTerminalPiSubagentRecord(record: unknown): boolean {
+  if (!record || typeof record !== "object") return false;
+  const value = record as { status?: unknown; resultConsumed?: unknown };
+  if (value.resultConsumed !== true) return false;
+  return typeof value.status === "string" && value.status.length > 0
+    && value.status !== "running" && value.status !== "queued";
+}
+
+export function ledgerStatusFromPiSubagentRecord(record: unknown): ConsumedPiSubagentTerminalStatus {
+  const status = typeof record === "object" && record && "status" in record
+    ? String((record as { status?: unknown }).status || "").trim().toLowerCase()
+    : "";
+  if (status === "error") return "failed";
+  if (status === "aborted" || status === "stopped") return "cancelled";
+  if (status === "steered") return "timed_out";
+  return "completed";
+}
+
+export function readConsumedPiSubagentTerminal(file: string | undefined): ConsumedPiSubagentTerminal | null {
+  if (!file) return null;
+  try {
+    const stat = fs.lstatSync(file);
+    if (stat.isSymbolicLink() || !stat.isFile()) return null;
+    const parsed = JSON.parse(fs.readFileSync(file, "utf8")) as Partial<ConsumedPiSubagentTerminal> & {
+      resultConsumed?: unknown;
+      consumed?: unknown;
+    };
+    if (!parsed || typeof parsed !== "object") return null;
+    if (parsed.resultConsumed !== true && parsed.consumed !== true) return null;
+    if (typeof parsed.taskId !== "string" || parsed.taskId.length === 0) return null;
+    if (parsed.status !== "completed" && parsed.status !== "failed"
+      && parsed.status !== "cancelled" && parsed.status !== "timed_out") {
+      return null;
+    }
+    return { taskId: parsed.taskId, status: parsed.status };
+  } catch {
+    return null;
+  }
+}
+
+export function writeConsumedPiSubagentTerminal(
+  file: string,
+  input: ConsumedPiSubagentTerminal,
+): void {
+  const existing = (() => { try { return fs.lstatSync(file); } catch { return null; } })();
+  if (existing?.isSymbolicLink()) throw new Error("subagent record file must not be a symlink");
+  fs.writeFileSync(file, `${JSON.stringify({
+    taskId: input.taskId,
+    resultConsumed: true,
+    status: input.status,
+  })}\n`, { mode: 0o600 });
+  fs.chmodSync(file, 0o600);
+}
+
 /** Probe the Pi task record sidecar. A leftover transcript is never presence. */
 export function probePiSubagentRecord(record: DispatchedSubagentRecord): PiSubagentRecordPresence {
   if (!record.recordFile) return "absent";
   try {
-    fs.accessSync(record.recordFile);
+    const stat = fs.lstatSync(record.recordFile);
+    if (stat.isSymbolicLink() || !stat.isFile()) return "absent";
+    if (readConsumedPiSubagentTerminal(record.recordFile)) return "consumed";
     return "present";
   } catch {
     return "absent";
@@ -296,7 +391,20 @@ export function sweepAbsentPiSubagentRecordFiles(
     } catch {
       continue;
     }
-    if (getRecord(name) != null) continue;
+    const record = getRecord(name);
+    if (isConsumedTerminalPiSubagentRecord(record)) {
+      try {
+        writeConsumedPiSubagentTerminal(file, {
+          taskId: name,
+          status: ledgerStatusFromPiSubagentRecord(record),
+        });
+      } catch {
+        // Keep the sidecar; the next sweep retries the consumed bridge.
+      }
+      continue;
+    }
+    if (record != null) continue;
+    if (readConsumedPiSubagentTerminal(file)) continue;
     try {
       fs.unlinkSync(file);
       removed.push(name);

--- a/src/runtime/pi-subagent-ledger.ts
+++ b/src/runtime/pi-subagent-ledger.ts
@@ -511,7 +511,7 @@ export function extractBackgroundPiSubagentDispatch(event: {
   if (!taskId) return null;
   const outputFile = firstNonEmpty(
     stringValue(details?.outputFile),
-    matchCapture(resultText, /Output file:\s*(\S+)/i),
+    matchCapture(resultText, /Output file:\s*(.+)/i),
   );
   return outputFile ? { taskId, outputFile } : { taskId };
 }

--- a/src/runtime/pi-subagent-ledger.ts
+++ b/src/runtime/pi-subagent-ledger.ts
@@ -280,12 +280,16 @@ export function noteConsumedDispatchedSubagent(
   return noteDispatchedSubagentWakeAcknowledged(next, { completionKey: input.taskId, now });
 }
 
-export function isConsumedTerminalPiSubagentRecord(record: unknown): boolean {
+export function isTerminalPiSubagentRecord(record: unknown): boolean {
   if (!record || typeof record !== "object") return false;
-  const value = record as { status?: unknown; resultConsumed?: unknown };
-  if (value.resultConsumed !== true) return false;
-  return typeof value.status === "string" && value.status.length > 0
-    && value.status !== "running" && value.status !== "queued";
+  const status = (record as { status?: unknown }).status;
+  return typeof status === "string" && status.length > 0
+    && status !== "running" && status !== "queued";
+}
+
+export function isConsumedTerminalPiSubagentRecord(record: unknown): boolean {
+  if (!isTerminalPiSubagentRecord(record)) return false;
+  return (record as { resultConsumed?: unknown }).resultConsumed === true;
 }
 
 export function ledgerStatusFromPiSubagentRecord(record: unknown): ConsumedPiSubagentTerminalStatus {
@@ -299,52 +303,44 @@ export function ledgerStatusFromPiSubagentRecord(record: unknown): ConsumedPiSub
   return "completed";
 }
 
+export function readPersistedPiSubagentTerminal(file: string | undefined): ConsumedPiSubagentTerminal | null {
+  return readPiSubagentTerminalFile(file, false);
+}
+
 export function readConsumedPiSubagentTerminal(file: string | undefined): ConsumedPiSubagentTerminal | null {
-  if (!file) return null;
-  try {
-    const stat = fs.lstatSync(file);
-    if (stat.isSymbolicLink() || !stat.isFile()) return null;
-    const parsed = JSON.parse(fs.readFileSync(file, "utf8")) as Partial<ConsumedPiSubagentTerminal> & {
-      resultConsumed?: unknown;
-      consumed?: unknown;
-    };
-    if (!parsed || typeof parsed !== "object") return null;
-    if (parsed.resultConsumed !== true && parsed.consumed !== true) return null;
-    if (typeof parsed.taskId !== "string" || parsed.taskId.length === 0) return null;
-    if (parsed.status !== "completed" && parsed.status !== "failed"
-      && parsed.status !== "cancelled" && parsed.status !== "timed_out") {
-      return null;
-    }
-    return { taskId: parsed.taskId, status: parsed.status };
-  } catch {
-    return null;
-  }
+  return readPiSubagentTerminalFile(file, true);
+}
+
+export function writePersistedPiSubagentTerminal(
+  file: string,
+  input: ConsumedPiSubagentTerminal,
+  options?: { resultConsumed?: boolean },
+): void {
+  writePiSubagentTerminalFile(file, input, options?.resultConsumed === true);
 }
 
 export function writeConsumedPiSubagentTerminal(
   file: string,
   input: ConsumedPiSubagentTerminal,
 ): void {
-  const existing = (() => { try { return fs.lstatSync(file); } catch { return null; } })();
-  if (existing?.isSymbolicLink()) throw new Error("subagent record file must not be a symlink");
-  const owner = readPiSubagentRecordOwner(file);
-  fs.writeFileSync(file, `${JSON.stringify({
-    taskId: input.taskId,
-    resultConsumed: true,
-    status: input.status,
-    ...(owner ? { owner } : {}),
-  })}\n`, { mode: 0o600 });
-  fs.chmodSync(file, 0o600);
+  writePersistedPiSubagentTerminal(file, input, { resultConsumed: true });
 }
 
-export function retireConsumedPiSubagentRecord(file: string | undefined): boolean {
-  if (!file || !readConsumedPiSubagentTerminal(file)) return false;
+export function retirePiSubagentRecord(file: string | undefined): boolean {
+  if (!file) return false;
   try {
+    const stat = fs.lstatSync(file);
+    if (stat.isSymbolicLink() || !stat.isFile()) return false;
     fs.unlinkSync(file);
     return true;
   } catch {
     return false;
   }
+}
+
+export function retireConsumedPiSubagentRecord(file: string | undefined): boolean {
+  if (!file || !readConsumedPiSubagentTerminal(file)) return false;
+  return retirePiSubagentRecord(file);
 }
 
 /** Probe the Pi task record sidecar. A leftover transcript is never presence. */
@@ -418,19 +414,19 @@ export function sweepAbsentPiSubagentRecordFiles(
     const owner = typeof options?.owner === "string" && options.owner.trim() ? options.owner.trim() : undefined;
     if (owner && readPiSubagentRecordOwner(file) !== owner) continue;
     const record = getRecord(name);
-    if (isConsumedTerminalPiSubagentRecord(record)) {
+    if (isTerminalPiSubagentRecord(record)) {
       try {
-        writeConsumedPiSubagentTerminal(file, {
+        writePersistedPiSubagentTerminal(file, {
           taskId: name,
           status: ledgerStatusFromPiSubagentRecord(record),
-        });
+        }, { resultConsumed: isConsumedTerminalPiSubagentRecord(record) });
       } catch {
-        // Keep the sidecar; the next sweep retries the consumed bridge.
+        // Keep the sidecar; the next sweep retries the terminal bridge.
       }
       continue;
     }
     if (record != null) continue;
-    if (readConsumedPiSubagentTerminal(file)) continue;
+    if (readPersistedPiSubagentTerminal(file)) continue;
     try {
       fs.unlinkSync(file);
       removed.push(name);
@@ -494,6 +490,48 @@ export function extractBackgroundPiSubagentDispatch(event: {
     matchCapture(resultText, /Output file:\s*(\S+)/i),
   );
   return outputFile ? { taskId, outputFile } : { taskId };
+}
+
+function readPiSubagentTerminalFile(
+  file: string | undefined,
+  requireConsumed: boolean,
+): ConsumedPiSubagentTerminal | null {
+  if (!file) return null;
+  try {
+    const stat = fs.lstatSync(file);
+    if (stat.isSymbolicLink() || !stat.isFile()) return null;
+    const parsed = JSON.parse(fs.readFileSync(file, "utf8")) as Partial<ConsumedPiSubagentTerminal> & {
+      resultConsumed?: unknown;
+      consumed?: unknown;
+    };
+    if (!parsed || typeof parsed !== "object") return null;
+    if (requireConsumed && parsed.resultConsumed !== true && parsed.consumed !== true) return null;
+    if (typeof parsed.taskId !== "string" || parsed.taskId.length === 0) return null;
+    if (parsed.status !== "completed" && parsed.status !== "failed"
+      && parsed.status !== "cancelled" && parsed.status !== "timed_out") {
+      return null;
+    }
+    return { taskId: parsed.taskId, status: parsed.status };
+  } catch {
+    return null;
+  }
+}
+
+function writePiSubagentTerminalFile(
+  file: string,
+  input: ConsumedPiSubagentTerminal,
+  resultConsumed: boolean,
+): void {
+  const existing = (() => { try { return fs.lstatSync(file); } catch { return null; } })();
+  if (existing?.isSymbolicLink()) throw new Error("subagent record file must not be a symlink");
+  const owner = readPiSubagentRecordOwner(file);
+  fs.writeFileSync(file, `${JSON.stringify({
+    taskId: input.taskId,
+    ...(resultConsumed ? { resultConsumed: true } : {}),
+    status: input.status,
+    ...(owner ? { owner } : {}),
+  })}\n`, { mode: 0o600 });
+  fs.chmodSync(file, 0o600);
 }
 
 function refreshActivityFromOutput(task: DispatchedSubagentRecord, now: number): DispatchedSubagentRecord {

--- a/src/runtime/pi-subagent-record-watchdog-injection.ts
+++ b/src/runtime/pi-subagent-record-watchdog-injection.ts
@@ -1,0 +1,49 @@
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { piVersionSupportsSubagents, probeExternalPiVersion } from "./pi-subagent-injection.js";
+
+declare global {
+  var __LARKIN_EMBEDDED_PI_SUBAGENT_RECORD_WATCHDOG_BUNDLE__: string | undefined;
+}
+
+export function materializeEmbeddedPiSubagentRecordWatchdogBundle(configDir: string | undefined): string | null {
+  const embedded = globalThis.__LARKIN_EMBEDDED_PI_SUBAGENT_RECORD_WATCHDOG_BUNDLE__;
+  if (!embedded || !configDir) return null;
+  const dir = path.join(path.resolve(configDir), "providers", "pi", "extensions");
+  const target = path.join(dir, "pi-subagent-record-watchdog.bundle.js");
+  try {
+    fs.mkdirSync(dir, { recursive: true, mode: 0o700 });
+    fs.chmodSync(dir, 0o700);
+    if (!fs.existsSync(target) || fs.readFileSync(target, "utf8") !== embedded) {
+      const temporary = `${target}.${process.pid}.tmp`;
+      fs.writeFileSync(temporary, embedded, { mode: 0o600, flag: "wx" });
+      fs.renameSync(temporary, target);
+      fs.chmodSync(target, 0o600);
+    }
+    return target;
+  } catch {
+    return null;
+  }
+}
+
+export function bundledPiSubagentRecordWatchdogExtensionPath(configDir?: string): string | null {
+  try {
+    const url = new URL("./pi-subagent-record-watchdog.bundle.js", import.meta.url);
+    const resolved = fileURLToPath(url);
+    if (fs.existsSync(resolved)) return resolved;
+  } catch {
+    /* fall through to embedded */
+  }
+  return materializeEmbeddedPiSubagentRecordWatchdogBundle(configDir);
+}
+
+export function resolvePiSubagentRecordWatchdogExtensionArg(
+  input: { distribution: "external"; piCommand: string; env: NodeJS.ProcessEnv },
+  probeVersion: () => { major: number; minor: number } | null = () => probeExternalPiVersion(input.piCommand, input.env),
+  resolveBundle: () => string | null = () => bundledPiSubagentRecordWatchdogExtensionPath(input.env.LARKIN_CONFIG_DIR),
+): string | null {
+  const bundle = resolveBundle();
+  if (!bundle) return null;
+  return piVersionSupportsSubagents(probeVersion()) ? bundle : null;
+}

--- a/src/runtime/pi-subagent-record-watchdog.ts
+++ b/src/runtime/pi-subagent-record-watchdog.ts
@@ -10,7 +10,10 @@ interface PiSubagentsManagerRegistry {
 
 /**
  * Pi-process watchdog: delete Larkin record sidecars once AgentManager no longer
- * has the in-memory task. Leftover transcripts are intentionally ignored.
+ * has the in-memory task. A get_subagent_result consume suppresses the canonical
+ * completion notification and later removes the successful record; bridge that
+ * consumed terminal state into the sidecar before treating a missing getRecord
+ * as a genuine orphan. Leftover transcripts are intentionally ignored.
  */
 export default function piSubagentRecordWatchdog(pi: ExtensionAPI): void {
   const stateDir = process.env.LARKIN_STATE_DIR;

--- a/src/runtime/pi-subagent-record-watchdog.ts
+++ b/src/runtime/pi-subagent-record-watchdog.ts
@@ -1,0 +1,38 @@
+import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
+import { dispatchedSubagentRecordDir, sweepAbsentPiSubagentRecordFiles } from "./pi-subagent-ledger.js";
+
+const PI_SUBAGENTS_MANAGER = Symbol.for("pi-subagents:manager");
+const DEFAULT_SWEEP_INTERVAL_MS = 15_000;
+
+interface PiSubagentsManagerRegistry {
+  getRecord?: (id: string) => unknown;
+}
+
+/**
+ * Pi-process watchdog: delete Larkin record sidecars once AgentManager no longer
+ * has the in-memory task. Leftover transcripts are intentionally ignored.
+ */
+export default function piSubagentRecordWatchdog(pi: ExtensionAPI): void {
+  const stateDir = process.env.LARKIN_STATE_DIR;
+  if (!stateDir) return;
+  const recordDir = dispatchedSubagentRecordDir(stateDir);
+  const intervalMs = sweepIntervalMs();
+  const tick = (): void => {
+    const manager = (globalThis as Record<symbol, PiSubagentsManagerRegistry | undefined>)[PI_SUBAGENTS_MANAGER];
+    if (typeof manager?.getRecord !== "function") return;
+    sweepAbsentPiSubagentRecordFiles(recordDir, (taskId) => manager.getRecord!(taskId));
+  };
+  const timer = setInterval(tick, intervalMs);
+  timer.unref?.();
+  const stop = (): void => {
+    clearInterval(timer);
+    tick();
+  };
+  pi.on("session_shutdown", stop);
+}
+
+function sweepIntervalMs(): number {
+  const raw = Number.parseInt(process.env.LARKIN_PI_SUBAGENT_RECORD_SWEEP_MS || "", 10);
+  if (Number.isInteger(raw) && raw > 0) return raw;
+  return DEFAULT_SWEEP_INTERVAL_MS;
+}

--- a/src/runtime/pi-subagent-record-watchdog.ts
+++ b/src/runtime/pi-subagent-record-watchdog.ts
@@ -30,9 +30,13 @@ export default function piSubagentRecordWatchdog(pi: ExtensionAPI): void {
   const recordDir = dispatchedSubagentRecordDir(stateDir);
   const intervalMs = sweepIntervalMs();
   const tick = (): void => {
-    const manager = (globalThis as Record<symbol, PiSubagentsManagerRegistry | undefined>)[PI_SUBAGENTS_MANAGER];
-    if (typeof manager?.getRecord !== "function") return;
-    sweepAbsentPiSubagentRecordFiles(recordDir, (taskId) => manager.getRecord!(taskId), { owner });
+    try {
+      const manager = (globalThis as Record<symbol, PiSubagentsManagerRegistry | undefined>)[PI_SUBAGENTS_MANAGER];
+      if (typeof manager?.getRecord !== "function") return;
+      sweepAbsentPiSubagentRecordFiles(recordDir, (taskId) => manager.getRecord!(taskId), { owner });
+    } catch {
+      // Best-effort: a transient EACCES/EMFILE must not crash the Pi timer.
+    }
   };
   const timer = setInterval(tick, intervalMs);
   timer.unref?.();

--- a/src/runtime/pi-subagent-record-watchdog.ts
+++ b/src/runtime/pi-subagent-record-watchdog.ts
@@ -14,12 +14,14 @@ interface PiSubagentsManagerRegistry {
 
 /**
  * Pi-process watchdog: delete Larkin record sidecars once AgentManager no longer
- * has the in-memory task. A get_subagent_result consume suppresses the canonical
- * completion notification and later removes the successful record; bridge that
- * consumed terminal state into the sidecar before treating a missing getRecord
- * as a genuine orphan. Leftover transcripts are intentionally ignored. Sidecars
- * are owner-tagged so a staged Pi sharing LARKIN_STATE_DIR cannot sweep another
- * session's records.
+ * has the in-memory task. Persist any terminal AgentRecord — including an
+ * unconsumed completion Pi may evict after ten minutes — before treating a
+ * missing getRecord as a genuine orphan. A get_subagent_result consume also
+ * suppresses the canonical notification; bridge that consumed marker before
+ * cleanup can delete the sidecar. Leftover transcripts are intentionally
+ * ignored. Sidecars are owner-tagged so a staged Pi sharing LARKIN_STATE_DIR
+ * cannot sweep another session's records. This extension registers
+ * session_shutdown first so the final sweep still sees getRecord.
  */
 export default function piSubagentRecordWatchdog(pi: ExtensionAPI): void {
   const stateDir = process.env.LARKIN_STATE_DIR;

--- a/src/runtime/pi-subagent-record-watchdog.ts
+++ b/src/runtime/pi-subagent-record-watchdog.ts
@@ -1,5 +1,9 @@
 import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
-import { dispatchedSubagentRecordDir, sweepAbsentPiSubagentRecordFiles } from "./pi-subagent-ledger.js";
+import {
+  dispatchedSubagentRecordDir,
+  PI_SUBAGENT_SESSION_OWNER_ENV,
+  sweepAbsentPiSubagentRecordFiles,
+} from "./pi-subagent-ledger.js";
 
 const PI_SUBAGENTS_MANAGER = Symbol.for("pi-subagents:manager");
 const DEFAULT_SWEEP_INTERVAL_MS = 15_000;
@@ -13,17 +17,20 @@ interface PiSubagentsManagerRegistry {
  * has the in-memory task. A get_subagent_result consume suppresses the canonical
  * completion notification and later removes the successful record; bridge that
  * consumed terminal state into the sidecar before treating a missing getRecord
- * as a genuine orphan. Leftover transcripts are intentionally ignored.
+ * as a genuine orphan. Leftover transcripts are intentionally ignored. Sidecars
+ * are owner-tagged so a staged Pi sharing LARKIN_STATE_DIR cannot sweep another
+ * session's records.
  */
 export default function piSubagentRecordWatchdog(pi: ExtensionAPI): void {
   const stateDir = process.env.LARKIN_STATE_DIR;
-  if (!stateDir) return;
+  const owner = process.env[PI_SUBAGENT_SESSION_OWNER_ENV];
+  if (!stateDir || !owner) return;
   const recordDir = dispatchedSubagentRecordDir(stateDir);
   const intervalMs = sweepIntervalMs();
   const tick = (): void => {
     const manager = (globalThis as Record<symbol, PiSubagentsManagerRegistry | undefined>)[PI_SUBAGENTS_MANAGER];
     if (typeof manager?.getRecord !== "function") return;
-    sweepAbsentPiSubagentRecordFiles(recordDir, (taskId) => manager.getRecord!(taskId));
+    sweepAbsentPiSubagentRecordFiles(recordDir, (taskId) => manager.getRecord!(taskId), { owner });
   };
   const timer = setInterval(tick, intervalMs);
   timer.unref?.();

--- a/src/runtime/pi-subagents-notification.ts
+++ b/src/runtime/pi-subagents-notification.ts
@@ -51,6 +51,21 @@ const TERMINAL_STATUS_TOKENS = new Set([
   "turn_limit",
 ]);
 
+export type LedgerStatusFromPiNotification = "completed" | "failed" | "cancelled" | "timed_out";
+
+export function ledgerStatusFromPiNotificationStatus(status: string): LedgerStatusFromPiNotification {
+  const normalized = status.trim().toLowerCase();
+  if (normalized.startsWith("error") || normalized === "error") return "failed";
+  if (normalized.startsWith("aborted") || normalized.startsWith("stopped")) return "cancelled";
+  if (
+    normalized.includes("turn limit")
+    || normalized.includes("turn-limit")
+    || normalized.includes("turn_limit")
+    || normalized.includes("steered")
+  ) return "timed_out";
+  return "completed";
+}
+
 export function isCanonicalTerminalPiSubagentStatus(status: string): boolean {
   const normalized = status.trim().toLowerCase();
   if (!normalized) return false;

--- a/src/runtime/pi-subagents-notification.ts
+++ b/src/runtime/pi-subagents-notification.ts
@@ -56,9 +56,10 @@ export type LedgerStatusFromPiNotification = "completed" | "failed" | "cancelled
 export function ledgerStatusFromPiNotificationStatus(status: string): LedgerStatusFromPiNotification {
   const normalized = status.trim().toLowerCase();
   if (normalized.startsWith("error") || normalized === "error") return "failed";
-  if (normalized.startsWith("aborted") || normalized.startsWith("stopped")) return "cancelled";
+  if (normalized.startsWith("stopped")) return "cancelled";
   if (
-    normalized.includes("turn limit")
+    normalized.startsWith("aborted")
+    || normalized.includes("turn limit")
     || normalized.includes("turn-limit")
     || normalized.includes("turn_limit")
     || normalized.includes("steered")

--- a/src/runtime/runtime-adapters.ts
+++ b/src/runtime/runtime-adapters.ts
@@ -1033,12 +1033,14 @@ export function resolvePiProcessExtensionArgs(input: {
   if (input.distribution === "builtin") return [];
   const resolverInput = { distribution: "external" as const, piCommand: input.piCommand, env: input.env };
   const args: string[] = [];
+  // Watchdog must load before the subagent extension so session_shutdown still
+  // sees AgentManager.getRecord and can bridge consumed or terminal state.
+  const recordWatchdog = (resolvers.recordWatchdog ?? resolvePiSubagentRecordWatchdogExtensionArg)(resolverInput);
+  if (recordWatchdog) args.push("-e", recordWatchdog);
   const subagents = (resolvers.subagents ?? resolvePiSubagentExtensionArg)(resolverInput);
   if (subagents) args.push("-e", subagents);
   const bashTimeout = (resolvers.bashTimeout ?? resolvePiBashTimeoutExtensionArg)(resolverInput);
   if (bashTimeout) args.push("-e", bashTimeout);
-  const recordWatchdog = (resolvers.recordWatchdog ?? resolvePiSubagentRecordWatchdogExtensionArg)(resolverInput);
-  if (recordWatchdog) args.push("-e", recordWatchdog);
   return args;
 }
 

--- a/src/runtime/runtime-adapters.ts
+++ b/src/runtime/runtime-adapters.ts
@@ -23,7 +23,11 @@ import { BUNDLED_PI_VERSION, piAgentDirectory } from "./pi-provider-config.js";
 import { recordPiRuntimeArtifactProvenance } from "./pi-artifact-provenance.js";
 import { traceProcessBoundary } from "../platform/process-boundary-trace.js";
 import { resolvePiSubagentExtensionArg } from "./pi-subagent-injection.js";
-import { extractCanonicalPiSubagentCompletionKeyFromMessages } from "./pi-subagents-notification.js";
+import {
+  extractCanonicalPiSubagentNotification,
+  ledgerStatusFromPiNotificationStatus,
+} from "./pi-subagents-notification.js";
+import { resolvePiSubagentRecordWatchdogExtensionArg } from "./pi-subagent-record-watchdog-injection.js";
 import { extractBackgroundPiSubagentDispatch } from "./pi-subagent-ledger.js";
 import { resolvePiBashTimeoutExtensionArg } from "./pi-bash-timeout-injection.js";
 import {
@@ -527,6 +531,7 @@ class PiSession extends EventSession {
   private readonly observedCompletedEpochs = new Set<number>();
   private readonly observedBackgroundCompletionKeys = new Set<string>();
   private readonly pendingUnownedCompletionKeys = new Set<string>();
+  private readonly pendingUnownedCompletionStatuses = new Map<string, Record<string, "completed" | "failed" | "cancelled" | "timed_out">>();
   private readonly observedAgentEndEpochs = new Set<number>();
   private firstOutputObserved = false;
   private toolCallOpen = false;
@@ -620,6 +625,7 @@ class PiSession extends EventSession {
       this.observedCompletedEpochs.clear();
       this.observedBackgroundCompletionKeys.clear();
       this.pendingUnownedCompletionKeys.clear();
+      this.pendingUnownedCompletionStatuses.clear();
       this.observedAgentEndEpochs.clear();
       this.activeEpoch = null;
       this.settleArmedEpoch = null;
@@ -664,13 +670,20 @@ class PiSession extends EventSession {
         this.observedCompletedEpochs.add(this.activeEpoch);
         this.emitObservation("completed");
       }
-      const completionNotificationKey = extractCanonicalPiSubagentCompletionKeyFromMessages(event.messages);
-      if (completionNotificationKey
+      const completionNotification = extractCanonicalPiSubagentNotification(event.messages);
+      if (completionNotification
         && this.activeEpoch === null
-        && !this.observedBackgroundCompletionKeys.has(completionNotificationKey)) {
+        && !this.observedBackgroundCompletionKeys.has(completionNotification.key)) {
         // agent_end can still have an active Pi session. Prompting before
         // unowned agent_settled is rejected as "Agent is already processing".
-        this.pendingUnownedCompletionKeys.add(completionNotificationKey);
+        this.pendingUnownedCompletionKeys.add(completionNotification.key);
+        this.pendingUnownedCompletionStatuses.set(
+          completionNotification.key,
+          Object.fromEntries(completionNotification.notifications.map((notification) => [
+            notification.taskId,
+            ledgerStatusFromPiNotificationStatus(notification.status),
+          ])),
+        );
       }
     } else if (event?.type === "agent_settled") {
       const epoch = this.activeEpoch;
@@ -755,13 +768,19 @@ class PiSession extends EventSession {
     for (const completionKey of this.pendingUnownedCompletionKeys) {
       if (this.observedBackgroundCompletionKeys.has(completionKey)) continue;
       this.observedBackgroundCompletionKeys.add(completionKey);
-      this.emitObservation("completed", { completionKey });
+      const completionStatuses = this.pendingUnownedCompletionStatuses.get(completionKey);
+      this.emitObservation("completed", {
+        completionKey,
+        ...(completionStatuses ? { completionStatuses } : {}),
+      });
     }
     this.pendingUnownedCompletionKeys.clear();
+    this.pendingUnownedCompletionStatuses.clear();
   }
 
   private emitObservation(phase: Extract<NormalizedRuntimeEvent, { type: "runtime-observation" }>['phase'], fields: {
     reason?: "manual" | "threshold" | "overflow"; willRetry?: boolean; success?: boolean; completionKey?: string;
+    completionStatuses?: Record<string, "completed" | "failed" | "cancelled" | "timed_out">;
     taskId?: string; outputFile?: string;
   } = {}): void {
     const inputId = this.oldestOwnedInput();
@@ -1007,6 +1026,7 @@ export function resolvePiProcessExtensionArgs(input: {
 }, resolvers: {
   subagents?: typeof resolvePiSubagentExtensionArg;
   bashTimeout?: typeof resolvePiBashTimeoutExtensionArg;
+  recordWatchdog?: typeof resolvePiSubagentRecordWatchdogExtensionArg;
 } = {}): string[] {
   // Builtin factories are passed directly to Pi main on every platform. The platform
   // field makes that invariant explicit and testable without changing process.platform.
@@ -1017,6 +1037,8 @@ export function resolvePiProcessExtensionArgs(input: {
   if (subagents) args.push("-e", subagents);
   const bashTimeout = (resolvers.bashTimeout ?? resolvePiBashTimeoutExtensionArg)(resolverInput);
   if (bashTimeout) args.push("-e", bashTimeout);
+  const recordWatchdog = (resolvers.recordWatchdog ?? resolvePiSubagentRecordWatchdogExtensionArg)(resolverInput);
+  if (recordWatchdog) args.push("-e", recordWatchdog);
   return args;
 }
 

--- a/src/runtime/runtime-adapters.ts
+++ b/src/runtime/runtime-adapters.ts
@@ -24,6 +24,7 @@ import { recordPiRuntimeArtifactProvenance } from "./pi-artifact-provenance.js";
 import { traceProcessBoundary } from "../platform/process-boundary-trace.js";
 import { resolvePiSubagentExtensionArg } from "./pi-subagent-injection.js";
 import { extractCanonicalPiSubagentCompletionKeyFromMessages } from "./pi-subagents-notification.js";
+import { extractBackgroundPiSubagentDispatch } from "./pi-subagent-ledger.js";
 import { resolvePiBashTimeoutExtensionArg } from "./pi-bash-timeout-injection.js";
 import {
   classifyRuntimePrerequisite,
@@ -732,6 +733,13 @@ class PiSession extends EventSession {
         this.toolCallOpen = false;
         this.emit({ type: "runtime-observation", runtime: "pi", distribution: this.distribution, phase: "tool_result" });
       }
+      const dispatched = extractBackgroundPiSubagentDispatch(event);
+      if (dispatched) {
+        this.emitObservation("background_dispatched", {
+          taskId: dispatched.taskId,
+          ...(dispatched.outputFile ? { outputFile: dispatched.outputFile } : {}),
+        });
+      }
     }
     else if (event?.type === "message_update" && event.assistantMessageEvent?.delta) {
       if (!this.firstOutputObserved) {
@@ -754,6 +762,7 @@ class PiSession extends EventSession {
 
   private emitObservation(phase: Extract<NormalizedRuntimeEvent, { type: "runtime-observation" }>['phase'], fields: {
     reason?: "manual" | "threshold" | "overflow"; willRetry?: boolean; success?: boolean; completionKey?: string;
+    taskId?: string; outputFile?: string;
   } = {}): void {
     const inputId = this.oldestOwnedInput();
     const observation = { type: "runtime-observation" as const, runtime: "pi" as const,

--- a/src/runtime/runtime-adapters.ts
+++ b/src/runtime/runtime-adapters.ts
@@ -28,7 +28,7 @@ import {
   ledgerStatusFromPiNotificationStatus,
 } from "./pi-subagents-notification.js";
 import { resolvePiSubagentRecordWatchdogExtensionArg } from "./pi-subagent-record-watchdog-injection.js";
-import { extractBackgroundPiSubagentDispatch } from "./pi-subagent-ledger.js";
+import { effectivePiStateDir, extractBackgroundPiSubagentDispatch } from "./pi-subagent-ledger.js";
 import { resolvePiBashTimeoutExtensionArg } from "./pi-bash-timeout-injection.js";
 import {
   classifyRuntimePrerequisite,
@@ -1047,7 +1047,7 @@ export function resolvePiProcessExtensionArgs(input: {
 async function createPiRpcBackend(input: RuntimeSessionCreate, dependencies: NativeRuntimeAdapterDependencies,
   spawn: (command: string, args: readonly string[], options: Record<string, unknown>) => ProcessLike,
   productionSpawn = true): Promise<PiSessionProcessLike> {
-  const stateRoot = input.stateDir ?? path.join(input.workspaceDir, ".larkin");
+  const stateRoot = effectivePiStateDir(input);
   const mergedEnv: NodeJS.ProcessEnv = { ...globalThis.process.env, ...dependencies.env, ...input.env, NO_COLOR: "1" };
   assertNoProjectPiCompactionOverride(input.workspaceDir);
   const ownedPiDirectory = mergedEnv.LARKIN_CONFIG_DIR

--- a/src/runtime/runtime-adapters.ts
+++ b/src/runtime/runtime-adapters.ts
@@ -676,9 +676,15 @@ class PiSession extends EventSession {
           notification.taskId,
           ledgerStatusFromPiNotificationStatus(notification.status),
         ]));
-        if (this.activeEpoch === null) {
-          // agent_end can still have an active Pi session. Prompting before
-          // unowned agent_settled is rejected as "Agent is already processing".
+        const owningTurnFailed = event.willRetry === true
+          || this.finalAssistantStopReason === "error"
+          || this.finalAssistantStopReason === "aborted";
+        if (this.activeEpoch === null || owningTurnFailed) {
+          // Unowned agent_end still has an active Pi session, so prompting
+          // before settle is rejected as "Agent is already processing".
+          // A failed or retrying owned turn also did not process the
+          // notification; do not emit handledInTurn so RuntimeHost can still
+          // wake after input-error, retry, or restart.
           this.pendingUnownedCompletionKeys.add(completionNotification.key);
           this.pendingUnownedCompletionStatuses.set(completionNotification.key, completionStatuses);
         } else {

--- a/src/runtime/runtime-adapters.ts
+++ b/src/runtime/runtime-adapters.ts
@@ -671,19 +671,26 @@ class PiSession extends EventSession {
         this.emitObservation("completed");
       }
       const completionNotification = extractCanonicalPiSubagentNotification(event.messages);
-      if (completionNotification
-        && this.activeEpoch === null
-        && !this.observedBackgroundCompletionKeys.has(completionNotification.key)) {
-        // agent_end can still have an active Pi session. Prompting before
-        // unowned agent_settled is rejected as "Agent is already processing".
-        this.pendingUnownedCompletionKeys.add(completionNotification.key);
-        this.pendingUnownedCompletionStatuses.set(
-          completionNotification.key,
-          Object.fromEntries(completionNotification.notifications.map((notification) => [
-            notification.taskId,
-            ledgerStatusFromPiNotificationStatus(notification.status),
-          ])),
-        );
+      if (completionNotification && !this.observedBackgroundCompletionKeys.has(completionNotification.key)) {
+        const completionStatuses = Object.fromEntries(completionNotification.notifications.map((notification) => [
+          notification.taskId,
+          ledgerStatusFromPiNotificationStatus(notification.status),
+        ]));
+        if (this.activeEpoch === null) {
+          // agent_end can still have an active Pi session. Prompting before
+          // unowned agent_settled is rejected as "Agent is already processing".
+          this.pendingUnownedCompletionKeys.add(completionNotification.key);
+          this.pendingUnownedCompletionStatuses.set(completionNotification.key, completionStatuses);
+        } else {
+          // Already visible in the owned turn. Persist as acknowledged; do not
+          // schedule another wake after the parent turn settles.
+          this.observedBackgroundCompletionKeys.add(completionNotification.key);
+          this.emitObservation("completed", {
+            completionKey: completionNotification.key,
+            completionStatuses,
+            handledInTurn: true,
+          });
+        }
       }
     } else if (event?.type === "agent_settled") {
       const epoch = this.activeEpoch;
@@ -781,6 +788,7 @@ class PiSession extends EventSession {
   private emitObservation(phase: Extract<NormalizedRuntimeEvent, { type: "runtime-observation" }>['phase'], fields: {
     reason?: "manual" | "threshold" | "overflow"; willRetry?: boolean; success?: boolean; completionKey?: string;
     completionStatuses?: Record<string, "completed" | "failed" | "cancelled" | "timed_out">;
+    handledInTurn?: boolean;
     taskId?: string; outputFile?: string;
   } = {}): void {
     const inputId = this.oldestOwnedInput();

--- a/src/runtime/runtime-contracts.ts
+++ b/src/runtime/runtime-contracts.ts
@@ -43,6 +43,7 @@ export type NormalizedRuntimeEvent =
         | "rpc_timeout" | "rpc_error" | "turn_start" | "first_output" | "tool_call" | "tool_result" | "agent_end" | "completed" | "settled"
         | "background_dispatched";
       reason?: "manual" | "threshold" | "overflow"; willRetry?: boolean; success?: boolean; inputId?: string; sessionId?: string; completionKey?: string;
+      completionStatuses?: Record<string, "completed" | "failed" | "cancelled" | "timed_out">;
       taskId?: string; outputFile?: string }
   | { type: "turn-start"; turnId?: string }
   | { type: "activity"; activity: "thinking" | "text" | "tool" | "internal"; text?: string; name?: string }

--- a/src/runtime/runtime-contracts.ts
+++ b/src/runtime/runtime-contracts.ts
@@ -44,6 +44,7 @@ export type NormalizedRuntimeEvent =
         | "background_dispatched";
       reason?: "manual" | "threshold" | "overflow"; willRetry?: boolean; success?: boolean; inputId?: string; sessionId?: string; completionKey?: string;
       completionStatuses?: Record<string, "completed" | "failed" | "cancelled" | "timed_out">;
+      handledInTurn?: boolean;
       taskId?: string; outputFile?: string }
   | { type: "turn-start"; turnId?: string }
   | { type: "activity"; activity: "thinking" | "text" | "tool" | "internal"; text?: string; name?: string }

--- a/src/runtime/runtime-contracts.ts
+++ b/src/runtime/runtime-contracts.ts
@@ -40,8 +40,10 @@ export type NormalizedRuntimeEvent =
   | { type: "session-init"; sessionId: string; model?: string; reasoningEffort?: string }
   | { type: "runtime-observation"; runtime: "pi"; distribution: "builtin" | "external";
       phase: "rpc_submit" | "rpc_accepted" | "compaction_start" | "compaction_end" | "retry_progress"
-        | "rpc_timeout" | "rpc_error" | "turn_start" | "first_output" | "tool_call" | "tool_result" | "agent_end" | "completed" | "settled";
-      reason?: "manual" | "threshold" | "overflow"; willRetry?: boolean; success?: boolean; inputId?: string; sessionId?: string; completionKey?: string }
+        | "rpc_timeout" | "rpc_error" | "turn_start" | "first_output" | "tool_call" | "tool_result" | "agent_end" | "completed" | "settled"
+        | "background_dispatched";
+      reason?: "manual" | "threshold" | "overflow"; willRetry?: boolean; success?: boolean; inputId?: string; sessionId?: string; completionKey?: string;
+      taskId?: string; outputFile?: string }
   | { type: "turn-start"; turnId?: string }
   | { type: "activity"; activity: "thinking" | "text" | "tool" | "internal"; text?: string; name?: string }
   | { type: "turn-end"; sessionId?: string; turnId?: string }

--- a/src/runtime/runtime-host.ts
+++ b/src/runtime/runtime-host.ts
@@ -28,6 +28,7 @@ import {
 import {
   type DispatchedSubagentLedger,
   type DispatchedSubagentRecord,
+  type PiSubagentRecordPresence,
   getDispatchedSubagent as lookupDispatchedSubagent,
   ledgerFilePath,
   noteDispatchedSubagent,
@@ -280,7 +281,7 @@ export function createRuntimeHost(options: {
   retryPolicy?: { baseDelayMs?: number; maxDelayMs?: number; maxAttempts?: number; stableWindowMs?: number };
   compactTimeoutMs?: number;
   telemetry?: TelemetryRuntime;
-  subagentRecordProbe?: (record: DispatchedSubagentRecord) => "present" | "absent";
+  subagentRecordProbe?: (record: DispatchedSubagentRecord) => PiSubagentRecordPresence;
   subagentReconcileIntervalMs?: number;
 }): RuntimeHost {
   const managed = new Map<string, ManagedAgent>();
@@ -975,8 +976,9 @@ export function createRuntimeHost(options: {
       forceMissing: input.forceMissing === true,
       missingReason: input.missingReason,
     });
+    const previousLedger = agent.subagentLedger;
     agent.subagentLedger = result.ledger;
-    if (result.orphaned.length > 0) persistSubagentLedger(agent);
+    if (result.orphaned.length > 0 || result.ledger !== previousLedger) persistSubagentLedger(agent);
     for (const record of result.orphaned) {
       noteBackgroundCompletion(agent, record.wakeKey ?? record.taskId);
     }

--- a/src/runtime/runtime-host.ts
+++ b/src/runtime/runtime-host.ts
@@ -41,6 +41,7 @@ import {
   undeliveredTerminalWakeKeys,
   PI_SUBAGENT_SESSION_OWNER_ENV,
   retirePiSubagentRecord,
+  effectivePiStateDir,
   writeDispatchedSubagentLedger,
   writeDispatchedSubagentRecordFile,
 } from "./pi-subagent-ledger.js";
@@ -317,7 +318,7 @@ export function createRuntimeHost(options: {
     LARKIN_CONFIG_DIR: process.env.LARKIN_CONFIG_DIR,
     LARKIN_HOME: process.env.LARKIN_HOME,
     ...(config.piDistribution ? { LARKIN_PI_DISTRIBUTION: config.piDistribution } : {}),
-    ...(config.stateDir ? { LARKIN_STATE_DIR: config.stateDir } : {}),
+    LARKIN_STATE_DIR: effectivePiStateDir(config),
     ...(process.env.HOME ? { HOME: process.env.HOME } : {}),
     ...(process.env.SHELL ? { SHELL: process.env.SHELL } : {}),
     ...(process.env.ZDOTDIR ? { ZDOTDIR: process.env.ZDOTDIR } : {}),
@@ -963,7 +964,7 @@ export function createRuntimeHost(options: {
   };
 
   const recordDispatchedSubagent = (agent: ManagedAgent, taskId: string, outputFile?: string): void => {
-    const recordFile = writeDispatchedSubagentRecordFile(agent.config.stateDir, taskId, agent.piSessionOwner);
+    const recordFile = writeDispatchedSubagentRecordFile(effectivePiStateDir(agent.config), taskId, agent.piSessionOwner);
     agent.subagentLedger = noteDispatchedSubagent(agent.subagentLedger, { taskId, outputFile, recordFile });
     persistSubagentLedger(agent);
     armSubagentReconcileTimer(agent);

--- a/src/runtime/runtime-host.ts
+++ b/src/runtime/runtime-host.ts
@@ -25,6 +25,19 @@ import {
   PiCompactionBreaker,
   PiCompactionRecoveryMachine,
 } from "./pi-compaction-recovery.js";
+import {
+  type DispatchedSubagentLedger,
+  type DispatchedSubagentRecord,
+  getDispatchedSubagent as lookupDispatchedSubagent,
+  ledgerFilePath,
+  noteDispatchedSubagent,
+  noteDispatchedSubagentTerminal,
+  probePiSubagentOutputRecord,
+  readDispatchedSubagentLedger,
+  reconcileDispatchedSubagents,
+  taskIdsFromCompletionKey,
+  writeDispatchedSubagentLedger,
+} from "./pi-subagent-ledger.js";
 
 export interface AgentRuntimeConfig {
   agentId: string; name: string; displayName?: string | null; description?: string | null;
@@ -101,6 +114,8 @@ interface ManagedAgent {
   backgroundCompletionInFlight: string | null; backgroundCompletionWakeInputId: string | null;
   backgroundCompletionRejectStreak: number;
   backgroundCompletionRetryTimer: NodeJS.Timeout | null;
+  subagentLedger: DispatchedSubagentLedger;
+  subagentReconcileTimer: NodeJS.Timeout | null;
 }
 
 export interface RuntimeHost {
@@ -118,6 +133,7 @@ export interface RuntimeHost {
   recoverSession?(agentId: string, reason: "context-overflow"): Promise<RuntimeSessionRecoveryResult>;
   /** Internal recovery boundary for Pi compaction failures; never exposed as session reset. */
   recoverContextOverflow?(agentId: string, deliveryKey: string, reason: string): Promise<RuntimeSessionRecoveryResult>;
+  getDispatchedSubagent(agentId: string, taskId: string): DispatchedSubagentRecord | null;
 }
 
 export interface RuntimeSessionResetResult {
@@ -162,6 +178,7 @@ export interface StagedRuntimeCandidate {
 
 const MAX_DELIVERIES = 2048;
 const BACKGROUND_COMPLETION_IMMEDIATE_RETRY_LIMIT = 5;
+const DEFAULT_SUBAGENT_RECONCILE_INTERVAL_MS = 15_000;
 const now = (): string => new Date().toISOString();
 const isActiveDelivery = (status: DeliveryStatus): boolean => ["pending", "submitting", "accepted"].includes(status);
 type ReplayFailureCode = "canonical_inbox_row_missing" | "canonical_inbox_malformed" | "duplicate_message_id"
@@ -260,6 +277,8 @@ export function createRuntimeHost(options: {
   retryPolicy?: { baseDelayMs?: number; maxDelayMs?: number; maxAttempts?: number; stableWindowMs?: number };
   compactTimeoutMs?: number;
   telemetry?: TelemetryRuntime;
+  subagentRecordProbe?: (record: DispatchedSubagentRecord) => "present" | "absent";
+  subagentReconcileIntervalMs?: number;
 }): RuntimeHost {
   const managed = new Map<string, ManagedAgent>();
   const listeners = new Set<(event: RuntimeHostEvent) => void>();
@@ -273,6 +292,10 @@ export function createRuntimeHost(options: {
     maxAttempts: options.retryPolicy?.maxAttempts ?? 6,
     stableWindowMs: options.retryPolicy?.stableWindowMs ?? 30_000,
   };
+  const subagentReconcileIntervalMs = options.subagentReconcileIntervalMs ?? DEFAULT_SUBAGENT_RECONCILE_INTERVAL_MS;
+  if (!Number.isFinite(subagentReconcileIntervalMs) || subagentReconcileIntervalMs < 0) {
+    throw new Error("subagentReconcileIntervalMs must be >= 0");
+  }
   const emit = (event: RuntimeHostEvent): void => {
     if (event.type === "delivery") telemetry?.delivery(event.agentId, event.messageId, event.status);
     for (const listener of listeners) listener(event);
@@ -798,7 +821,14 @@ export function createRuntimeHost(options: {
     try {
       const session = await ensureSession(agent);
       if (agent.session !== session || agent.stopped) return { status: "dropped" };
-      const input = options.promptBuilder.buildRuntimeInput("wake", crypto.randomUUID(), { wakeReason: "background subagent completed" });
+      const headKey = agent.backgroundCompletionQueue[0];
+      const orphaned = taskIdsFromCompletionKey(headKey ?? "")
+        .map((taskId) => lookupDispatchedSubagent(agent.subagentLedger, taskId))
+        .filter((task): task is DispatchedSubagentRecord => task?.status === "orphaned");
+      const wakeReason = orphaned.length > 0
+        ? `background subagent completed; ${orphaned.map((task) => `task ${task.taskId} status=orphaned`).join("; ")}`
+        : "background subagent completed";
+      const input = options.promptBuilder.buildRuntimeInput("wake", crypto.randomUUID(), { wakeReason });
       const result = await session.prompt(input);
       if (agent.session !== session || agent.stopped) return { status: "dropped" };
       if (result.status === "accepted") {
@@ -864,15 +894,82 @@ export function createRuntimeHost(options: {
     }
   };
 
+  const persistSubagentLedger = (agent: ManagedAgent): void => {
+    writeDispatchedSubagentLedger(ledgerFilePath(agent.config.stateDir), agent.subagentLedger);
+  };
+
+  const loadSubagentLedger = (stateDir: string | undefined): DispatchedSubagentLedger => {
+    return readDispatchedSubagentLedger(ledgerFilePath(stateDir));
+  };
+
+  const clearSubagentReconcileTimer = (agent: ManagedAgent): void => {
+    if (!agent.subagentReconcileTimer) return;
+    clearInterval(agent.subagentReconcileTimer);
+    agent.subagentReconcileTimer = null;
+  };
+
+  const hasActiveDispatchedSubagent = (agent: ManagedAgent): boolean =>
+    agent.subagentLedger.tasks.some((task) => task.status === "dispatched");
+
   const noteBackgroundCompletion = (agent: ManagedAgent, completionKey: string): void => {
+    const taskIds = taskIdsFromCompletionKey(completionKey);
     if (agent.backgroundCompletionKeys.has(completionKey)) return;
+    if (taskIds.length > 0 && taskIds.every((taskId) => agent.backgroundCompletionKeys.has(taskId))) return;
     agent.backgroundCompletionKeys.add(completionKey);
+    for (const taskId of taskIds) agent.backgroundCompletionKeys.add(taskId);
     if (!agent.backgroundCompletionQueue.includes(completionKey)) {
       agent.backgroundCompletionQueue.push(completionKey);
     }
     if (!agent.busy && !agent.turnInProgress && !agent.submitting && !agent.backgroundCompletionInFlight) {
       scheduleBackgroundCompletionDrain(agent);
     }
+  };
+
+  const recordDispatchedSubagent = (agent: ManagedAgent, taskId: string, outputFile?: string): void => {
+    agent.subagentLedger = noteDispatchedSubagent(agent.subagentLedger, { taskId, outputFile });
+    persistSubagentLedger(agent);
+    armSubagentReconcileTimer(agent);
+  };
+
+  const recordTerminalSubagentNotification = (agent: ManagedAgent, completionKey: string): void => {
+    let next = agent.subagentLedger;
+    for (const taskId of taskIdsFromCompletionKey(completionKey)) {
+      next = noteDispatchedSubagentTerminal(next, { taskId, status: "completed", wakeKey: completionKey });
+    }
+    agent.subagentLedger = next;
+    persistSubagentLedger(agent);
+    if (!hasActiveDispatchedSubagent(agent)) clearSubagentReconcileTimer(agent);
+  };
+
+  const reconcileSubagentLedger = (agent: ManagedAgent, input: {
+    forceMissing?: boolean; missingReason?: string;
+  } = {}): void => {
+    if (agent.stopped) return;
+    const result = reconcileDispatchedSubagents(agent.subagentLedger, {
+      probe: options.subagentRecordProbe ?? probePiSubagentOutputRecord,
+      forceMissing: input.forceMissing === true,
+      missingReason: input.missingReason,
+    });
+    agent.subagentLedger = result.ledger;
+    if (result.orphaned.length > 0) persistSubagentLedger(agent);
+    for (const record of result.orphaned) {
+      noteBackgroundCompletion(agent, record.wakeKey ?? record.taskId);
+    }
+    if (!hasActiveDispatchedSubagent(agent)) clearSubagentReconcileTimer(agent);
+    else armSubagentReconcileTimer(agent);
+  };
+
+  const armSubagentReconcileTimer = (agent: ManagedAgent): void => {
+    if (agent.stopped || agent.subagentReconcileTimer || subagentReconcileIntervalMs === 0) return;
+    if (!hasActiveDispatchedSubagent(agent)) return;
+    agent.subagentReconcileTimer = setInterval(() => {
+      if (agent.stopped) {
+        clearSubagentReconcileTimer(agent);
+        return;
+      }
+      reconcileSubagentLedger(agent);
+    }, subagentReconcileIntervalMs);
+    agent.subagentReconcileTimer.unref?.();
   };
 
   const scheduleRecreate = (agent: ManagedAgent, reason: string): void => {
@@ -914,6 +1011,7 @@ export function createRuntimeHost(options: {
     if (agent.session !== session || agent.stopped) return;
     agent.session = null; agent.busy = false; agent.submitting = false; agent.generation += 1;
     rearmBackgroundCompletion(agent);
+    reconcileSubagentLedger(agent, { forceMissing: true, missingReason: "pi session gone" });
     agent.recreateReason = reason;
     if (agent.stabilityTimer) clearTimeout(agent.stabilityTimer);
     agent.stabilityTimer = null;
@@ -929,6 +1027,7 @@ export function createRuntimeHost(options: {
     agent.disabledReason = `runtime configuration recovery in progress: ${message}`;
     agent.session = null; agent.busy = false; agent.submitting = false; agent.generation += 1;
     rearmBackgroundCompletion(agent);
+    reconcileSubagentLedger(agent, { forceMissing: true, missingReason: "pi session gone" });
     if (agent.stabilityTimer) clearTimeout(agent.stabilityTimer);
     agent.stabilityTimer = null;
     for (const record of agent.records.values()) {
@@ -1198,6 +1297,7 @@ export function createRuntimeHost(options: {
       if (agent.backgroundCompletionQueue.length > 0 && !agent.backgroundCompletionRetryTimer) {
         scheduleBackgroundCompletionDrain(agent);
       }
+      reconcileSubagentLedger(agent);
       telemetry?.runtimeEvent(agent.config.agentId, event);
       if (recoveredAuthentication) {
         agent.authFailureActive = false;
@@ -1216,7 +1316,10 @@ export function createRuntimeHost(options: {
       });
       queueMicrotask(() => { void scanAndPromoteAcceptedInboxUpdates(agent); });
     } else if (event.type === "runtime-observation") {
-      if (event.phase === "completed" && typeof event.completionKey === "string") {
+      if (event.phase === "background_dispatched" && typeof event.taskId === "string" && event.taskId) {
+        recordDispatchedSubagent(agent, event.taskId, typeof event.outputFile === "string" ? event.outputFile : undefined);
+      } else if (event.phase === "completed" && typeof event.completionKey === "string") {
+        recordTerminalSubagentNotification(agent, event.completionKey);
         noteBackgroundCompletion(agent, event.completionKey);
       }
     } else if (event.type === "activity") {
@@ -1515,11 +1618,12 @@ export function createRuntimeHost(options: {
           if (previous.retryTimer) clearTimeout(previous.retryTimer);
           if (previous.stabilityTimer) clearTimeout(previous.stabilityTimer);
           if (previous.backgroundCompletionRetryTimer) clearTimeout(previous.backgroundCompletionRetryTimer);
+          if (previous.subagentReconcileTimer) clearInterval(previous.subagentReconcileTimer);
           const candidate: ManagedAgent = {
             ...previous, config, adapter, session, launchId: crypto.randomUUID(), busy: false, submitting: false,
             starting: null, retryAfterSubmit: false, generation: 0, poller: null, retryTimer: null,
             recreateAttempts: 0, stabilityTimer: null, recreateReason: null, stopped: false,
-            backgroundCompletionRetryTimer: null,
+            backgroundCompletionRetryTimer: null, subagentReconcileTimer: null,
             disabledReason: null, configurationRecovery: null,
             readiness: previous.authFailureActive ? previous.readiness : readiness,
           };
@@ -1538,6 +1642,7 @@ export function createRuntimeHost(options: {
           }
           // Commit clears any inherited backoff timer; reschedule so a queued
           // completion still drains on the new session.
+          reconcileSubagentLedger(candidate, { forceMissing: true, missingReason: "pi session gone" });
           if (candidate.backgroundCompletionQueue.length > 0) {
             scheduleBackgroundCompletionDrain(candidate);
           }
@@ -1827,7 +1932,8 @@ export function createRuntimeHost(options: {
           promotedInboxUpdateIds: new Set(),
           backgroundCompletionQueue: [], backgroundCompletionKeys: new Set(),
           backgroundCompletionInFlight: null, backgroundCompletionWakeInputId: null,
-          backgroundCompletionRejectStreak: 0, backgroundCompletionRetryTimer: null };
+          backgroundCompletionRejectStreak: 0, backgroundCompletionRetryTimer: null,
+          subagentLedger: loadSubagentLedger(config.stateDir), subagentReconcileTimer: null };
         const startupConsumed: DeliveryRecord[] = [];
         const startupQuarantined: Array<{ record: DeliveryRecord; code: ReplayFailureCode }> = [];
         for (const record of agent.records.values()) {
@@ -1856,6 +1962,7 @@ export function createRuntimeHost(options: {
         emitConsumed(agent, [...startupConsumed, ...persist(agent)]);
         try {
           await ensureSession(agent);
+          reconcileSubagentLedger(agent, { forceMissing: true, missingReason: "runtime restarted" });
           await recoverStalePiCompaction(agent);
           const startupSession = agent.session;
           const proactive = startupSession ? proactivelyCompactPiAtIdle(agent, startupSession) : null;
@@ -1955,11 +2062,16 @@ export function createRuntimeHost(options: {
       if (agent.retryTimer) clearTimeout(agent.retryTimer);
       if (agent.stabilityTimer) clearTimeout(agent.stabilityTimer);
       if (agent.backgroundCompletionRetryTimer) clearTimeout(agent.backgroundCompletionRetryTimer);
+      if (agent.subagentReconcileTimer) clearInterval(agent.subagentReconcileTimer);
       if (agent.busy) await agent.session?.cancel(reason);
       await agent.session?.close(reason); managed.delete(agentId);
       emit({ type: "agent-status", agentId, status: "inactive" });
     },
     async shutdown(reason): Promise<void> { await Promise.allSettled([...managed.keys()].map((id) => this.stop(id, reason))); },
     subscribe(listener): () => void { listeners.add(listener); return () => listeners.delete(listener); },
+    getDispatchedSubagent(agentId, taskId): DispatchedSubagentRecord | null {
+      const agent = managed.get(agentId);
+      return agent ? lookupDispatchedSubagent(agent.subagentLedger, taskId) : null;
+    },
   };
 }

--- a/src/runtime/runtime-host.ts
+++ b/src/runtime/runtime-host.ts
@@ -40,7 +40,7 @@ import {
   taskIdsFromCompletionKey,
   undeliveredTerminalWakeKeys,
   PI_SUBAGENT_SESSION_OWNER_ENV,
-  retireConsumedPiSubagentRecord,
+  retirePiSubagentRecord,
   writeDispatchedSubagentLedger,
   writeDispatchedSubagentRecordFile,
 } from "./pi-subagent-ledger.js";
@@ -917,7 +917,7 @@ export function createRuntimeHost(options: {
     agent.subagentLedger = next;
     persistSubagentLedger(agent);
     for (const taskId of taskIdsFromCompletionKey(completionKey)) {
-      retireConsumedPiSubagentRecord(lookupDispatchedSubagent(agent.subagentLedger, taskId)?.recordFile);
+      retirePiSubagentRecord(lookupDispatchedSubagent(agent.subagentLedger, taskId)?.recordFile);
     }
   };
 
@@ -1691,11 +1691,13 @@ export function createRuntimeHost(options: {
             emit({ type: "agent-status", agentId: config.agentId, status: "active", readiness: candidate.readiness ?? readiness });
           }
           candidate.piSessionOwner = stageEnv[PI_SUBAGENT_SESSION_OWNER_ENV];
-          // Commit clears any inherited backoff timer; reschedule so a queued
-          // completion still drains on the new session.
-          reconcileAfterSessionSwap(candidate);
+          // Close first so the old session's shutdown sweep can bridge consumed
+          // terminals before force-missing reconcile. Commit also clears any
+          // inherited backoff timer; reschedule so a queued completion still
+          // drains on the new session.
           await previous.session?.close("runtime candidate committed")
             .catch((error) => log("previous runtime close after candidate commit failed", String(error)));
+          reconcileAfterSessionSwap(candidate);
         },
         rollback,
       };

--- a/src/runtime/runtime-host.ts
+++ b/src/runtime/runtime-host.ts
@@ -995,8 +995,10 @@ export function createRuntimeHost(options: {
     });
     const previousLedger = agent.subagentLedger;
     agent.subagentLedger = result.ledger;
-    if (result.orphaned.length > 0 || result.ledger !== previousLedger) persistSubagentLedger(agent);
-    for (const record of result.orphaned) {
+    if (result.orphaned.length > 0 || result.terminals.length > 0 || result.ledger !== previousLedger) {
+      persistSubagentLedger(agent);
+    }
+    for (const record of [...result.orphaned, ...result.terminals]) {
       noteBackgroundCompletion(agent, record.wakeKey ?? record.taskId);
     }
     if (!hasActiveDispatchedSubagent(agent)) clearSubagentReconcileTimer(agent);
@@ -1057,15 +1059,21 @@ export function createRuntimeHost(options: {
     if (agent.session !== session || agent.stopped) return;
     agent.session = null; agent.busy = false; agent.submitting = false; agent.generation += 1;
     rearmBackgroundCompletion(agent);
-    reconcileSubagentLedger(agent, { forceMissing: true, missingReason: "pi session gone" });
     agent.recreateReason = reason;
     if (agent.stabilityTimer) clearTimeout(agent.stabilityTimer);
     agent.stabilityTimer = null;
-    void session.close(`replace after ${reason}`).catch((error) => log("runtime close after replacement failed", String(error)));
     for (const record of agent.records.values()) if (isActiveDelivery(record.status)) record.status = "pending";
     emitConsumed(agent, persist(agent));
     emit({ type: "agent-status", agentId: agent.config.agentId, status: "error", error: reason });
-    scheduleRecreate(agent, reason);
+    // Close first so the shutdown sweep can bridge consumed or terminal state
+    // before force-missing reconcile treats a plain sidecar as orphaned.
+    void session.close(`replace after ${reason}`)
+      .catch((error) => log("runtime close after replacement failed", String(error)))
+      .finally(() => {
+        if (agent.stopped) return;
+        reconcileAfterSessionSwap(agent);
+        scheduleRecreate(agent, reason);
+      });
   };
 
   const recoverConfiguration = (agent: ManagedAgent, session: RuntimeSession, message: string): void => {
@@ -1073,7 +1081,6 @@ export function createRuntimeHost(options: {
     agent.disabledReason = `runtime configuration recovery in progress: ${message}`;
     agent.session = null; agent.busy = false; agent.submitting = false; agent.generation += 1;
     rearmBackgroundCompletion(agent);
-    reconcileSubagentLedger(agent, { forceMissing: true, missingReason: "pi session gone" });
     if (agent.stabilityTimer) clearTimeout(agent.stabilityTimer);
     agent.stabilityTimer = null;
     for (const record of agent.records.values()) {
@@ -1086,6 +1093,7 @@ export function createRuntimeHost(options: {
     const recovery = (async () => {
       try {
         await session.close("runtime configuration error");
+        if (!agent.stopped) reconcileAfterSessionSwap(agent);
         const result = agent.adapter.recoverConfigurationError
           ? await agent.adapter.recoverConfigurationError(message)
           : { recovered: false, reason: "runtime adapter does not support automatic configuration recovery" };

--- a/src/runtime/runtime-host.ts
+++ b/src/runtime/runtime-host.ts
@@ -913,6 +913,15 @@ export function createRuntimeHost(options: {
     writeDispatchedSubagentLedger(ledgerFilePath(effectivePiStateDir(agent.config)), agent.subagentLedger);
   };
 
+  const dropQueuedBackgroundCompletionFallback = (agent: ManagedAgent, completionKey: string): void => {
+    const keys = new Set([completionKey, ...taskIdsFromCompletionKey(completionKey)]);
+    for (let index = agent.backgroundCompletionQueue.length - 1; index >= 0; index -= 1) {
+      const queued = agent.backgroundCompletionQueue[index];
+      if (queued && keys.has(queued)) agent.backgroundCompletionQueue.splice(index, 1);
+    }
+    for (const key of keys) agent.backgroundCompletionKeys.add(key);
+  };
+
   const acknowledgeSubagentWake = (agent: ManagedAgent, completionKey: string): void => {
     const next = noteDispatchedSubagentWakeAcknowledged(agent.subagentLedger, { completionKey });
     if (next === agent.subagentLedger) return;
@@ -1378,6 +1387,7 @@ export function createRuntimeHost(options: {
         recordTerminalSubagentNotification(agent, event.completionKey, event.completionStatuses);
         if (event.handledInTurn === true) {
           acknowledgeSubagentWake(agent, event.completionKey);
+          dropQueuedBackgroundCompletionFallback(agent, event.completionKey);
         } else {
           noteBackgroundCompletion(agent, event.completionKey);
         }

--- a/src/runtime/runtime-host.ts
+++ b/src/runtime/runtime-host.ts
@@ -39,6 +39,8 @@ import {
   reconcileDispatchedSubagents,
   taskIdsFromCompletionKey,
   undeliveredTerminalWakeKeys,
+  PI_SUBAGENT_SESSION_OWNER_ENV,
+  retireConsumedPiSubagentRecord,
   writeDispatchedSubagentLedger,
   writeDispatchedSubagentRecordFile,
 } from "./pi-subagent-ledger.js";
@@ -120,6 +122,7 @@ interface ManagedAgent {
   backgroundCompletionRetryTimer: NodeJS.Timeout | null;
   subagentLedger: DispatchedSubagentLedger;
   subagentReconcileTimer: NodeJS.Timeout | null;
+  piSessionOwner?: string;
 }
 
 export interface RuntimeHost {
@@ -307,7 +310,10 @@ export function createRuntimeHost(options: {
   const runtimeEnv = (config: AgentRuntimeConfig, generation?: string): NodeJS.ProcessEnv => {
     const base: NodeJS.ProcessEnv = {
       LARKIN_AGENT_ID: config.agentId,
-    ...(generation ? { LARKIN_RUNTIME_OBSERVATION_GENERATION: generation } : {}),
+    ...(generation ? {
+      LARKIN_RUNTIME_OBSERVATION_GENERATION: generation,
+      [PI_SUBAGENT_SESSION_OWNER_ENV]: generation,
+    } : {}),
     LARKIN_CONFIG_DIR: process.env.LARKIN_CONFIG_DIR,
     LARKIN_HOME: process.env.LARKIN_HOME,
     ...(config.piDistribution ? { LARKIN_PI_DISTRIBUTION: config.piDistribution } : {}),
@@ -749,7 +755,7 @@ export function createRuntimeHost(options: {
     }
     agent.backgroundCompletionRejectStreak = 0;
     clearBackgroundCompletionRetryTimer(agent);
-    acknowledgeSubagentWake(agent, completionKey);
+    // Leave the durable wake pending so a later restart can requeue it.
   };
 
   const scheduleBackgroundCompletionRetry = (agent: ManagedAgent): void => {
@@ -910,12 +916,23 @@ export function createRuntimeHost(options: {
     if (next === agent.subagentLedger) return;
     agent.subagentLedger = next;
     persistSubagentLedger(agent);
+    for (const taskId of taskIdsFromCompletionKey(completionKey)) {
+      retireConsumedPiSubagentRecord(lookupDispatchedSubagent(agent.subagentLedger, taskId)?.recordFile);
+    }
   };
 
   const enqueueUndeliveredTerminalWakes = (agent: ManagedAgent): void => {
     for (const key of undeliveredTerminalWakeKeys(agent.subagentLedger)) {
+      agent.backgroundCompletionKeys.delete(key);
+      for (const taskId of taskIdsFromCompletionKey(key)) agent.backgroundCompletionKeys.delete(taskId);
       noteBackgroundCompletion(agent, key);
     }
+  };
+
+  const reconcileAfterSessionSwap = (agent: ManagedAgent): void => {
+    reconcileSubagentLedger(agent, { forceMissing: true, missingReason: "pi session gone" });
+    enqueueUndeliveredTerminalWakes(agent);
+    if (agent.backgroundCompletionQueue.length > 0) scheduleBackgroundCompletionDrain(agent);
   };
 
   const loadSubagentLedger = (stateDir: string | undefined): DispatchedSubagentLedger => {
@@ -946,7 +963,7 @@ export function createRuntimeHost(options: {
   };
 
   const recordDispatchedSubagent = (agent: ManagedAgent, taskId: string, outputFile?: string): void => {
-    const recordFile = writeDispatchedSubagentRecordFile(agent.config.stateDir, taskId);
+    const recordFile = writeDispatchedSubagentRecordFile(agent.config.stateDir, taskId, agent.piSessionOwner);
     agent.subagentLedger = noteDispatchedSubagent(agent.subagentLedger, { taskId, outputFile, recordFile });
     persistSubagentLedger(agent);
     armSubagentReconcileTimer(agent);
@@ -1452,15 +1469,17 @@ export function createRuntimeHost(options: {
     });
     const generation = ++agent.generation;
     let completedSession: RuntimeSession | null = null;
+    const sessionEnv = runtimeEnv(agent.config, `${agent.launchId}:${generation}`);
     agent.starting = agent.adapter.createSession({
       agentId: agent.config.agentId, model: agent.config.model, reasoningEffort: agent.config.effort || null,
       workspaceDir: agent.config.workspaceDir, stateDir: agent.config.stateDir,
       resumeSessionId: agent.config.sessionId || null, standingPrompt,
-      env: runtimeEnv(agent.config, `${agent.launchId}:${generation}`),
+      env: sessionEnv,
     }).then((session) => {
       completedSession = session;
       if (agent.stopped || generation !== agent.generation) { void session.close("stale creation"); throw new Error("stale runtime session creation"); }
       agent.session = session;
+      agent.piSessionOwner = sessionEnv[PI_SUBAGENT_SESSION_OWNER_ENV];
       session.subscribe((event) => observe(agent, session, event));
       if (agent.session !== session) return session;
       if (session.sessionId) {
@@ -1580,7 +1599,9 @@ export function createRuntimeHost(options: {
         ...(fresh.effectiveReasoningEffort ? { reasoningEffort: fresh.effectiveReasoningEffort } : {}) });
     }
     emit({ type: "agent-status", agentId, status: "active", readiness });
+    agent.piSessionOwner = probeEnv[PI_SUBAGENT_SESSION_OWNER_ENV];
     await oldSession.close("Pi context fallback committed").catch((error) => log("previous Pi session close after fallback failed", String(error)));
+    reconcileAfterSessionSwap(agent);
     const proactive = proactivelyCompactPiAtIdle(agent, fresh);
     void (proactive ?? Promise.resolve("noop" as const)).then((outcome) => {
       if (outcome !== "failed") return retryPending(agent);
@@ -1669,12 +1690,10 @@ export function createRuntimeHost(options: {
           if (!candidate.authFailureActive) {
             emit({ type: "agent-status", agentId: config.agentId, status: "active", readiness: candidate.readiness ?? readiness });
           }
+          candidate.piSessionOwner = stageEnv[PI_SUBAGENT_SESSION_OWNER_ENV];
           // Commit clears any inherited backoff timer; reschedule so a queued
           // completion still drains on the new session.
-          reconcileSubagentLedger(candidate, { forceMissing: true, missingReason: "pi session gone" });
-          if (candidate.backgroundCompletionQueue.length > 0) {
-            scheduleBackgroundCompletionDrain(candidate);
-          }
+          reconcileAfterSessionSwap(candidate);
           await previous.session?.close("runtime candidate committed")
             .catch((error) => log("previous runtime close after candidate commit failed", String(error)));
         },
@@ -1756,8 +1775,10 @@ export function createRuntimeHost(options: {
           ...(fresh.effectiveReasoningEffort ? { reasoningEffort: fresh.effectiveReasoningEffort } : {}) });
       }
       emit({ type: "agent-status", agentId, status: "active", readiness });
+      agent.piSessionOwner = probeEnv[PI_SUBAGENT_SESSION_OWNER_ENV];
       await oldSession.close("fresh session reset committed")
         .catch((error) => log("previous runtime close after fresh reset failed", String(error)));
+      reconcileAfterSessionSwap(agent);
       return { generationChanged: true, sessionChanged: oldSessionId !== fresh.sessionId, turns: 0,
         runtimeReady: true, pendingCount: 0, sessionId: fresh.sessionId };
     },
@@ -1887,8 +1908,10 @@ export function createRuntimeHost(options: {
         }
         emit({ type: "agent-status", agentId, status: "active", readiness });
         durableRollback = null;
+        agent.piSessionOwner = probeEnv[PI_SUBAGENT_SESSION_OWNER_ENV];
         await oldSession.close("context-window recovery committed")
           .catch((error) => log("previous runtime close after context-window recovery failed", String(error)));
+        reconcileAfterSessionSwap(agent);
         const proactive = proactivelyCompactPiAtIdle(agent, fresh);
         void (proactive ?? Promise.resolve("noop" as const)).then((outcome) => {
           if (outcome !== "failed") return retryPending(agent);

--- a/src/runtime/runtime-host.ts
+++ b/src/runtime/runtime-host.ts
@@ -32,11 +32,14 @@ import {
   ledgerFilePath,
   noteDispatchedSubagent,
   noteDispatchedSubagentTerminal,
-  probePiSubagentOutputRecord,
+  noteDispatchedSubagentWakeAcknowledged,
+  probePiSubagentRecord,
   readDispatchedSubagentLedger,
   reconcileDispatchedSubagents,
   taskIdsFromCompletionKey,
+  undeliveredTerminalWakeKeys,
   writeDispatchedSubagentLedger,
+  writeDispatchedSubagentRecordFile,
 } from "./pi-subagent-ledger.js";
 
 export interface AgentRuntimeConfig {
@@ -307,6 +310,7 @@ export function createRuntimeHost(options: {
     LARKIN_CONFIG_DIR: process.env.LARKIN_CONFIG_DIR,
     LARKIN_HOME: process.env.LARKIN_HOME,
     ...(config.piDistribution ? { LARKIN_PI_DISTRIBUTION: config.piDistribution } : {}),
+    ...(config.stateDir ? { LARKIN_STATE_DIR: config.stateDir } : {}),
     ...(process.env.HOME ? { HOME: process.env.HOME } : {}),
     ...(process.env.SHELL ? { SHELL: process.env.SHELL } : {}),
     ...(process.env.ZDOTDIR ? { ZDOTDIR: process.env.ZDOTDIR } : {}),
@@ -744,6 +748,7 @@ export function createRuntimeHost(options: {
     }
     agent.backgroundCompletionRejectStreak = 0;
     clearBackgroundCompletionRetryTimer(agent);
+    acknowledgeSubagentWake(agent, completionKey);
   };
 
   const scheduleBackgroundCompletionRetry = (agent: ManagedAgent): void => {
@@ -811,6 +816,7 @@ export function createRuntimeHost(options: {
     agent.backgroundCompletionWakeInputId = null;
     agent.backgroundCompletionRejectStreak = 0;
     clearBackgroundCompletionRetryTimer(agent);
+    acknowledgeSubagentWake(agent, completionKey);
   };
 
   const wakeOnBackgroundCompletion = async (agent: ManagedAgent): Promise<
@@ -898,6 +904,19 @@ export function createRuntimeHost(options: {
     writeDispatchedSubagentLedger(ledgerFilePath(agent.config.stateDir), agent.subagentLedger);
   };
 
+  const acknowledgeSubagentWake = (agent: ManagedAgent, completionKey: string): void => {
+    const next = noteDispatchedSubagentWakeAcknowledged(agent.subagentLedger, { completionKey });
+    if (next === agent.subagentLedger) return;
+    agent.subagentLedger = next;
+    persistSubagentLedger(agent);
+  };
+
+  const enqueueUndeliveredTerminalWakes = (agent: ManagedAgent): void => {
+    for (const key of undeliveredTerminalWakeKeys(agent.subagentLedger)) {
+      noteBackgroundCompletion(agent, key);
+    }
+  };
+
   const loadSubagentLedger = (stateDir: string | undefined): DispatchedSubagentLedger => {
     return readDispatchedSubagentLedger(ledgerFilePath(stateDir));
   };
@@ -926,15 +945,21 @@ export function createRuntimeHost(options: {
   };
 
   const recordDispatchedSubagent = (agent: ManagedAgent, taskId: string, outputFile?: string): void => {
-    agent.subagentLedger = noteDispatchedSubagent(agent.subagentLedger, { taskId, outputFile });
+    const recordFile = writeDispatchedSubagentRecordFile(agent.config.stateDir, taskId);
+    agent.subagentLedger = noteDispatchedSubagent(agent.subagentLedger, { taskId, outputFile, recordFile });
     persistSubagentLedger(agent);
     armSubagentReconcileTimer(agent);
   };
 
-  const recordTerminalSubagentNotification = (agent: ManagedAgent, completionKey: string): void => {
+  const recordTerminalSubagentNotification = (agent: ManagedAgent, completionKey: string, statuses?: Record<string, DispatchedSubagentRecord["status"]>): void => {
     let next = agent.subagentLedger;
     for (const taskId of taskIdsFromCompletionKey(completionKey)) {
-      next = noteDispatchedSubagentTerminal(next, { taskId, status: "completed", wakeKey: completionKey });
+      const status = statuses?.[taskId];
+      next = noteDispatchedSubagentTerminal(next, {
+        taskId,
+        status: status && status !== "dispatched" && status !== "orphaned" ? status : "completed",
+        wakeKey: completionKey,
+      });
     }
     agent.subagentLedger = next;
     persistSubagentLedger(agent);
@@ -946,7 +971,7 @@ export function createRuntimeHost(options: {
   } = {}): void => {
     if (agent.stopped) return;
     const result = reconcileDispatchedSubagents(agent.subagentLedger, {
-      probe: options.subagentRecordProbe ?? probePiSubagentOutputRecord,
+      probe: options.subagentRecordProbe ?? probePiSubagentRecord,
       forceMissing: input.forceMissing === true,
       missingReason: input.missingReason,
     });
@@ -990,6 +1015,8 @@ export function createRuntimeHost(options: {
         const session = agent.session;
         const proactive = session ? proactivelyCompactPiAtIdle(agent, session) : null;
         if (proactive && await proactive === "failed") return;
+        reconcileSubagentLedger(agent, { forceMissing: true, missingReason: "pi session gone" });
+        enqueueUndeliveredTerminalWakes(agent);
         await retryPending(agent);
         if (agent.backgroundCompletionQueue.length > 0) scheduleBackgroundCompletionDrain(agent);
       }).catch((error) => {
@@ -1319,7 +1346,7 @@ export function createRuntimeHost(options: {
       if (event.phase === "background_dispatched" && typeof event.taskId === "string" && event.taskId) {
         recordDispatchedSubagent(agent, event.taskId, typeof event.outputFile === "string" ? event.outputFile : undefined);
       } else if (event.phase === "completed" && typeof event.completionKey === "string") {
-        recordTerminalSubagentNotification(agent, event.completionKey);
+        recordTerminalSubagentNotification(agent, event.completionKey, event.completionStatuses);
         noteBackgroundCompletion(agent, event.completionKey);
       }
     } else if (event.type === "activity") {
@@ -1963,6 +1990,7 @@ export function createRuntimeHost(options: {
         try {
           await ensureSession(agent);
           reconcileSubagentLedger(agent, { forceMissing: true, missingReason: "runtime restarted" });
+          enqueueUndeliveredTerminalWakes(agent);
           await recoverStalePiCompaction(agent);
           const startupSession = agent.session;
           const proactive = startupSession ? proactivelyCompactPiAtIdle(agent, startupSession) : null;
@@ -1973,6 +2001,8 @@ export function createRuntimeHost(options: {
           const reason = error instanceof Error ? error.message : String(error);
           const transient = error instanceof RuntimePrerequisiteError && error.readiness.state === "unavailable";
           agent.disabledReason = transient ? null : reason;
+          reconcileSubagentLedger(agent, { forceMissing: true, missingReason: "runtime restarted" });
+          enqueueUndeliveredTerminalWakes(agent);
           if (transient) { recoveringCount += 1; scheduleRecreate(agent, reason); }
           startupFailures.push(`${config.agentId}: ${reason}`);
           emit({ type: "agent-status", agentId: config.agentId, status: "error", error: reason,

--- a/src/runtime/runtime-host.ts
+++ b/src/runtime/runtime-host.ts
@@ -836,11 +836,12 @@ export function createRuntimeHost(options: {
       const session = await ensureSession(agent);
       if (agent.session !== session || agent.stopped) return { status: "dropped" };
       const headKey = agent.backgroundCompletionQueue[0];
-      const orphaned = taskIdsFromCompletionKey(headKey ?? "")
+      const tasks = taskIdsFromCompletionKey(headKey ?? "")
         .map((taskId) => lookupDispatchedSubagent(agent.subagentLedger, taskId))
-        .filter((task): task is DispatchedSubagentRecord => task?.status === "orphaned");
-      const wakeReason = orphaned.length > 0
-        ? `background subagent completed; ${orphaned.map((task) => `task ${task.taskId} status=orphaned`).join("; ")}`
+        .filter((task): task is DispatchedSubagentRecord => Boolean(task));
+      const details = tasks.map((task) => `task ${task.taskId} status=${task.status}`).join("; ");
+      const wakeReason = details
+        ? `background subagent completed; ${details}`
         : "background subagent completed";
       const input = options.promptBuilder.buildRuntimeInput("wake", crypto.randomUUID(), { wakeReason });
       const result = await session.prompt(input);
@@ -909,7 +910,7 @@ export function createRuntimeHost(options: {
   };
 
   const persistSubagentLedger = (agent: ManagedAgent): void => {
-    writeDispatchedSubagentLedger(ledgerFilePath(agent.config.stateDir), agent.subagentLedger);
+    writeDispatchedSubagentLedger(ledgerFilePath(effectivePiStateDir(agent.config)), agent.subagentLedger);
   };
 
   const acknowledgeSubagentWake = (agent: ManagedAgent, completionKey: string): void => {
@@ -936,8 +937,8 @@ export function createRuntimeHost(options: {
     if (agent.backgroundCompletionQueue.length > 0) scheduleBackgroundCompletionDrain(agent);
   };
 
-  const loadSubagentLedger = (stateDir: string | undefined): DispatchedSubagentLedger => {
-    return readDispatchedSubagentLedger(ledgerFilePath(stateDir));
+  const loadSubagentLedger = (config: AgentRuntimeConfig): DispatchedSubagentLedger => {
+    return readDispatchedSubagentLedger(ledgerFilePath(effectivePiStateDir(config)));
   };
 
   const clearSubagentReconcileTimer = (agent: ManagedAgent): void => {
@@ -1375,7 +1376,11 @@ export function createRuntimeHost(options: {
         recordDispatchedSubagent(agent, event.taskId, typeof event.outputFile === "string" ? event.outputFile : undefined);
       } else if (event.phase === "completed" && typeof event.completionKey === "string") {
         recordTerminalSubagentNotification(agent, event.completionKey, event.completionStatuses);
-        noteBackgroundCompletion(agent, event.completionKey);
+        if (event.handledInTurn === true) {
+          acknowledgeSubagentWake(agent, event.completionKey);
+        } else {
+          noteBackgroundCompletion(agent, event.completionKey);
+        }
       }
     } else if (event.type === "activity") {
       if (agent.turnInProgress && event.activity !== "internal") agent.turnHadAuthenticatedOutput = true;
@@ -1996,7 +2001,7 @@ export function createRuntimeHost(options: {
           backgroundCompletionQueue: [], backgroundCompletionKeys: new Set(),
           backgroundCompletionInFlight: null, backgroundCompletionWakeInputId: null,
           backgroundCompletionRejectStreak: 0, backgroundCompletionRetryTimer: null,
-          subagentLedger: loadSubagentLedger(config.stateDir), subagentReconcileTimer: null };
+          subagentLedger: loadSubagentLedger(config), subagentReconcileTimer: null };
         const startupConsumed: DeliveryRecord[] = [];
         const startupQuarantined: Array<{ record: DeliveryRecord; code: ReplayFailureCode }> = [];
         for (const record of agent.records.values()) {

--- a/test/unit/runtime/pi-inline-extensions.test.mjs
+++ b/test/unit/runtime/pi-inline-extensions.test.mjs
@@ -18,12 +18,32 @@ test("builtin Pi RPC receives exactly the three static inline extension factorie
   assert.ok(BUILTIN_PI_EXTENSION_FACTORIES.every((factory) => typeof factory === "function"));
 });
 
+test("record watchdog registers session_shutdown before bundled subagents", async () => {
+  const priorStateDir = process.env.LARKIN_STATE_DIR;
+  const priorOwner = process.env.LARKIN_PI_SESSION_OWNER;
+  process.env.LARKIN_STATE_DIR = "/tmp/larkin-watchdog-order";
+  process.env.LARKIN_PI_SESSION_OWNER = "session-order";
+  try {
+    const events = [];
+    const first = BUILTIN_PI_EXTENSION_FACTORIES[0];
+    const factory = typeof first === "function" ? first : first.factory;
+    await factory({ on(event) { events.push(event); } });
+    assert.deepEqual(events, ["session_shutdown"],
+      "shutdown sweep must register before AgentManager teardown");
+  } finally {
+    if (priorStateDir === undefined) delete process.env.LARKIN_STATE_DIR;
+    else process.env.LARKIN_STATE_DIR = priorStateDir;
+    if (priorOwner === undefined) delete process.env.LARKIN_PI_SESSION_OWNER;
+    else process.env.LARKIN_PI_SESSION_OWNER = priorOwner;
+  }
+});
+
 test("inline bash extension preserves the 60s foreground hard guard", async () => {
   const prior = process.env.LARKIN_PI_BASH_TIMEOUT_SECONDS;
   delete process.env.LARKIN_PI_BASH_TIMEOUT_SECONDS;
   try {
     let bashTool;
-    const extension = BUILTIN_PI_EXTENSION_FACTORIES[1];
+    const extension = BUILTIN_PI_EXTENSION_FACTORIES[2];
     const factory = typeof extension === "function" ? extension : extension.factory;
     await factory({ registerTool(tool) { bashTool = tool; } });
     assert.equal(bashTool.name, "bash");

--- a/test/unit/runtime/pi-inline-extensions.test.mjs
+++ b/test/unit/runtime/pi-inline-extensions.test.mjs
@@ -1,4 +1,7 @@
 import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
 import { test } from "bun:test";
 import {
   BUILTIN_PI_EXTENSION_FACTORIES,
@@ -35,6 +38,34 @@ test("record watchdog registers session_shutdown before bundled subagents", asyn
     else process.env.LARKIN_STATE_DIR = priorStateDir;
     if (priorOwner === undefined) delete process.env.LARKIN_PI_SESSION_OWNER;
     else process.env.LARKIN_PI_SESSION_OWNER = priorOwner;
+  }
+});
+
+test("record watchdog contains non-ENOENT filesystem errors on sweep", async () => {
+  const priorStateDir = process.env.LARKIN_STATE_DIR;
+  const priorOwner = process.env.LARKIN_PI_SESSION_OWNER;
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "larkin-watchdog-fs-"));
+  const managerKey = Symbol.for("pi-subagents:manager");
+  const priorManager = globalThis[managerKey];
+  process.env.LARKIN_STATE_DIR = root;
+  process.env.LARKIN_PI_SESSION_OWNER = "session-fs-error";
+  fs.writeFileSync(path.join(root, "pi-subagent-records"), "not-a-directory\n");
+  globalThis[managerKey] = { getRecord: () => undefined };
+  try {
+    let shutdown;
+    const first = BUILTIN_PI_EXTENSION_FACTORIES[0];
+    const factory = typeof first === "function" ? first : first.factory;
+    await factory({ on(event, handler) { if (event === "session_shutdown") shutdown = handler; } });
+    assert.equal(typeof shutdown, "function");
+    shutdown();
+  } finally {
+    if (priorManager === undefined) delete globalThis[managerKey];
+    else globalThis[managerKey] = priorManager;
+    if (priorStateDir === undefined) delete process.env.LARKIN_STATE_DIR;
+    else process.env.LARKIN_STATE_DIR = priorStateDir;
+    if (priorOwner === undefined) delete process.env.LARKIN_PI_SESSION_OWNER;
+    else process.env.LARKIN_PI_SESSION_OWNER = priorOwner;
+    fs.rmSync(root, { recursive: true, force: true });
   }
 });
 

--- a/test/unit/runtime/pi-inline-extensions.test.mjs
+++ b/test/unit/runtime/pi-inline-extensions.test.mjs
@@ -5,13 +5,13 @@ import {
   invokeBuiltinPiRpc,
 } from "../../../dist/runtime/pi-inline-extensions.mjs";
 
-test("builtin Pi RPC receives exactly the two static inline extension factories", async () => {
+test("builtin Pi RPC receives exactly the three static inline extension factories", async () => {
   let invocation;
   await invokeBuiltinPiRpc(async (args, options) => { invocation = { args, options }; }, ["--no-session"]);
 
   assert.deepEqual(invocation.args, ["--mode", "rpc", "--no-session"]);
   assert.equal(Object.isFrozen(BUILTIN_PI_EXTENSION_FACTORIES), true);
-  assert.equal(BUILTIN_PI_EXTENSION_FACTORIES.length, 2);
+  assert.equal(BUILTIN_PI_EXTENSION_FACTORIES.length, 3);
   assert.deepEqual(invocation.options.extensionFactories, [...BUILTIN_PI_EXTENSION_FACTORIES]);
   assert.notEqual(invocation.options.extensionFactories, BUILTIN_PI_EXTENSION_FACTORIES,
     "Pi receives a mutable copy while the exported factory list remains immutable");

--- a/test/unit/runtime/pi-subagent-ledger.test.mjs
+++ b/test/unit/runtime/pi-subagent-ledger.test.mjs
@@ -22,6 +22,7 @@ import {
   undeliveredTerminalWakeKeys,
   writeDispatchedSubagentLedger,
   writeDispatchedSubagentRecordFile,
+  PI_SUBAGENT_TERMINAL_NOTIFICATION_GRACE_MS,
 } from "../../../dist/runtime/pi-subagent-ledger.mjs";
 
 test("extractBackgroundPiSubagentDispatch reads Agent ID and output file from a background spawn", () => {
@@ -298,7 +299,7 @@ test("sweep persists an unconsumed terminal before eviction can delete the sidec
     assert.equal(readConsumedPiSubagentTerminal(recordFile), null);
     assert.equal(probePiSubagentRecord({
       taskId: "task-evict-1", status: "dispatched", dispatchedAt: 10, lastActivityAt: 10, recordFile,
-    }), "present");
+    }), "terminal");
 
     live.delete("task-evict-1");
     const secondRemoved = sweepAbsentPiSubagentRecordFiles(recordDir, (taskId) => live.get(taskId));
@@ -306,23 +307,55 @@ test("sweep persists an unconsumed terminal before eviction can delete the sidec
     assert.ok(fs.existsSync(recordFile));
     assert.equal(probePiSubagentRecord({
       taskId: "task-evict-1", status: "dispatched", dispatchedAt: 10, lastActivityAt: 10, recordFile,
-    }), "present");
+    }), "terminal");
 
-    const result = reconcileDispatchedSubagents(ledger, {
+    const duringGrace = reconcileDispatchedSubagents(ledger, {
       probe: probePiSubagentRecord,
       now: 11,
     });
-    assert.deepEqual(result.orphaned, []);
-    assert.equal(getDispatchedSubagent(result.ledger, "task-evict-1")?.status, "dispatched");
+    assert.deepEqual(duringGrace.orphaned, []);
+    assert.deepEqual(duringGrace.terminals, []);
+    assert.equal(getDispatchedSubagent(duringGrace.ledger, "task-evict-1")?.status, "dispatched");
 
-    ledger = noteDispatchedSubagentTerminal(result.ledger, {
-      taskId: "task-evict-1",
-      status: "completed",
-      wakeKey: "task-evict-1",
-      now: 12,
+    const persistedAt = 1_700_000_400_000;
+    fs.utimesSync(recordFile, new Date(persistedAt), new Date(persistedAt));
+    const afterGrace = reconcileDispatchedSubagents(duringGrace.ledger, {
+      probe: probePiSubagentRecord,
+      now: persistedAt + PI_SUBAGENT_TERMINAL_NOTIFICATION_GRACE_MS,
     });
-    assert.equal(getDispatchedSubagent(ledger, "task-evict-1")?.status, "completed");
-    assert.equal(getDispatchedSubagent(ledger, "task-evict-1")?.wakeState, "pending");
+    assert.deepEqual(afterGrace.orphaned, []);
+    assert.equal(afterGrace.terminals.length, 1);
+    assert.equal(afterGrace.terminals[0].taskId, "task-evict-1");
+    assert.equal(afterGrace.terminals[0].status, "completed");
+    assert.equal(afterGrace.terminals[0].wakeState, "pending");
+    assert.equal(getDispatchedSubagent(afterGrace.ledger, "task-evict-1")?.status, "completed");
+    assert.deepEqual(undeliveredTerminalWakeKeys(afterGrace.ledger), ["task-evict-1"]);
+    assert.ok(fs.existsSync(recordFile), "unconsumed terminal sidecar stays until the wake is acknowledged");
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("force-missing immediately advances a persisted unconsumed terminal instead of orphaning it", () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "larkin-subagent-force-terminal-"));
+  try {
+    const recordFile = writeDispatchedSubagentRecordFile(root, "task-force-1", "session-a");
+    sweepAbsentPiSubagentRecordFiles(path.dirname(recordFile), () => ({ status: "error" }));
+    let ledger = noteDispatchedSubagent(emptyDispatchedSubagentLedger(), {
+      taskId: "task-force-1", recordFile, now: 10,
+    });
+    const result = reconcileDispatchedSubagents(ledger, {
+      probe: probePiSubagentRecord,
+      forceMissing: true,
+      now: 11,
+      missingReason: "pi session gone",
+    });
+    assert.deepEqual(result.orphaned, []);
+    assert.equal(result.terminals.length, 1);
+    assert.equal(result.terminals[0].status, "failed");
+    assert.equal(result.terminals[0].wakeState, "pending");
+    assert.equal(getDispatchedSubagent(result.ledger, "task-force-1")?.status, "failed");
+    assert.deepEqual(undeliveredTerminalWakeKeys(result.ledger), ["task-force-1"]);
   } finally {
     fs.rmSync(root, { recursive: true, force: true });
   }

--- a/test/unit/runtime/pi-subagent-ledger.test.mjs
+++ b/test/unit/runtime/pi-subagent-ledger.test.mjs
@@ -8,13 +8,18 @@ import {
   extractBackgroundPiSubagentDispatch,
   getDispatchedSubagent,
   ledgerFilePath,
+  dispatchedSubagentRecordFile,
   noteDispatchedSubagent,
   noteDispatchedSubagentTerminal,
-  probePiSubagentOutputRecord,
+  noteDispatchedSubagentWakeAcknowledged,
+  probePiSubagentRecord,
   readDispatchedSubagentLedger,
   reconcileDispatchedSubagents,
+  sweepAbsentPiSubagentRecordFiles,
   taskIdsFromCompletionKey,
+  undeliveredTerminalWakeKeys,
   writeDispatchedSubagentLedger,
+  writeDispatchedSubagentRecordFile,
 } from "../../../dist/runtime/pi-subagent-ledger.mjs";
 
 test("extractBackgroundPiSubagentDispatch reads Agent ID and output file from a background spawn", () => {
@@ -131,21 +136,103 @@ test("ledger file persists orphaned state after the Pi record is gone", () => {
   }
 });
 
-test("default output-file probe reports absent only when the known file is gone", () => {
+test("default probe uses the Pi record sidecar and ignores a leftover transcript", () => {
   const root = fs.mkdtempSync(path.join(os.tmpdir(), "larkin-subagent-probe-"));
   try {
     const outputFile = path.join(root, "task-probe-1.output");
-    fs.writeFileSync(outputFile, "alive\n");
-    assert.equal(probePiSubagentOutputRecord({
-      taskId: "task-probe-1", status: "dispatched", dispatchedAt: 1, lastActivityAt: 1, outputFile,
+    const recordFile = writeDispatchedSubagentRecordFile(root, "task-probe-1");
+    fs.writeFileSync(outputFile, "leftover transcript\n");
+    assert.equal(probePiSubagentRecord({
+      taskId: "task-probe-1", status: "dispatched", dispatchedAt: 1, lastActivityAt: 1, outputFile, recordFile,
     }), "present");
-    fs.rmSync(outputFile);
-    assert.equal(probePiSubagentOutputRecord({
-      taskId: "task-probe-1", status: "dispatched", dispatchedAt: 1, lastActivityAt: 1, outputFile,
+    fs.rmSync(recordFile);
+    assert.equal(probePiSubagentRecord({
+      taskId: "task-probe-1", status: "dispatched", dispatchedAt: 1, lastActivityAt: 1, outputFile, recordFile,
+    }), "absent", "a leftover transcript must not count as a present Pi record");
+    assert.ok(fs.existsSync(outputFile));
+    assert.equal(probePiSubagentRecord({
+      taskId: "task-probe-2", status: "dispatched", dispatchedAt: 1, lastActivityAt: 1, outputFile,
+    }), "absent", "tasks without a record sidecar are not unconditionally present");
+    assert.equal(probePiSubagentRecord({
+      taskId: "task-probe-3", status: "dispatched", dispatchedAt: 1, lastActivityAt: 1,
     }), "absent");
-    assert.equal(probePiSubagentOutputRecord({
-      taskId: "task-probe-2", status: "dispatched", dispatchedAt: 1, lastActivityAt: 1,
-    }), "present");
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("reconcile orphans when the Pi record sidecar is gone even if the transcript remains", () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "larkin-subagent-leftover-"));
+  try {
+    const outputFile = path.join(root, "task-leftover-1.output");
+    fs.writeFileSync(outputFile, "still here\n");
+    const recordFile = writeDispatchedSubagentRecordFile(root, "task-leftover-1");
+    let ledger = noteDispatchedSubagent(emptyDispatchedSubagentLedger(), {
+      taskId: "task-leftover-1", outputFile, recordFile, now: 10,
+    });
+    fs.rmSync(recordFile);
+    const result = reconcileDispatchedSubagents(ledger, {
+      probe: probePiSubagentRecord,
+      now: 11,
+      missingReason: "pi record missing",
+    });
+    assert.equal(result.orphaned.length, 1);
+    assert.equal(result.orphaned[0].taskId, "task-leftover-1");
+    assert.equal(result.orphaned[0].status, "orphaned");
+    assert.equal(result.orphaned[0].wakeState, "pending");
+    assert.equal(result.orphaned[0].outputFile, outputFile);
+    assert.ok(fs.existsSync(outputFile));
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("reconcile persists transcript mtime into lastActivityAt", () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "larkin-subagent-mtime-"));
+  try {
+    const outputFile = path.join(root, "task-mtime-1.output");
+    fs.writeFileSync(outputFile, "alive\n");
+    const now = 1_000;
+    let ledger = noteDispatchedSubagent(emptyDispatchedSubagentLedger(), {
+      taskId: "task-mtime-1", outputFile, now,
+    });
+    const later = new Date(5_000);
+    fs.utimesSync(outputFile, later, later);
+    const result = reconcileDispatchedSubagents(ledger, {
+      probe: () => "present",
+      now: 10_000,
+    });
+    assert.deepEqual(result.orphaned, []);
+    assert.equal(getDispatchedSubagent(result.ledger, "task-mtime-1")?.lastActivityAt, 5_000);
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("pending terminal wakes stay queryable until acknowledged", () => {
+  const now = 1_700_000_300_000;
+  let ledger = noteDispatchedSubagent(emptyDispatchedSubagentLedger(), { taskId: "task-wake-1", now });
+  ledger = reconcileDispatchedSubagents(ledger, { forceMissing: true, now: now + 1 }).ledger;
+  assert.deepEqual(undeliveredTerminalWakeKeys(ledger), ["task-wake-1"]);
+  ledger = noteDispatchedSubagentWakeAcknowledged(ledger, { completionKey: "task-wake-1", now: now + 2 });
+  assert.deepEqual(undeliveredTerminalWakeKeys(ledger), []);
+  assert.equal(getDispatchedSubagent(ledger, "task-wake-1")?.wakeState, "acknowledged");
+});
+
+test("sweep removes record sidecars only after the Pi record is gone", () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "larkin-subagent-sweep-"));
+  try {
+    const alive = writeDispatchedSubagentRecordFile(root, "task-alive");
+    const gone = writeDispatchedSubagentRecordFile(root, "task-gone");
+    const present = new Set(["task-alive"]);
+    const removed = sweepAbsentPiSubagentRecordFiles(
+      path.dirname(alive),
+      (taskId) => present.has(taskId) ? { id: taskId } : undefined,
+    );
+    assert.deepEqual(removed, ["task-gone"]);
+    assert.ok(fs.existsSync(alive));
+    assert.equal(fs.existsSync(gone), false);
+    assert.equal(dispatchedSubagentRecordFile(root, "task-alive"), alive);
   } finally {
     fs.rmSync(root, { recursive: true, force: true });
   }

--- a/test/unit/runtime/pi-subagent-ledger.test.mjs
+++ b/test/unit/runtime/pi-subagent-ledger.test.mjs
@@ -5,6 +5,7 @@ import path from "node:path";
 import { test } from "bun:test";
 import {
   emptyDispatchedSubagentLedger,
+  effectivePiStateDir,
   extractBackgroundPiSubagentDispatch,
   getDispatchedSubagent,
   ledgerFilePath,
@@ -336,6 +337,53 @@ test("sweep persists an unconsumed terminal before eviction can delete the sidec
   }
 });
 
+test("repeated sweeps do not reset the terminal notification grace clock", () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "larkin-subagent-grace-clock-"));
+  try {
+    const recordFile = writeDispatchedSubagentRecordFile(root, "task-grace-clock-1", "session-a");
+    const recordDir = path.dirname(recordFile);
+    const live = new Map([
+      ["task-grace-clock-1", { status: "completed" }],
+    ]);
+    let ledger = noteDispatchedSubagent(emptyDispatchedSubagentLedger(), {
+      taskId: "task-grace-clock-1", recordFile, now: 10,
+    });
+
+    assert.deepEqual(sweepAbsentPiSubagentRecordFiles(recordDir, (taskId) => live.get(taskId)), []);
+    const persistedAt = fs.statSync(recordFile).mtimeMs;
+    assert.ok(Number.isFinite(persistedAt));
+
+    assert.deepEqual(sweepAbsentPiSubagentRecordFiles(recordDir, (taskId) => live.get(taskId)), []);
+    assert.deepEqual(sweepAbsentPiSubagentRecordFiles(recordDir, (taskId) => live.get(taskId)), []);
+    assert.equal(
+      fs.statSync(recordFile).mtimeMs,
+      persistedAt,
+      "an unchanged terminal sidecar must keep the original grace-clock mtime",
+    );
+
+    const duringGrace = reconcileDispatchedSubagents(ledger, {
+      probe: probePiSubagentRecord,
+      now: persistedAt + PI_SUBAGENT_TERMINAL_NOTIFICATION_GRACE_MS - 1,
+    });
+    assert.deepEqual(duringGrace.orphaned, []);
+    assert.deepEqual(duringGrace.terminals, []);
+    assert.equal(getDispatchedSubagent(duringGrace.ledger, "task-grace-clock-1")?.status, "dispatched");
+
+    const afterGrace = reconcileDispatchedSubagents(duringGrace.ledger, {
+      probe: probePiSubagentRecord,
+      now: persistedAt + PI_SUBAGENT_TERMINAL_NOTIFICATION_GRACE_MS,
+    });
+    assert.deepEqual(afterGrace.orphaned, []);
+    assert.equal(afterGrace.terminals.length, 1);
+    assert.equal(afterGrace.terminals[0].taskId, "task-grace-clock-1");
+    assert.equal(afterGrace.terminals[0].status, "completed");
+    assert.equal(afterGrace.terminals[0].wakeState, "pending");
+    assert.deepEqual(undeliveredTerminalWakeKeys(afterGrace.ledger), ["task-grace-clock-1"]);
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});
+
 test("force-missing immediately advances a persisted unconsumed terminal instead of orphaning it", () => {
   const root = fs.mkdtempSync(path.join(os.tmpdir(), "larkin-subagent-force-terminal-"));
   try {
@@ -423,4 +471,9 @@ test("consumed Pi record mapper treats aborted as timed_out and stopped as cance
   assert.equal(ledgerStatusFromPiSubagentRecord({ status: "aborted", resultConsumed: true }), "timed_out");
   assert.equal(ledgerStatusFromPiSubagentRecord({ status: "stopped", resultConsumed: true }), "cancelled");
   assert.equal(ledgerStatusFromPiSubagentRecord({ status: "error", resultConsumed: true }), "failed");
+});
+
+test("effectivePiStateDir matches the Pi adapter implicit root", () => {
+  assert.equal(effectivePiStateDir({ workspaceDir: "/ws", stateDir: "/explicit" }), "/explicit");
+  assert.equal(effectivePiStateDir({ workspaceDir: "/ws" }), path.join("/ws", ".larkin"));
 });

--- a/test/unit/runtime/pi-subagent-ledger.test.mjs
+++ b/test/unit/runtime/pi-subagent-ledger.test.mjs
@@ -41,6 +41,23 @@ test("extractBackgroundPiSubagentDispatch reads Agent ID and output file from a 
   assert.deepEqual(parsed, { taskId: "task-ledger-1", outputFile: "/tmp/task-ledger-1.output" });
 });
 
+test("extractBackgroundPiSubagentDispatch keeps spaces in text-only output-file paths", () => {
+  const parsed = extractBackgroundPiSubagentDispatch({
+    toolName: "Agent",
+    args: { prompt: "do work", run_in_background: true },
+    result: {
+      content: [{
+        type: "text",
+        text: "Agent started in background.\nAgent ID: task-space-1\nOutput file: /tmp/my workspace/task space.output\n",
+      }],
+    },
+  });
+  assert.deepEqual(parsed, {
+    taskId: "task-space-1",
+    outputFile: "/tmp/my workspace/task space.output",
+  });
+});
+
 test("extractBackgroundPiSubagentDispatch ignores foreground Agent calls", () => {
   assert.equal(extractBackgroundPiSubagentDispatch({
     toolName: "Agent",

--- a/test/unit/runtime/pi-subagent-ledger.test.mjs
+++ b/test/unit/runtime/pi-subagent-ledger.test.mjs
@@ -275,6 +275,59 @@ test("consumed completed result is bridged into the sidecar and is not orphaned"
   }
 });
 
+test("sweep persists an unconsumed terminal before eviction can delete the sidecar", () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "larkin-subagent-evict-"));
+  try {
+    const recordFile = writeDispatchedSubagentRecordFile(root, "task-evict-1", "session-a");
+    const recordDir = path.dirname(recordFile);
+    const live = new Map([
+      ["task-evict-1", { status: "completed" }],
+    ]);
+    let ledger = noteDispatchedSubagent(emptyDispatchedSubagentLedger(), {
+      taskId: "task-evict-1", recordFile, now: 10,
+    });
+
+    const firstRemoved = sweepAbsentPiSubagentRecordFiles(recordDir, (taskId) => live.get(taskId));
+    assert.deepEqual(firstRemoved, []);
+    assert.ok(fs.existsSync(recordFile));
+    const persisted = JSON.parse(fs.readFileSync(recordFile, "utf8"));
+    assert.equal(persisted.taskId, "task-evict-1");
+    assert.equal(persisted.status, "completed");
+    assert.equal(persisted.owner, "session-a");
+    assert.equal(persisted.resultConsumed, undefined);
+    assert.equal(readConsumedPiSubagentTerminal(recordFile), null);
+    assert.equal(probePiSubagentRecord({
+      taskId: "task-evict-1", status: "dispatched", dispatchedAt: 10, lastActivityAt: 10, recordFile,
+    }), "present");
+
+    live.delete("task-evict-1");
+    const secondRemoved = sweepAbsentPiSubagentRecordFiles(recordDir, (taskId) => live.get(taskId));
+    assert.deepEqual(secondRemoved, [], "an evicted unconsumed terminal must keep its persisted sidecar");
+    assert.ok(fs.existsSync(recordFile));
+    assert.equal(probePiSubagentRecord({
+      taskId: "task-evict-1", status: "dispatched", dispatchedAt: 10, lastActivityAt: 10, recordFile,
+    }), "present");
+
+    const result = reconcileDispatchedSubagents(ledger, {
+      probe: probePiSubagentRecord,
+      now: 11,
+    });
+    assert.deepEqual(result.orphaned, []);
+    assert.equal(getDispatchedSubagent(result.ledger, "task-evict-1")?.status, "dispatched");
+
+    ledger = noteDispatchedSubagentTerminal(result.ledger, {
+      taskId: "task-evict-1",
+      status: "completed",
+      wakeKey: "task-evict-1",
+      now: 12,
+    });
+    assert.equal(getDispatchedSubagent(ledger, "task-evict-1")?.status, "completed");
+    assert.equal(getDispatchedSubagent(ledger, "task-evict-1")?.wakeState, "pending");
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});
+
 test("sweep removes record sidecars only after the Pi record is gone", () => {
   const root = fs.mkdtempSync(path.join(os.tmpdir(), "larkin-subagent-sweep-"));
   try {

--- a/test/unit/runtime/pi-subagent-ledger.test.mjs
+++ b/test/unit/runtime/pi-subagent-ledger.test.mjs
@@ -1,0 +1,152 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { test } from "bun:test";
+import {
+  emptyDispatchedSubagentLedger,
+  extractBackgroundPiSubagentDispatch,
+  getDispatchedSubagent,
+  ledgerFilePath,
+  noteDispatchedSubagent,
+  noteDispatchedSubagentTerminal,
+  probePiSubagentOutputRecord,
+  readDispatchedSubagentLedger,
+  reconcileDispatchedSubagents,
+  taskIdsFromCompletionKey,
+  writeDispatchedSubagentLedger,
+} from "../../../dist/runtime/pi-subagent-ledger.mjs";
+
+test("extractBackgroundPiSubagentDispatch reads Agent ID and output file from a background spawn", () => {
+  const parsed = extractBackgroundPiSubagentDispatch({
+    toolName: "Agent",
+    args: { prompt: "do work", run_in_background: true },
+    result: {
+      content: [{
+        type: "text",
+        text: "Agent started in background.\nAgent ID: task-ledger-1\nType: general-purpose\nOutput file: /tmp/task-ledger-1.output\n",
+      }],
+      details: { agentId: "task-ledger-1", outputFile: "/tmp/task-ledger-1.output", status: "background" },
+    },
+  });
+  assert.deepEqual(parsed, { taskId: "task-ledger-1", outputFile: "/tmp/task-ledger-1.output" });
+});
+
+test("extractBackgroundPiSubagentDispatch ignores foreground Agent calls", () => {
+  assert.equal(extractBackgroundPiSubagentDispatch({
+    toolName: "Agent",
+    args: { prompt: "do work", run_in_background: false },
+    result: { content: [{ type: "text", text: "Agent finished.\n" }] },
+  }), null);
+  assert.equal(extractBackgroundPiSubagentDispatch({
+    toolName: "bash",
+    args: { command: "echo hi" },
+    result: { content: [{ type: "text", text: "hi" }] },
+  }), null);
+});
+
+test("reconcile marks a missing Pi record orphaned once and keeps it queryable", () => {
+  const now = 1_700_000_000_000;
+  let ledger = noteDispatchedSubagent(emptyDispatchedSubagentLedger(), {
+    taskId: "task-missing-1",
+    outputFile: "/tmp/task-missing-1.output",
+    now,
+  });
+  const first = reconcileDispatchedSubagents(ledger, {
+    probe: () => "absent",
+    now: now + 10,
+    missingReason: "pi record missing",
+  });
+  assert.equal(first.orphaned.length, 1);
+  assert.equal(first.orphaned[0].taskId, "task-missing-1");
+  assert.equal(first.orphaned[0].status, "orphaned");
+  assert.equal(first.orphaned[0].reason, "pi record missing");
+  assert.equal(first.orphaned[0].outputFile, "/tmp/task-missing-1.output");
+  assert.equal(first.orphaned[0].lastActivityAt, now);
+  assert.equal(getDispatchedSubagent(first.ledger, "task-missing-1")?.status, "orphaned");
+
+  const second = reconcileDispatchedSubagents(first.ledger, {
+    probe: () => "absent",
+    now: now + 20,
+    missingReason: "pi record missing",
+  });
+  assert.deepEqual(second.orphaned, []);
+  assert.equal(getDispatchedSubagent(second.ledger, "task-missing-1")?.status, "orphaned");
+});
+
+test("a canonical terminal notification is not marked orphaned", () => {
+  const now = 1_700_000_100_000;
+  let ledger = noteDispatchedSubagent(emptyDispatchedSubagentLedger(), {
+    taskId: "task-done-1",
+    outputFile: "/tmp/task-done-1.output",
+    now,
+  });
+  ledger = noteDispatchedSubagentTerminal(ledger, {
+    taskId: "task-done-1",
+    status: "completed",
+    wakeKey: "task-done-1",
+    now: now + 5,
+  });
+  const result = reconcileDispatchedSubagents(ledger, {
+    forceMissing: true,
+    now: now + 10,
+    missingReason: "pi record missing",
+  });
+  assert.deepEqual(result.orphaned, []);
+  assert.equal(getDispatchedSubagent(result.ledger, "task-done-1")?.status, "completed");
+});
+
+test("late terminal notification after orphan does not change the queryable orphaned status", () => {
+  const now = 1_700_000_200_000;
+  let ledger = noteDispatchedSubagent(emptyDispatchedSubagentLedger(), { taskId: "task-late-1", now });
+  const orphaned = reconcileDispatchedSubagents(ledger, { forceMissing: true, now: now + 1 });
+  ledger = noteDispatchedSubagentTerminal(orphaned.ledger, {
+    taskId: "task-late-1",
+    status: "completed",
+    now: now + 2,
+  });
+  assert.equal(getDispatchedSubagent(ledger, "task-late-1")?.status, "orphaned");
+});
+
+test("taskIdsFromCompletionKey splits the existing drain key", () => {
+  assert.deepEqual(taskIdsFromCompletionKey("task-a|task-b"), ["task-a", "task-b"]);
+  assert.deepEqual(taskIdsFromCompletionKey("task-only"), ["task-only"]);
+});
+
+test("ledger file persists orphaned state after the Pi record is gone", () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "larkin-subagent-ledger-"));
+  try {
+    const file = ledgerFilePath(root);
+    let ledger = noteDispatchedSubagent(emptyDispatchedSubagentLedger(), {
+      taskId: "task-persist-1",
+      outputFile: "/tmp/task-persist-1.output",
+      now: 10,
+    });
+    ledger = reconcileDispatchedSubagents(ledger, { forceMissing: true, now: 11 }).ledger;
+    writeDispatchedSubagentLedger(file, ledger);
+    const loaded = readDispatchedSubagentLedger(file);
+    assert.equal(getDispatchedSubagent(loaded, "task-persist-1")?.status, "orphaned");
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("default output-file probe reports absent only when the known file is gone", () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "larkin-subagent-probe-"));
+  try {
+    const outputFile = path.join(root, "task-probe-1.output");
+    fs.writeFileSync(outputFile, "alive\n");
+    assert.equal(probePiSubagentOutputRecord({
+      taskId: "task-probe-1", status: "dispatched", dispatchedAt: 1, lastActivityAt: 1, outputFile,
+    }), "present");
+    fs.rmSync(outputFile);
+    assert.equal(probePiSubagentOutputRecord({
+      taskId: "task-probe-1", status: "dispatched", dispatchedAt: 1, lastActivityAt: 1, outputFile,
+    }), "absent");
+    assert.equal(probePiSubagentOutputRecord({
+      taskId: "task-probe-2", status: "dispatched", dispatchedAt: 1, lastActivityAt: 1,
+    }), "present");
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});

--- a/test/unit/runtime/pi-subagent-ledger.test.mjs
+++ b/test/unit/runtime/pi-subagent-ledger.test.mjs
@@ -13,6 +13,7 @@ import {
   noteDispatchedSubagentTerminal,
   noteDispatchedSubagentWakeAcknowledged,
   probePiSubagentRecord,
+  readConsumedPiSubagentTerminal,
   readDispatchedSubagentLedger,
   reconcileDispatchedSubagents,
   sweepAbsentPiSubagentRecordFiles,
@@ -217,6 +218,59 @@ test("pending terminal wakes stay queryable until acknowledged", () => {
   ledger = noteDispatchedSubagentWakeAcknowledged(ledger, { completionKey: "task-wake-1", now: now + 2 });
   assert.deepEqual(undeliveredTerminalWakeKeys(ledger), []);
   assert.equal(getDispatchedSubagent(ledger, "task-wake-1")?.wakeState, "acknowledged");
+});
+
+test("consumed completed result is bridged into the sidecar and is not orphaned", () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "larkin-subagent-consumed-"));
+  try {
+    const consumedFile = writeDispatchedSubagentRecordFile(root, "task-consumed");
+    const missingFile = writeDispatchedSubagentRecordFile(root, "task-missing");
+    const recordDir = path.dirname(consumedFile);
+    const live = new Map([
+      ["task-consumed", { status: "completed", resultConsumed: true }],
+    ]);
+    let ledger = noteDispatchedSubagent(emptyDispatchedSubagentLedger(), {
+      taskId: "task-consumed", recordFile: consumedFile, now: 10,
+    });
+    ledger = noteDispatchedSubagent(ledger, {
+      taskId: "task-missing", recordFile: missingFile, now: 10,
+    });
+
+    const firstRemoved = sweepAbsentPiSubagentRecordFiles(recordDir, (taskId) => live.get(taskId));
+    assert.deepEqual(firstRemoved, ["task-missing"]);
+    assert.ok(fs.existsSync(consumedFile));
+    assert.deepEqual(readConsumedPiSubagentTerminal(consumedFile), {
+      taskId: "task-consumed",
+      status: "completed",
+    });
+    assert.equal(probePiSubagentRecord({
+      taskId: "task-consumed", status: "dispatched", dispatchedAt: 10, lastActivityAt: 10, recordFile: consumedFile,
+    }), "consumed");
+
+    live.delete("task-consumed");
+    const secondRemoved = sweepAbsentPiSubagentRecordFiles(recordDir, (taskId) => live.get(taskId));
+    assert.deepEqual(secondRemoved, [], "a consumed terminal sidecar must not be treated as absent after cleanup");
+    assert.ok(fs.existsSync(consumedFile));
+
+    const result = reconcileDispatchedSubagents(ledger, {
+      probe: probePiSubagentRecord,
+      now: 11,
+    });
+    assert.deepEqual(result.orphaned.map((task) => task.taskId), ["task-missing"]);
+    assert.equal(getDispatchedSubagent(result.ledger, "task-consumed")?.status, "completed");
+    assert.equal(getDispatchedSubagent(result.ledger, "task-consumed")?.wakeState, "acknowledged");
+    assert.equal(getDispatchedSubagent(result.ledger, "task-missing")?.status, "orphaned");
+    assert.deepEqual(undeliveredTerminalWakeKeys(result.ledger), ["task-missing"]);
+
+    const again = reconcileDispatchedSubagents(result.ledger, {
+      probe: probePiSubagentRecord,
+      now: 12,
+    });
+    assert.deepEqual(again.orphaned, [], "a genuine missing record orphans only once");
+    assert.equal(getDispatchedSubagent(again.ledger, "task-missing")?.status, "orphaned");
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
 });
 
 test("sweep removes record sidecars only after the Pi record is gone", () => {

--- a/test/unit/runtime/pi-subagent-ledger.test.mjs
+++ b/test/unit/runtime/pi-subagent-ledger.test.mjs
@@ -8,6 +8,7 @@ import {
   extractBackgroundPiSubagentDispatch,
   getDispatchedSubagent,
   ledgerFilePath,
+  ledgerStatusFromPiSubagentRecord,
   dispatchedSubagentRecordFile,
   noteDispatchedSubagent,
   noteDispatchedSubagentTerminal,
@@ -259,6 +260,7 @@ test("consumed completed result is bridged into the sidecar and is not orphaned"
     assert.deepEqual(result.orphaned.map((task) => task.taskId), ["task-missing"]);
     assert.equal(getDispatchedSubagent(result.ledger, "task-consumed")?.status, "completed");
     assert.equal(getDispatchedSubagent(result.ledger, "task-consumed")?.wakeState, "acknowledged");
+    assert.equal(fs.existsSync(consumedFile), false, "acknowledged consumed sidecar must be retired");
     assert.equal(getDispatchedSubagent(result.ledger, "task-missing")?.status, "orphaned");
     assert.deepEqual(undeliveredTerminalWakeKeys(result.ledger), ["task-missing"]);
 
@@ -290,4 +292,49 @@ test("sweep removes record sidecars only after the Pi record is gone", () => {
   } finally {
     fs.rmSync(root, { recursive: true, force: true });
   }
+});
+
+test("sweep leaves another session's owner-tagged sidecar in place", () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "larkin-subagent-owner-"));
+  try {
+    const mine = writeDispatchedSubagentRecordFile(root, "task-mine", "session-a");
+    const theirs = writeDispatchedSubagentRecordFile(root, "task-theirs", "session-b");
+    const untagged = writeDispatchedSubagentRecordFile(root, "task-untagged");
+    const removed = sweepAbsentPiSubagentRecordFiles(
+      path.dirname(mine),
+      () => undefined,
+      { owner: "session-a" },
+    );
+    assert.deepEqual(removed, ["task-mine"]);
+    assert.equal(fs.existsSync(mine), false);
+    assert.ok(fs.existsSync(theirs), "a staged session must not delete another session's sidecar");
+    assert.ok(fs.existsSync(untagged), "untagged sidecars are not owned by the sweeping session");
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("ledger cap evicts acknowledged terminals before active or pending-wake records", () => {
+  let ledger = emptyDispatchedSubagentLedger();
+  for (let index = 0; index < 2048; index += 1) {
+    const taskId = `task-ack-${index}`;
+    ledger = noteDispatchedSubagentTerminal(ledger, { taskId, status: "completed", now: index + 1 });
+    ledger = noteDispatchedSubagentWakeAcknowledged(ledger, { completionKey: taskId, now: index + 1 });
+  }
+  ledger = noteDispatchedSubagent(ledger, { taskId: "task-keep-dispatched", now: 3000 });
+  ledger = noteDispatchedSubagentTerminal(ledger, {
+    taskId: "task-keep-pending", status: "failed", wakeKey: "task-keep-pending", now: 3001,
+  });
+  assert.equal(getDispatchedSubagent(ledger, "task-keep-dispatched")?.status, "dispatched");
+  assert.equal(getDispatchedSubagent(ledger, "task-keep-pending")?.wakeState, "pending");
+  assert.equal(getDispatchedSubagent(ledger, "task-ack-0"), null);
+  assert.equal(getDispatchedSubagent(ledger, "task-ack-1"), null);
+  assert.ok(getDispatchedSubagent(ledger, "task-ack-2"));
+  assert.equal(ledger.tasks.length, 2048);
+});
+
+test("consumed Pi record mapper treats aborted as timed_out and stopped as cancelled", () => {
+  assert.equal(ledgerStatusFromPiSubagentRecord({ status: "aborted", resultConsumed: true }), "timed_out");
+  assert.equal(ledgerStatusFromPiSubagentRecord({ status: "stopped", resultConsumed: true }), "cancelled");
+  assert.equal(ledgerStatusFromPiSubagentRecord({ status: "error", resultConsumed: true }), "failed");
 });

--- a/test/unit/runtime/pi-subagents-notification.test.mjs
+++ b/test/unit/runtime/pi-subagents-notification.test.mjs
@@ -5,6 +5,7 @@ import {
   buildCanonicalPiSubagentNotificationContent,
   extractCanonicalPiSubagentCompletionKeyFromMessages,
   extractCanonicalPiSubagentNotification,
+  ledgerStatusFromPiNotificationStatus,
 } from "../../../dist/runtime/pi-subagents-notification.mjs";
 
 function mixedContent(blocks) {
@@ -156,4 +157,12 @@ test("queued or running notifications do not produce a completion key", () => {
     }),
   ]);
   assert.equal(key, null);
+});
+
+test("canonical notification statuses map onto ledger terminal states", () => {
+  assert.equal(ledgerStatusFromPiNotificationStatus("Done"), "completed");
+  assert.equal(ledgerStatusFromPiNotificationStatus("Error: provider failed"), "failed");
+  assert.equal(ledgerStatusFromPiNotificationStatus("Aborted (max turns exceeded)"), "cancelled");
+  assert.equal(ledgerStatusFromPiNotificationStatus("Stopped"), "cancelled");
+  assert.equal(ledgerStatusFromPiNotificationStatus("Wrapped up (turn limit)"), "timed_out");
 });

--- a/test/unit/runtime/pi-subagents-notification.test.mjs
+++ b/test/unit/runtime/pi-subagents-notification.test.mjs
@@ -162,7 +162,8 @@ test("queued or running notifications do not produce a completion key", () => {
 test("canonical notification statuses map onto ledger terminal states", () => {
   assert.equal(ledgerStatusFromPiNotificationStatus("Done"), "completed");
   assert.equal(ledgerStatusFromPiNotificationStatus("Error: provider failed"), "failed");
-  assert.equal(ledgerStatusFromPiNotificationStatus("Aborted (max turns exceeded)"), "cancelled");
+  assert.equal(ledgerStatusFromPiNotificationStatus("Aborted (max turns exceeded)"), "timed_out");
+  assert.equal(ledgerStatusFromPiNotificationStatus("aborted"), "timed_out");
   assert.equal(ledgerStatusFromPiNotificationStatus("Stopped"), "cancelled");
   assert.equal(ledgerStatusFromPiNotificationStatus("Wrapped up (turn limit)"), "timed_out");
 });

--- a/test/unit/runtime/runtime-adapters.test.mjs
+++ b/test/unit/runtime/runtime-adapters.test.mjs
@@ -400,6 +400,40 @@ test("Pi canonical late completion notifications bridge once and ignore assistan
   assert.equal(observations[0].completionKey, "task-bridge-1");
 });
 
+test("Pi in-turn completion notifications emit immediately as handled without a second settle bridge", async () => {
+  let listener;
+  const sdk = {
+    sessionId: "pi-in-turn-complete", prompt() {}, steer() {}, abort() {},
+    subscribe(next) { listener = next; return () => {}; },
+  };
+  const session = await createNativeRuntimeAdapter("pi", {
+    createPiSession: async () => sdk,
+    env: { LARKIN_PI_DISTRIBUTION: "builtin" },
+  }).createSession(create());
+  const events = [];
+  session.subscribe((event) => events.push(event));
+  await session.prompt({ inputId: "pi-in-turn-input", kind: "user", text: "work", attempt: 0 });
+  listener({ type: "turn_start" });
+  const canonical = buildCanonicalPiSubagentAssistantMessage({
+    taskId: "task-in-turn-1",
+    toolUseId: "tool-use-in-turn-1",
+    outputFile: "/tmp/task-in-turn-1.output",
+    summary: "Agent \"fixture\" completed",
+    result: "Fixture result.",
+  });
+  listener({ type: "agent_end", willRetry: false, messages: [canonical] });
+  await new Promise((resolve) => setImmediate(resolve));
+  const beforeSettle = events.filter((event) => event.type === "runtime-observation" && event.completionKey);
+  assert.deepEqual(beforeSettle.map((event) => event.phase), ["completed"]);
+  assert.equal(beforeSettle[0].completionKey, "task-in-turn-1");
+  assert.equal(beforeSettle[0].handledInTurn, true);
+  assert.deepEqual(beforeSettle[0].completionStatuses, { "task-in-turn-1": "completed" });
+  listener({ type: "agent_settled" });
+  await new Promise((resolve) => setImmediate(resolve));
+  const afterSettle = events.filter((event) => event.type === "runtime-observation" && event.completionKey);
+  assert.equal(afterSettle.length, 1, "in-turn completion must not emit a second wake bridge after settle");
+});
+
 test("Pi assistant text lookalikes do not trigger the late completion bridge", async () => {
   let listener;
   const sdk = {

--- a/test/unit/runtime/runtime-adapters.test.mjs
+++ b/test/unit/runtime/runtime-adapters.test.mjs
@@ -765,10 +765,10 @@ test.each(["win32", "linux"])("external Pi retains all -e extension args on simu
     recordWatchdog: () => "/fixture/pi-subagent-record-watchdog.bundle.js",
   });
   assert.deepEqual(args, [
+    "-e", "/fixture/pi-subagent-record-watchdog.bundle.js",
     "-e", "/fixture/pi-subagents.bundle.js",
     "-e", "/fixture/pi-bash-timeout.bundle.js",
-    "-e", "/fixture/pi-subagent-record-watchdog.bundle.js",
-  ]);
+  ], "watchdog must precede the subagent extension so shutdown can still read getRecord");
 });
 
 test.each(["external", "builtin"])("%s Pi launches one shared append standing-prompt path without replacement", async (distribution) => {

--- a/test/unit/runtime/runtime-adapters.test.mjs
+++ b/test/unit/runtime/runtime-adapters.test.mjs
@@ -579,6 +579,40 @@ test("Pi repeated canonical late completion notifications only bridge once", asy
   assert.equal(observations[0].completionKey, "task-bridge-repeat");
 });
 
+test("Pi background Agent tool results emit a dispatched-task observation", async () => {
+  let listener;
+  const sdk = {
+    sessionId: "pi-dispatch-observe", prompt() {}, steer() {}, abort() {},
+    subscribe(next) { listener = next; return () => {}; },
+  };
+  const session = await createNativeRuntimeAdapter("pi", {
+    createPiSession: async () => sdk,
+    env: { LARKIN_PI_DISTRIBUTION: "builtin" },
+  }).createSession(create());
+  const events = [];
+  session.subscribe((event) => events.push(event));
+  listener({
+    type: "tool_execution_start",
+    toolName: "Agent",
+    args: { prompt: "do work", run_in_background: true, description: "work" },
+  });
+  listener({
+    type: "tool_execution_end",
+    toolName: "Agent",
+    args: { prompt: "do work", run_in_background: true, description: "work" },
+    result: {
+      content: [{ type: "text", text: "Agent started in background.\nAgent ID: task-dispatch-1\nOutput file: /tmp/task-dispatch-1.output\n" }],
+      details: { agentId: "task-dispatch-1", outputFile: "/tmp/task-dispatch-1.output", status: "background" },
+    },
+    isError: false,
+  });
+  await new Promise((resolve) => setImmediate(resolve));
+  const dispatched = events.filter((event) => event.type === "runtime-observation" && event.phase === "background_dispatched");
+  assert.equal(dispatched.length, 1);
+  assert.equal(dispatched[0].taskId, "task-dispatch-1");
+  assert.equal(dispatched[0].outputFile, "/tmp/task-dispatch-1.output");
+});
+
 test("Codex resume failure falls back to a fresh thread with the same standing prompt", async () => {
   const child = new FakeProcess();
   await createNativeRuntimeAdapter("codex", { spawn: () => child }).createSession(create({ resumeSessionId: "stale-thread" }));

--- a/test/unit/runtime/runtime-adapters.test.mjs
+++ b/test/unit/runtime/runtime-adapters.test.mjs
@@ -988,9 +988,10 @@ test("inherited builtin PI_PACKAGE_DIR does not drop production extension versio
     for (let index = 0; index < sessionLaunch.args.length; index += 1) {
       if (sessionLaunch.args[index] === "-e") extensionPaths.push(sessionLaunch.args[index + 1]);
     }
-    assert.equal(extensionPaths.length, 2, JSON.stringify(sessionLaunch.args));
+    assert.equal(extensionPaths.length, 3, JSON.stringify(sessionLaunch.args));
     const expected = [
       path.join(ADAPTERS_ROOT, "dist", "runtime", "pi-bash-timeout.bundle.js"),
+      path.join(ADAPTERS_ROOT, "dist", "runtime", "pi-subagent-record-watchdog.bundle.js"),
       path.join(ADAPTERS_ROOT, "dist", "runtime", "pi-subagents.bundle.js"),
     ].map((entry) => fs.realpathSync(entry)).sort();
     assert.deepEqual(extensionPaths.map((entry) => fs.realpathSync(entry)).sort(), expected);

--- a/test/unit/runtime/runtime-adapters.test.mjs
+++ b/test/unit/runtime/runtime-adapters.test.mjs
@@ -434,6 +434,98 @@ test("Pi in-turn completion notifications emit immediately as handled without a 
   assert.equal(afterSettle.length, 1, "in-turn completion must not emit a second wake bridge after settle");
 });
 
+test("Pi failed owning turn does not mark in-turn completions handled so retry can still wake", async () => {
+  for (const stopReason of ["error", "aborted"]) {
+    let listener;
+    const sdk = {
+      sessionId: `pi-failed-owning-${stopReason}`,
+      prompt() {}, steer() {}, abort() {},
+      subscribe(next) { listener = next; return () => {}; },
+    };
+    const session = await createNativeRuntimeAdapter("pi", {
+      createPiSession: async () => sdk,
+      env: { LARKIN_PI_DISTRIBUTION: "builtin" },
+    }).createSession(create());
+    const events = [];
+    session.subscribe((event) => events.push(event));
+    await session.prompt({ inputId: `pi-failed-owning-${stopReason}`, kind: "user", text: "work", attempt: 0 });
+    listener({ type: "turn_start" });
+    const canonical = buildCanonicalPiSubagentAssistantMessage({
+      taskId: `task-failed-owning-${stopReason}`,
+      toolUseId: `tool-use-failed-owning-${stopReason}`,
+      outputFile: `/tmp/task-failed-owning-${stopReason}.output`,
+      summary: "Agent \"fixture\" completed",
+      result: "Fixture result.",
+    });
+    listener({
+      type: "agent_end",
+      willRetry: false,
+      messages: [
+        canonical,
+        {
+          role: "assistant",
+          stopReason,
+          ...(stopReason === "error" ? { errorMessage: "provider failed" } : {}),
+        },
+      ],
+    });
+    await new Promise((resolve) => setImmediate(resolve));
+    const beforeSettle = events.filter((event) => event.type === "runtime-observation" && event.completionKey);
+    assert.deepEqual(beforeSettle, [], `${stopReason} owning turn must not emit handledInTurn before input-error`);
+    listener({ type: "agent_settled" });
+    await new Promise((resolve) => setImmediate(resolve));
+    const afterSettle = events.filter((event) => event.type === "runtime-observation" && event.completionKey);
+    assert.equal(afterSettle.length, 1, `${stopReason} owning turn must still bridge the completion after settle`);
+    assert.equal(afterSettle[0].phase, "completed");
+    assert.equal(afterSettle[0].completionKey, `task-failed-owning-${stopReason}`);
+    assert.equal(afterSettle[0].handledInTurn, undefined);
+    const errorIndex = events.findIndex((event) => event.type === "input-error");
+    assert.ok(errorIndex >= 0, `${stopReason} owning turn must emit input-error`);
+    assert.ok(errorIndex < events.indexOf(afterSettle[0]), "completion bridge must not precede input-error on a failed owning turn");
+  }
+});
+
+test("Pi retrying owning turn can still handle the completion after a later successful agent_end", async () => {
+  let listener;
+  const sdk = {
+    sessionId: "pi-retry-owning-complete",
+    prompt() {}, steer() {}, abort() {},
+    subscribe(next) { listener = next; return () => {}; },
+  };
+  const session = await createNativeRuntimeAdapter("pi", {
+    createPiSession: async () => sdk,
+    env: { LARKIN_PI_DISTRIBUTION: "builtin" },
+  }).createSession(create());
+  const events = [];
+  session.subscribe((event) => events.push(event));
+  await session.prompt({ inputId: "pi-retry-owning-input", kind: "user", text: "work", attempt: 0 });
+  listener({ type: "turn_start" });
+  const canonical = buildCanonicalPiSubagentAssistantMessage({
+    taskId: "task-retry-owning-1",
+    toolUseId: "tool-use-retry-owning-1",
+    outputFile: "/tmp/task-retry-owning-1.output",
+    summary: "Agent \"fixture\" completed",
+    result: "Fixture result.",
+  });
+  listener({
+    type: "agent_end",
+    willRetry: true,
+    messages: [canonical, { role: "assistant", stopReason: "error", errorMessage: "fetch failed" }],
+  });
+  await new Promise((resolve) => setImmediate(resolve));
+  assert.deepEqual(events.filter((event) => event.type === "runtime-observation" && event.completionKey), [],
+    "retrying owning turn must not ack the completion before a successful agent_end");
+  listener({ type: "agent_end", willRetry: false, messages: [canonical] });
+  await new Promise((resolve) => setImmediate(resolve));
+  const handled = events.filter((event) => event.type === "runtime-observation" && event.completionKey);
+  assert.equal(handled.length, 1);
+  assert.equal(handled[0].handledInTurn, true);
+  listener({ type: "agent_settled" });
+  await new Promise((resolve) => setImmediate(resolve));
+  const afterSettle = events.filter((event) => event.type === "runtime-observation" && event.completionKey);
+  assert.equal(afterSettle.length, 1, "successful retry must not emit a second wake bridge after settle");
+});
+
 test("Pi assistant text lookalikes do not trigger the late completion bridge", async () => {
   let listener;
   const sdk = {

--- a/test/unit/runtime/runtime-adapters.test.mjs
+++ b/test/unit/runtime/runtime-adapters.test.mjs
@@ -459,6 +459,10 @@ test("Pi failed and aborted late notifications still bridge a completion key", a
   const observations = events.filter((event) => event.type === "runtime-observation");
   assert.deepEqual(observations.map((event) => event.phase), ["completed", "completed"]);
   assert.deepEqual(observations.map((event) => event.completionKey), ["task-aborted-bridge", "task-error-bridge"]);
+  assert.deepEqual(observations.map((event) => event.completionStatuses), [
+    { "task-aborted-bridge": "cancelled" },
+    { "task-error-bridge": "failed" },
+  ]);
 });
 
 test("Pi mixed-status late notification groups keep terminal successes", async () => {
@@ -510,6 +514,10 @@ test("Pi mixed-status late notification groups keep terminal successes", async (
   const observations = events.filter((event) => event.type === "runtime-observation");
   assert.deepEqual(observations.map((event) => event.phase), ["completed"]);
   assert.equal(observations[0].completionKey, "task-mixed-ok|task-mixed-error");
+  assert.deepEqual(observations[0].completionStatuses, {
+    "task-mixed-ok": "completed",
+    "task-mixed-error": "failed",
+  });
 });
 
 test("Pi batched agent_end messages bridge every canonical notification", async () => {
@@ -742,21 +750,24 @@ test.each(["win32", "linux"])("builtin Pi resolves no -e extension args on simul
   }, {
     subagents: () => { resolverCalls += 1; return "/must/not/resolve-subagents.js"; },
     bashTimeout: () => { resolverCalls += 1; return "/must/not/resolve-bash-timeout.js"; },
+    recordWatchdog: () => { resolverCalls += 1; return "/must/not/resolve-record-watchdog.js"; },
   });
   assert.deepEqual(args, []);
   assert.equal(resolverCalls, 0, "builtin must not resolve file-based extensions");
 });
 
-test.each(["win32", "linux"])("external Pi retains both -e extension args on simulated %s", (platform) => {
+test.each(["win32", "linux"])("external Pi retains all -e extension args on simulated %s", (platform) => {
   const args = resolvePiProcessExtensionArgs({
     distribution: "external", piCommand: "external-pi", env: {}, platform,
   }, {
     subagents: () => "/fixture/pi-subagents.bundle.js",
     bashTimeout: () => "/fixture/pi-bash-timeout.bundle.js",
+    recordWatchdog: () => "/fixture/pi-subagent-record-watchdog.bundle.js",
   });
   assert.deepEqual(args, [
     "-e", "/fixture/pi-subagents.bundle.js",
     "-e", "/fixture/pi-bash-timeout.bundle.js",
+    "-e", "/fixture/pi-subagent-record-watchdog.bundle.js",
   ]);
 });
 

--- a/test/unit/runtime/runtime-adapters.test.mjs
+++ b/test/unit/runtime/runtime-adapters.test.mjs
@@ -460,7 +460,7 @@ test("Pi failed and aborted late notifications still bridge a completion key", a
   assert.deepEqual(observations.map((event) => event.phase), ["completed", "completed"]);
   assert.deepEqual(observations.map((event) => event.completionKey), ["task-aborted-bridge", "task-error-bridge"]);
   assert.deepEqual(observations.map((event) => event.completionStatuses), [
-    { "task-aborted-bridge": "cancelled" },
+    { "task-aborted-bridge": "timed_out" },
     { "task-error-bridge": "failed" },
   ]);
 });

--- a/test/unit/runtime/runtime-host.test.mjs
+++ b/test/unit/runtime/runtime-host.test.mjs
@@ -7,6 +7,7 @@ import { ContextPromptBuilder } from "../../../dist/agent/context-prompt.mjs";
 import { createRuntimeHost as createProductionRuntimeHost } from "../../../dist/runtime/runtime-host.mjs";
 import {
   ledgerFilePath,
+  sweepAbsentPiSubagentRecordFiles,
   writeDispatchedSubagentLedger,
 } from "../../../dist/runtime/pi-subagent-ledger.mjs";
 import { RuntimePrerequisiteError } from "../../../dist/runtime/runtime-readiness.mjs";
@@ -2297,6 +2298,47 @@ test("RuntimeHost does not double-wake if a real terminal notification arrives a
     assert.equal(host.getDispatchedSubagent("cli_piOrphanLateA1", "task-late-1")?.status, "orphaned");
   } finally {
     await host.shutdown("done");
+  }
+});
+
+test("RuntimeHost does not orphan a consumed completed result after the Pi record is cleaned up", async () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "larkin-host-consumed-sidecar-"));
+  const session = new FakeSession();
+  const adapter = { id: "pi", capabilities: {}, async createSession() { return session; } };
+  const host = createRuntimeHost({
+    adapterFor: () => adapter,
+    promptBuilder: new ContextPromptBuilder(),
+    subagentReconcileIntervalMs: 0,
+  });
+  try {
+    await host.start([{ agentId: "cli_piConsumedA1", name: "consumed", runtime: "pi", model: "model", workspaceDir: "/tmp", stateDir: root }]);
+    await host.deliver("cli_piConsumedA1", { message_id: "om_pi_consumed", chat_id: "oc_pi_consumed", content: "start" });
+    session.emit({ type: "turn-start" });
+    session.emit({ type: "turn-end" });
+    session.emit({
+      type: "runtime-observation", runtime: "pi", distribution: "builtin", phase: "background_dispatched",
+      taskId: "task-consumed-1", outputFile: path.join(root, "task-consumed-1.output"),
+    });
+    const dispatched = host.getDispatchedSubagent("cli_piConsumedA1", "task-consumed-1");
+    assert.equal(dispatched?.status, "dispatched");
+    assert.ok(dispatched?.recordFile);
+    const recordDir = path.dirname(dispatched.recordFile);
+    const firstRemoved = sweepAbsentPiSubagentRecordFiles(recordDir, (taskId) => (
+      taskId === "task-consumed-1" ? { status: "completed", resultConsumed: true } : undefined
+    ));
+    assert.deepEqual(firstRemoved, []);
+    const secondRemoved = sweepAbsentPiSubagentRecordFiles(recordDir, () => undefined);
+    assert.deepEqual(secondRemoved, [], "consumed terminal state must survive later record cleanup");
+    assert.ok(fs.existsSync(dispatched.recordFile));
+    session.emit({ type: "turn-end" });
+    for (let i = 0; i < 5; i += 1) await new Promise((resolve) => setImmediate(resolve));
+    assert.equal(session.prompts.length, 1, "a consumed completed result must not enqueue an orphan wake");
+    const record = host.getDispatchedSubagent("cli_piConsumedA1", "task-consumed-1");
+    assert.equal(record?.status, "completed");
+    assert.equal(record?.wakeState, "acknowledged");
+  } finally {
+    await host.shutdown("done");
+    fs.rmSync(root, { recursive: true, force: true });
   }
 });
 

--- a/test/unit/runtime/runtime-host.test.mjs
+++ b/test/unit/runtime/runtime-host.test.mjs
@@ -8,6 +8,7 @@ import { createRuntimeHost as createProductionRuntimeHost } from "../../../dist/
 import {
   ledgerFilePath,
   sweepAbsentPiSubagentRecordFiles,
+  writeConsumedPiSubagentTerminal,
   writeDispatchedSubagentLedger,
 } from "../../../dist/runtime/pi-subagent-ledger.mjs";
 import { RuntimePrerequisiteError } from "../../../dist/runtime/runtime-readiness.mjs";
@@ -2338,6 +2339,103 @@ test("RuntimeHost does not orphan a consumed completed result after the Pi recor
     assert.equal(record?.status, "completed");
     assert.equal(record?.wakeState, "acknowledged");
     assert.equal(fs.existsSync(dispatched.recordFile), false, "acknowledged consumed sidecar must be retired");
+  } finally {
+    await host.shutdown("done");
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("RuntimeHost retires an acknowledged canonical sidecar without a consumed marker", async () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "larkin-host-canonical-sidecar-"));
+  const session = new FakeSession();
+  const adapter = { id: "pi", capabilities: {}, async createSession() { return session; } };
+  const host = createRuntimeHost({
+    adapterFor: () => adapter,
+    promptBuilder: new ContextPromptBuilder(),
+    subagentReconcileIntervalMs: 0,
+  });
+  try {
+    await host.start([{ agentId: "cli_piCanonicalA1", name: "canonical", runtime: "pi", model: "model", workspaceDir: "/tmp", stateDir: root }]);
+    await host.deliver("cli_piCanonicalA1", { message_id: "om_pi_canonical", chat_id: "oc_pi_canonical", content: "start" });
+    session.emit({ type: "turn-start" });
+    session.emit({ type: "turn-end" });
+    session.emit({
+      type: "runtime-observation", runtime: "pi", distribution: "builtin", phase: "background_dispatched",
+      taskId: "task-canonical-1", outputFile: path.join(root, "task-canonical-1.output"),
+    });
+    const dispatched = host.getDispatchedSubagent("cli_piCanonicalA1", "task-canonical-1");
+    assert.ok(dispatched?.recordFile);
+    assert.ok(fs.existsSync(dispatched.recordFile));
+    session.emit({
+      type: "runtime-observation", runtime: "pi", distribution: "builtin", phase: "completed",
+      completionKey: "task-canonical-1",
+    });
+    await waitForPromptCount(session, 2);
+    assert.ok(fs.existsSync(dispatched.recordFile), "canonical sidecar stays until the wake is acknowledged");
+    session.emit({ type: "turn-start" });
+    session.emit({ type: "turn-end" });
+    assert.equal(host.getDispatchedSubagent("cli_piCanonicalA1", "task-canonical-1")?.status, "completed");
+    assert.equal(host.getDispatchedSubagent("cli_piCanonicalA1", "task-canonical-1")?.wakeState, "acknowledged");
+    assert.equal(fs.existsSync(dispatched.recordFile), false, "acknowledged canonical sidecar must be retired");
+  } finally {
+    await host.shutdown("done");
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("RuntimeHost closes the old Pi session before force-missing reconcile on stage commit", async () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "larkin-host-stage-close-first-"));
+  const sessions = [];
+  let host;
+  class CloseBridgesSession extends FakeSession {
+    async close(reason) {
+      this.closes.push(reason);
+      const dispatched = host.getDispatchedSubagent("cli_piStageCloseA1", "task-stage-close-1");
+      if (!dispatched?.recordFile || !fs.existsSync(dispatched.recordFile)) return;
+      writeConsumedPiSubagentTerminal(dispatched.recordFile, {
+        taskId: "task-stage-close-1",
+        status: "completed",
+      });
+    }
+  }
+  const adapter = {
+    id: "pi", capabilities: {},
+    async createSession() {
+      const session = new CloseBridgesSession();
+      session.sessionId = `stage-close-${sessions.length + 1}`;
+      sessions.push(session);
+      return session;
+    },
+  };
+  host = createRuntimeHost({
+    adapterFor: () => adapter,
+    promptBuilder: new ContextPromptBuilder(),
+    subagentReconcileIntervalMs: 0,
+  });
+  const base = {
+    agentId: "cli_piStageCloseA1", name: "stage-close", runtime: "pi", model: "old",
+    workspaceDir: "/tmp", stateDir: root,
+  };
+  try {
+    await host.start([base]);
+    await host.deliver(base.agentId, { message_id: "om_pi_stage_close", chat_id: "oc_pi_stage_close", content: "start" });
+    sessions[0].emit({ type: "turn-start" });
+    sessions[0].emit({ type: "turn-end" });
+    sessions[0].emit({
+      type: "runtime-observation", runtime: "pi", distribution: "builtin", phase: "background_dispatched",
+      taskId: "task-stage-close-1", outputFile: path.join(root, "task-stage-close-1.output"),
+    });
+    const dispatched = host.getDispatchedSubagent(base.agentId, "task-stage-close-1");
+    assert.equal(dispatched?.status, "dispatched");
+    assert.ok(dispatched?.recordFile);
+    assert.equal(JSON.parse(fs.readFileSync(dispatched.recordFile, "utf8")).resultConsumed, undefined);
+    const staged = await host.stage({ ...base, model: "next" });
+    await staged.commit();
+    assert.deepEqual(sessions[0].closes, ["runtime candidate committed"]);
+    const record = host.getDispatchedSubagent(base.agentId, "task-stage-close-1");
+    assert.equal(record?.status, "completed");
+    assert.equal(record?.wakeState, "acknowledged");
+    assert.equal(fs.existsSync(dispatched.recordFile), false, "consumed sidecar retired after close-first reconcile");
   } finally {
     await host.shutdown("done");
     fs.rmSync(root, { recursive: true, force: true });

--- a/test/unit/runtime/runtime-host.test.mjs
+++ b/test/unit/runtime/runtime-host.test.mjs
@@ -2,7 +2,7 @@ import assert from "node:assert/strict";
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
-import { test } from "bun:test";
+import { afterEach, test } from "bun:test";
 import { ContextPromptBuilder } from "../../../dist/agent/context-prompt.mjs";
 import { createRuntimeHost as createProductionRuntimeHost } from "../../../dist/runtime/runtime-host.mjs";
 import {
@@ -11,11 +11,21 @@ import {
   sweepAbsentPiSubagentRecordFiles,
   writeConsumedPiSubagentTerminal,
   writeDispatchedSubagentLedger,
+  writePersistedPiSubagentTerminal,
 } from "../../../dist/runtime/pi-subagent-ledger.mjs";
 import { RuntimePrerequisiteError } from "../../../dist/runtime/runtime-readiness.mjs";
 import { calculatePiCompactionSettings } from "../../../dist/runtime/pi-compaction-recovery.mjs";
 import { createAgentStateStore } from "../../../dist/agent/agent-state-store.mjs";
 import { ProcessingEyeOrchestrator } from "../../../dist/feishu/host-processing-eye.mjs";
+
+function cleanupSharedImplicitPiState() {
+  const implicit = path.join("/tmp", ".larkin");
+  fs.rmSync(path.join(implicit, "pi-subagent-ledger.json"), { force: true });
+  fs.rmSync(path.join(implicit, "pi-subagent-records"), { recursive: true, force: true });
+}
+
+cleanupSharedImplicitPiState();
+afterEach(cleanupSharedImplicitPiState);
 
 // Unrelated RuntimeHost scenarios use a producer-valid canonical chat locator. The dedicated
 // runtime-inbox-target contract invokes the unwrapped production host for rejection coverage.
@@ -2258,6 +2268,7 @@ test("RuntimeHost does not mark a normally completed background task orphaned", 
     await waitForPromptCount(session, 2);
     assert.equal(session.prompts[1].kind, "wake");
     assert.match(session.prompts[1].text, /reason=background subagent completed/i);
+    assert.match(session.prompts[1].text, /task task-happy-1 status=completed/);
     assert.doesNotMatch(session.prompts[1].text, /status=orphaned/);
     assert.equal(host.getDispatchedSubagent("cli_piOrphanHappyA1", "task-happy-1")?.status, "completed");
     session.emit({ type: "turn-start" });
@@ -2470,11 +2481,46 @@ test("RuntimeHost writes sidecars to the Pi adapter fallback state dir when stat
     assert.equal(dispatched?.status, "dispatched");
     assert.equal(dispatched?.recordFile, path.join(expectedStateDir, "pi-subagent-records", "task-implicit-1"));
     assert.ok(fs.existsSync(dispatched.recordFile), "omitted stateDir must still create a sidecar");
+    const ledgerPath = path.join(expectedStateDir, "pi-subagent-ledger.json");
+    assert.ok(fs.existsSync(ledgerPath), "omitted stateDir must still persist the ledger");
+    assert.equal(JSON.parse(fs.readFileSync(ledgerPath, "utf8")).tasks[0]?.taskId, "task-implicit-1");
     assert.equal(createdEnv.LARKIN_STATE_DIR, expectedStateDir);
     session.emit({ type: "turn-end" });
     for (let i = 0; i < 5; i += 1) await new Promise((resolve) => setImmediate(resolve));
     assert.equal(host.getDispatchedSubagent("cli_piImplicitStateA1", "task-implicit-1")?.status, "dispatched");
     assert.equal(session.prompts.length, 1, "a live implicit-state sidecar must not be false-orphaned");
+  } finally {
+    await host.shutdown("done");
+    fs.rmSync(workspace, { recursive: true, force: true });
+  }
+});
+
+test("RuntimeHost reloads a pending implicit-state ledger wake after restart", async () => {
+  const workspace = fs.mkdtempSync(path.join(os.tmpdir(), "larkin-host-implicit-ledger-"));
+  writeDispatchedSubagentLedger(ledgerFilePath(path.join(workspace, ".larkin")), {
+    version: 1,
+    tasks: [{
+      taskId: "task-implicit-restart-1",
+      status: "orphaned",
+      dispatchedAt: 1,
+      lastActivityAt: 1,
+      reason: "pi record missing",
+      wakeKey: "task-implicit-restart-1",
+      wakeState: "pending",
+    }],
+  });
+  const session = new FakeSession();
+  const adapter = { id: "pi", capabilities: {}, async createSession() { return session; } };
+  const host = createRuntimeHost({
+    adapterFor: () => adapter,
+    promptBuilder: new ContextPromptBuilder(),
+    subagentReconcileIntervalMs: 0,
+  });
+  try {
+    await host.start([{ agentId: "cli_piImplicitLedgerA1", name: "implicit-ledger", runtime: "pi", model: "model", workspaceDir: workspace }]);
+    await waitForPromptCount(session, 1);
+    assert.equal(session.prompts[0].kind, "wake");
+    assert.match(session.prompts[0].text, /task task-implicit-restart-1 status=orphaned/);
   } finally {
     await host.shutdown("done");
     fs.rmSync(workspace, { recursive: true, force: true });
@@ -2508,10 +2554,57 @@ test("RuntimeHost wakes a persisted unconsumed terminal after the notification g
     await waitForPromptCount(session, 2);
     assert.equal(session.prompts[1].kind, "wake");
     assert.match(session.prompts[1].text, /reason=background subagent completed/i);
+    assert.match(session.prompts[1].text, /task task-terminal-grace-1 status=completed/);
     assert.doesNotMatch(session.prompts[1].text, /status=orphaned/);
     const record = host.getDispatchedSubagent("cli_piTerminalGraceA1", "task-terminal-grace-1");
     assert.equal(record?.status, "completed");
     assert.equal(record?.wakeState, "pending");
+  } finally {
+    await host.shutdown("done");
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("RuntimeHost acknowledges an in-turn completion and does not wake again after grace", async () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "larkin-host-in-turn-ack-"));
+  const session = new FakeSession();
+  const adapter = { id: "pi", capabilities: {}, async createSession() { return session; } };
+  const host = createRuntimeHost({
+    adapterFor: () => adapter,
+    promptBuilder: new ContextPromptBuilder(),
+    subagentReconcileIntervalMs: 0,
+  });
+  try {
+    await host.start([{ agentId: "cli_piInTurnAckA1", name: "in-turn-ack", runtime: "pi", model: "model", workspaceDir: "/tmp", stateDir: root }]);
+    await host.deliver("cli_piInTurnAckA1", { message_id: "om_pi_in_turn_ack", chat_id: "oc_pi_in_turn_ack", content: "start" });
+    session.emit({ type: "turn-start" });
+    session.emit({
+      type: "runtime-observation", runtime: "pi", distribution: "builtin", phase: "background_dispatched",
+      taskId: "task-in-turn-1", outputFile: path.join(root, "task-in-turn-1.output"),
+    });
+    const dispatched = host.getDispatchedSubagent("cli_piInTurnAckA1", "task-in-turn-1");
+    assert.ok(dispatched?.recordFile);
+    session.emit({
+      type: "runtime-observation", runtime: "pi", distribution: "builtin", phase: "completed",
+      completionKey: "task-in-turn-1",
+      completionStatuses: { "task-in-turn-1": "completed" },
+      handledInTurn: true,
+    });
+    await new Promise((resolve) => setImmediate(resolve));
+    assert.equal(session.prompts.length, 1, "in-turn completion must not schedule another wake");
+    assert.equal(host.getDispatchedSubagent("cli_piInTurnAckA1", "task-in-turn-1")?.status, "completed");
+    assert.equal(host.getDispatchedSubagent("cli_piInTurnAckA1", "task-in-turn-1")?.wakeState, "acknowledged");
+    session.emit({ type: "turn-end" });
+    writePersistedPiSubagentTerminal(dispatched.recordFile, {
+      taskId: "task-in-turn-1",
+      status: "completed",
+    });
+    const persistedAt = Date.now() - PI_SUBAGENT_TERMINAL_NOTIFICATION_GRACE_MS;
+    fs.utimesSync(dispatched.recordFile, new Date(persistedAt), new Date(persistedAt));
+    session.emit({ type: "turn-end" });
+    for (let i = 0; i < 5; i += 1) await new Promise((resolve) => setImmediate(resolve));
+    assert.equal(session.prompts.length, 1, "grace reconcile must not queue a second wake for an in-turn completion");
+    assert.equal(host.getDispatchedSubagent("cli_piInTurnAckA1", "task-in-turn-1")?.wakeState, "acknowledged");
   } finally {
     await host.shutdown("done");
     fs.rmSync(root, { recursive: true, force: true });
@@ -2723,6 +2816,7 @@ test("RuntimeHost maps failed canonical notifications onto the ledger instead of
       completionStatuses: { "task-failed-1": "failed" },
     });
     await waitForPromptCount(session, 2);
+    assert.match(session.prompts[1].text, /task task-failed-1 status=failed/);
     assert.equal(host.getDispatchedSubagent("cli_piStatusMapA1", "task-failed-1")?.status, "failed");
   } finally {
     await host.shutdown("done");

--- a/test/unit/runtime/runtime-host.test.mjs
+++ b/test/unit/runtime/runtime-host.test.mjs
@@ -7,6 +7,7 @@ import { ContextPromptBuilder } from "../../../dist/agent/context-prompt.mjs";
 import { createRuntimeHost as createProductionRuntimeHost } from "../../../dist/runtime/runtime-host.mjs";
 import {
   ledgerFilePath,
+  PI_SUBAGENT_TERMINAL_NOTIFICATION_GRACE_MS,
   sweepAbsentPiSubagentRecordFiles,
   writeConsumedPiSubagentTerminal,
   writeDispatchedSubagentLedger,
@@ -2436,6 +2437,153 @@ test("RuntimeHost closes the old Pi session before force-missing reconcile on st
     assert.equal(record?.status, "completed");
     assert.equal(record?.wakeState, "acknowledged");
     assert.equal(fs.existsSync(dispatched.recordFile), false, "consumed sidecar retired after close-first reconcile");
+  } finally {
+    await host.shutdown("done");
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("RuntimeHost wakes a persisted unconsumed terminal after the notification grace", async () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "larkin-host-terminal-grace-"));
+  const session = new FakeSession();
+  const adapter = { id: "pi", capabilities: {}, async createSession() { return session; } };
+  const host = createRuntimeHost({
+    adapterFor: () => adapter,
+    promptBuilder: new ContextPromptBuilder(),
+    subagentReconcileIntervalMs: 0,
+  });
+  try {
+    await host.start([{ agentId: "cli_piTerminalGraceA1", name: "terminal-grace", runtime: "pi", model: "model", workspaceDir: "/tmp", stateDir: root }]);
+    await host.deliver("cli_piTerminalGraceA1", { message_id: "om_pi_terminal_grace", chat_id: "oc_pi_terminal_grace", content: "start" });
+    session.emit({ type: "turn-start" });
+    session.emit({ type: "turn-end" });
+    session.emit({
+      type: "runtime-observation", runtime: "pi", distribution: "builtin", phase: "background_dispatched",
+      taskId: "task-terminal-grace-1", outputFile: path.join(root, "task-terminal-grace-1.output"),
+    });
+    const dispatched = host.getDispatchedSubagent("cli_piTerminalGraceA1", "task-terminal-grace-1");
+    assert.ok(dispatched?.recordFile);
+    sweepAbsentPiSubagentRecordFiles(path.dirname(dispatched.recordFile), () => ({ status: "completed" }));
+    const persistedAt = Date.now() - PI_SUBAGENT_TERMINAL_NOTIFICATION_GRACE_MS;
+    fs.utimesSync(dispatched.recordFile, new Date(persistedAt), new Date(persistedAt));
+    session.emit({ type: "turn-end" });
+    await waitForPromptCount(session, 2);
+    assert.equal(session.prompts[1].kind, "wake");
+    assert.match(session.prompts[1].text, /reason=background subagent completed/i);
+    assert.doesNotMatch(session.prompts[1].text, /status=orphaned/);
+    const record = host.getDispatchedSubagent("cli_piTerminalGraceA1", "task-terminal-grace-1");
+    assert.equal(record?.status, "completed");
+    assert.equal(record?.wakeState, "pending");
+  } finally {
+    await host.shutdown("done");
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("RuntimeHost closes the failed session before force-missing reconcile on replaceSession", async () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "larkin-host-replace-close-first-"));
+  const sessions = [];
+  let host;
+  class CloseBridgesSession extends FakeSession {
+    async close(reason) {
+      this.closes.push(reason);
+      const dispatched = host.getDispatchedSubagent("cli_piReplaceCloseA1", "task-replace-close-1");
+      if (!dispatched?.recordFile || !fs.existsSync(dispatched.recordFile)) return;
+      writeConsumedPiSubagentTerminal(dispatched.recordFile, {
+        taskId: "task-replace-close-1",
+        status: "completed",
+      });
+    }
+  }
+  const adapter = {
+    id: "pi", capabilities: {},
+    async createSession() {
+      const session = new CloseBridgesSession();
+      session.sessionId = `replace-close-${sessions.length + 1}`;
+      sessions.push(session);
+      return session;
+    },
+  };
+  host = createRuntimeHost({
+    adapterFor: () => adapter,
+    promptBuilder: new ContextPromptBuilder(),
+    retryPolicy: { baseDelayMs: 5, maxDelayMs: 10, maxAttempts: 2 },
+    subagentReconcileIntervalMs: 0,
+  });
+  try {
+    await host.start([{ agentId: "cli_piReplaceCloseA1", name: "replace-close", runtime: "pi", model: "model", workspaceDir: "/tmp", stateDir: root }]);
+    await host.deliver("cli_piReplaceCloseA1", { message_id: "om_pi_replace_close", chat_id: "oc_pi_replace_close", content: "start" });
+    sessions[0].emit({ type: "turn-start" });
+    sessions[0].emit({ type: "turn-end" });
+    sessions[0].emit({
+      type: "runtime-observation", runtime: "pi", distribution: "builtin", phase: "background_dispatched",
+      taskId: "task-replace-close-1", outputFile: path.join(root, "task-replace-close-1.output"),
+    });
+    const dispatched = host.getDispatchedSubagent("cli_piReplaceCloseA1", "task-replace-close-1");
+    assert.equal(dispatched?.status, "dispatched");
+    sessions[0].emit({ type: "closed", code: 1, signal: null });
+    await new Promise((resolve) => setTimeout(resolve, 30));
+    assert.ok(sessions[0].closes.some((reason) => String(reason).startsWith("replace after")));
+    const record = host.getDispatchedSubagent("cli_piReplaceCloseA1", "task-replace-close-1");
+    assert.equal(record?.status, "completed");
+    assert.equal(record?.wakeState, "acknowledged");
+    assert.equal(fs.existsSync(dispatched.recordFile), false, "consumed sidecar retired after close-first replace");
+  } finally {
+    await host.shutdown("done");
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("RuntimeHost closes the failed session before force-missing reconcile on recoverConfiguration", async () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "larkin-host-recover-close-first-"));
+  const sessions = [];
+  let host;
+  class CloseBridgesSession extends FakeSession {
+    async close(reason) {
+      this.closes.push(reason);
+      const dispatched = host.getDispatchedSubagent("cli_piRecoverCloseA1", "task-recover-close-1");
+      if (!dispatched?.recordFile || !fs.existsSync(dispatched.recordFile)) return;
+      writeConsumedPiSubagentTerminal(dispatched.recordFile, {
+        taskId: "task-recover-close-1",
+        status: "completed",
+      });
+    }
+  }
+  const adapter = {
+    id: "pi", capabilities: {},
+    async createSession() {
+      const session = new CloseBridgesSession();
+      session.sessionId = `recover-close-${sessions.length + 1}`;
+      sessions.push(session);
+      return session;
+    },
+    async recoverConfigurationError() {
+      return { recovered: false, reason: "configuration recovery not needed for close-order coverage" };
+    },
+  };
+  host = createRuntimeHost({
+    adapterFor: () => adapter,
+    promptBuilder: new ContextPromptBuilder(),
+    subagentReconcileIntervalMs: 0,
+  });
+  try {
+    await host.start([{ agentId: "cli_piRecoverCloseA1", name: "recover-close", runtime: "pi", model: "model", workspaceDir: "/tmp", stateDir: root }]);
+    await host.deliver("cli_piRecoverCloseA1", { message_id: "om_pi_recover_close", chat_id: "oc_pi_recover_close", content: "start" });
+    sessions[0].emit({ type: "turn-start" });
+    sessions[0].emit({ type: "turn-end" });
+    sessions[0].emit({
+      type: "runtime-observation", runtime: "pi", distribution: "builtin", phase: "background_dispatched",
+      taskId: "task-recover-close-1", outputFile: path.join(root, "task-recover-close-1.output"),
+    });
+    const dispatched = host.getDispatchedSubagent("cli_piRecoverCloseA1", "task-recover-close-1");
+    assert.equal(dispatched?.status, "dispatched");
+    sessions[0].emit({ type: "configuration-error", message: "selected model requires a newer version of Codex" });
+    await new Promise((resolve) => setTimeout(resolve, 20));
+    assert.deepEqual(sessions[0].closes, ["runtime configuration error"]);
+    const record = host.getDispatchedSubagent("cli_piRecoverCloseA1", "task-recover-close-1");
+    assert.equal(record?.status, "completed");
+    assert.equal(record?.wakeState, "acknowledged");
+    assert.equal(fs.existsSync(dispatched.recordFile), false, "consumed sidecar retired after close-first recover");
   } finally {
     await host.shutdown("done");
     fs.rmSync(root, { recursive: true, force: true });

--- a/test/unit/runtime/runtime-host.test.mjs
+++ b/test/unit/runtime/runtime-host.test.mjs
@@ -635,6 +635,7 @@ test("RuntimeHost does not let an exhausted background wake block a later comple
     assert.equal(wakeAttempts, 7, "after the exhausted head is dropped the later completion must still wake");
     assert.equal(session.prompts.filter(isBackgroundCompletionWake).length, 7);
     assert.equal(session.prompts.at(-1).kind, "wake");
+    assert.equal(host.getDispatchedSubagent("cli_piWakeSkipA1", "task-skip-head")?.wakeState, "pending");
   } finally {
     await host.shutdown("done");
   }
@@ -2336,6 +2337,7 @@ test("RuntimeHost does not orphan a consumed completed result after the Pi recor
     const record = host.getDispatchedSubagent("cli_piConsumedA1", "task-consumed-1");
     assert.equal(record?.status, "completed");
     assert.equal(record?.wakeState, "acknowledged");
+    assert.equal(fs.existsSync(dispatched.recordFile), false, "acknowledged consumed sidecar must be retired");
   } finally {
     await host.shutdown("done");
     fs.rmSync(root, { recursive: true, force: true });
@@ -2479,6 +2481,223 @@ test("RuntimeHost reconciles persisted dispatched tasks after a failed startup l
     assert.match(session.prompts[0].text, /task task-recreate-1 status=orphaned/);
   } finally {
     await host.shutdown("done");
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("RuntimeHost owner-tags sidecars so a foreign session sweep cannot delete them", async () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "larkin-host-sidecar-owner-"));
+  const session = new FakeSession();
+  let createdEnv;
+  const adapter = {
+    id: "pi", capabilities: {},
+    async createSession(input) { createdEnv = input.env; return session; },
+  };
+  const host = createRuntimeHost({
+    adapterFor: () => adapter,
+    promptBuilder: new ContextPromptBuilder(),
+    subagentReconcileIntervalMs: 0,
+  });
+  try {
+    await host.start([{ agentId: "cli_piOwnerSweepA1", name: "owner", runtime: "pi", model: "model", workspaceDir: "/tmp", stateDir: root }]);
+    await host.deliver("cli_piOwnerSweepA1", { message_id: "om_pi_owner_sweep", chat_id: "oc_pi_owner_sweep", content: "start" });
+    session.emit({ type: "turn-start" });
+    session.emit({ type: "turn-end" });
+    session.emit({
+      type: "runtime-observation", runtime: "pi", distribution: "builtin", phase: "background_dispatched",
+      taskId: "task-owner-1", outputFile: path.join(root, "task-owner-1.output"),
+    });
+    const dispatched = host.getDispatchedSubagent("cli_piOwnerSweepA1", "task-owner-1");
+    assert.ok(dispatched?.recordFile);
+    const sidecar = JSON.parse(fs.readFileSync(dispatched.recordFile, "utf8"));
+    assert.equal(sidecar.owner, createdEnv.LARKIN_PI_SESSION_OWNER);
+    assert.ok(sidecar.owner);
+    const foreignRemoved = sweepAbsentPiSubagentRecordFiles(
+      path.dirname(dispatched.recordFile),
+      () => undefined,
+      { owner: "other-session" },
+    );
+    assert.deepEqual(foreignRemoved, []);
+    assert.ok(fs.existsSync(dispatched.recordFile), "another Pi session must not delete this session's sidecar");
+  } finally {
+    await host.shutdown("done");
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("RuntimeHost force-missing reconciles dispatched tasks on resetSession", async () => {
+  const sessions = [];
+  const adapter = {
+    id: "pi", capabilities: {},
+    async createSession() {
+      const session = new FakeSession();
+      session.sessionId = `reset-orphan-${sessions.length + 1}`;
+      sessions.push(session);
+      return session;
+    },
+  };
+  const host = createRuntimeHost({
+    adapterFor: () => adapter,
+    promptBuilder: new ContextPromptBuilder(),
+    subagentRecordProbe: () => "present",
+    subagentReconcileIntervalMs: 0,
+  });
+  try {
+    await host.start([{ agentId: "cli_piResetOrphanA1", name: "reset-orphan", runtime: "pi", model: "model", workspaceDir: "/tmp" }]);
+    sessions[0].emit({
+      type: "runtime-observation", runtime: "pi", distribution: "builtin", phase: "background_dispatched",
+      taskId: "task-reset-1", outputFile: "/tmp/task-reset-1.output",
+    });
+    assert.equal(host.getDispatchedSubagent("cli_piResetOrphanA1", "task-reset-1")?.status, "dispatched");
+    await host.resetSession("cli_piResetOrphanA1");
+    assert.equal(host.getDispatchedSubagent("cli_piResetOrphanA1", "task-reset-1")?.status, "orphaned");
+    await waitForPromptCount(sessions[1], 1);
+    assert.equal(sessions[1].prompts[0].kind, "wake");
+    assert.match(sessions[1].prompts[0].text, /task task-reset-1 status=orphaned/);
+  } finally {
+    await host.shutdown("done");
+  }
+});
+
+test("RuntimeHost force-missing reconciles dispatched tasks on recoverContextOverflow", async () => {
+  const sessions = [];
+  const adapter = {
+    id: "pi", capabilities: {},
+    async createSession() {
+      const session = new FakeSession();
+      session.sessionId = `overflow-orphan-${sessions.length + 1}`;
+      sessions.push(session);
+      return session;
+    },
+  };
+  const host = createRuntimeHost({
+    adapterFor: () => adapter,
+    promptBuilder: new ContextPromptBuilder(),
+    subagentRecordProbe: () => "present",
+    subagentReconcileIntervalMs: 0,
+  });
+  try {
+    await host.start([{ agentId: "cli_piOverflowOrphanA1", name: "overflow-orphan", runtime: "pi", model: "model", workspaceDir: "/tmp" }]);
+    const receipt = await host.deliver("cli_piOverflowOrphanA1", {
+      message_id: "om_pi_overflow_orphan", chat_id: "oc_pi_overflow_orphan", content: "start",
+    });
+    sessions[0].emit({ type: "turn-start" });
+    sessions[0].emit({ type: "turn-end" });
+    sessions[0].emit({
+      type: "runtime-observation", runtime: "pi", distribution: "builtin", phase: "background_dispatched",
+      taskId: "task-overflow-1", outputFile: "/tmp/task-overflow-1.output",
+    });
+    assert.equal(host.getDispatchedSubagent("cli_piOverflowOrphanA1", "task-overflow-1")?.status, "dispatched");
+    const idleDeadline = Date.now() + 1_000;
+    while (host.isBusy?.("cli_piOverflowOrphanA1") && Date.now() < idleDeadline) {
+      await new Promise((resolve) => setImmediate(resolve));
+    }
+    await host.recoverContextOverflow("cli_piOverflowOrphanA1", receipt.deliveryId, "pi session gone");
+    assert.equal(host.getDispatchedSubagent("cli_piOverflowOrphanA1", "task-overflow-1")?.status, "orphaned");
+    await waitForPromptCount(sessions[1], 1);
+    assert.equal(sessions[1].prompts[0].kind, "wake");
+    assert.match(sessions[1].prompts[0].text, /task task-overflow-1 status=orphaned/);
+  } finally {
+    await host.shutdown("done");
+  }
+});
+
+test("RuntimeHost keeps auth-dropped terminal wakes pending so a restart can requeue them", async () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "larkin-host-auth-drop-"));
+  const session = new FakeSession();
+  const adapter = { id: "pi", capabilities: {}, async createSession() { return session; } };
+  const host = createRuntimeHost({
+    adapterFor: () => adapter,
+    promptBuilder: new ContextPromptBuilder(),
+    subagentReconcileIntervalMs: 0,
+  });
+  try {
+    await host.start([{ agentId: "cli_piAuthDropA1", name: "auth-drop", runtime: "pi", model: "model", workspaceDir: "/tmp", stateDir: root }]);
+    await host.deliver("cli_piAuthDropA1", { message_id: "om_pi_auth_drop", chat_id: "oc_pi_auth_drop", content: "start" });
+    session.emit({ type: "turn-start" });
+    session.emit({ type: "turn-end" });
+    session.emit({
+      type: "runtime-observation", runtime: "pi", distribution: "builtin", phase: "completed",
+      completionKey: "task-auth-drop-1",
+    });
+    await waitForPromptCount(session, 2);
+    const wake = session.prompts[1];
+    session.emit({ type: "turn-start" });
+    session.emit({
+      type: "input-error", inputId: wake.inputId, retryable: false, willRetry: false,
+      errorCategory: "auth", message: "provider authentication failed",
+    });
+    session.emit({ type: "turn-end" });
+    await new Promise((resolve) => setImmediate(resolve));
+    assert.equal(host.getDispatchedSubagent("cli_piAuthDropA1", "task-auth-drop-1")?.wakeState, "pending");
+  } finally {
+    await host.shutdown("done");
+  }
+  const restarted = new FakeSession();
+  const host2 = createRuntimeHost({
+    adapterFor: () => ({ id: "pi", capabilities: {}, async createSession() { return restarted; } }),
+    promptBuilder: new ContextPromptBuilder(),
+    subagentReconcileIntervalMs: 0,
+  });
+  try {
+    await host2.start([{ agentId: "cli_piAuthDropA1", name: "auth-drop", runtime: "pi", model: "model", workspaceDir: "/tmp", stateDir: root }]);
+    await waitForPromptCount(restarted, 1);
+    assert.equal(restarted.prompts[0].kind, "wake");
+    assert.equal(host2.getDispatchedSubagent("cli_piAuthDropA1", "task-auth-drop-1")?.wakeState, "pending");
+  } finally {
+    await host2.shutdown("done");
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("RuntimeHost keeps exhausted terminal wakes pending so a restart can requeue them", async () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "larkin-host-exhausted-drop-"));
+  let wakeAttempts = 0;
+  const session = new FakeSession();
+  session.prompt = async function(input) {
+    this.prompts.push(input);
+    if (isBackgroundCompletionWake(input)) {
+      wakeAttempts += 1;
+      return { status: "rejected", inputId: input.inputId, retryable: true, reason: "still failing" };
+    }
+    return { status: "accepted", inputId: input.inputId };
+  };
+  const adapter = { id: "pi", capabilities: {}, async createSession() { return session; } };
+  const host = createRuntimeHost({
+    adapterFor: () => adapter,
+    promptBuilder: new ContextPromptBuilder(),
+    retryPolicy: { baseDelayMs: 15, maxDelayMs: 20, maxAttempts: 1 },
+    subagentReconcileIntervalMs: 0,
+  });
+  try {
+    await host.start([{ agentId: "cli_piExhaustedDropA1", name: "exhausted-drop", runtime: "pi", model: "model", workspaceDir: "/tmp", stateDir: root }]);
+    await host.deliver("cli_piExhaustedDropA1", { message_id: "om_pi_exhausted_drop", chat_id: "oc_pi_exhausted_drop", content: "start" });
+    session.emit({ type: "turn-start" });
+    session.emit({ type: "turn-end" });
+    session.emit({
+      type: "runtime-observation", runtime: "pi", distribution: "builtin", phase: "completed",
+      completionKey: "task-exhausted-drop-1",
+    });
+    const deadline = Date.now() + 400;
+    while (wakeAttempts < 6 && Date.now() < deadline) await new Promise((resolve) => setTimeout(resolve, 5));
+    assert.equal(wakeAttempts, 6);
+    assert.equal(host.getDispatchedSubagent("cli_piExhaustedDropA1", "task-exhausted-drop-1")?.wakeState, "pending");
+  } finally {
+    await host.shutdown("done");
+  }
+  const restarted = new FakeSession();
+  const host2 = createRuntimeHost({
+    adapterFor: () => ({ id: "pi", capabilities: {}, async createSession() { return restarted; } }),
+    promptBuilder: new ContextPromptBuilder(),
+    subagentReconcileIntervalMs: 0,
+  });
+  try {
+    await host2.start([{ agentId: "cli_piExhaustedDropA1", name: "exhausted-drop", runtime: "pi", model: "model", workspaceDir: "/tmp", stateDir: root }]);
+    await waitForPromptCount(restarted, 1);
+    assert.equal(restarted.prompts[0].kind, "wake");
+    assert.equal(host2.getDispatchedSubagent("cli_piExhaustedDropA1", "task-exhausted-drop-1")?.wakeState, "pending");
+  } finally {
+    await host2.shutdown("done");
     fs.rmSync(root, { recursive: true, force: true });
   }
 });

--- a/test/unit/runtime/runtime-host.test.mjs
+++ b/test/unit/runtime/runtime-host.test.mjs
@@ -2175,3 +2175,123 @@ test("issue 138: reopening a terminal wake failure can be promoted again", async
     fs.rmSync(root, { recursive: true, force: true });
   }
 });
+
+const waitForPromptCount = async (session, count, timeoutMs = 1_000) => {
+  const deadline = Date.now() + timeoutMs;
+  while (session.prompts.length < count && Date.now() < deadline) {
+    await new Promise((resolve) => setImmediate(resolve));
+  }
+  assert.equal(session.prompts.length, count);
+};
+
+test("RuntimeHost wakes once when a dispatched Pi record disappears and keeps the task queryable as orphaned", async () => {
+  const session = new FakeSession();
+  let present = true;
+  const adapter = { id: "pi", capabilities: {}, async createSession() { return session; } };
+  const host = createRuntimeHost({
+    adapterFor: () => adapter,
+    promptBuilder: new ContextPromptBuilder(),
+    subagentRecordProbe: () => present ? "present" : "absent",
+    subagentReconcileIntervalMs: 0,
+  });
+  try {
+    await host.start([{ agentId: "cli_piOrphanA1", name: "orphan", runtime: "pi", model: "model", workspaceDir: "/tmp" }]);
+    await host.deliver("cli_piOrphanA1", { message_id: "om_pi_orphan", chat_id: "oc_pi_orphan", content: "start" });
+    session.emit({ type: "turn-start" });
+    session.emit({ type: "turn-end" });
+    assert.equal(session.prompts.length, 1);
+    session.emit({
+      type: "runtime-observation", runtime: "pi", distribution: "builtin", phase: "background_dispatched",
+      taskId: "task-orphan-1", outputFile: "/tmp/task-orphan-1.output",
+    });
+    assert.equal(host.getDispatchedSubagent("cli_piOrphanA1", "task-orphan-1")?.status, "dispatched");
+    present = false;
+    session.emit({ type: "turn-end" });
+    await waitForPromptCount(session, 2);
+    assert.equal(session.prompts[1].kind, "wake");
+    assert.match(session.prompts[1].text, /reason=background subagent completed/i);
+    assert.match(session.prompts[1].text, /task task-orphan-1 status=orphaned/);
+    const record = host.getDispatchedSubagent("cli_piOrphanA1", "task-orphan-1");
+    assert.equal(record?.status, "orphaned");
+    assert.equal(record?.outputFile, "/tmp/task-orphan-1.output");
+    assert.equal(record?.reason, "pi record missing");
+    session.emit({ type: "turn-start" });
+    session.emit({ type: "turn-end" });
+    present = false;
+    session.emit({ type: "turn-end" });
+    await new Promise((resolve) => setImmediate(resolve));
+    assert.equal(session.prompts.length, 2, "repeat reconciliation must not send another orphan wake");
+    assert.equal(host.getDispatchedSubagent("cli_piOrphanA1", "task-orphan-1")?.status, "orphaned");
+  } finally {
+    await host.shutdown("done");
+  }
+});
+
+test("RuntimeHost does not mark a normally completed background task orphaned", async () => {
+  const session = new FakeSession();
+  const adapter = { id: "pi", capabilities: {}, async createSession() { return session; } };
+  const host = createRuntimeHost({
+    adapterFor: () => adapter,
+    promptBuilder: new ContextPromptBuilder(),
+    subagentRecordProbe: () => "absent",
+    subagentReconcileIntervalMs: 0,
+  });
+  try {
+    await host.start([{ agentId: "cli_piOrphanHappyA1", name: "happy", runtime: "pi", model: "model", workspaceDir: "/tmp" }]);
+    await host.deliver("cli_piOrphanHappyA1", { message_id: "om_pi_orphan_happy", chat_id: "oc_pi_orphan_happy", content: "start" });
+    session.emit({ type: "turn-start" });
+    session.emit({ type: "turn-end" });
+    assert.equal(session.prompts.length, 1);
+    session.emit({
+      type: "runtime-observation", runtime: "pi", distribution: "builtin", phase: "background_dispatched",
+      taskId: "task-happy-1", outputFile: "/tmp/task-happy-1.output",
+    });
+    session.emit({ type: "runtime-observation", runtime: "pi", distribution: "builtin", phase: "completed", completionKey: "task-happy-1" });
+    await waitForPromptCount(session, 2);
+    assert.equal(session.prompts[1].kind, "wake");
+    assert.match(session.prompts[1].text, /reason=background subagent completed/i);
+    assert.doesNotMatch(session.prompts[1].text, /status=orphaned/);
+    assert.equal(host.getDispatchedSubagent("cli_piOrphanHappyA1", "task-happy-1")?.status, "completed");
+    session.emit({ type: "turn-start" });
+    session.emit({ type: "turn-end" });
+    session.emit({ type: "turn-end" });
+    await new Promise((resolve) => setImmediate(resolve));
+    assert.equal(session.prompts.length, 2, "happy-path completion must stay a single wake and not be reclassified as orphaned");
+    assert.equal(host.getDispatchedSubagent("cli_piOrphanHappyA1", "task-happy-1")?.status, "completed");
+  } finally {
+    await host.shutdown("done");
+  }
+});
+
+test("RuntimeHost does not double-wake if a real terminal notification arrives after orphaning", async () => {
+  const session = new FakeSession();
+  let present = true;
+  const adapter = { id: "pi", capabilities: {}, async createSession() { return session; } };
+  const host = createRuntimeHost({
+    adapterFor: () => adapter,
+    promptBuilder: new ContextPromptBuilder(),
+    subagentRecordProbe: () => present ? "present" : "absent",
+    subagentReconcileIntervalMs: 0,
+  });
+  try {
+    await host.start([{ agentId: "cli_piOrphanLateA1", name: "late", runtime: "pi", model: "model", workspaceDir: "/tmp" }]);
+    await host.deliver("cli_piOrphanLateA1", { message_id: "om_pi_orphan_late", chat_id: "oc_pi_orphan_late", content: "start" });
+    session.emit({ type: "turn-start" });
+    session.emit({ type: "turn-end" });
+    session.emit({
+      type: "runtime-observation", runtime: "pi", distribution: "builtin", phase: "background_dispatched",
+      taskId: "task-late-1", outputFile: "/tmp/task-late-1.output",
+    });
+    present = false;
+    session.emit({ type: "turn-end" });
+    await waitForPromptCount(session, 2);
+    session.emit({ type: "turn-start" });
+    session.emit({ type: "turn-end" });
+    session.emit({ type: "runtime-observation", runtime: "pi", distribution: "builtin", phase: "completed", completionKey: "task-late-1" });
+    await new Promise((resolve) => setImmediate(resolve));
+    assert.equal(session.prompts.length, 2, "a later canonical notification must reuse the orphan wake key");
+    assert.equal(host.getDispatchedSubagent("cli_piOrphanLateA1", "task-late-1")?.status, "orphaned");
+  } finally {
+    await host.shutdown("done");
+  }
+});

--- a/test/unit/runtime/runtime-host.test.mjs
+++ b/test/unit/runtime/runtime-host.test.mjs
@@ -2611,6 +2611,101 @@ test("RuntimeHost acknowledges an in-turn completion and does not wake again aft
   }
 });
 
+test("RuntimeHost does not ack a completion from a failed owning turn so retry and restart can still wake", async () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "larkin-host-failed-owning-"));
+  const session = new FakeSession();
+  const adapter = { id: "pi", capabilities: {}, async createSession() { return session; } };
+  const host = createRuntimeHost({
+    adapterFor: () => adapter,
+    promptBuilder: new ContextPromptBuilder(),
+    subagentReconcileIntervalMs: 0,
+  });
+  try {
+    await host.start([{ agentId: "cli_piFailedOwningA1", name: "failed-owning", runtime: "pi", model: "model", workspaceDir: "/tmp", stateDir: root }]);
+    await host.deliver("cli_piFailedOwningA1", { message_id: "om_pi_failed_owning", chat_id: "oc_pi_failed_owning", content: "start" });
+    session.emit({ type: "turn-start" });
+    session.emit({
+      type: "runtime-observation", runtime: "pi", distribution: "builtin", phase: "background_dispatched",
+      taskId: "task-failed-owning-1", outputFile: path.join(root, "task-failed-owning-1.output"),
+    });
+    const dispatched = host.getDispatchedSubagent("cli_piFailedOwningA1", "task-failed-owning-1");
+    assert.ok(dispatched?.recordFile);
+    session.emit({
+      type: "runtime-observation", runtime: "pi", distribution: "builtin", phase: "completed",
+      completionKey: "task-failed-owning-1",
+      completionStatuses: { "task-failed-owning-1": "completed" },
+    });
+    session.emit({
+      type: "input-error", inputId: session.prompts[0].inputId, retryable: true, willRetry: false,
+      message: "Pi assistant turn aborted",
+    });
+    session.emit({ type: "turn-end" });
+    await waitForPromptCount(session, 2);
+    assert.equal(session.prompts[1].kind, "wake");
+    assert.match(session.prompts[1].text, /task task-failed-owning-1 status=completed/);
+    assert.equal(host.getDispatchedSubagent("cli_piFailedOwningA1", "task-failed-owning-1")?.wakeState, "pending");
+    assert.ok(fs.existsSync(dispatched.recordFile), "failed owning turn must not delete the sidecar before a successful wake");
+  } finally {
+    await host.shutdown("done");
+  }
+  const restarted = new FakeSession();
+  const host2 = createRuntimeHost({
+    adapterFor: () => ({ id: "pi", capabilities: {}, async createSession() { return restarted; } }),
+    promptBuilder: new ContextPromptBuilder(),
+    subagentReconcileIntervalMs: 0,
+  });
+  try {
+    await host2.start([{ agentId: "cli_piFailedOwningA1", name: "failed-owning", runtime: "pi", model: "model", workspaceDir: "/tmp", stateDir: root }]);
+    await waitForPromptCount(restarted, 1);
+    assert.equal(restarted.prompts[0].kind, "wake");
+    assert.match(restarted.prompts[0].text, /task task-failed-owning-1 status=completed/);
+    assert.equal(host2.getDispatchedSubagent("cli_piFailedOwningA1", "task-failed-owning-1")?.wakeState, "pending");
+    const record = host2.getDispatchedSubagent("cli_piFailedOwningA1", "task-failed-owning-1");
+    assert.ok(record?.recordFile && fs.existsSync(record.recordFile), "restart must still see the unacked sidecar");
+  } finally {
+    await host2.shutdown("done");
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("RuntimeHost drops queued fallbacks after in-turn handling so drain does not start a redundant wake", async () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "larkin-host-in-turn-drop-fallback-"));
+  const session = new FakeSession();
+  const adapter = { id: "pi", capabilities: {}, async createSession() { return session; } };
+  const host = createRuntimeHost({
+    adapterFor: () => adapter,
+    promptBuilder: new ContextPromptBuilder(),
+    subagentReconcileIntervalMs: 0,
+  });
+  try {
+    await host.start([{ agentId: "cli_piInTurnDropA1", name: "in-turn-drop", runtime: "pi", model: "model", workspaceDir: "/tmp", stateDir: root }]);
+    await host.deliver("cli_piInTurnDropA1", { message_id: "om_pi_in_turn_drop", chat_id: "oc_pi_in_turn_drop", content: "start" });
+    session.emit({ type: "turn-start" });
+    session.emit({
+      type: "runtime-observation", runtime: "pi", distribution: "builtin", phase: "background_dispatched",
+      taskId: "task-in-turn-drop-1", outputFile: path.join(root, "task-in-turn-drop-1.output"),
+    });
+    session.emit({
+      type: "runtime-observation", runtime: "pi", distribution: "builtin", phase: "completed",
+      completionKey: "task-in-turn-drop-1",
+      completionStatuses: { "task-in-turn-drop-1": "completed" },
+    });
+    session.emit({
+      type: "runtime-observation", runtime: "pi", distribution: "builtin", phase: "completed",
+      completionKey: "task-in-turn-drop-1",
+      completionStatuses: { "task-in-turn-drop-1": "completed" },
+      handledInTurn: true,
+    });
+    session.emit({ type: "turn-end" });
+    for (let i = 0; i < 5; i += 1) await new Promise((resolve) => setImmediate(resolve));
+    assert.equal(session.prompts.length, 1, "in-turn handling must drop the queued fallback before drain");
+    assert.equal(host.getDispatchedSubagent("cli_piInTurnDropA1", "task-in-turn-drop-1")?.wakeState, "acknowledged");
+  } finally {
+    await host.shutdown("done");
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});
+
 test("RuntimeHost closes the failed session before force-missing reconcile on replaceSession", async () => {
   const root = fs.mkdtempSync(path.join(os.tmpdir(), "larkin-host-replace-close-first-"));
   const sessions = [];

--- a/test/unit/runtime/runtime-host.test.mjs
+++ b/test/unit/runtime/runtime-host.test.mjs
@@ -5,6 +5,10 @@ import path from "node:path";
 import { test } from "bun:test";
 import { ContextPromptBuilder } from "../../../dist/agent/context-prompt.mjs";
 import { createRuntimeHost as createProductionRuntimeHost } from "../../../dist/runtime/runtime-host.mjs";
+import {
+  ledgerFilePath,
+  writeDispatchedSubagentLedger,
+} from "../../../dist/runtime/pi-subagent-ledger.mjs";
 import { RuntimePrerequisiteError } from "../../../dist/runtime/runtime-readiness.mjs";
 import { calculatePiCompactionSettings } from "../../../dist/runtime/pi-compaction-recovery.mjs";
 import { createAgentStateStore } from "../../../dist/agent/agent-state-store.mjs";
@@ -2293,5 +2297,146 @@ test("RuntimeHost does not double-wake if a real terminal notification arrives a
     assert.equal(host.getDispatchedSubagent("cli_piOrphanLateA1", "task-late-1")?.status, "orphaned");
   } finally {
     await host.shutdown("done");
+  }
+});
+
+test("RuntimeHost default probe orphans when the Pi record sidecar is gone and the transcript remains", async () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "larkin-host-record-probe-"));
+  const session = new FakeSession();
+  const adapter = { id: "pi", capabilities: {}, async createSession() { return session; } };
+  const host = createRuntimeHost({
+    adapterFor: () => adapter,
+    promptBuilder: new ContextPromptBuilder(),
+    subagentReconcileIntervalMs: 0,
+  });
+  try {
+    await host.start([{ agentId: "cli_piRecordProbeA1", name: "probe", runtime: "pi", model: "model", workspaceDir: "/tmp", stateDir: root }]);
+    await host.deliver("cli_piRecordProbeA1", { message_id: "om_pi_record_probe", chat_id: "oc_pi_record_probe", content: "start" });
+    session.emit({ type: "turn-start" });
+    session.emit({ type: "turn-end" });
+    const outputFile = path.join(root, "task-record-probe-1.output");
+    fs.writeFileSync(outputFile, "leftover transcript\n");
+    session.emit({
+      type: "runtime-observation", runtime: "pi", distribution: "builtin", phase: "background_dispatched",
+      taskId: "task-record-probe-1", outputFile,
+    });
+    const dispatched = host.getDispatchedSubagent("cli_piRecordProbeA1", "task-record-probe-1");
+    assert.equal(dispatched?.status, "dispatched");
+    assert.ok(dispatched?.recordFile);
+    fs.rmSync(dispatched.recordFile);
+    session.emit({ type: "turn-end" });
+    await waitForPromptCount(session, 2);
+    assert.match(session.prompts[1].text, /task task-record-probe-1 status=orphaned/);
+    assert.ok(fs.existsSync(outputFile), "leftover transcript must not be treated as the Pi record");
+    assert.equal(host.getDispatchedSubagent("cli_piRecordProbeA1", "task-record-probe-1")?.wakeState, "pending");
+  } finally {
+    await host.shutdown("done");
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("RuntimeHost requeues a persisted pending orphan wake after restart", async () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "larkin-host-orphan-restart-"));
+  writeDispatchedSubagentLedger(ledgerFilePath(root), {
+    version: 1,
+    tasks: [{
+      taskId: "task-restart-wake-1",
+      status: "orphaned",
+      dispatchedAt: 1,
+      lastActivityAt: 1,
+      reason: "pi record missing",
+      wakeKey: "task-restart-wake-1",
+      wakeState: "pending",
+    }],
+  });
+  const session = new FakeSession();
+  const adapter = { id: "pi", capabilities: {}, async createSession() { return session; } };
+  const host = createRuntimeHost({
+    adapterFor: () => adapter,
+    promptBuilder: new ContextPromptBuilder(),
+    subagentReconcileIntervalMs: 0,
+  });
+  try {
+    await host.start([{ agentId: "cli_piRestartWakeA1", name: "restart", runtime: "pi", model: "model", workspaceDir: "/tmp", stateDir: root }]);
+    await waitForPromptCount(session, 1);
+    assert.equal(session.prompts[0].kind, "wake");
+    assert.match(session.prompts[0].text, /task task-restart-wake-1 status=orphaned/);
+    session.emit({ type: "turn-start" });
+    session.emit({ type: "turn-end" });
+    await new Promise((resolve) => setImmediate(resolve));
+    assert.equal(host.getDispatchedSubagent("cli_piRestartWakeA1", "task-restart-wake-1")?.wakeState, "acknowledged");
+    assert.equal(session.prompts.length, 1, "acknowledged restart wake must not repeat");
+  } finally {
+    await host.shutdown("done");
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("RuntimeHost maps failed canonical notifications onto the ledger instead of completed", async () => {
+  const session = new FakeSession();
+  const adapter = { id: "pi", capabilities: {}, async createSession() { return session; } };
+  const host = createRuntimeHost({
+    adapterFor: () => adapter,
+    promptBuilder: new ContextPromptBuilder(),
+    subagentReconcileIntervalMs: 0,
+  });
+  try {
+    await host.start([{ agentId: "cli_piStatusMapA1", name: "status", runtime: "pi", model: "model", workspaceDir: "/tmp" }]);
+    await host.deliver("cli_piStatusMapA1", { message_id: "om_pi_status_map", chat_id: "oc_pi_status_map", content: "start" });
+    session.emit({ type: "turn-start" });
+    session.emit({ type: "turn-end" });
+    session.emit({
+      type: "runtime-observation", runtime: "pi", distribution: "builtin", phase: "background_dispatched",
+      taskId: "task-failed-1", outputFile: "/tmp/task-failed-1.output",
+    });
+    session.emit({
+      type: "runtime-observation", runtime: "pi", distribution: "builtin", phase: "completed",
+      completionKey: "task-failed-1",
+      completionStatuses: { "task-failed-1": "failed" },
+    });
+    await waitForPromptCount(session, 2);
+    assert.equal(host.getDispatchedSubagent("cli_piStatusMapA1", "task-failed-1")?.status, "failed");
+  } finally {
+    await host.shutdown("done");
+  }
+});
+
+test("RuntimeHost reconciles persisted dispatched tasks after a failed startup later succeeds", async () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "larkin-host-recreate-ledger-"));
+  writeDispatchedSubagentLedger(ledgerFilePath(root), {
+    version: 1,
+    tasks: [{
+      taskId: "task-recreate-1",
+      status: "dispatched",
+      dispatchedAt: 1,
+      lastActivityAt: 1,
+    }],
+  });
+  const session = new FakeSession();
+  let probes = 0;
+  const adapter = {
+    id: "pi", capabilities: {},
+    async probe() {
+      probes += 1;
+      return probes === 1
+        ? { runtime: "pi", state: "unavailable", reason: "get_state timeout", nextAction: "retry" }
+        : { runtime: "pi", state: "ready" };
+    },
+    async createSession() { return session; },
+  };
+  const host = createRuntimeHost({
+    adapterFor: () => adapter,
+    promptBuilder: new ContextPromptBuilder(),
+    retryPolicy: { baseDelayMs: 2, maxDelayMs: 2, maxAttempts: 2 },
+    subagentReconcileIntervalMs: 0,
+  });
+  try {
+    await host.start([{ agentId: "cli_piRecreateLedgerA1", name: "recreate", runtime: "pi", model: "model", workspaceDir: "/tmp", stateDir: root }]);
+    await waitForPromptCount(session, 1);
+    assert.equal(host.getDispatchedSubagent("cli_piRecreateLedgerA1", "task-recreate-1")?.status, "orphaned");
+    assert.match(session.prompts[0].text, /task task-recreate-1 status=orphaned/);
+  } finally {
+    await host.shutdown("done");
+    fs.rmSync(root, { recursive: true, force: true });
   }
 });

--- a/test/unit/runtime/runtime-host.test.mjs
+++ b/test/unit/runtime/runtime-host.test.mjs
@@ -2443,6 +2443,44 @@ test("RuntimeHost closes the old Pi session before force-missing reconcile on st
   }
 });
 
+test("RuntimeHost writes sidecars to the Pi adapter fallback state dir when stateDir is omitted", async () => {
+  const workspace = fs.mkdtempSync(path.join(os.tmpdir(), "larkin-host-implicit-state-"));
+  const session = new FakeSession();
+  let createdEnv;
+  const adapter = {
+    id: "pi", capabilities: {},
+    async createSession(input) { createdEnv = input.env; return session; },
+  };
+  const host = createRuntimeHost({
+    adapterFor: () => adapter,
+    promptBuilder: new ContextPromptBuilder(),
+    subagentReconcileIntervalMs: 0,
+  });
+  try {
+    await host.start([{ agentId: "cli_piImplicitStateA1", name: "implicit-state", runtime: "pi", model: "model", workspaceDir: workspace }]);
+    await host.deliver("cli_piImplicitStateA1", { message_id: "om_pi_implicit_state", chat_id: "oc_pi_implicit_state", content: "start" });
+    session.emit({ type: "turn-start" });
+    session.emit({ type: "turn-end" });
+    session.emit({
+      type: "runtime-observation", runtime: "pi", distribution: "builtin", phase: "background_dispatched",
+      taskId: "task-implicit-1", outputFile: path.join(workspace, "task-implicit-1.output"),
+    });
+    const expectedStateDir = path.join(workspace, ".larkin");
+    const dispatched = host.getDispatchedSubagent("cli_piImplicitStateA1", "task-implicit-1");
+    assert.equal(dispatched?.status, "dispatched");
+    assert.equal(dispatched?.recordFile, path.join(expectedStateDir, "pi-subagent-records", "task-implicit-1"));
+    assert.ok(fs.existsSync(dispatched.recordFile), "omitted stateDir must still create a sidecar");
+    assert.equal(createdEnv.LARKIN_STATE_DIR, expectedStateDir);
+    session.emit({ type: "turn-end" });
+    for (let i = 0; i < 5; i += 1) await new Promise((resolve) => setImmediate(resolve));
+    assert.equal(host.getDispatchedSubagent("cli_piImplicitStateA1", "task-implicit-1")?.status, "dispatched");
+    assert.equal(session.prompts.length, 1, "a live implicit-state sidecar must not be false-orphaned");
+  } finally {
+    await host.shutdown("done");
+    fs.rmSync(workspace, { recursive: true, force: true });
+  }
+});
+
 test("RuntimeHost wakes a persisted unconsumed terminal after the notification grace", async () => {
   const root = fs.mkdtempSync(path.join(os.tmpdir(), "larkin-host-terminal-grace-"));
   const session = new FakeSession();


### PR DESCRIPTION
## Summary
- Persist dispatched background Pi task ids (`Agent` + `run_in_background: true`) with last-seen activity and optional output file.
- Reconcile that ledger on turn end, idle timer, session replace/recover, and runtime restart.
- If the underlying Pi record/session is gone and no canonical terminal `<task-notification>` exists, mark the task `orphaned` once and enqueue one idempotent background-completion wake.
- A later real terminal notification reuses the same drain/dedupe keys and does not double-wake.
- Happy-path completed notifications keep the current single-wake behavior and are not marked orphaned.

Addresses issue 117.

## Root cause
Pi `AgentManager` keeps records only in memory. The only Larkin wake path was `extractCanonicalPiSubagentNotification` in `src/runtime/runtime-adapters.ts` → `noteBackgroundCompletion` in `src/runtime/runtime-host.ts`. If Pi deleted the record (process gone, session replace, `get_subagent_result` already returns not-found) without emitting a terminal notification, the main session never woke.

Investigated Pi store paths before coding:
- in-memory `AgentManager.agents` in `@tintinweb/pi-subagents`
- output transcripts at `/tmp/pi-subagents-<uid>/<encoded-cwd>/<sessionId>/tasks/<id>.output`
- no durable dispatched-task ledger

## Scope
- New `src/runtime/pi-subagent-ledger.ts` plus host/adapter wiring.
- Queryable terminal state via `RuntimeHost.getDispatchedSubagent` and `stateDir/pi-subagent-ledger.json`.
- Package version `0.4.16`.

## Non-goals
- Does not change the 30s default / 60s hard cap from issue 118.
- Does not change processing-eye UX or activity-idle leftovers from issue 79.
- Does not patch `@tintinweb/pi-subagents` further.
- Does not merge, release, retag, close issues, or touch production Host.
- Does not claim Feishu client banners or real-client wake UX.

## Tests
Deterministic E2 unit coverage:
- record disappearance / process gone → exactly one terminal wake; task queryable as `orphaned`
- repeat reconciliation does not send another wake
- normal completion still wakes once and is not marked orphaned
- late canonical notification after orphan does not double-wake
- Agent tool dispatch extraction and adapter observation

Local verification:
- `bun run typecheck` PASS
- `bun run build` PASS (via `bun install --frozen-lockfile` prepare)
- focused ledger / notification / wait tests PASS (15/15)
- focused host wake + orphan tests PASS (13/13)
- focused adapter completion + dispatch tests PASS (7/7)
- related host replace/recreate/session tests PASS (15/15)
- `bun run licenses:check` PASS
- `bun run publication:check:tree` PASS

## Unproven
- No live Pi process-crash or Feishu client banner evidence. Fake-session wakes prove host enqueue/dedupe only.
- Default production probe can only observe the output file and session/process replacement. An in-process `AgentManager` delete that leaves the output file in place is covered by the injectable probe and by session-gone reconciliation, not by a live Pi `getRecord` RPC.
- Heartbeat-based orphaning of still-running but silent tasks is intentionally disabled to avoid false orphans during long tool calls.