### PR TITLE
fix(dashboard): allow Lark regional avatar CDN hosts (#154)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "larkin",
-  "version": "0.4.16",
+  "version": "0.4.17",
   "private": false,
   "larkinPackageRole": "npm-published",
   "files": [

--- a/src/dashboard/dashboard-avatar.ts
+++ b/src/dashboard/dashboard-avatar.ts
@@ -21,7 +21,9 @@ export function isAllowedDashboardAvatarUrl(value: unknown): value is string {
       && url.username === ""
       && url.password === ""
       && (url.port === "" || url.port === "443")
-      && /^s\d+-imfile\.feishucdn\.com$/i.test(url.hostname)
+      // Feishu: s1-imfile.feishucdn.com
+      // Lark regional: s16-imfile-sg.feishucdn.com
+      && /^s\d+-imfile(?:-[a-z]{2,3})?\.feishucdn\.com$/i.test(url.hostname)
       && url.pathname.startsWith("/static-resource/v1/");
   } catch {
     return false;

--- a/test/unit/dashboard/dashboard-avatar.test.mjs
+++ b/test/unit/dashboard/dashboard-avatar.test.mjs
@@ -8,15 +8,21 @@ import {
 } from "../../../dist/dashboard/dashboard-avatar.mjs";
 
 const AVATAR = "https://s1-imfile.feishucdn.com/static-resource/v1/avatar.png";
+const LARK_AVATAR = "https://s16-imfile-sg.feishucdn.com/static-resource/v1/avatar.png";
 
-test("dashboard avatar source accepts only the bounded Feishu CDN shape", () => {
+test("dashboard avatar source accepts bounded Feishu and Lark CDN hosts", () => {
   assert.equal(isAllowedDashboardAvatarUrl(AVATAR), true);
+  assert.equal(isAllowedDashboardAvatarUrl(LARK_AVATAR), true);
+  assert.equal(isAllowedDashboardAvatarUrl("https://s1-imfile-us.feishucdn.com/static-resource/v1/avatar.png"), true);
   for (const value of [
     "http://s1-imfile.feishucdn.com/static-resource/v1/avatar.png",
     "https://user:pass@s1-imfile.feishucdn.com/static-resource/v1/avatar.png",
     "https://s1-imfile.feishucdn.com:8443/static-resource/v1/avatar.png",
     "https://s1-imfile.feishucdn.com/other/avatar.png",
     "https://s1-imfile.feishucdn.com.evil.invalid/static-resource/v1/avatar.png",
+    "https://s16-imfile-sg.feishucdn.com.evil.invalid/static-resource/v1/avatar.png",
+    "https://s16-imfile-singapore.feishucdn.com/static-resource/v1/avatar.png",
+    "https://s1-imfile-.feishucdn.com/static-resource/v1/avatar.png",
     "https://127.0.0.1/static-resource/v1/avatar.png",
   ]) assert.equal(isAllowedDashboardAvatarUrl(value), false, value);
 });


### PR DESCRIPTION
Closes #154

Dashboard 配置页里国际版 Lark Agent 看不到头像，是因为头像代理白名单只允许 `sN-imfile.feishucdn.com`。Lark 实际 URL 是 `s16-imfile-sg.feishucdn.com`，被当成非法源丢掉，页面只显示首字母。

这个 PR 把 host 白名单扩到带 2–3 字母区域后缀的官方 Feishu CDN，同时保留 https、无 userinfo、仅 443、路径 `/static-resource/v1/`、以及 suffix 伪装拒绝。

## 验收

- `https://s16-imfile-sg.feishucdn.com/static-resource/v1/...` 允许
- 飞书 `s1-imfile.feishucdn.com` 仍允许
- `feishucdn.com.evil.invalid`、错误路径、http、userinfo 仍拒绝

Version bump: 0.4.16 → 0.4.17