### PR TITLE
fix(setup): import external Pi profile and resolve a concrete model (#152)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "larkin",
-  "version": "0.4.15",
+  "version": "0.4.16",
   "private": false,
   "larkinPackageRole": "npm-published",
   "files": [

--- a/src/app/setup.ts
+++ b/src/app/setup.ts
@@ -179,8 +179,9 @@ export async function main(): Promise<void> {
   const configuredAgent = configured.agents[selectedAgentId];
   if (!configuredAgent) die(`setup 完成但 Agent ${selectedAgentId} 配置不可读`);
   if (!(["codex", "claude", "pi"] as const).includes(configuredAgent.runtime as "codex" | "claude" | "pi")) die(`Runtime ${configuredAgent.runtime} 不受支持`);
-  // 非交互（Agent 驱动）时跳过 RPC probe：无 TTY 环境无法进行 pi RPC，探测留到 daemon 启动；
-  // 其余真实阻塞（缺 runtime 可执行文件 / 缺 key / 缺 lark-cli）一律 fast-fail 并给出 agent 可读的修复提示。
+  // 非交互（Agent 驱动）时仍跳过 probeNativeRuntimeReadiness：该探测保持 interactive-only。
+  // external-pi 绑定已在 setup-bind 内做非交互 Pi RPC catalog discovery（RPC over pipes 不需要 TTY）；
+  // daemon attach 探测仍是权威校验。其余真实阻塞（缺 runtime 可执行文件 / 缺 key / 缺 lark-cli）一律 fast-fail。
   if (!OPT.nonInteractive) {
     const runtimeReadiness = await probeNativeRuntimeReadiness({ runtime: configuredAgent.runtime as "codex" | "claude" | "pi",
       agentId: selectedAgentId, cwd: configuredAgent.workspaceDir,

--- a/src/runtime/pi-profile-migration.ts
+++ b/src/runtime/pi-profile-migration.ts
@@ -3,6 +3,7 @@ import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
 import { spawnSync } from "node:child_process";
+import processInspect from "../platform/process-inspect.cjs";
 import { resolveRuntimeExecutable } from "./runtime-readiness.js";
 import { mergeOwnedPiSettings, parsePiExecutableVersion } from "./pi-compaction-recovery.js";
 import { BUNDLED_PI_VERSION } from "./pi-provider-config.js";
@@ -61,6 +62,91 @@ function acquireTargetLock(state: PiProfileMigrationState): void {
 export function releasePiProfileMigrationLock(state: PiProfileMigrationState): void {
   try { fs.unlinkSync(targetLockFile(state)); fsyncDirectory(path.dirname(targetLockFile(state))); }
   catch (error) { if ((error as NodeJS.ErrnoException).code !== "ENOENT") throw error; }
+}
+const TARGET_BUSY = "Pi provider target is busy";
+export interface ClearStalePiProfileMigrationLockOptions {
+  kill?: typeof process.kill;
+}
+function migrationLockPath(configDir: string, agentId: string): string {
+  if (!AGENT_ID.test(agentId)) throw new Error("Pi Agent ID 格式无效");
+  return path.join(path.resolve(configDir), "providers", "pi", `${agentId}${TARGET_LOCK_SUFFIX}`);
+}
+function lockPidFromBytes(bytes: Buffer): number | null {
+  const text = bytes.toString("utf8");
+  if (text.endsWith("\n") ? text.slice(0, -1).includes("\n") : text.includes("\n")) return null;
+  const line = text.endsWith("\n") ? text.slice(0, -1) : text;
+  if (!/^[1-9][0-9]*$/.test(line)) return null;
+  const pid = Number(line);
+  return Number.isSafeInteger(pid) && pid > 0 ? pid : null;
+}
+function inspectOwnedLock(file: string): { pid: number; dev: number; ino: number } | null {
+  let fd: number | undefined;
+  try {
+    const initial = fs.lstatSync(file);
+    if (initial.isSymbolicLink() || !initial.isFile() || initial.nlink !== 1 || (initial.mode & 0o777) !== 0o600) {
+      throw new Error(TARGET_BUSY);
+    }
+    assertOwner(initial, "Pi provider lock");
+    const noFollow = fs.constants.O_NOFOLLOW ?? 0;
+    fd = fs.openSync(file, fs.constants.O_RDONLY | noFollow);
+    const before = fs.fstatSync(fd);
+    if (!before.isFile() || before.nlink !== 1 || (before.mode & 0o777) !== 0o600) throw new Error(TARGET_BUSY);
+    assertOwner(before, "Pi provider lock");
+    const bytes = Buffer.allocUnsafe(before.size);
+    let offset = 0;
+    while (offset < before.size) {
+      const read = fs.readSync(fd, bytes, offset, before.size - offset, null);
+      if (read === 0) throw new Error(TARGET_BUSY);
+      offset += read;
+    }
+    const after = fs.fstatSync(fd);
+    if (after.dev !== before.dev || after.ino !== before.ino || after.size !== before.size || after.nlink !== before.nlink
+        || after.uid !== before.uid || (after.mode & 0o777) !== 0o600) throw new Error(TARGET_BUSY);
+    const pid = lockPidFromBytes(bytes.subarray(0, after.size));
+    if (pid === null) throw new Error(TARGET_BUSY);
+    return { pid, dev: after.dev, ino: after.ino };
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") return null;
+    if ((error as NodeJS.ErrnoException).code === "ELOOP") throw new Error(TARGET_BUSY);
+    if (error instanceof Error && error.message === TARGET_BUSY) throw error;
+    if (error instanceof Error && /unsafe/.test(error.message)) throw new Error(TARGET_BUSY);
+    throw new Error(TARGET_BUSY);
+  } finally { if (fd !== undefined) fs.closeSync(fd); }
+}
+/** Reclaim a credential-adjacent import lock only when it is a proven-dead owned regular file. */
+export function clearStalePiProfileMigrationLock(
+  configDir: string,
+  agentId: string,
+  options: ClearStalePiProfileMigrationLockOptions = {},
+): void {
+  const file = migrationLockPath(configDir, agentId);
+  assertNoSymlinkAncestors(path.dirname(file));
+  const inspected = inspectOwnedLock(file);
+  if (!inspected) return;
+  const kill = options.kill ?? process.kill;
+  if (processInspect.pidAlive(inspected.pid, kill)) throw new Error(TARGET_BUSY);
+  const quarantine = `${file}.stale-${process.pid}-${crypto.randomUUID()}`;
+  try { fs.renameSync(file, quarantine); }
+  catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") return;
+    throw new Error(TARGET_BUSY);
+  }
+  fsyncDirectory(path.dirname(file));
+  try {
+    const quarantined = fs.lstatSync(quarantine);
+    if (quarantined.isSymbolicLink() || !quarantined.isFile() || quarantined.nlink !== 1
+        || (quarantined.mode & 0o777) !== 0o600 || quarantined.dev !== inspected.dev || quarantined.ino !== inspected.ino) {
+      throw new Error(TARGET_BUSY);
+    }
+    assertOwner(quarantined, "Pi provider lock");
+    const bytes = fs.readFileSync(quarantine);
+    if (lockPidFromBytes(bytes) !== inspected.pid || processInspect.pidAlive(inspected.pid, kill)) {
+      throw new Error(TARGET_BUSY);
+    }
+  } finally {
+    try { fs.unlinkSync(quarantine); } catch { /* quarantine is not the live lock path */ }
+    fsyncDirectory(path.dirname(file));
+  }
 }
 function isKnownSystemSymlink(value: string): boolean {
   return value === "/tmp" || value === "/private/tmp" || value === "/var" || value === "/private/var"
@@ -193,7 +279,7 @@ export function preparePiProfileMigration(env: NodeJS.ProcessEnv, configDir: str
   const sourceDirectoryState = assertDirectory(sourceDir, "external Pi profile") as fs.Stats;
   const sourceExecutable = sourceVersion(env, sourceDir);
   const sourceFiles = Object.fromEntries(FILES.map((name) => {
-    const file = readRegular(path.join(sourceDir, name), `external Pi ${name}`);
+    const file = readRegular(path.join(sourceDir, name), `external Pi ${name}`, false);
     if (!file) throw new Error(`external Pi ${name} is required`);
     if (name === "auth.json" && file.mode !== 0o600) throw new Error("external Pi auth.json has an unsafe mode");
     if (name !== "auth.json" && !SOURCE_MODES.has(file.mode)) throw new Error(`external Pi ${name} has an unsafe mode`);

--- a/src/setup/setup-bind.ts
+++ b/src/setup/setup-bind.ts
@@ -10,7 +10,17 @@ import { fileURLToPath } from "node:url";
 import { isWindows } from "../platform/secure-metadata.js";
 import { TargetRootLayout } from "../platform/root-layout.js";
 import { planSingleRootBinding, type StoredConfig } from "./setup-binding.js";
-import { configureBuiltinPiProviderModel, type BuiltinPiProviderSetupSelection } from "../runtime/pi-provider-config.js";
+import { configureBuiltinPiProviderModel, piAgentDirectory, type BuiltinPiProviderSetupSelection } from "../runtime/pi-provider-config.js";
+import {
+  applyPiProfileMigration,
+  clearStalePiProfileMigrationLock,
+  preparePiProfileMigration,
+  releasePiProfileMigrationLock,
+  rollbackPiProfileMigration,
+  type PiProfileMigrationPlan,
+} from "../runtime/pi-profile-migration.js";
+import { discoverPiModelCatalog } from "../runtime/pi-model-catalog.js";
+import { calculatePiCompactionSettings } from "../runtime/pi-compaction-recovery.js";
 import { terminalSetupQuestioner, type OfficialPiAuthSelection, type SetupAgentChoice } from "./setup-agent-choice.js";
 import {
   beginBuiltinPiCredentialTransaction,
@@ -257,6 +267,30 @@ function fabricateAttachment(root: string, serverId: string): void {
   fs.writeFileSync(file, JSON.stringify(attachment, null, 2), { mode: 0o600 });
 }
 
+function catalogModelsFromError(error: unknown): string[] {
+  if (!error || typeof error !== "object" || !("catalogModels" in error)) return [];
+  const models = (error as { catalogModels?: unknown }).catalogModels;
+  return Array.isArray(models) ? models.filter((id): id is string => typeof id === "string" && id.length > 0) : [];
+}
+
+function formatExternalPiSetupFailure(error: unknown, options: { agentExisted: boolean }): string {
+  const original = (error instanceof Error ? error.message : String(error)).replace(/[\r\n]+/g, " ").trim();
+  const alternatives = catalogModelsFromError(error);
+  const parts: string[] = [];
+  if (/external Pi (?:auth\.json|models\.json|settings\.json) is required|external Pi profile|external Pi auth\.json has an unsafe mode|external Pi models\.json has an unsafe mode|external Pi settings\.json has an unsafe mode/.test(original)) {
+    parts.push("external-pi requires the official file-backed Pi profile containing auth.json (0600), models.json, and settings.json, normally after `pi` login and default-model selection. Environment-variable-only credentials are unsupported.");
+  }
+  if (original) parts.push(original);
+  parts.push("Fix the official `pi` login and default model, then rerun `larkin setup --runtime external-pi`.");
+  if (options.agentExisted) {
+    parts.push("This Agent already exists; after a successful setup you can switch models with `larkin model <provider>/<model>`.");
+  }
+  if (alternatives.length) {
+    parts.push(`Alternative models that report a context window: ${alternatives.join(", ")}.`);
+  }
+  return parts.join(" ");
+}
+
 function safeProviderFailure(error: unknown): Error {
   const message = error instanceof Error ? error.message : String(error);
   if (/\b(?:401|403)\b|unauth|invalid.*(?:key|token)|credential/i.test(message)) {
@@ -329,48 +363,84 @@ export async function main(): Promise<void> {
   validateRuntime(runtime);
   const defaultModel = larkinConfig.defaultModelFor(runtime);
   const selectedModel = selection?.runtime === "pi" && selection.distribution === "builtin" ? selection.model : undefined;
-  const targetModelId = selectedModel || (prior?.runtime === runtime ? prior.model : defaultModel);
-  let runtimeModels = larkinConfig.loadRuntimeModels()[runtime];
-  if (runtime === "pi") {
-    const preservedEffort = prior?.runtime === "pi" && typeof prior.effort === "string" && prior.effort.trim()
-      ? [prior.effort]
-      : [];
-    runtimeModels = [{ id: targetModelId, supportedReasoningEfforts: preservedEffort }];
-  }
-  const targetModel = runtimeModels.find((model) => model.id === targetModelId);
-  if (!targetModel) die(`目标模型 ${runtime}/${targetModelId} 不在 runtime 模型目录中；未修改 Agent 配置`);
-  const stored = planSingleRootBinding({
-    config: larkinConfig.toStored(config),
-    profile,
-    requestedAgent,
-    runtime: selection?.runtime || options.runtime,
-    ...(runtime === "pi" && piDistribution ? { piDistribution } : {}),
-    ...(selectedModel ? { model: selectedModel } : {}),
-    defaultModel,
-    supportedReasoningEfforts: targetModel!.supportedReasoningEfforts || [],
-    now: new Date().toISOString(),
-  });
-  const bound = stored.agents[profile.appId];
-
-  fs.mkdirSync(CFG_DIR, { recursive: true });
+  let targetModelId = selectedModel || (prior?.runtime === runtime ? prior.model : defaultModel);
+  let resolvedExternalModel: string | undefined;
+  let pendingMigration: PiProfileMigrationPlan | null = null;
+  let setupConfigCommitted = false;
   let providerTransaction: ReturnType<typeof beginBuiltinPiCredentialTransaction> | null = null;
   let providerPublished = false;
-  const authAlreadyCompleted = selection?.runtime === "pi" && selection.distribution === "builtin"
-    && (selection as SetupAgentChoice & { authCompleted?: true }).authCompleted === true;
-  const readinessAlreadyCompleted = authAlreadyCompleted
-    && (selection as SetupAgentChoice & { readinessCompleted?: true }).readinessCompleted === true;
   const authAbort = new AbortController();
-  const cancelProviderTransaction = (signal: NodeJS.Signals): void => {
+  const cancelOnSignal = (signal: NodeJS.Signals): void => {
     authAbort.abort();
+    if (!setupConfigCommitted && pendingMigration) {
+      try { rollbackPiProfileMigration(pendingMigration.state); } catch { /* best effort */ }
+    }
     if (!providerPublished) providerTransaction?.rollback();
     process.exit(signal === "SIGINT" ? 130 : 143);
   };
-  const onSigint = (): void => cancelProviderTransaction("SIGINT");
-  const onSigterm = (): void => cancelProviderTransaction("SIGTERM");
+  const onSigint = (): void => cancelOnSignal("SIGINT");
+  const onSigterm = (): void => cancelOnSignal("SIGTERM");
   process.once("SIGINT", onSigint);
   process.once("SIGTERM", onSigterm);
+  let runtimeModels = larkinConfig.loadRuntimeModels()[runtime];
   let authQuestioner: ReturnType<typeof terminalSetupQuestioner> | null = null;
   try {
+    if (runtime === "pi" && piDistribution === "external" && targetModelId === "default") {
+      fs.mkdirSync(CFG_DIR, { recursive: true, mode: 0o700 });
+      try {
+        clearStalePiProfileMigrationLock(CFG_DIR, profile.appId);
+        const plan = preparePiProfileMigration(process.env, CFG_DIR, profile.appId, "external");
+        pendingMigration = plan;
+        applyPiProfileMigration(plan);
+        const catalog = await discoverPiModelCatalog({
+          cwd: CFG_DIR,
+          agentDir: piAgentDirectory(CFG_DIR, profile.appId),
+          env: process.env,
+        });
+        const effective = catalog.effectiveModel;
+        const entry = effective ? catalog.models.find((model) => model.id === effective) : undefined;
+        if (!effective || !entry) {
+          throw new Error("Pi official default resolution returned an unavailable model");
+        }
+        if (!entry.contextWindow) {
+          const alternatives = catalog.models
+            .filter((model) => Number.isFinite(model.contextWindow) && Number(model.contextWindow) > 0)
+            .map((model) => model.id);
+          throw Object.assign(new Error("Pi effective model is missing a context window"), { catalogModels: alternatives });
+        }
+        calculatePiCompactionSettings(entry.contextWindow);
+        targetModelId = effective;
+        resolvedExternalModel = effective;
+        runtimeModels = [{ id: effective, supportedReasoningEfforts: entry.supportedReasoningEfforts }];
+      } catch (error) {
+        throw new Error(formatExternalPiSetupFailure(error, { agentExisted: Boolean(prior) }));
+      }
+    } else if (runtime === "pi") {
+      const preservedEffort = prior?.runtime === "pi" && typeof prior.effort === "string" && prior.effort.trim()
+        ? [prior.effort]
+        : [];
+      runtimeModels = [{ id: targetModelId, supportedReasoningEfforts: preservedEffort }];
+    }
+    const targetModel = runtimeModels.find((model) => model.id === targetModelId);
+    if (!targetModel) throw new Error(`目标模型 ${runtime}/${targetModelId} 不在 runtime 模型目录中；未修改 Agent 配置`);
+    const stored = planSingleRootBinding({
+      config: larkinConfig.toStored(config),
+      profile,
+      requestedAgent,
+      runtime: selection?.runtime || options.runtime,
+      ...(runtime === "pi" && piDistribution ? { piDistribution } : {}),
+      ...(selectedModel || resolvedExternalModel ? { model: selectedModel || resolvedExternalModel } : {}),
+      defaultModel,
+      supportedReasoningEfforts: targetModel!.supportedReasoningEfforts || [],
+      now: new Date().toISOString(),
+    });
+    const bound = stored.agents[profile.appId];
+
+    fs.mkdirSync(CFG_DIR, { recursive: true });
+    const authAlreadyCompleted = selection?.runtime === "pi" && selection.distribution === "builtin"
+      && (selection as SetupAgentChoice & { authCompleted?: true }).authCompleted === true;
+    const readinessAlreadyCompleted = authAlreadyCompleted
+      && (selection as SetupAgentChoice & { readinessCompleted?: true }).readinessCompleted === true;
     providerTransaction = selection?.runtime === "pi" && selection.distribution === "builtin"
       && !authAlreadyCompleted ? beginBuiltinPiCredentialTransaction(CFG_DIR, profile.appId)
       : null;
@@ -405,9 +475,28 @@ export async function main(): Promise<void> {
       }
     }
     larkinConfig.commitSetupConfig(process.env, loaded.revision, stored);
+    setupConfigCommitted = true;
     providerTransaction?.commit();
     providerPublished = true;
+    if (pendingMigration) {
+      try { releasePiProfileMigrationLock(pendingMigration.state); }
+      catch { /* post-commit lock release is best-effort; do not roll back credentials */ }
+      pendingMigration = null;
+    }
+    fabricateAttachment(layout.root, stored.serverId);
+    say(`\n✓ 已写配置: ${CFG_FILE}`);
+    say(`  agent=${profile.appId}  runtime=${bound.runtime}  model=${bound.model}`);
+    say(`  单服务 serverId=${stored.serverId}  larkinHome=${layout.root}`);
+    say("\n启动这个 Agent：");
+    say("  larkin start                     # 单服务启动全部已配置 Agent");
+    say(`  larkin start --agent ${profile.appId}  # 仅调试这个 Agent`);
+    say("创建独立飞书（Lark）机器人 + Agent：");
+    say("  larkin setup");
   } catch (error) {
+    if (!setupConfigCommitted && pendingMigration) {
+      try { rollbackPiProfileMigration(pendingMigration.state); } catch { /* best effort */ }
+      pendingMigration = null;
+    }
     providerTransaction?.rollback();
     throw error;
   } finally {
@@ -415,16 +504,6 @@ export async function main(): Promise<void> {
     process.off("SIGINT", onSigint);
     process.off("SIGTERM", onSigterm);
   }
-  fabricateAttachment(layout.root, stored.serverId);
-
-  say(`\n✓ 已写配置: ${CFG_FILE}`);
-  say(`  agent=${profile.appId}  runtime=${bound.runtime}  model=${bound.model}`);
-  say(`  单服务 serverId=${stored.serverId}  larkinHome=${layout.root}`);
-  say("\n启动这个 Agent：");
-  say("  larkin start                     # 单服务启动全部已配置 Agent");
-  say(`  larkin start --agent ${profile.appId}  # 仅调试这个 Agent`);
-  say("创建独立飞书（Lark）机器人 + Agent：");
-  say("  larkin setup");
 }
 
 if (path.resolve(process.argv[1] || "") === path.resolve(fileURLToPath(import.meta.url))) {

--- a/test/integration/setup/external-pi-setup-hot-attach.test.mjs
+++ b/test/integration/setup/external-pi-setup-hot-attach.test.mjs
@@ -1,0 +1,240 @@
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { test } from "bun:test";
+import { fileURLToPath, pathToFileURL } from "node:url";
+
+const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..", "..", "..");
+const BIND = path.join(ROOT, "dist/setup/setup-bind.mjs");
+const APP = "cli_extPiHotA1";
+
+function writeOfficialLarkCliStub(root, profiles = [{ name: APP, appId: APP, active: true }]) {
+  const pkg = path.join(root, "official-cli");
+  const binDir = path.join(pkg, "bin");
+  fs.mkdirSync(binDir, { recursive: true });
+  fs.writeFileSync(path.join(pkg, "package.json"), JSON.stringify({
+    name: "@larksuite/cli",
+    version: "1.0.87",
+    bin: { "lark-cli": "bin/lark-cli" },
+  }));
+  fs.writeFileSync(path.join(binDir, "lark-cli"), `#!/usr/bin/env bun
+const args = process.argv.slice(2);
+if (args[0] === "--version") { console.log("1.0.87"); process.exit(0); }
+if (args[0] === "config" && args[1] === "bind" && args[2] === "--help") {
+  console.log("Usage: config bind --source lark-channel --identity bot-only");
+  process.exit(0);
+}
+if (args[0] === "profile" && args[1] === "list") {
+  console.log(JSON.stringify(${JSON.stringify(profiles)}));
+  process.exit(0);
+}
+console.log(JSON.stringify({ ok: true, identity: "bot", data: { chats: [] } }));
+`, { mode: 0o755 });
+  return binDir;
+}
+
+function writeCredential(root, appId = APP) {
+  const botsDir = path.join(root, "bots");
+  fs.mkdirSync(botsDir, { recursive: true, mode: 0o700 });
+  fs.chmodSync(botsDir, 0o700);
+  const file = path.join(botsDir, `${appId}.json`);
+  fs.writeFileSync(file, `${JSON.stringify({
+    appId,
+    appSecret: "secret-value",
+    tenant: "feishu",
+  }, null, 2)}\n`, { mode: 0o600 });
+  return file;
+}
+
+function writeExternalPiProfile(home) {
+  const dir = path.join(home, ".pi", "agent");
+  fs.mkdirSync(dir, { recursive: true, mode: 0o755 });
+  const auth = Buffer.from('{"fixture":{"type":"api_key","key":"PRIVATE_FIXTURE_SECRET"}}\n');
+  const models = Buffer.from('{"providers":{"fixture":{"models":[{"id":"pi-fixture","contextWindow":32000}]}}}\n');
+  const settings = Buffer.from('{"theme":"dark","packages":{"enabled":true}}\n');
+  fs.writeFileSync(path.join(dir, "auth.json"), auth, { mode: 0o600 });
+  fs.writeFileSync(path.join(dir, "models.json"), models, { mode: 0o644 });
+  fs.writeFileSync(path.join(dir, "settings.json"), settings, { mode: 0o644 });
+  return { dir, auth, models, settings };
+}
+
+function writeFakePi(root, { missingWindow = false } = {}) {
+  const command = path.join(root, "fake-pi");
+  const marker = path.join(root, "fake-pi-marker.ndjson");
+  fs.writeFileSync(marker, "");
+  fs.writeFileSync(command, `#!${process.execPath}
+import fs from "node:fs";
+const marker = ${JSON.stringify(marker)};
+const args = process.argv.slice(2);
+fs.appendFileSync(marker, JSON.stringify({
+  args, cwd: process.cwd(), agentDir: process.env.PI_CODING_AGENT_DIR || null,
+}) + "\\n");
+if (args.includes("--version")) { process.stdout.write("0.84.2\\n"); process.exit(0); }
+const missingWindow = ${missingWindow ? "true" : "false"};
+const effective = { provider: "fixture", id: "pi-fixture", reasoning: false, ...(missingWindow ? {} : { contextWindow: 32000 }) };
+const windowed = { provider: "fixture", id: "pi-windowed", reasoning: false, contextWindow: 32000 };
+const respond = (request, data) => process.stdout.write(JSON.stringify({
+  type: "response", id: request.id, command: request.type, success: true, data,
+}) + "\\n");
+let buffer = "";
+process.stdin.on("data", (chunk) => {
+  buffer += chunk.toString();
+  while (true) {
+    const newline = buffer.indexOf("\\n");
+    if (newline < 0) break;
+    const line = buffer.slice(0, newline); buffer = buffer.slice(newline + 1);
+    if (!line.trim()) continue;
+    const request = JSON.parse(line);
+    if (request.type === "get_state") respond(request, {
+      sessionId: "fixture-session",
+      model: effective,
+      thinkingLevel: "off",
+      isStreaming: false,
+      autoCompactionEnabled: true,
+      compactionCapabilities: {
+        reserveTokens: 4800,
+        keepRecentTokens: 20000,
+        events: ["compaction_start", "compaction_end", "agent_end", "agent_settled"],
+      },
+    });
+    else if (request.type === "get_available_models") respond(request, {
+      models: missingWindow ? [effective, windowed] : [effective],
+    });
+    else respond(request, {});
+  }
+});
+`, { mode: 0o700 });
+  fs.chmodSync(command, 0o700);
+  return { command, marker };
+}
+
+function readLaunches(marker) {
+  return fs.readFileSync(marker, "utf8").trim().split("\n").filter(Boolean).map(JSON.parse);
+}
+
+function runBind(root, extraEnv = {}, args = ["--profile", APP, "--agent", APP, "--runtime", "pi", "--yes"]) {
+  const binDir = writeOfficialLarkCliStub(root);
+  const env = {
+    ...process.env,
+    HOME: path.join(root, "home"),
+    LARKIN_CONFIG_DIR: root,
+    PATH: `${binDir}${path.delimiter}${process.env.PATH}`,
+    ...extraEnv,
+  };
+  delete env.PI_CODING_AGENT_DIR;
+  return spawnSync(process.execPath, [BIND, ...args], {
+    cwd: ROOT,
+    encoding: "utf8",
+    env,
+  });
+}
+
+function resultFiles(root) {
+  return fs.readdirSync(root).filter((name) => /^\.setup-result-\d+\.json$/.test(name));
+}
+
+test("external-pi setup failure keeps the bot credential, leaves config untouched, and does not upsert", () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "larkin-external-pi-hot-fail-"));
+  try {
+    const configFile = path.join(root, "config.json");
+    const before = `${JSON.stringify({ version: 3, serverId: "server-existing", activeAgent: null, agents: {} }, null, 2)}\n`;
+    fs.writeFileSync(configFile, before, { mode: 0o600 });
+    const botFile = writeCredential(root);
+    const botBefore = fs.readFileSync(botFile);
+    writeExternalPiProfile(path.join(root, "home"));
+    const fake = writeFakePi(root, { missingWindow: true });
+    const result = runBind(root, { LARKIN_PI_COMMAND: fake.command });
+    assert.notEqual(result.status, 0, result.stdout + result.stderr);
+    assert.equal(fs.readFileSync(configFile, "utf8"), before);
+    assert.deepEqual(fs.readFileSync(botFile), botBefore);
+    assert.equal(fs.existsSync(path.join(root, "providers", "pi", APP)), false);
+    assert.deepEqual(resultFiles(root), []);
+    assert.equal(fs.existsSync(path.join(root, "control")), false);
+    assert.match(`${result.stdout}\n${result.stderr}`, /larkin setup --runtime external-pi/);
+    assert.doesNotMatch(`${result.stdout}\n${result.stderr}`, /larkin model/);
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("rerunning external-pi setup repairs model=default and hot-attach uses the imported owned profile", async () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "larkin-external-pi-hot-attach-"));
+  try {
+    const configFile = path.join(root, "config.json");
+    fs.writeFileSync(configFile, `${JSON.stringify({
+      version: 4,
+      serverId: "server-existing",
+      mentionPolicy: "require",
+      activeAgent: APP,
+      agents: {
+        [APP]: { runtime: "pi", model: "default", piDistribution: "external" },
+      },
+    }, null, 2)}\n`, { mode: 0o600 });
+    writeCredential(root);
+    const profile = writeExternalPiProfile(path.join(root, "home"));
+    const fake = writeFakePi(root);
+    const result = runBind(root, { LARKIN_PI_COMMAND: fake.command });
+    assert.equal(result.status, 0, result.stdout + result.stderr);
+    const stored = JSON.parse(fs.readFileSync(configFile, "utf8"));
+    assert.equal(stored.agents[APP].model, "fixture/pi-fixture");
+    assert.deepEqual(resultFiles(root), []);
+    const ownedDir = path.join(root, "providers", "pi", APP);
+    assert.deepEqual(fs.readFileSync(path.join(ownedDir, "auth.json")), profile.auth);
+    assert.deepEqual(fs.readFileSync(path.join(profile.dir, "auth.json")), profile.auth);
+
+    const adapters = await import(pathToFileURL(path.join(ROOT, "dist/runtime/runtime-adapters.mjs")).href);
+    const compaction = await import(pathToFileURL(path.join(ROOT, "dist/runtime/pi-compaction-recovery.mjs")).href);
+    const workspaceDir = path.join(root, "workspace");
+    const stateDir = path.join(root, "state");
+    fs.mkdirSync(workspaceDir, { recursive: true, mode: 0o700 });
+    fs.mkdirSync(stateDir, { recursive: true, mode: 0o700 });
+    fs.writeFileSync(fake.marker, "");
+    const adapter = adapters.createNativeRuntimeAdapter("pi", {
+      piCommand: fake.command,
+      env: {
+        LARKIN_CONFIG_DIR: root,
+        LARKIN_PI_COMMAND: fake.command,
+        LARKIN_PI_DISTRIBUTION: "external",
+        HOME: path.join(root, "home"),
+      },
+      resolvePiProcessExtensionArgs: () => [],
+      piRpcClientOptions: { requestTimeoutMs: 3_000, shutdownGraceMs: 100 },
+    });
+    const session = await adapter.createSession({
+      agentId: APP,
+      workspaceDir,
+      stateDir,
+      model: stored.agents[APP].model,
+      standingPrompt: { version: "fixture", content: "standing", hash: "fixture" },
+      env: { LARKIN_CONFIG_DIR: root, LARKIN_PI_DISTRIBUTION: "external" },
+    });
+    try {
+      const launches = readLaunches(fake.marker);
+      assert.equal(launches.some((row) => row.args.includes("--version")), true, JSON.stringify(launches));
+      const isolated = launches.find((row) => row.args.includes("--no-session") && row.args.includes("--no-extensions"));
+      assert.ok(isolated, JSON.stringify(launches));
+      assert.equal(isolated.args.includes("--model"), true);
+      assert.equal(isolated.args[isolated.args.indexOf("--model") + 1], "fixture/pi-fixture");
+      const sessionLaunch = launches.find((row) => row.args.includes("--session-dir"));
+      assert.ok(sessionLaunch, JSON.stringify(launches));
+      assert.equal(sessionLaunch.args.includes("--model"), true);
+      assert.equal(sessionLaunch.args[sessionLaunch.args.indexOf("--model") + 1], "fixture/pi-fixture");
+      assert.equal(sessionLaunch.agentDir, ownedDir);
+      assert.equal(isolated.agentDir, ownedDir);
+      assert.equal(fs.existsSync(path.join(ownedDir, "auth.json")), true);
+      const expected = compaction.calculatePiCompactionSettings(32_000);
+      const ownedSettings = JSON.parse(fs.readFileSync(path.join(ownedDir, "settings.json"), "utf8"));
+      assert.deepEqual(ownedSettings.compaction, {
+        enabled: true,
+        reserveTokens: expected.reserveTokens,
+        keepRecentTokens: expected.keepRecentTokens,
+      });
+    } finally {
+      await session.close("external-pi hot-attach test complete").catch(() => {});
+    }
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});

--- a/test/unit/runtime/pi-profile-migration.test.mjs
+++ b/test/unit/runtime/pi-profile-migration.test.mjs
@@ -1,4 +1,5 @@
 import assert from "node:assert/strict";
+import { spawn } from "node:child_process";
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
@@ -197,5 +198,118 @@ test("refuses target content or mode tampering during rollback", () => {
       fs.chmodSync(path.join(second.targetDir, "models.json"), 0o644);
       assert.throws(() => migration.rollbackPiProfileMigration(secondPlan.state), /changed/);
     } finally { clean(second); }
+  } finally { clean(f); }
+});
+
+function lockPath(config, agent) {
+  return path.join(config, "providers", "pi", `${agent}.larkin-pi-import.lock`);
+}
+
+function writeLock(config, agent, body, mode = 0o600) {
+  const file = lockPath(config, agent);
+  fs.mkdirSync(path.dirname(file), { recursive: true, mode: 0o700 });
+  fs.writeFileSync(file, body, { mode });
+  fs.chmodSync(file, mode);
+  return file;
+}
+
+async function deadPid() {
+  const child = spawn(process.execPath, ["-e", "setInterval(() => {}, 1000)"], { stdio: "ignore" });
+  const pid = child.pid;
+  assert.equal(typeof pid, "number");
+  child.kill("SIGKILL");
+  await new Promise((resolve) => child.once("exit", resolve));
+  return pid;
+}
+
+test("reclaims a stale lock whose recorded pid is dead", async () => {
+  const f = fixture();
+  try {
+    const file = writeLock(f.config, f.agent, `${await deadPid()}\n`);
+    migration.clearStalePiProfileMigrationLock(f.config, f.agent);
+    assert.equal(fs.existsSync(file), false);
+  } finally { clean(f); }
+});
+
+test("refuses to reclaim a lock owned by the current live pid", () => {
+  const f = fixture();
+  try {
+    const file = writeLock(f.config, f.agent, `${process.pid}\n`);
+    assert.throws(() => migration.clearStalePiProfileMigrationLock(f.config, f.agent), /Pi provider target is busy/);
+    assert.equal(fs.existsSync(file), true);
+  } finally { clean(f); }
+});
+
+test("treats EPERM as a possibly live lock and refuses reclaim", async () => {
+  const f = fixture();
+  try {
+    const file = writeLock(f.config, f.agent, `${await deadPid()}\n`);
+    const kill = () => {
+      const error = new Error("EPERM");
+      error.code = "EPERM";
+      throw error;
+    };
+    assert.throws(() => migration.clearStalePiProfileMigrationLock(f.config, f.agent, { kill }), /Pi provider target is busy/);
+    assert.equal(fs.existsSync(file), true);
+  } finally { clean(f); }
+});
+
+test("refuses malformed lock pid lines", () => {
+  const f = fixture();
+  try {
+    for (const body of ["", "not-a-pid\n", "0\n", "-3\n", "12\n34\n", "12 34\n"]) {
+      const file = writeLock(f.config, f.agent, body);
+      assert.throws(() => migration.clearStalePiProfileMigrationLock(f.config, f.agent), /Pi provider target is busy/, body);
+      assert.equal(fs.existsSync(file), true, body);
+    }
+  } finally { clean(f); }
+});
+
+test("refuses symlink or hardlinked lock metadata", async () => {
+  const f = fixture();
+  try {
+    const pid = await deadPid();
+    const file = lockPath(f.config, f.agent);
+    fs.mkdirSync(path.dirname(file), { recursive: true, mode: 0o700 });
+    const target = path.join(f.config, "providers", "pi", "lock-target");
+    fs.writeFileSync(target, `${pid}\n`, { mode: 0o600 });
+    fs.symlinkSync(target, file);
+    assert.throws(() => migration.clearStalePiProfileMigrationLock(f.config, f.agent), /Pi provider target is busy/);
+    fs.unlinkSync(file);
+    writeLock(f.config, f.agent, `${pid}\n`, 0o644);
+    assert.throws(() => migration.clearStalePiProfileMigrationLock(f.config, f.agent), /Pi provider target is busy/);
+    fs.unlinkSync(file);
+    writeLock(f.config, f.agent, `${pid}\n`);
+    fs.linkSync(file, `${file}.hard`);
+    assert.throws(() => migration.clearStalePiProfileMigrationLock(f.config, f.agent), /Pi provider target is busy/);
+  } finally { clean(f); }
+});
+
+test("concurrent stale-lock reclaimers leave the lock path empty without stealing a live lock", async () => {
+  const f = fixture();
+  try {
+    const file = writeLock(f.config, f.agent, `${await deadPid()}\n`);
+    const script = path.join(f.root, "reclaim.mjs");
+    fs.writeFileSync(script, `import { pathToFileURL } from "node:url";
+const migration = await import(pathToFileURL(${JSON.stringify(path.join(ROOT, "dist/runtime/pi-profile-migration.mjs"))}).href);
+try {
+  migration.clearStalePiProfileMigrationLock(process.env.LOCK_CONFIG, process.env.LOCK_AGENT);
+  process.stdout.write("ok\\n");
+} catch (error) {
+  process.stdout.write(String(error && error.message || error) + "\\n");
+  process.exit(2);
+}
+`);
+    const env = { ...process.env, LOCK_CONFIG: f.config, LOCK_AGENT: f.agent };
+    const first = spawn(process.execPath, [script], { env, encoding: "utf8" });
+    const second = spawn(process.execPath, [script], { env, encoding: "utf8" });
+    const results = await Promise.all([first, second].map((child) => new Promise((resolve) => {
+      let stdout = ""; let stderr = "";
+      child.stdout.on("data", (chunk) => { stdout += chunk; });
+      child.stderr.on("data", (chunk) => { stderr += chunk; });
+      child.once("exit", (status) => resolve({ status, stdout, stderr }));
+    })));
+    assert.equal(results.every((result) => result.status === 0 && result.stdout.includes("ok")), true, JSON.stringify(results));
+    assert.equal(fs.existsSync(file), false);
   } finally { clean(f); }
 });

--- a/test/unit/setup/setup-bind-typescript.test.mjs
+++ b/test/unit/setup/setup-bind-typescript.test.mjs
@@ -45,6 +45,67 @@ console.log(JSON.stringify({ ok: true, identity: "bot", data: { chats: [] } }));
   return binDir;
 }
 
+function writeExternalPiProfile(home, omit) {
+  const dir = path.join(home, ".pi", "agent");
+  fs.mkdirSync(dir, { recursive: true, mode: 0o755 });
+  const auth = Buffer.from('{"fixture":{"type":"api_key","key":"PRIVATE_FIXTURE_SECRET"}}\n');
+  const models = Buffer.from('{"providers":{"fixture":{"models":[{"id":"pi-fixture","contextWindow":32000}]}}}\n');
+  const settings = Buffer.from('{"theme":"dark","packages":{"enabled":true}}\n');
+  if (omit !== "auth.json") fs.writeFileSync(path.join(dir, "auth.json"), auth, { mode: 0o600 });
+  if (omit !== "models.json") fs.writeFileSync(path.join(dir, "models.json"), models, { mode: 0o644 });
+  if (omit !== "settings.json") fs.writeFileSync(path.join(dir, "settings.json"), settings, { mode: 0o644 });
+  return { dir, auth, models, settings };
+}
+
+function writeFakePi(root, { missingWindow = false } = {}) {
+  const command = path.join(root, "fake-pi");
+  const marker = path.join(root, "fake-pi-marker.ndjson");
+  fs.writeFileSync(marker, "");
+  fs.writeFileSync(command, `#!${process.execPath}
+import fs from "node:fs";
+const marker = ${JSON.stringify(marker)};
+const args = process.argv.slice(2);
+fs.appendFileSync(marker, JSON.stringify({ args, cwd: process.cwd(), agentDir: process.env.PI_CODING_AGENT_DIR || null }) + "\\n");
+if (args.includes("--version")) { process.stdout.write("0.84.2\\n"); process.exit(0); }
+const missingWindow = ${missingWindow ? "true" : "false"};
+const effective = { provider: "fixture", id: "pi-fixture", reasoning: false, ...(missingWindow ? {} : { contextWindow: 32000 }) };
+const windowed = { provider: "fixture", id: "pi-windowed", reasoning: false, contextWindow: 32000 };
+const respond = (request, data) => process.stdout.write(JSON.stringify({ type: "response", id: request.id, command: request.type, success: true, data }) + "\\n");
+let buffer = "";
+process.stdin.on("data", (chunk) => {
+  buffer += chunk.toString();
+  while (true) {
+    const newline = buffer.indexOf("\\n");
+    if (newline < 0) break;
+    const line = buffer.slice(0, newline); buffer = buffer.slice(newline + 1);
+    if (!line.trim()) continue;
+    const request = JSON.parse(line);
+    if (request.type === "get_state") respond(request, {
+      model: effective, thinkingLevel: "off", isStreaming: false, autoCompactionEnabled: true,
+      compactionCapabilities: { reserveTokens: 4800, keepRecentTokens: 20000,
+        events: ["compaction_start", "compaction_end", "agent_end", "agent_settled"] },
+    });
+    else if (request.type === "get_available_models") respond(request, { models: missingWindow ? [effective, windowed] : [effective] });
+    else respond(request, {});
+  }
+});
+`, { mode: 0o700 });
+  fs.chmodSync(command, 0o700);
+  return { command, marker };
+}
+
+function writeSentinelPi(root) {
+  const command = path.join(root, "sentinel-pi");
+  const marker = path.join(root, "sentinel-pi-marker");
+  fs.writeFileSync(command, `#!${process.execPath}
+import fs from "node:fs";
+fs.appendFileSync(${JSON.stringify(marker)}, "spawned\\n");
+process.exit(1);
+`, { mode: 0o700 });
+  fs.chmodSync(command, 0o700);
+  return { command, marker };
+}
+
 function writeCredential(root, appId = APP) {
   const botsDir = path.join(root, "bots");
   fs.mkdirSync(botsDir, { recursive: true, mode: 0o700 });
@@ -58,16 +119,18 @@ function writeCredential(root, appId = APP) {
 
 function runBind(root, extraEnv = {}, args = ["--profile", APP, "--agent", APP, "--runtime", "codex", "--yes"]) {
   const binDir = writeOfficialLarkCliStub(root);
+  const env = {
+    ...process.env,
+    HOME: path.join(root, "home"),
+    LARKIN_CONFIG_DIR: root,
+    PATH: `${binDir}${path.delimiter}${process.env.PATH}`,
+    ...extraEnv,
+  };
+  delete env.PI_CODING_AGENT_DIR;
   return spawnSync(process.execPath, [ENTRY, ...args], {
     cwd: ROOT,
     encoding: "utf8",
-    env: {
-      ...process.env,
-      HOME: path.join(root, "home"),
-      LARKIN_CONFIG_DIR: root,
-      PATH: `${binDir}${path.delimiter}${process.env.PATH}`,
-      ...extraEnv,
-    },
+    env,
   });
 }
 
@@ -167,12 +230,13 @@ test("Pi rebind keeps a previously stored effort without spawning pi catalog", (
       },
     }, null, 2)}\n`, { mode: 0o600 });
     writeCredential(root);
-    const result = runBind(root, {}, ["--profile", APP, "--agent", APP, "--runtime", "pi", "--yes"]);
+    const sentinel = writeSentinelPi(root);
+    const result = runBind(root, { LARKIN_PI_COMMAND: sentinel.command }, ["--profile", APP, "--agent", APP, "--runtime", "pi", "--yes"]);
     assert.equal(result.status, 0, result.stdout + result.stderr);
     const stored = JSON.parse(fs.readFileSync(configFile, "utf8"));
     assert.equal(stored.agents[APP].runtime, "pi");
     assert.equal(stored.agents[APP].effort, "high");
-    assert.doesNotMatch(`${result.stdout}\n${result.stderr}`, /--mode rpc|discoverPiModelCatalog/);
+    assert.equal(fs.existsSync(sentinel.marker), false);
   } finally {
     fs.rmSync(root, { recursive: true, force: true });
   }
@@ -192,10 +256,14 @@ test("switching a Codex agent to Pi does not carry Codex effort into the Pi cata
       },
     }, null, 2)}\n`, { mode: 0o600 });
     writeCredential(root);
-    const result = runBind(root, {}, ["--profile", APP, "--agent", APP, "--runtime", "pi", "--yes"]);
+    const home = path.join(root, "home");
+    writeExternalPiProfile(home);
+    const fake = writeFakePi(root);
+    const result = runBind(root, { LARKIN_PI_COMMAND: fake.command }, ["--profile", APP, "--agent", APP, "--runtime", "pi", "--yes"]);
     assert.equal(result.status, 0, result.stdout + result.stderr);
     const stored = JSON.parse(fs.readFileSync(configFile, "utf8"));
     assert.equal(stored.agents[APP].runtime, "pi");
+    assert.equal(stored.agents[APP].model, "fixture/pi-fixture");
     assert.equal(Object.hasOwn(stored.agents[APP], "effort"), false);
   } finally {
     fs.rmSync(root, { recursive: true, force: true });
@@ -235,6 +303,137 @@ test("successful binding writes one stable 0600 runner attachment and no workspa
     assert.equal(fs.readFileSync(attachmentFile, "utf8"), before, "same server must reuse its attachment");
     const workspace = path.join(root, "agents", APP);
     assert.equal(fs.existsSync(workspace) && fs.lstatSync(workspace).isSymbolicLink(), false);
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("external-pi setup imports the official profile and stores the concrete catalog model", () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "larkin-setup-bind-external-pi-"));
+  try {
+    const configFile = path.join(root, "config.json");
+    fs.writeFileSync(configFile, `${JSON.stringify({ version: 3, serverId: "server-existing", activeAgent: null, agents: {} }, null, 2)}\n`, { mode: 0o600 });
+    writeCredential(root);
+    const home = path.join(root, "home");
+    const profile = writeExternalPiProfile(home);
+    const fake = writeFakePi(root);
+    const result = runBind(root, { LARKIN_PI_COMMAND: fake.command }, ["--profile", APP, "--agent", APP, "--runtime", "pi", "--yes"]);
+    assert.equal(result.status, 0, result.stdout + result.stderr);
+    const stored = JSON.parse(fs.readFileSync(configFile, "utf8"));
+    assert.equal(stored.agents[APP].runtime, "pi");
+    assert.equal(stored.agents[APP].model, "fixture/pi-fixture");
+    assert.equal(stored.agents[APP].piDistribution, "external");
+    const ownedAuth = path.join(root, "providers", "pi", APP, "auth.json");
+    const ownedModels = path.join(root, "providers", "pi", APP, "models.json");
+    assert.equal(fs.statSync(ownedAuth).mode & 0o777, 0o600);
+    assert.deepEqual(fs.readFileSync(ownedAuth), profile.auth);
+    assert.deepEqual(fs.readFileSync(ownedModels), profile.models);
+    assert.deepEqual(fs.readFileSync(path.join(profile.dir, "auth.json")), profile.auth);
+    assert.deepEqual(fs.readFileSync(path.join(profile.dir, "models.json")), profile.models);
+    assert.deepEqual(fs.readFileSync(path.join(profile.dir, "settings.json")), profile.settings);
+    const ownedSettings = JSON.parse(fs.readFileSync(path.join(root, "providers", "pi", APP, "settings.json"), "utf8"));
+    assert.equal(ownedSettings.theme, "dark");
+    assert.notEqual(fs.readFileSync(path.join(root, "providers", "pi", APP, "settings.json")), profile.settings);
+    const launches = fs.readFileSync(fake.marker, "utf8").trim().split("\n").filter(Boolean).map(JSON.parse);
+    const catalog = launches.find((row) => row.args.includes("--mode") && row.args.includes("rpc"));
+    assert.ok(catalog, JSON.stringify(launches));
+    assert.equal(fs.realpathSync(catalog.cwd), fs.realpathSync(root));
+    assert.equal(fs.existsSync(path.join(root, "agents", APP)), false);
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("external-pi setup rolls back when the effective model lacks a context window", () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "larkin-setup-bind-external-pi-window-"));
+  try {
+    const configFile = path.join(root, "config.json");
+    const before = `${JSON.stringify({ version: 3, serverId: "server-existing", activeAgent: null, agents: {} }, null, 2)}\n`;
+    fs.writeFileSync(configFile, before, { mode: 0o600 });
+    writeCredential(root);
+    writeExternalPiProfile(path.join(root, "home"));
+    const fake = writeFakePi(root, { missingWindow: true });
+    const result = runBind(root, { LARKIN_PI_COMMAND: fake.command }, ["--profile", APP, "--agent", APP, "--runtime", "pi", "--yes"]);
+    assert.notEqual(result.status, 0, result.stdout + result.stderr);
+    assert.equal(fs.readFileSync(configFile, "utf8"), before);
+    assert.equal(fs.existsSync(path.join(root, "providers", "pi", APP)), false);
+    assert.equal(fs.existsSync(path.join(root, "bots", `${APP}.json`)), true);
+    const output = `${result.stdout}\n${result.stderr}`;
+    assert.match(output, /larkin setup --runtime external-pi/);
+    assert.match(output, /fixture\/pi-windowed/);
+    assert.doesNotMatch(output, /larkin model/);
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("external-pi setup fails closed without an official auth.json", () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "larkin-setup-bind-external-pi-auth-"));
+  try {
+    const configFile = path.join(root, "config.json");
+    const before = `${JSON.stringify({ version: 3, serverId: "server-existing", activeAgent: null, agents: {} }, null, 2)}\n`;
+    fs.writeFileSync(configFile, before, { mode: 0o600 });
+    writeCredential(root);
+    writeExternalPiProfile(path.join(root, "home"), "auth.json");
+    const fake = writeFakePi(root);
+    const result = runBind(root, { LARKIN_PI_COMMAND: fake.command }, ["--profile", APP, "--agent", APP, "--runtime", "pi", "--yes"]);
+    assert.notEqual(result.status, 0, result.stdout + result.stderr);
+    assert.equal(fs.readFileSync(configFile, "utf8"), before);
+    const output = `${result.stdout}\n${result.stderr}`;
+    assert.match(output, /official file-backed Pi profile/);
+    assert.match(output, /auth\.json/);
+    assert.match(output, /settings\.json/);
+    assert.match(output, /larkin setup --runtime external-pi/);
+    assert.doesNotMatch(output, /larkin model/);
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("external-pi setup fails closed without settings.json or models.json", () => {
+  for (const missing of ["settings.json", "models.json"]) {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), `larkin-setup-bind-external-pi-${missing}-`));
+    try {
+      const configFile = path.join(root, "config.json");
+      const before = `${JSON.stringify({ version: 3, serverId: "server-existing", activeAgent: null, agents: {} }, null, 2)}\n`;
+      fs.writeFileSync(configFile, before, { mode: 0o600 });
+      writeCredential(root);
+      writeExternalPiProfile(path.join(root, "home"), missing);
+      const fake = writeFakePi(root);
+      const result = runBind(root, { LARKIN_PI_COMMAND: fake.command }, ["--profile", APP, "--agent", APP, "--runtime", "pi", "--yes"]);
+      assert.notEqual(result.status, 0, `${missing}: ${result.stdout}\n${result.stderr}`);
+      assert.equal(fs.readFileSync(configFile, "utf8"), before);
+      const output = `${result.stdout}\n${result.stderr}`;
+      assert.match(output, /official file-backed Pi profile/);
+      assert.match(output, new RegExp(missing.replace(".", "\\.")));
+      assert.match(output, /larkin setup --runtime external-pi/);
+    } finally {
+      fs.rmSync(root, { recursive: true, force: true });
+    }
+  }
+});
+
+test("external-pi setup repairs a stored model=default without mentioning a brand-new agent", () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "larkin-setup-bind-external-pi-repair-"));
+  try {
+    const configFile = path.join(root, "config.json");
+    fs.writeFileSync(configFile, `${JSON.stringify({
+      version: 4,
+      serverId: "server-existing",
+      mentionPolicy: "require",
+      activeAgent: APP,
+      agents: {
+        [APP]: { runtime: "pi", model: "default", piDistribution: "external" },
+      },
+    }, null, 2)}\n`, { mode: 0o600 });
+    writeCredential(root);
+    writeExternalPiProfile(path.join(root, "home"));
+    const fake = writeFakePi(root);
+    const result = runBind(root, { LARKIN_PI_COMMAND: fake.command }, ["--profile", APP, "--agent", APP, "--runtime", "pi", "--yes"]);
+    assert.equal(result.status, 0, result.stdout + result.stderr);
+    const stored = JSON.parse(fs.readFileSync(configFile, "utf8"));
+    assert.equal(stored.agents[APP].model, "fixture/pi-fixture");
+    assert.equal(stored.agents[APP].piDistribution, "external");
   } finally {
     fs.rmSync(root, { recursive: true, force: true });
   }


### PR DESCRIPTION
Fixes https://github.com/eddiearc/larkin/issues/152

## Summary
Non-interactive `larkin setup --runtime external-pi` no longer commits the static Pi model placeholder `default`. Setup now imports the official file-backed Pi profile (`auth.json` 0600, `models.json`, `settings.json`) into the owned per-Agent directory, discovers the catalog against that directory, and persists a concrete `provider/model` before `commitSetupConfig`.

## Trigger
Import + discover runs only when `runtime === "pi" && piDistribution === "external" && targetModelId === "default"`. Concrete-model rebinds stay no-spawn. Rerunning setup after a concrete model is stored does **not** refresh credentials; agents that only ran `larkin model` after the bug are out of scope.

## Failure / rollback
- Pre-commit failure rolls back the import and leaves `config.json` byte-identical.
- Bot credential is kept.
- SIGINT/SIGTERM handlers are installed before prepare/apply and roll back a pending migration.
- Post-commit lock-release failure does not roll back credentials.
- Failure copy tells the user to fix official `pi` login/default and rerun `larkin setup --runtime external-pi`. `larkin model` is mentioned only for a pre-existing agent. Alternative models are listed only when a catalog was returned and the effective model lacks a context window.

## Stale lock
`clearStalePiProfileMigrationLock` is fail-closed: owned regular file, not a symlink, `nlink === 1`, mode `0600`, single positive PID line. Only `ESRCH` is death; `EPERM` stays live. Reclaim is rename-to-quarantine, re-check, then acquire — never unlink-then-wx.

## Version
`0.4.15` → `0.4.16`

Do not merge this PR from this delivery.