### PR TITLE
fix(runtime): stop leaking builtin PI_PACKAGE_DIR to external Pi

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "larkin",
-  "version": "0.4.17",
+  "version": "0.4.18",
   "private": false,
   "larkinPackageRole": "npm-published",
   "files": [

--- a/src/runtime/builtin-pi-assets.ts
+++ b/src/runtime/builtin-pi-assets.ts
@@ -59,12 +59,34 @@ export function piChildDistributionFromOverrides(
   return "external";
 }
 
+export function isLarkinBuiltinPiPackageDir(directory: string | undefined): boolean {
+  if (!directory) return false;
+  if (path.basename(directory) !== ".larkin-official-pi-package") return false;
+  try {
+    return !fs.existsSync(path.join(directory, "dist", "modes", "interactive", "theme", "dark.json"));
+  } catch {
+    return true;
+  }
+}
+
+export function catalogPiChildDistribution(commandArgs?: readonly string[]): "builtin" | "external" {
+  return commandArgs?.includes("pi-rpc") ? "builtin" : "external";
+}
+
 /** External/npm Pi resolves PI_PACKAGE_DIR as a Node package root and looks for dist/themes. */
 export function applyPiPackageDirForChild(
   env: NodeJS.ProcessEnv,
-  distribution: "builtin" | "external" = piChildDistribution(env),
+  distribution: "builtin" | "external" | { distribution?: "builtin" | "external"; explicitPackageDir?: string } = piChildDistribution(env),
 ): NodeJS.ProcessEnv {
+  const options = typeof distribution === "string" ? { distribution } : distribution;
+  const resolved = options.distribution ?? piChildDistribution(env);
   const next = { ...env };
-  if (distribution !== "builtin") delete next.PI_PACKAGE_DIR;
+  if (resolved === "builtin") return next;
+  const explicit = options.explicitPackageDir?.trim();
+  if (explicit && !isLarkinBuiltinPiPackageDir(explicit)) {
+    next.PI_PACKAGE_DIR = explicit;
+    return next;
+  }
+  delete next.PI_PACKAGE_DIR;
   return next;
 }

--- a/src/runtime/builtin-pi-assets.ts
+++ b/src/runtime/builtin-pi-assets.ts
@@ -61,10 +61,16 @@ export function piChildDistributionFromOverrides(
 
 function existingPiThemeFile(directory: string): string | undefined {
   const theme = path.join(directory, "dist", "modes", "interactive", "theme", "dark.json");
+  let fd: number | undefined;
   try {
-    return fs.statSync(theme).isFile() ? theme : undefined;
+    fd = fs.openSync(theme, fs.constants.O_RDONLY);
+    return fs.fstatSync(fd).isFile() ? theme : undefined;
   } catch {
     return undefined;
+  } finally {
+    if (fd !== undefined) {
+      try { fs.closeSync(fd); } catch { /* already closed or unreadable */ }
+    }
   }
 }
 

--- a/src/runtime/builtin-pi-assets.ts
+++ b/src/runtime/builtin-pi-assets.ts
@@ -61,7 +61,11 @@ export function piChildDistributionFromOverrides(
 
 function existingPiThemeFile(directory: string): string | undefined {
   const theme = path.join(directory, "dist", "modes", "interactive", "theme", "dark.json");
-  return fs.existsSync(theme) ? theme : undefined;
+  try {
+    return fs.statSync(theme).isFile() ? theme : undefined;
+  } catch {
+    return undefined;
+  }
 }
 
 export function resolveExternalPiPackageDir(directory: string | undefined): string | undefined {

--- a/src/runtime/builtin-pi-assets.ts
+++ b/src/runtime/builtin-pi-assets.ts
@@ -59,13 +59,29 @@ export function piChildDistributionFromOverrides(
   return "external";
 }
 
+function existingPiThemeFile(directory: string): string | undefined {
+  const theme = path.join(directory, "dist", "modes", "interactive", "theme", "dark.json");
+  return fs.existsSync(theme) ? theme : undefined;
+}
+
+export function resolveExternalPiPackageDir(directory: string | undefined): string | undefined {
+  if (!directory?.trim()) return undefined;
+  try {
+    const resolved = fs.realpathSync(directory);
+    return existingPiThemeFile(resolved) ? resolved : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
 export function isLarkinBuiltinPiPackageDir(directory: string | undefined): boolean {
   if (!directory) return false;
-  if (path.basename(directory) !== ".larkin-official-pi-package") return false;
   try {
-    return !fs.existsSync(path.join(directory, "dist", "modes", "interactive", "theme", "dark.json"));
+    const resolved = fs.realpathSync(directory);
+    if (path.basename(resolved).toLowerCase() !== ".larkin-official-pi-package") return false;
+    return !existingPiThemeFile(resolved);
   } catch {
-    return true;
+    return path.basename(directory).toLowerCase() === ".larkin-official-pi-package";
   }
 }
 
@@ -82,11 +98,8 @@ export function applyPiPackageDirForChild(
   const resolved = options.distribution ?? piChildDistribution(env);
   const next = { ...env };
   if (resolved === "builtin") return next;
-  const explicit = options.explicitPackageDir?.trim();
-  if (explicit && !isLarkinBuiltinPiPackageDir(explicit)) {
-    next.PI_PACKAGE_DIR = explicit;
-    return next;
-  }
-  delete next.PI_PACKAGE_DIR;
+  const kept = resolveExternalPiPackageDir(options.explicitPackageDir) ?? resolveExternalPiPackageDir(next.PI_PACKAGE_DIR);
+  if (kept) next.PI_PACKAGE_DIR = kept;
+  else delete next.PI_PACKAGE_DIR;
   return next;
 }

--- a/src/runtime/builtin-pi-assets.ts
+++ b/src/runtime/builtin-pi-assets.ts
@@ -43,3 +43,28 @@ export function prepareBuiltinPiPackageAssets(): void {
   writeEmbeddedFile(path.join(themeDir, "light.json"), assets.lightTheme);
   process.env.PI_PACKAGE_DIR = packageDir;
 }
+
+export function piChildDistribution(env: NodeJS.ProcessEnv | undefined): "builtin" | "external" {
+  return env?.LARKIN_PI_DISTRIBUTION === "builtin" ? "builtin" : "external";
+}
+
+/** Host process env may be builtin Pi; only explicit child overrides select bundled assets. */
+export function piChildDistributionFromOverrides(
+  ...overrides: Array<NodeJS.ProcessEnv | undefined>
+): "builtin" | "external" {
+  for (let index = overrides.length - 1; index >= 0; index -= 1) {
+    const value = overrides[index]?.LARKIN_PI_DISTRIBUTION;
+    if (value === "builtin" || value === "external") return value;
+  }
+  return "external";
+}
+
+/** External/npm Pi resolves PI_PACKAGE_DIR as a Node package root and looks for dist/themes. */
+export function applyPiPackageDirForChild(
+  env: NodeJS.ProcessEnv,
+  distribution: "builtin" | "external" = piChildDistribution(env),
+): NodeJS.ProcessEnv {
+  const next = { ...env };
+  if (distribution !== "builtin") delete next.PI_PACKAGE_DIR;
+  return next;
+}

--- a/src/runtime/pi-model-catalog.ts
+++ b/src/runtime/pi-model-catalog.ts
@@ -74,10 +74,24 @@ export function findExactPiModel<T extends PiModelLike>(reference: string, model
 const discoveryCache = new Map<string, Promise<PiModelCatalog>>();
 
 /** Discover only through Pi's structured RPC protocol; no table parsing or static fallback. */
+function piCatalogChildEnv(options: DiscoverPiCatalogOptions): NodeJS.ProcessEnv {
+  const mergedEnv = {
+    ...process.env,
+    ...options.env,
+    ...(options.agentDir ? { PI_CODING_AGENT_DIR: path.resolve(options.agentDir) } : {}),
+    NO_COLOR: "1",
+  };
+  return applyPiPackageDirForChild(mergedEnv, {
+    distribution: catalogPiChildDistribution(options.commandArgs),
+    explicitPackageDir: options.packageDir,
+  });
+}
+
 export async function discoverPiModelCatalog(options: DiscoverPiCatalogOptions): Promise<PiModelCatalog> {
   if (!options.spawn) {
     const command = options.command ?? options.env?.LARKIN_PI_COMMAND ?? process.env.LARKIN_PI_COMMAND ?? "pi";
-    const key = `${command}|${(options.commandArgs ?? []).join("\0")}|${options.env?.PI_CODING_AGENT_DIR ?? ""}|${options.agentDir ?? ""}`;
+    const childEnv = piCatalogChildEnv(options);
+    const key = `${command}|${(options.commandArgs ?? []).join("\0")}|${childEnv.PI_CODING_AGENT_DIR ?? ""}|${options.agentDir ?? ""}|${childEnv.PI_PACKAGE_DIR ?? ""}|${options.packageDir ?? ""}`;
     const cached = discoveryCache.get(key);
     if (cached) return cached;
     const pending = discoverPiModelCatalogUncached(options);
@@ -93,18 +107,9 @@ export async function discoverPiModelCatalog(options: DiscoverPiCatalogOptions):
 async function discoverPiModelCatalogUncached(options: DiscoverPiCatalogOptions): Promise<PiModelCatalog> {
   const spawn = options.spawn ?? ((command, args, spawnOptions) => nodeSpawn(command, [...args], spawnOptions as any) as unknown as PiRpcProcess);
   const command = options.command ?? options.env?.LARKIN_PI_COMMAND ?? process.env.LARKIN_PI_COMMAND ?? "pi";
-  const mergedEnv = {
-    ...process.env,
-    ...options.env,
-    ...(options.agentDir ? { PI_CODING_AGENT_DIR: path.resolve(options.agentDir) } : {}),
-    NO_COLOR: "1",
-  };
   const child = spawn(command, [...(options.commandArgs ?? []), "--mode", "rpc", "--no-session"], {
     cwd: options.cwd,
-    env: applyPiPackageDirForChild(mergedEnv, {
-      distribution: catalogPiChildDistribution(options.commandArgs),
-      explicitPackageDir: options.packageDir,
-    }),
+    env: piCatalogChildEnv(options),
     stdio: ["pipe", "pipe", "pipe"],
   });
   const client = new PiRpcClient(child, { requestTimeoutMs: options.timeoutMs ?? 10_000 });

--- a/src/runtime/pi-model-catalog.ts
+++ b/src/runtime/pi-model-catalog.ts
@@ -1,6 +1,6 @@
 import { spawn as nodeSpawn } from "node:child_process";
 import * as path from "node:path";
-import { applyPiPackageDirForChild, piChildDistributionFromOverrides } from "./builtin-pi-assets.js";
+import { applyPiPackageDirForChild, catalogPiChildDistribution } from "./builtin-pi-assets.js";
 import { PiRpcClient, type PiRpcProcess } from "./pi-rpc-client.js";
 import { classifyRuntimePrerequisite, RuntimePrerequisiteError } from "./runtime-readiness.js";
 
@@ -39,6 +39,8 @@ export interface DiscoverPiCatalogOptions {
   command?: string;
   commandArgs?: readonly string[];
   env?: NodeJS.ProcessEnv;
+  /** Child-explicit Node package root. Host process.env.PI_PACKAGE_DIR is not this. */
+  packageDir?: string;
   spawn?: (command: string, args: readonly string[], options: Record<string, unknown>) => PiRpcProcess;
   timeoutMs?: number;
 }
@@ -99,7 +101,10 @@ async function discoverPiModelCatalogUncached(options: DiscoverPiCatalogOptions)
   };
   const child = spawn(command, [...(options.commandArgs ?? []), "--mode", "rpc", "--no-session"], {
     cwd: options.cwd,
-    env: applyPiPackageDirForChild(mergedEnv, piChildDistributionFromOverrides(options.env)),
+    env: applyPiPackageDirForChild(mergedEnv, {
+      distribution: catalogPiChildDistribution(options.commandArgs),
+      explicitPackageDir: options.packageDir,
+    }),
     stdio: ["pipe", "pipe", "pipe"],
   });
   const client = new PiRpcClient(child, { requestTimeoutMs: options.timeoutMs ?? 10_000 });

--- a/src/runtime/pi-model-catalog.ts
+++ b/src/runtime/pi-model-catalog.ts
@@ -1,5 +1,6 @@
 import { spawn as nodeSpawn } from "node:child_process";
 import * as path from "node:path";
+import { applyPiPackageDirForChild, piChildDistributionFromOverrides } from "./builtin-pi-assets.js";
 import { PiRpcClient, type PiRpcProcess } from "./pi-rpc-client.js";
 import { classifyRuntimePrerequisite, RuntimePrerequisiteError } from "./runtime-readiness.js";
 
@@ -90,9 +91,15 @@ export async function discoverPiModelCatalog(options: DiscoverPiCatalogOptions):
 async function discoverPiModelCatalogUncached(options: DiscoverPiCatalogOptions): Promise<PiModelCatalog> {
   const spawn = options.spawn ?? ((command, args, spawnOptions) => nodeSpawn(command, [...args], spawnOptions as any) as unknown as PiRpcProcess);
   const command = options.command ?? options.env?.LARKIN_PI_COMMAND ?? process.env.LARKIN_PI_COMMAND ?? "pi";
+  const mergedEnv = {
+    ...process.env,
+    ...options.env,
+    ...(options.agentDir ? { PI_CODING_AGENT_DIR: path.resolve(options.agentDir) } : {}),
+    NO_COLOR: "1",
+  };
   const child = spawn(command, [...(options.commandArgs ?? []), "--mode", "rpc", "--no-session"], {
     cwd: options.cwd,
-    env: { ...process.env, ...options.env, ...(options.agentDir ? { PI_CODING_AGENT_DIR: path.resolve(options.agentDir) } : {}), NO_COLOR: "1" },
+    env: applyPiPackageDirForChild(mergedEnv, piChildDistributionFromOverrides(options.env)),
     stdio: ["pipe", "pipe", "pipe"],
   });
   const client = new PiRpcClient(child, { requestTimeoutMs: options.timeoutMs ?? 10_000 });

--- a/src/runtime/pi-profile-migration.ts
+++ b/src/runtime/pi-profile-migration.ts
@@ -4,7 +4,7 @@ import * as os from "node:os";
 import * as path from "node:path";
 import { spawnSync } from "node:child_process";
 import processInspect from "../platform/process-inspect.cjs";
-import { applyPiPackageDirForChild } from "./builtin-pi-assets.js";
+import { applyPiPackageDirForChild, resolveExternalPiPackageDir } from "./builtin-pi-assets.js";
 import { resolveRuntimeExecutable } from "./runtime-readiness.js";
 import { mergeOwnedPiSettings, parsePiExecutableVersion } from "./pi-compaction-recovery.js";
 import { BUNDLED_PI_VERSION } from "./pi-provider-config.js";
@@ -41,7 +41,7 @@ export interface PiProfileMigrationState {
 export interface PiProfileMigrationPlan {
   state: PiProfileMigrationState;
   sourceBytes: Record<FileName, Buffer>;
-  sourceEnvironment: { PATH?: string; LARKIN_PI_COMMAND?: string };
+  sourceEnvironment: { PATH?: string; LARKIN_PI_COMMAND?: string; PI_PACKAGE_DIR?: string };
 }
 
 const TARGET_LOCK_SUFFIX = ".larkin-pi-import.lock";
@@ -310,7 +310,11 @@ export function preparePiProfileMigration(env: NodeJS.ProcessEnv, configDir: str
       priorFiles: target.files, afterFiles },
     sourceBytes: { "auth.json": sourceFiles["auth.json"].bytes, "models.json": sourceFiles["models.json"].bytes,
       "settings.json": imported["settings.json"] },
-    sourceEnvironment: { PATH: env.PATH, LARKIN_PI_COMMAND: env.LARKIN_PI_COMMAND },
+    sourceEnvironment: {
+      PATH: env.PATH,
+      LARKIN_PI_COMMAND: env.LARKIN_PI_COMMAND,
+      ...(resolveExternalPiPackageDir(env.PI_PACKAGE_DIR) ? { PI_PACKAGE_DIR: resolveExternalPiPackageDir(env.PI_PACKAGE_DIR) } : {}),
+    },
   };
 }
 
@@ -437,8 +441,13 @@ function restoreFile(file: string, prior: FileState): void {
 
 export function applyPiProfileMigration(plan: PiProfileMigrationPlan): void {
   const sameEnvironment = process.env.PATH === plan.sourceEnvironment.PATH
-    && process.env.LARKIN_PI_COMMAND === plan.sourceEnvironment.LARKIN_PI_COMMAND;
-  assertSourceUnchanged(plan.state, sameEnvironment ? process.env : plan.sourceEnvironment);
+    && process.env.LARKIN_PI_COMMAND === plan.sourceEnvironment.LARKIN_PI_COMMAND
+    && (resolveExternalPiPackageDir(process.env.PI_PACKAGE_DIR) ?? undefined) === plan.sourceEnvironment.PI_PACKAGE_DIR;
+  const replayEnv = {
+    ...(sameEnvironment ? process.env : { ...process.env, ...plan.sourceEnvironment }),
+    ...(plan.sourceEnvironment.PI_PACKAGE_DIR ? { PI_PACKAGE_DIR: plan.sourceEnvironment.PI_PACKAGE_DIR } : {}),
+  };
+  assertSourceUnchanged(plan.state, replayEnv);
   const parent = path.dirname(plan.state.targetDir); assertNoSymlinkAncestors(parent); fs.mkdirSync(parent, { recursive: true, mode: 0o700 }); fs.chmodSync(parent, 0o700);
   acquireTargetLock(plan.state);
   assertTargetUnchanged(plan.state);

--- a/src/runtime/pi-profile-migration.ts
+++ b/src/runtime/pi-profile-migration.ts
@@ -235,14 +235,15 @@ function targetDirectory(configDir: string, agentId: string): string {
   if (!AGENT_ID.test(agentId)) throw new Error("Pi Agent ID 格式无效");
   return path.join(path.resolve(configDir), "providers", "pi", agentId);
 }
-function sourceVersion(env: NodeJS.ProcessEnv, cwd: string): ExecutableState {
+function sourceVersion(env: NodeJS.ProcessEnv, cwd: string, alreadySanitized = false): ExecutableState {
   const command = String(env.LARKIN_PI_COMMAND || "pi");
   const executable = resolveRuntimeExecutable(command, env);
   if (!executable) throw new Error("外部 Pi 0.84.2 profile import requires an installed Pi executable");
   const executableState = readExecutable(executable, "external Pi executable");
+  const probeEnv = alreadySanitized ? env : applyPiPackageDirForChild(env, { distribution: "external" });
   const result = spawnSync(executableState.path, ["--version"], {
     cwd,
-    env: applyPiPackageDirForChild(env, { distribution: "external" }),
+    env: probeEnv,
     encoding: "utf8",
     timeout: 5_000,
     maxBuffer: 64 * 1024,
@@ -285,7 +286,7 @@ export function preparePiProfileMigration(env: NodeJS.ProcessEnv, configDir: str
   const sourceDir = sourceDirectory(sanitized);
   verifySourceProfile(sourceDir);
   const sourceDirectoryState = assertDirectory(sourceDir, "external Pi profile") as fs.Stats;
-  const sourceExecutable = sourceVersion(sanitized, sourceDir);
+  const sourceExecutable = sourceVersion(sanitized, sourceDir, true);
   const sourceFiles = Object.fromEntries(FILES.map((name) => {
     const file = readRegular(path.join(sourceDir, name), `external Pi ${name}`, false);
     if (!file) throw new Error(`external Pi ${name} is required`);
@@ -313,7 +314,7 @@ export function preparePiProfileMigration(env: NodeJS.ProcessEnv, configDir: str
       "settings.json": imported["settings.json"] },
     sourceEnvironment: {
       PATH: sanitized.PATH,
-      LARKIN_PI_COMMAND: sanitized.LARKIN_PI_COMMAND,
+      LARKIN_PI_COMMAND: String(sanitized.LARKIN_PI_COMMAND || "pi"),
       ...(sanitized.PI_PACKAGE_DIR ? { PI_PACKAGE_DIR: sanitized.PI_PACKAGE_DIR } : {}),
     },
   };
@@ -352,11 +353,24 @@ export function validatePiProfileMigrationState(value: unknown): asserts value i
   }
 }
 
+function replayExternalPiPackageEnv(env: NodeJS.ProcessEnv): NodeJS.ProcessEnv {
+  const next = { ...env };
+  const planned = env.PI_PACKAGE_DIR;
+  if (!planned) {
+    delete next.PI_PACKAGE_DIR;
+    return next;
+  }
+  const resolved = applyPiPackageDirForChild({ PI_PACKAGE_DIR: planned }, { distribution: "external", explicitPackageDir: planned }).PI_PACKAGE_DIR;
+  if (!resolved) throw new Error("external Pi package root changed; refusing migration");
+  next.PI_PACKAGE_DIR = resolved;
+  return next;
+}
+
 function assertSourceUnchanged(state: PiProfileMigrationState, resolutionEnvironment: NodeJS.ProcessEnv = process.env, verifyResolution = true): void {
   const directory = assertDirectory(state.sourceDir, "external Pi profile");
   if ((directory!.mode & 0o777) !== state.sourceDirMode) throw new Error("external Pi profile changed; refusing migration");
   verifySourceProfile(state.sourceDir);
-  const probeEnvironment = { ...process.env, ...resolutionEnvironment };
+  const probeEnvironment = replayExternalPiPackageEnv(resolutionEnvironment);
   const resolved = verifyResolution ? resolveRuntimeExecutable(state.sourceCommand, probeEnvironment) : state.sourceExecutable.path;
   if (!resolved) throw new Error("external Pi executable changed; refusing migration");
   const executable = readExecutable(resolved, "external Pi executable");
@@ -366,7 +380,7 @@ function assertSourceUnchanged(state: PiProfileMigrationState, resolutionEnviron
   }
   const result = spawnSync(executable.path, ["--version"], {
     cwd: state.sourceDir,
-    env: applyPiPackageDirForChild(probeEnvironment, { distribution: "external" }),
+    env: probeEnvironment,
     encoding: "utf8",
     timeout: 5_000,
     maxBuffer: 64 * 1024,
@@ -441,7 +455,9 @@ function restoreFile(file: string, prior: FileState): void {
 }
 
 export function applyPiProfileMigration(plan: PiProfileMigrationPlan): void {
-  const replayEnv = { ...process.env, ...plan.sourceEnvironment };
+  const replayEnv: NodeJS.ProcessEnv = { ...process.env, PATH: plan.sourceEnvironment.PATH ?? process.env.PATH };
+  if (plan.sourceEnvironment.LARKIN_PI_COMMAND) replayEnv.LARKIN_PI_COMMAND = plan.sourceEnvironment.LARKIN_PI_COMMAND;
+  else delete replayEnv.LARKIN_PI_COMMAND;
   if (plan.sourceEnvironment.PI_PACKAGE_DIR) replayEnv.PI_PACKAGE_DIR = plan.sourceEnvironment.PI_PACKAGE_DIR;
   else delete replayEnv.PI_PACKAGE_DIR;
   assertSourceUnchanged(plan.state, replayEnv);

--- a/src/runtime/pi-profile-migration.ts
+++ b/src/runtime/pi-profile-migration.ts
@@ -4,6 +4,7 @@ import * as os from "node:os";
 import * as path from "node:path";
 import { spawnSync } from "node:child_process";
 import processInspect from "../platform/process-inspect.cjs";
+import { applyPiPackageDirForChild } from "./builtin-pi-assets.js";
 import { resolveRuntimeExecutable } from "./runtime-readiness.js";
 import { mergeOwnedPiSettings, parsePiExecutableVersion } from "./pi-compaction-recovery.js";
 import { BUNDLED_PI_VERSION } from "./pi-provider-config.js";
@@ -239,7 +240,13 @@ function sourceVersion(env: NodeJS.ProcessEnv, cwd: string): ExecutableState {
   const executable = resolveRuntimeExecutable(command, env);
   if (!executable) throw new Error("外部 Pi 0.84.2 profile import requires an installed Pi executable");
   const executableState = readExecutable(executable, "external Pi executable");
-  const result = spawnSync(executableState.path, ["--version"], { cwd, env, encoding: "utf8", timeout: 5_000, maxBuffer: 64 * 1024 });
+  const result = spawnSync(executableState.path, ["--version"], {
+    cwd,
+    env: applyPiPackageDirForChild(env, { distribution: "external" }),
+    encoding: "utf8",
+    timeout: 5_000,
+    maxBuffer: 64 * 1024,
+  });
   if (result.status !== 0) throw new Error("external Pi version probe failed");
   try { parsePiExecutableVersion(String(result.stdout || result.stderr || "").trim()); }
   catch { throw new Error(`external Pi must be exactly ${BUNDLED_PI_VERSION}`); }
@@ -352,7 +359,13 @@ function assertSourceUnchanged(state: PiProfileMigrationState, resolutionEnviron
       || executable.bytes !== state.sourceExecutable.bytes || executable.mode !== state.sourceExecutable.mode) {
     throw new Error("external Pi executable changed; refusing migration");
   }
-  const result = spawnSync(executable.path, ["--version"], { cwd: state.sourceDir, env: probeEnvironment, encoding: "utf8", timeout: 5_000, maxBuffer: 64 * 1024 });
+  const result = spawnSync(executable.path, ["--version"], {
+    cwd: state.sourceDir,
+    env: applyPiPackageDirForChild(probeEnvironment, { distribution: "external" }),
+    encoding: "utf8",
+    timeout: 5_000,
+    maxBuffer: 64 * 1024,
+  });
   if (result.status !== 0) throw new Error("external Pi version probe failed");
   try { parsePiExecutableVersion(String(result.stdout || result.stderr || "").trim()); }
   catch { throw new Error(`external Pi must be exactly ${BUNDLED_PI_VERSION}`); }

--- a/src/runtime/pi-profile-migration.ts
+++ b/src/runtime/pi-profile-migration.ts
@@ -36,6 +36,11 @@ export interface PiProfileMigrationState {
   targetEntries: string[];
   priorFiles: Record<FileName, FileState>;
   afterFiles: Record<FileName, FileState>;
+  sourcePath?: string;
+  sourcePackageDir?: string;
+  sourcePackageDev?: number;
+  sourcePackageIno?: number;
+  sourcePackageThemeSha256?: string;
 }
 
 export interface PiProfileMigrationPlan {
@@ -46,6 +51,45 @@ export interface PiProfileMigrationPlan {
 
 const TARGET_LOCK_SUFFIX = ".larkin-pi-import.lock";
 function hash(bytes: Buffer): string { return crypto.createHash("sha256").update(bytes).digest("hex"); }
+function isPiOrLarkinEnvKey(key: string): boolean {
+  return key === "PATH" || key.startsWith("PI_") || key.startsWith("LARKIN_");
+}
+function isolatePlannedReplayEnv(source: { PATH?: string; LARKIN_PI_COMMAND?: string; PI_PACKAGE_DIR?: string }): NodeJS.ProcessEnv {
+  const next: NodeJS.ProcessEnv = {};
+  for (const [key, value] of Object.entries(process.env)) {
+    if (isPiOrLarkinEnvKey(key)) continue;
+    next[key] = value;
+  }
+  if (source.PATH) next.PATH = source.PATH;
+  if (source.LARKIN_PI_COMMAND) next.LARKIN_PI_COMMAND = source.LARKIN_PI_COMMAND;
+  if (source.PI_PACKAGE_DIR) next.PI_PACKAGE_DIR = source.PI_PACKAGE_DIR;
+  return next;
+}
+function capturePackageRootProof(directory: string): { dir: string; dev: number; ino: number; themeSha256: string } {
+  const resolved = fs.realpathSync(directory);
+  const rootStat = fs.statSync(resolved);
+  const theme = path.join(resolved, "dist", "modes", "interactive", "theme", "dark.json");
+  let fd: number | undefined;
+  try {
+    fd = fs.openSync(theme, fs.constants.O_RDONLY);
+    const themeStat = fs.fstatSync(fd);
+    if (!themeStat.isFile()) throw new Error("external Pi package root changed; refusing migration");
+    const bytes = fs.readFileSync(fd);
+    return { dir: resolved, dev: rootStat.dev, ino: rootStat.ino, themeSha256: hash(bytes) };
+  } finally {
+    if (fd !== undefined) try { fs.closeSync(fd); } catch { /* ignore */ }
+  }
+}
+function assertPackageRootProof(state: PiProfileMigrationState): void {
+  if (!state.sourcePackageDir) return;
+  let current: ReturnType<typeof capturePackageRootProof>;
+  try { current = capturePackageRootProof(state.sourcePackageDir); }
+  catch { throw new Error("external Pi package root changed; refusing migration"); }
+  if (current.dir !== state.sourcePackageDir || current.dev !== state.sourcePackageDev
+      || current.ino !== state.sourcePackageIno || current.themeSha256 !== state.sourcePackageThemeSha256) {
+    throw new Error("external Pi package root changed; refusing migration");
+  }
+}
 function targetLockFile(state: PiProfileMigrationState): string { return path.join(path.dirname(state.targetDir), `${state.agentId}${TARGET_LOCK_SUFFIX}`); }
 function acquireTargetLock(state: PiProfileMigrationState): void {
   const file = targetLockFile(state);
@@ -309,13 +353,23 @@ export function preparePiProfileMigration(env: NodeJS.ProcessEnv, configDir: str
       sourceFiles: Object.fromEntries(FILES.map((name) => [name, safeState(sourceFiles[name], false)])) as Record<FileName, FileState>,
       targetDir, targetDirExisted: Boolean(target.stat), targetDirMode: target.stat ? target.stat.mode & 0o777 : 0o700,
       ...(target.stat ? { targetDirDevice: target.stat.dev, targetDirInode: target.stat.ino } : {}), targetEntries: target.entries,
-      priorFiles: target.files, afterFiles },
+      priorFiles: target.files, afterFiles,
+      ...(sanitized.PATH ? { sourcePath: sanitized.PATH } : {}),
+      ...(sanitized.PI_PACKAGE_DIR ? (() => {
+        const proof = capturePackageRootProof(sanitized.PI_PACKAGE_DIR);
+        return {
+          sourcePackageDir: proof.dir,
+          sourcePackageDev: proof.dev,
+          sourcePackageIno: proof.ino,
+          sourcePackageThemeSha256: proof.themeSha256,
+        };
+      })() : {}) },
     sourceBytes: { "auth.json": sourceFiles["auth.json"].bytes, "models.json": sourceFiles["models.json"].bytes,
       "settings.json": imported["settings.json"] },
     sourceEnvironment: {
       PATH: sanitized.PATH,
       LARKIN_PI_COMMAND: String(sanitized.LARKIN_PI_COMMAND || "pi"),
-      ...(sanitized.PI_PACKAGE_DIR ? { PI_PACKAGE_DIR: sanitized.PI_PACKAGE_DIR } : {}),
+      ...(sanitized.PI_PACKAGE_DIR ? { PI_PACKAGE_DIR: capturePackageRootProof(sanitized.PI_PACKAGE_DIR).dir } : {}),
     },
   };
 }
@@ -370,6 +424,7 @@ function assertSourceUnchanged(state: PiProfileMigrationState, resolutionEnviron
   const directory = assertDirectory(state.sourceDir, "external Pi profile");
   if ((directory!.mode & 0o777) !== state.sourceDirMode) throw new Error("external Pi profile changed; refusing migration");
   verifySourceProfile(state.sourceDir);
+  assertPackageRootProof(state);
   const probeEnvironment = replayExternalPiPackageEnv(resolutionEnvironment);
   const resolved = verifyResolution ? resolveRuntimeExecutable(state.sourceCommand, probeEnvironment) : state.sourceExecutable.path;
   if (!resolved) throw new Error("external Pi executable changed; refusing migration");
@@ -455,11 +510,7 @@ function restoreFile(file: string, prior: FileState): void {
 }
 
 export function applyPiProfileMigration(plan: PiProfileMigrationPlan): void {
-  const replayEnv: NodeJS.ProcessEnv = { ...process.env, PATH: plan.sourceEnvironment.PATH ?? process.env.PATH };
-  if (plan.sourceEnvironment.LARKIN_PI_COMMAND) replayEnv.LARKIN_PI_COMMAND = plan.sourceEnvironment.LARKIN_PI_COMMAND;
-  else delete replayEnv.LARKIN_PI_COMMAND;
-  if (plan.sourceEnvironment.PI_PACKAGE_DIR) replayEnv.PI_PACKAGE_DIR = plan.sourceEnvironment.PI_PACKAGE_DIR;
-  else delete replayEnv.PI_PACKAGE_DIR;
+  const replayEnv = isolatePlannedReplayEnv(plan.sourceEnvironment);
   assertSourceUnchanged(plan.state, replayEnv);
   const parent = path.dirname(plan.state.targetDir); assertNoSymlinkAncestors(parent); fs.mkdirSync(parent, { recursive: true, mode: 0o700 }); fs.chmodSync(parent, 0o700);
   acquireTargetLock(plan.state);
@@ -487,7 +538,12 @@ function fsyncDirectory(directory: string): void {
 }
 
 export function rollbackPiProfileMigration(state: PiProfileMigrationState): void {
-  validatePiProfileMigrationState(state); assertSourceUnchanged(state, process.env, false);
+  validatePiProfileMigrationState(state);
+  assertSourceUnchanged(state, isolatePlannedReplayEnv({
+    PATH: state.sourcePath,
+    LARKIN_PI_COMMAND: state.sourceCommand,
+    ...(state.sourcePackageDir ? { PI_PACKAGE_DIR: state.sourcePackageDir } : {}),
+  }), false);
   const target = assertDirectory(state.targetDir, "Pi provider target", false);
   if (!target) {
     if (state.targetDirExisted) throw new Error("Pi provider target disappeared during rollback");

--- a/src/runtime/pi-profile-migration.ts
+++ b/src/runtime/pi-profile-migration.ts
@@ -4,7 +4,7 @@ import * as os from "node:os";
 import * as path from "node:path";
 import { spawnSync } from "node:child_process";
 import processInspect from "../platform/process-inspect.cjs";
-import { applyPiPackageDirForChild, resolveExternalPiPackageDir } from "./builtin-pi-assets.js";
+import { applyPiPackageDirForChild } from "./builtin-pi-assets.js";
 import { resolveRuntimeExecutable } from "./runtime-readiness.js";
 import { mergeOwnedPiSettings, parsePiExecutableVersion } from "./pi-compaction-recovery.js";
 import { BUNDLED_PI_VERSION } from "./pi-provider-config.js";
@@ -281,10 +281,11 @@ function targetPrior(directory: string): { stat: fs.Stats | null; entries: strin
 }
 
 export function preparePiProfileMigration(env: NodeJS.ProcessEnv, configDir: string, agentId: string, distribution: "builtin" | "external" = "builtin"): PiProfileMigrationPlan {
-  const sourceDir = sourceDirectory(env);
+  const sanitized = applyPiPackageDirForChild({ ...env }, { distribution: "external" });
+  const sourceDir = sourceDirectory(sanitized);
   verifySourceProfile(sourceDir);
   const sourceDirectoryState = assertDirectory(sourceDir, "external Pi profile") as fs.Stats;
-  const sourceExecutable = sourceVersion(env, sourceDir);
+  const sourceExecutable = sourceVersion(sanitized, sourceDir);
   const sourceFiles = Object.fromEntries(FILES.map((name) => {
     const file = readRegular(path.join(sourceDir, name), `external Pi ${name}`, false);
     if (!file) throw new Error(`external Pi ${name} is required`);
@@ -303,7 +304,7 @@ export function preparePiProfileMigration(env: NodeJS.ProcessEnv, configDir: str
   const afterFiles = Object.fromEntries(FILES.map((name) => [name, safeState({ bytes: imported[name], mode: 0o600 }, false)])) as Record<FileName, FileState>;
   return {
     state: { version: 1, agentId, sourceDir, sourceDirMode: sourceDirectoryState.mode & 0o777,
-      sourceCommand: String(env.LARKIN_PI_COMMAND || "pi"), sourceExecutable,
+      sourceCommand: String(sanitized.LARKIN_PI_COMMAND || "pi"), sourceExecutable,
       sourceFiles: Object.fromEntries(FILES.map((name) => [name, safeState(sourceFiles[name], false)])) as Record<FileName, FileState>,
       targetDir, targetDirExisted: Boolean(target.stat), targetDirMode: target.stat ? target.stat.mode & 0o777 : 0o700,
       ...(target.stat ? { targetDirDevice: target.stat.dev, targetDirInode: target.stat.ino } : {}), targetEntries: target.entries,
@@ -311,9 +312,9 @@ export function preparePiProfileMigration(env: NodeJS.ProcessEnv, configDir: str
     sourceBytes: { "auth.json": sourceFiles["auth.json"].bytes, "models.json": sourceFiles["models.json"].bytes,
       "settings.json": imported["settings.json"] },
     sourceEnvironment: {
-      PATH: env.PATH,
-      LARKIN_PI_COMMAND: env.LARKIN_PI_COMMAND,
-      ...(resolveExternalPiPackageDir(env.PI_PACKAGE_DIR) ? { PI_PACKAGE_DIR: resolveExternalPiPackageDir(env.PI_PACKAGE_DIR) } : {}),
+      PATH: sanitized.PATH,
+      LARKIN_PI_COMMAND: sanitized.LARKIN_PI_COMMAND,
+      ...(sanitized.PI_PACKAGE_DIR ? { PI_PACKAGE_DIR: sanitized.PI_PACKAGE_DIR } : {}),
     },
   };
 }
@@ -440,13 +441,9 @@ function restoreFile(file: string, prior: FileState): void {
 }
 
 export function applyPiProfileMigration(plan: PiProfileMigrationPlan): void {
-  const sameEnvironment = process.env.PATH === plan.sourceEnvironment.PATH
-    && process.env.LARKIN_PI_COMMAND === plan.sourceEnvironment.LARKIN_PI_COMMAND
-    && (resolveExternalPiPackageDir(process.env.PI_PACKAGE_DIR) ?? undefined) === plan.sourceEnvironment.PI_PACKAGE_DIR;
-  const replayEnv = {
-    ...(sameEnvironment ? process.env : { ...process.env, ...plan.sourceEnvironment }),
-    ...(plan.sourceEnvironment.PI_PACKAGE_DIR ? { PI_PACKAGE_DIR: plan.sourceEnvironment.PI_PACKAGE_DIR } : {}),
-  };
+  const replayEnv = { ...process.env, ...plan.sourceEnvironment };
+  if (plan.sourceEnvironment.PI_PACKAGE_DIR) replayEnv.PI_PACKAGE_DIR = plan.sourceEnvironment.PI_PACKAGE_DIR;
+  else delete replayEnv.PI_PACKAGE_DIR;
   assertSourceUnchanged(plan.state, replayEnv);
   const parent = path.dirname(plan.state.targetDir); assertNoSymlinkAncestors(parent); fs.mkdirSync(parent, { recursive: true, mode: 0o700 }); fs.chmodSync(parent, 0o700);
   acquireTargetLock(plan.state);

--- a/src/runtime/runtime-adapters.ts
+++ b/src/runtime/runtime-adapters.ts
@@ -15,6 +15,7 @@ import type {
   StandingPrompt,
   UpstreamProviderError,
 } from "./runtime-contracts.js";
+import { applyPiPackageDirForChild, piChildDistributionFromOverrides } from "./builtin-pi-assets.js";
 import { isPiThinkingLevel } from "./pi-model-catalog.js";
 import { PiRpcClient, type PiRpcClientOptions } from "./pi-rpc-client.js";
 import { internalCommandSpec } from "../app/internal-command.js";
@@ -1033,7 +1034,8 @@ async function createPiRpcBackend(input: RuntimeSessionCreate, dependencies: Nat
     ...(session.sessionFile ? ["--session", session.sessionFile] : []),
     ...(requestedModel ? ["--model", requestedModel] : []),
     ...(requestedEffort ? ["--thinking", requestedEffort] : [])];
-  const builtin = mergedEnv.LARKIN_PI_DISTRIBUTION === "builtin";
+  const builtin = piChildDistributionFromOverrides(dependencies.env, input.env) === "builtin";
+  if (!builtin && mergedEnv.LARKIN_PI_DISTRIBUTION === "builtin") delete mergedEnv.LARKIN_PI_DISTRIBUTION;
   const builtinSpec = builtin ? internalCommandSpec("pi-rpc", [], mergedEnv) : null;
   const command = builtinSpec?.command ?? dependencies.piCommand ?? dependencies.env?.LARKIN_PI_COMMAND ?? process.env.LARKIN_PI_COMMAND ?? "pi";
   const commandPrefix = builtinSpec?.args ?? dependencies.piCommandArgs ?? [];
@@ -1045,6 +1047,7 @@ async function createPiRpcBackend(input: RuntimeSessionCreate, dependencies: Nat
     : BUNDLED_PI_VERSION;
   mergedEnv.PI_CODING_AGENT_DIR = ownedPiDirectory;
   if (builtin) mergedEnv.PI_TELEMETRY = "0";
+  const childEnv = applyPiPackageDirForChild(mergedEnv, builtin ? "builtin" : "external");
   const extensionArgs = (dependencies.resolvePiProcessExtensionArgs ?? resolvePiProcessExtensionArgs)({
     distribution: builtin ? "builtin" : "external",
     piCommand: command,
@@ -1060,7 +1063,7 @@ async function createPiRpcBackend(input: RuntimeSessionCreate, dependencies: Nat
     // is loaded by the probe.
     probedModel = await discoverEffectivePiContextWindow(
       input, command, commandPrefix, requestedModel,
-      mergedEnv, spawn, dependencies.piRpcClientOptions,
+      childEnv, spawn, dependencies.piRpcClientOptions,
     );
     writeOwnedPiSettings(ownedPiDirectory, calculatePiCompactionSettings(probedModel.contextWindow));
   }
@@ -1068,7 +1071,7 @@ async function createPiRpcBackend(input: RuntimeSessionCreate, dependencies: Nat
   const artifactSpawnBoundary = Date.now();
   const child = spawn(command, commandArgs, {
     cwd: input.workspaceDir,
-    env: mergedEnv,
+    env: childEnv,
     stdio: ["pipe", "pipe", "pipe"],
   });
   traceProcessBoundary(mergedEnv, "pi-rpc:child-spawned", { configDir: mergedEnv.LARKIN_CONFIG_DIR, agentId: input.agentId, targetDir: ownedPiDirectory, childPid: (child as unknown as { pid?: number }).pid ?? null });
@@ -1220,8 +1223,7 @@ export function createNativeRuntimeAdapter(id: RuntimeId | string, dependencies:
         if (readiness.state !== "ready") throw new RuntimePrerequisiteError(readiness);
       }
       if (id === "pi") {
-        const distribution = ({ ...globalThis.process.env, ...dependencies.env, ...input.env }).LARKIN_PI_DISTRIBUTION === "builtin"
-          ? "builtin" : "external";
+        const distribution = piChildDistributionFromOverrides(dependencies.env, input.env);
         return new PiSession(await (dependencies.createPiSession
         ? dependencies.createPiSession(input)
         : createPiRpcBackend(input, { ...dependencies, piCommand: resolvedExecutable! }, spawn, productionSpawn)), distribution);

--- a/src/runtime/runtime-adapters.ts
+++ b/src/runtime/runtime-adapters.ts
@@ -1054,7 +1054,7 @@ async function createPiRpcBackend(input: RuntimeSessionCreate, dependencies: Nat
   const extensionArgs = (dependencies.resolvePiProcessExtensionArgs ?? resolvePiProcessExtensionArgs)({
     distribution: builtin ? "builtin" : "external",
     piCommand: command,
-    env: mergedEnv,
+    env: childEnv,
     platform: process.platform,
   });
   commandArgs.push(...extensionArgs);

--- a/src/runtime/runtime-adapters.ts
+++ b/src/runtime/runtime-adapters.ts
@@ -1040,14 +1040,17 @@ async function createPiRpcBackend(input: RuntimeSessionCreate, dependencies: Nat
   const command = builtinSpec?.command ?? dependencies.piCommand ?? dependencies.env?.LARKIN_PI_COMMAND ?? process.env.LARKIN_PI_COMMAND ?? "pi";
   const commandPrefix = builtinSpec?.args ?? dependencies.piCommandArgs ?? [];
   const commandArgs = [...commandPrefix, ...args];
-  const reportedVersion = productionSpawn && !builtin
-    ? parsePiExecutableVersion(String(spawnSync(command, [...commandPrefix, "--version"], {
-      cwd: input.workspaceDir, env: mergedEnv, encoding: "utf8", timeout: 5_000,
-    }).stdout || ""))
-    : BUNDLED_PI_VERSION;
   mergedEnv.PI_CODING_AGENT_DIR = ownedPiDirectory;
   if (builtin) mergedEnv.PI_TELEMETRY = "0";
-  const childEnv = applyPiPackageDirForChild(mergedEnv, builtin ? "builtin" : "external");
+  const childEnv = applyPiPackageDirForChild(mergedEnv, {
+    distribution: builtin ? "builtin" : "external",
+    explicitPackageDir: input.env?.PI_PACKAGE_DIR ?? dependencies.env?.PI_PACKAGE_DIR,
+  });
+  const reportedVersion = productionSpawn && !builtin
+    ? parsePiExecutableVersion(String(spawnSync(command, [...commandPrefix, "--version"], {
+      cwd: input.workspaceDir, env: childEnv, encoding: "utf8", timeout: 5_000,
+    }).stdout || ""))
+    : BUNDLED_PI_VERSION;
   const extensionArgs = (dependencies.resolvePiProcessExtensionArgs ?? resolvePiProcessExtensionArgs)({
     distribution: builtin ? "builtin" : "external",
     piCommand: command,

--- a/src/runtime/runtime-readiness.ts
+++ b/src/runtime/runtime-readiness.ts
@@ -1,6 +1,7 @@
 import fs from "node:fs";
 import path from "node:path";
 import { spawnSync } from "node:child_process";
+import { piChildDistributionFromOverrides } from "./builtin-pi-assets.js";
 import { assertBuiltinPiAgentDirectory, BUNDLED_PI_VERSION, piAgentDirectory } from "./pi-provider-config.js";
 import { traceProcessBoundary } from "../platform/process-boundary-trace.js";
 
@@ -106,7 +107,12 @@ function executableVersion(executable: string, env: NodeJS.ProcessEnv, commandAr
 /** Resolve and handshake through each runtime's structured native control protocol. */
 export async function probeNativeRuntimeReadiness(options: ProbeNativeRuntimeReadinessOptions): Promise<RuntimeReadiness> {
   const env = { ...process.env, ...options.env };
-  if (options.runtime === "pi" && env.LARKIN_PI_DISTRIBUTION === "builtin") {
+  const piDistribution = options.runtime === "pi" ? piChildDistributionFromOverrides(options.env) : "external";
+  if (piDistribution !== "builtin") {
+    if (env.LARKIN_PI_DISTRIBUTION === "builtin") delete env.LARKIN_PI_DISTRIBUTION;
+    delete env.PI_PACKAGE_DIR;
+  }
+  if (options.runtime === "pi" && piDistribution === "builtin") {
     try {
       if (!options.agentId || !env.LARKIN_CONFIG_DIR) throw new Error("内置 Pi readiness 缺少 Agent/config identity");
       assertBuiltinPiAgentDirectory(piAgentDirectory(env.LARKIN_CONFIG_DIR, options.agentId));

--- a/src/runtime/runtime-readiness.ts
+++ b/src/runtime/runtime-readiness.ts
@@ -1,7 +1,7 @@
 import fs from "node:fs";
 import path from "node:path";
 import { spawnSync } from "node:child_process";
-import { piChildDistributionFromOverrides } from "./builtin-pi-assets.js";
+import { applyPiPackageDirForChild, piChildDistributionFromOverrides } from "./builtin-pi-assets.js";
 import { assertBuiltinPiAgentDirectory, BUNDLED_PI_VERSION, piAgentDirectory } from "./pi-provider-config.js";
 import { traceProcessBoundary } from "../platform/process-boundary-trace.js";
 
@@ -106,11 +106,11 @@ function executableVersion(executable: string, env: NodeJS.ProcessEnv, commandAr
 
 /** Resolve and handshake through each runtime's structured native control protocol. */
 export async function probeNativeRuntimeReadiness(options: ProbeNativeRuntimeReadinessOptions): Promise<RuntimeReadiness> {
-  const env = { ...process.env, ...options.env };
+  let env = { ...process.env, ...options.env };
   const piDistribution = options.runtime === "pi" ? piChildDistributionFromOverrides(options.env) : "external";
-  if (piDistribution !== "builtin") {
+  if (options.runtime === "pi" && piDistribution !== "builtin") {
     if (env.LARKIN_PI_DISTRIBUTION === "builtin") delete env.LARKIN_PI_DISTRIBUTION;
-    delete env.PI_PACKAGE_DIR;
+    env = applyPiPackageDirForChild(env, { distribution: "external" });
   }
   if (options.runtime === "pi" && piDistribution === "builtin") {
     try {

--- a/src/setup/setup-bind.ts
+++ b/src/setup/setup-bind.ts
@@ -395,7 +395,7 @@ export async function main(): Promise<void> {
         const catalog = await discoverPiModelCatalog({
           cwd: CFG_DIR,
           agentDir: piAgentDirectory(CFG_DIR, profile.appId),
-          env: process.env,
+          env: { ...process.env, LARKIN_PI_DISTRIBUTION: "external" },
         });
         const effective = catalog.effectiveModel;
         const entry = effective ? catalog.models.find((model) => model.id === effective) : undefined;

--- a/test/integration/setup/external-pi-setup-hot-attach.test.mjs
+++ b/test/integration/setup/external-pi-setup-hot-attach.test.mjs
@@ -70,7 +70,15 @@ const marker = ${JSON.stringify(marker)};
 const args = process.argv.slice(2);
 fs.appendFileSync(marker, JSON.stringify({
   args, cwd: process.cwd(), agentDir: process.env.PI_CODING_AGENT_DIR || null,
+  packageDir: process.env.PI_PACKAGE_DIR || null,
 }) + "\\n");
+if (process.env.PI_PACKAGE_DIR) {
+  const theme = process.env.PI_PACKAGE_DIR + "/dist/modes/interactive/theme/dark.json";
+  if (!fs.existsSync(theme)) {
+    process.stderr.write("ENOENT: no such file or directory, open " + theme + "\\n");
+    process.exit(1);
+  }
+}
 if (args.includes("--version")) { process.stdout.write("0.84.2\\n"); process.exit(0); }
 const missingWindow = ${missingWindow ? "true" : "false"};
 const effective = { provider: "fixture", id: "pi-fixture", reasoning: false, ...(missingWindow ? {} : { contextWindow: 32000 }) };
@@ -234,6 +242,41 @@ test("rerunning external-pi setup repairs model=default and hot-attach uses the 
     } finally {
       await session.close("external-pi hot-attach test complete").catch(() => {});
     }
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("external-pi setup from a builtin host with minimal PI_PACKAGE_DIR still resolves models", async () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "larkin-external-pi-host-builtin-"));
+  try {
+    const configFile = path.join(root, "config.json");
+    fs.writeFileSync(configFile, `${JSON.stringify({
+      version: 4,
+      serverId: "server-existing",
+      mentionPolicy: "require",
+      activeAgent: APP,
+      agents: {
+        [APP]: { runtime: "pi", model: "default", piDistribution: "external" },
+      },
+    }, null, 2)}\n`, { mode: 0o600 });
+    writeCredential(root);
+    writeExternalPiProfile(path.join(root, "home"));
+    const fake = writeFakePi(root);
+    const packageDir = path.join(root, ".larkin-official-pi-package");
+    fs.mkdirSync(path.join(packageDir, "theme"), { recursive: true });
+    fs.writeFileSync(path.join(packageDir, "package.json"), "{\"name\":\"fixture-builtin-pi\"}\n");
+    fs.writeFileSync(path.join(packageDir, "theme", "dark.json"), "{}\n");
+    const result = runBind(root, {
+      LARKIN_PI_COMMAND: fake.command,
+      LARKIN_PI_DISTRIBUTION: "builtin",
+      PI_PACKAGE_DIR: packageDir,
+    });
+    assert.equal(result.status, 0, result.stdout + result.stderr);
+    const stored = JSON.parse(fs.readFileSync(configFile, "utf8"));
+    assert.equal(stored.agents[APP].model, "fixture/pi-fixture");
+    const launches = readLaunches(fake.marker);
+    assert.equal(launches.every((row) => row.packageDir == null), true, JSON.stringify(launches));
   } finally {
     fs.rmSync(root, { recursive: true, force: true });
   }

--- a/test/integration/setup/external-pi-setup-hot-attach.test.mjs
+++ b/test/integration/setup/external-pi-setup-hot-attach.test.mjs
@@ -247,6 +247,47 @@ test("rerunning external-pi setup repairs model=default and hot-attach uses the 
   }
 });
 
+test("builtin host + minimal PI_PACKAGE_DIR rolls back imported artifacts after catalog failure", () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "larkin-external-pi-host-builtin-fail-"));
+  try {
+    const configFile = path.join(root, "config.json");
+    const before = `${JSON.stringify({
+      version: 4,
+      serverId: "server-existing",
+      mentionPolicy: "require",
+      activeAgent: APP,
+      agents: {
+        [APP]: { runtime: "pi", model: "default", piDistribution: "external" },
+      },
+    }, null, 2)}\n`;
+    fs.writeFileSync(configFile, before, { mode: 0o600 });
+    const botFile = writeCredential(root);
+    const botBefore = fs.readFileSync(botFile);
+    const profile = writeExternalPiProfile(path.join(root, "home"));
+    const fake = writeFakePi(root, { missingWindow: true });
+    const packageDir = path.join(root, ".larkin-official-pi-package");
+    fs.mkdirSync(path.join(packageDir, "theme"), { recursive: true });
+    fs.writeFileSync(path.join(packageDir, "package.json"), "{\"name\":\"fixture-builtin-pi\"}\n");
+    fs.writeFileSync(path.join(packageDir, "theme", "dark.json"), "{}\n");
+    const result = runBind(root, {
+      LARKIN_PI_COMMAND: fake.command,
+      LARKIN_PI_DISTRIBUTION: "builtin",
+      PI_PACKAGE_DIR: packageDir,
+    });
+    assert.notEqual(result.status, 0, result.stdout + result.stderr);
+    assert.equal(fs.readFileSync(configFile, "utf8"), before);
+    assert.deepEqual(fs.readFileSync(botFile), botBefore);
+    assert.deepEqual(fs.readFileSync(path.join(profile.dir, "auth.json")), profile.auth);
+    assert.equal(fs.existsSync(path.join(root, "providers", "pi", APP)), false);
+    assert.equal(fs.existsSync(path.join(root, "providers", "pi", `${APP}.larkin-pi-import.lock`)), false);
+    assert.equal(fs.existsSync(path.join(root, "providers", "pi", APP, "auth.json")), false);
+    const launches = readLaunches(fake.marker);
+    assert.equal(launches.every((row) => row.packageDir == null), true, JSON.stringify(launches));
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});
+
 test("external-pi setup from a builtin host with minimal PI_PACKAGE_DIR still resolves models", async () => {
   const root = fs.mkdtempSync(path.join(os.tmpdir(), "larkin-external-pi-host-builtin-"));
   try {

--- a/test/integration/setup/external-pi-setup-hot-attach.test.mjs
+++ b/test/integration/setup/external-pi-setup-hot-attach.test.mjs
@@ -274,7 +274,10 @@ test("builtin host + minimal PI_PACKAGE_DIR rolls back imported artifacts after 
       LARKIN_PI_DISTRIBUTION: "builtin",
       PI_PACKAGE_DIR: packageDir,
     });
-    assert.notEqual(result.status, 0, result.stdout + result.stderr);
+    const output = `${result.stdout}\n${result.stderr}`;
+    assert.notEqual(result.status, 0, output);
+    assert.match(output, /Pi effective model is missing a context window/);
+    assert.match(output, /larkin setup --runtime external-pi/);
     assert.equal(fs.readFileSync(configFile, "utf8"), before);
     assert.deepEqual(fs.readFileSync(botFile), botBefore);
     assert.deepEqual(fs.readFileSync(path.join(profile.dir, "auth.json")), profile.auth);
@@ -282,6 +285,11 @@ test("builtin host + minimal PI_PACKAGE_DIR rolls back imported artifacts after 
     assert.equal(fs.existsSync(path.join(root, "providers", "pi", `${APP}.larkin-pi-import.lock`)), false);
     assert.equal(fs.existsSync(path.join(root, "providers", "pi", APP, "auth.json")), false);
     const launches = readLaunches(fake.marker);
+    assert.ok(launches.length > 0, JSON.stringify(launches));
+    assert.equal(launches.some((row) => row.args.includes("--version")), true, JSON.stringify(launches));
+    const catalogProbe = launches.find((row) => row.args.includes("--mode") && row.args.includes("rpc") && row.args.includes("--no-session"));
+    assert.ok(catalogProbe, JSON.stringify(launches));
+    assert.equal(catalogProbe.agentDir, path.join(root, "providers", "pi", APP));
     assert.equal(launches.every((row) => row.packageDir == null), true, JSON.stringify(launches));
   } finally {
     fs.rmSync(root, { recursive: true, force: true });

--- a/test/unit/runtime/pi-model-catalog.test.mjs
+++ b/test/unit/runtime/pi-model-catalog.test.mjs
@@ -1,5 +1,6 @@
 import assert from "node:assert/strict";
 import fs from "node:fs";
+import os from "node:os";
 import path from "node:path";
 import { createRequire } from "node:module";
 import { EventEmitter } from "node:events";
@@ -11,6 +12,7 @@ import {
   findExactPiModel,
   supportedPiThinkingLevels,
 } from "../../../dist/runtime/pi-model-catalog.mjs";
+import { applyPiPackageDirForChild, piChildDistributionFromOverrides } from "../../../dist/runtime/builtin-pi-assets.mjs";
 
 const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..", "..", "..");
 const require = createRequire(import.meta.url);
@@ -79,6 +81,68 @@ test("Pi thinking levels follow official reasoning metadata without Codex ultra"
   assert.deepEqual(supportedPiThinkingLevels(models[0]), ["off"]);
   assert.equal(supportedPiThinkingLevels(models[1]).includes("max"), true);
   assert.equal(supportedPiThinkingLevels(models[1]).includes("ultra"), false);
+});
+
+test("child Pi distribution ignores host builtin unless an override says so", () => {
+  assert.equal(piChildDistributionFromOverrides(undefined), "external");
+  assert.equal(piChildDistributionFromOverrides({ LARKIN_PI_DISTRIBUTION: "builtin" }), "builtin");
+  assert.equal(piChildDistributionFromOverrides({ LARKIN_PI_DISTRIBUTION: "builtin" }, { LARKIN_PI_DISTRIBUTION: "external" }), "external");
+});
+
+test("external Pi child env drops inherited builtin PI_PACKAGE_DIR", () => {
+  const env = applyPiPackageDirForChild({
+    PI_PACKAGE_DIR: "/tmp/agent/.larkin-official-pi-package",
+    PI_CODING_AGENT_DIR: "/tmp/agent",
+    LARKIN_PI_DISTRIBUTION: "external",
+  });
+  assert.equal(env.PI_PACKAGE_DIR, undefined);
+  assert.equal(env.PI_CODING_AGENT_DIR, "/tmp/agent");
+});
+
+test("builtin Pi child env keeps PI_PACKAGE_DIR", () => {
+  const packageDir = "/tmp/agent/.larkin-official-pi-package";
+  const env = applyPiPackageDirForChild({
+    PI_PACKAGE_DIR: packageDir,
+    LARKIN_PI_DISTRIBUTION: "builtin",
+  }, "builtin");
+  assert.equal(env.PI_PACKAGE_DIR, packageDir);
+});
+
+test("external catalog discovery succeeds after builtin assets materialize without reading dist themes", async () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "larkin-issue156-"));
+  const packageDir = path.join(root, ".larkin-official-pi-package");
+  const themeDir = path.join(packageDir, "theme");
+  fs.mkdirSync(themeDir, { recursive: true });
+  fs.writeFileSync(path.join(packageDir, "package.json"), "{\"name\":\"fixture-builtin-pi\"}\n");
+  fs.writeFileSync(path.join(themeDir, "dark.json"), "{}\n");
+  fs.writeFileSync(path.join(themeDir, "light.json"), "{}\n");
+  const probe = path.join(root, "external-pi.mjs");
+  fs.writeFileSync(probe, `
+import fs from "node:fs";
+import path from "node:path";
+import readline from "node:readline";
+const packageDir = process.env.PI_PACKAGE_DIR;
+if (packageDir) fs.readFileSync(path.join(packageDir, "dist/modes/interactive/theme/dark.json"));
+const rl = readline.createInterface({ input: process.stdin });
+rl.on("line", (line) => {
+  const request = JSON.parse(line);
+  const model = { provider: "plain", id: "chat", name: "Chat", reasoning: false, contextWindow: 32000 };
+  const data = request.type === "get_available_models" ? { models: [model] } : { model, thinkingLevel: "off" };
+  process.stdout.write(JSON.stringify({ id: request.id, type: "response", command: request.type, success: true, data }) + "\\n");
+});
+`);
+  try {
+    const catalog = await discoverPiModelCatalog({
+      cwd: root,
+      command: process.execPath,
+      commandArgs: [probe],
+      env: { PI_PACKAGE_DIR: packageDir },
+    });
+    assert.equal(catalog.effectiveModel, "plain/chat");
+    assert.equal(catalog.models[0].id, "plain/chat");
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
 });
 
 test("production graph pins official Pi and exposes it only through the shared RPC contract", () => {

--- a/test/unit/runtime/pi-model-catalog.test.mjs
+++ b/test/unit/runtime/pi-model-catalog.test.mjs
@@ -156,6 +156,25 @@ test("external env keeps a Nix-like package root and strips symlink/minimal/miss
     const dirAsTheme = path.join(root, "dir-theme");
     fs.mkdirSync(path.join(dirAsTheme, "dist", "modes", "interactive", "theme", "dark.json"), { recursive: true });
     assert.equal(applyPiPackageDirForChild({ PI_PACKAGE_DIR: dirAsTheme }, "external").PI_PACKAGE_DIR, undefined);
+    const linkedThemeRoot = path.join(root, "linked-theme");
+    const themeFile = path.join(root, "real-dark.json");
+    fs.writeFileSync(themeFile, "{}\n");
+    fs.mkdirSync(path.join(linkedThemeRoot, "dist", "modes", "interactive", "theme"), { recursive: true });
+    fs.symlinkSync(themeFile, path.join(linkedThemeRoot, "dist", "modes", "interactive", "theme", "dark.json"));
+    assert.equal(applyPiPackageDirForChild({ PI_PACKAGE_DIR: linkedThemeRoot }, "external").PI_PACKAGE_DIR, fs.realpathSync(linkedThemeRoot));
+    const brokenThemeRoot = path.join(root, "broken-theme");
+    fs.mkdirSync(path.join(brokenThemeRoot, "dist", "modes", "interactive", "theme"), { recursive: true });
+    fs.symlinkSync(path.join(root, "missing-dark.json"), path.join(brokenThemeRoot, "dist", "modes", "interactive", "theme", "dark.json"));
+    assert.equal(applyPiPackageDirForChild({ PI_PACKAGE_DIR: brokenThemeRoot }, "external").PI_PACKAGE_DIR, undefined);
+    if (process.platform !== "win32") {
+      const unread = path.join(root, "unread-root");
+      fs.mkdirSync(path.join(unread, "dist", "modes", "interactive", "theme"), { recursive: true });
+      const unreadTheme = path.join(unread, "dist", "modes", "interactive", "theme", "dark.json");
+      fs.writeFileSync(unreadTheme, "{}\n", { mode: 0o000 });
+      fs.chmodSync(unreadTheme, 0o000);
+      assert.equal(applyPiPackageDirForChild({ PI_PACKAGE_DIR: unread }, "external").PI_PACKAGE_DIR, undefined);
+      fs.chmodSync(unreadTheme, 0o644);
+    }
   } finally {
     fs.rmSync(root, { recursive: true, force: true });
   }

--- a/test/unit/runtime/pi-model-catalog.test.mjs
+++ b/test/unit/runtime/pi-model-catalog.test.mjs
@@ -108,6 +108,56 @@ test("builtin Pi child env keeps PI_PACKAGE_DIR", () => {
   assert.equal(env.PI_PACKAGE_DIR, packageDir);
 });
 
+test("setup-style catalog env with host builtin + minimal PI_PACKAGE_DIR still strips the builtin dir", async () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "larkin-issue156-setup-"));
+  const packageDir = path.join(root, ".larkin-official-pi-package");
+  fs.mkdirSync(path.join(packageDir, "theme"), { recursive: true });
+  fs.writeFileSync(path.join(packageDir, "package.json"), "{\"name\":\"fixture-builtin-pi\"}\n");
+  fs.writeFileSync(path.join(packageDir, "theme", "dark.json"), "{}\n");
+  try {
+    let childEnv;
+    const catalog = await discoverPiModelCatalog({
+      cwd: root,
+      env: {
+        LARKIN_PI_DISTRIBUTION: "builtin",
+        PI_PACKAGE_DIR: packageDir,
+        PI_CODING_AGENT_DIR: path.join(root, "agent"),
+      },
+      spawn: (_command, _args, options) => {
+        childEnv = options.env;
+        return new FakePi(models, models[0]);
+      },
+    });
+    assert.equal(childEnv.PI_PACKAGE_DIR, undefined);
+    assert.equal(catalog.effectiveModel, "plain/chat");
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("explicit external PI_PACKAGE_DIR is kept only when it is a real Node package root", () => {
+  const realRoot = fs.mkdtempSync(path.join(os.tmpdir(), "larkin-issue156-real-pkg-"));
+  const realDir = path.join(realRoot, "pi-pkg");
+  fs.mkdirSync(path.join(realDir, "dist", "modes", "interactive", "theme"), { recursive: true });
+  fs.writeFileSync(path.join(realDir, "dist", "modes", "interactive", "theme", "dark.json"), "{}\n");
+  const builtinDir = path.join(realRoot, ".larkin-official-pi-package");
+  fs.mkdirSync(path.join(builtinDir, "theme"), { recursive: true });
+  try {
+    const kept = applyPiPackageDirForChild({ PI_PACKAGE_DIR: builtinDir }, {
+      distribution: "external",
+      explicitPackageDir: realDir,
+    });
+    assert.equal(kept.PI_PACKAGE_DIR, realDir);
+    const stripped = applyPiPackageDirForChild({ PI_PACKAGE_DIR: builtinDir }, {
+      distribution: "external",
+      explicitPackageDir: builtinDir,
+    });
+    assert.equal(stripped.PI_PACKAGE_DIR, undefined);
+  } finally {
+    fs.rmSync(realRoot, { recursive: true, force: true });
+  }
+});
+
 test("external catalog discovery succeeds after builtin assets materialize without reading dist themes", async () => {
   const root = fs.mkdtempSync(path.join(os.tmpdir(), "larkin-issue156-"));
   const packageDir = path.join(root, ".larkin-official-pi-package");

--- a/test/unit/runtime/pi-model-catalog.test.mjs
+++ b/test/unit/runtime/pi-model-catalog.test.mjs
@@ -135,6 +135,29 @@ test("setup-style catalog env with host builtin + minimal PI_PACKAGE_DIR still s
   }
 });
 
+test("external env keeps a Nix-like package root and strips symlink/minimal/missing roots", () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "larkin-issue156-roots-"));
+  const nixDir = path.join(root, "nix", "store", "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa-pi-coding-agent-0.84.2");
+  fs.mkdirSync(path.join(nixDir, "dist", "modes", "interactive", "theme"), { recursive: true });
+  fs.writeFileSync(path.join(nixDir, "dist", "modes", "interactive", "theme", "dark.json"), "{}\n");
+  const minimal = path.join(root, ".larkin-official-pi-package");
+  fs.mkdirSync(path.join(minimal, "theme"), { recursive: true });
+  fs.writeFileSync(path.join(minimal, "theme", "dark.json"), "{}\n");
+  const aliasToMinimal = path.join(root, "alias-minimal");
+  const aliasToNix = path.join(root, "alias-nix");
+  fs.symlinkSync(minimal, aliasToMinimal);
+  fs.symlinkSync(nixDir, aliasToNix);
+  try {
+    assert.equal(applyPiPackageDirForChild({ PI_PACKAGE_DIR: nixDir }, "external").PI_PACKAGE_DIR, fs.realpathSync(nixDir));
+    assert.equal(applyPiPackageDirForChild({ PI_PACKAGE_DIR: aliasToNix }, "external").PI_PACKAGE_DIR, fs.realpathSync(nixDir));
+    assert.equal(applyPiPackageDirForChild({ PI_PACKAGE_DIR: minimal }, "external").PI_PACKAGE_DIR, undefined);
+    assert.equal(applyPiPackageDirForChild({ PI_PACKAGE_DIR: aliasToMinimal }, "external").PI_PACKAGE_DIR, undefined);
+    assert.equal(applyPiPackageDirForChild({ PI_PACKAGE_DIR: path.join(root, "missing") }, "external").PI_PACKAGE_DIR, undefined);
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});
+
 test("explicit external PI_PACKAGE_DIR is kept only when it is a real Node package root", () => {
   const realRoot = fs.mkdtempSync(path.join(os.tmpdir(), "larkin-issue156-real-pkg-"));
   const realDir = path.join(realRoot, "pi-pkg");
@@ -147,7 +170,7 @@ test("explicit external PI_PACKAGE_DIR is kept only when it is a real Node packa
       distribution: "external",
       explicitPackageDir: realDir,
     });
-    assert.equal(kept.PI_PACKAGE_DIR, realDir);
+    assert.equal(kept.PI_PACKAGE_DIR, fs.realpathSync(realDir));
     const stripped = applyPiPackageDirForChild({ PI_PACKAGE_DIR: builtinDir }, {
       distribution: "external",
       explicitPackageDir: builtinDir,
@@ -190,6 +213,43 @@ rl.on("line", (line) => {
     });
     assert.equal(catalog.effectiveModel, "plain/chat");
     assert.equal(catalog.models[0].id, "plain/chat");
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("catalog cache distinguishes sanitized package roots", async () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "larkin-issue156-cache-"));
+  const makePkg = (name) => {
+    const dir = path.join(root, name);
+    fs.mkdirSync(path.join(dir, "dist", "modes", "interactive", "theme"), { recursive: true });
+    fs.writeFileSync(path.join(dir, "dist", "modes", "interactive", "theme", "dark.json"), "{}\n");
+    return dir;
+  };
+  const first = makePkg("one");
+  const second = makePkg("two");
+  const script = path.join(root, "pi.mjs");
+  fs.writeFileSync(script, `
+import path from "node:path";
+import readline from "node:readline";
+const id = path.basename(process.env.PI_PACKAGE_DIR || "missing");
+const rl = readline.createInterface({ input: process.stdin });
+rl.on("line", (line) => {
+  const request = JSON.parse(line);
+  const model = { provider: "plain", id, name: id, reasoning: false, contextWindow: 32000 };
+  const data = request.type === "get_available_models" ? { models: [model] } : { model, thinkingLevel: "off" };
+  process.stdout.write(JSON.stringify({ id: request.id, type: "response", command: request.type, success: true, data }) + "\\n");
+});
+`);
+  try {
+    const a = await discoverPiModelCatalog({
+      cwd: root, command: process.execPath, commandArgs: [script], packageDir: first,
+    });
+    const b = await discoverPiModelCatalog({
+      cwd: root, command: process.execPath, commandArgs: [script], packageDir: second,
+    });
+    assert.equal(a.effectiveModel, "plain/one");
+    assert.equal(b.effectiveModel, "plain/two");
   } finally {
     fs.rmSync(root, { recursive: true, force: true });
   }

--- a/test/unit/runtime/pi-model-catalog.test.mjs
+++ b/test/unit/runtime/pi-model-catalog.test.mjs
@@ -153,6 +153,9 @@ test("external env keeps a Nix-like package root and strips symlink/minimal/miss
     assert.equal(applyPiPackageDirForChild({ PI_PACKAGE_DIR: minimal }, "external").PI_PACKAGE_DIR, undefined);
     assert.equal(applyPiPackageDirForChild({ PI_PACKAGE_DIR: aliasToMinimal }, "external").PI_PACKAGE_DIR, undefined);
     assert.equal(applyPiPackageDirForChild({ PI_PACKAGE_DIR: path.join(root, "missing") }, "external").PI_PACKAGE_DIR, undefined);
+    const dirAsTheme = path.join(root, "dir-theme");
+    fs.mkdirSync(path.join(dirAsTheme, "dist", "modes", "interactive", "theme", "dark.json"), { recursive: true });
+    assert.equal(applyPiPackageDirForChild({ PI_PACKAGE_DIR: dirAsTheme }, "external").PI_PACKAGE_DIR, undefined);
   } finally {
     fs.rmSync(root, { recursive: true, force: true });
   }

--- a/test/unit/runtime/pi-profile-migration.test.mjs
+++ b/test/unit/runtime/pi-profile-migration.test.mjs
@@ -42,6 +42,28 @@ function fixture({ target = false } = {}) {
 
 function clean(f) { fs.rmSync(f.root, { recursive: true, force: true }); }
 
+test("profile apply does not inherit a later ambient package root when the plan had none", () => {
+  const f = fixture();
+  const minimal = path.join(f.root, ".larkin-official-pi-package");
+  fs.mkdirSync(path.join(minimal, "theme"), { recursive: true });
+  fs.writeFileSync(path.join(minimal, "theme", "dark.json"), "{}\n");
+  const later = path.join(f.root, "later-root");
+  fs.mkdirSync(path.join(later, "dist", "modes", "interactive", "theme"), { recursive: true });
+  fs.writeFileSync(path.join(later, "dist", "modes", "interactive", "theme", "dark.json"), "{}\n");
+  const previous = process.env.PI_PACKAGE_DIR;
+  try {
+    const plan = migration.preparePiProfileMigration({ ...f.env, PI_PACKAGE_DIR: minimal }, f.config, f.agent, "external");
+    assert.equal(plan.sourceEnvironment.PI_PACKAGE_DIR, undefined);
+    process.env.PI_PACKAGE_DIR = later;
+    migration.applyPiProfileMigration(plan);
+    assert.equal(fs.existsSync(path.join(f.targetDir, "auth.json")), true);
+  } finally {
+    if (previous === undefined) delete process.env.PI_PACKAGE_DIR;
+    else process.env.PI_PACKAGE_DIR = previous;
+    clean(f);
+  }
+});
+
 test("profile migration plan persists a canonical external package root", () => {
   const f = fixture();
   const pkg = path.join(f.root, "nix", "store", "hash-pi");

--- a/test/unit/runtime/pi-profile-migration.test.mjs
+++ b/test/unit/runtime/pi-profile-migration.test.mjs
@@ -20,11 +20,24 @@ function fixture({ target = false } = {}) {
   fs.mkdirSync(bin, { recursive: true, mode: 0o700 });
   fs.mkdirSync(config, { recursive: true, mode: 0o700 });
   const version = path.join(bin, "pi");
-  const probeLog = path.join(root, "pi-version.ndjson");
+  const probeLog = path.join(bin, "probe.ndjson");
   fs.writeFileSync(probeLog, "");
   fs.writeFileSync(version, `#!${process.execPath}
 const fs = require("node:fs");
-try { if (process.env.LARKIN_PI_PROBE_LOG) fs.appendFileSync(process.env.LARKIN_PI_PROBE_LOG, JSON.stringify({ packageDir: process.env.PI_PACKAGE_DIR || null }) + "\\n"); } catch {}
+const path = require("node:path");
+try {
+  fs.appendFileSync(path.join(path.dirname(process.argv[1]), "probe.ndjson"), JSON.stringify({
+    packageDir: process.env.PI_PACKAGE_DIR || null,
+    cwd: process.cwd(),
+    path: process.env.PATH || null,
+    command: process.env.LARKIN_PI_COMMAND || null,
+    codingAgentDir: process.env.PI_CODING_AGENT_DIR || null,
+    offline: process.env.PI_OFFLINE || null,
+    skipVersion: process.env.PI_SKIP_VERSION_CHECK || null,
+    distribution: process.env.LARKIN_PI_DISTRIBUTION || null,
+    configDir: process.env.LARKIN_CONFIG_DIR || null,
+  }) + "\\n");
+} catch {}
 console.log("0.84.2");
 `, { mode: 0o700 });
   fs.chmodSync(version, 0o700);
@@ -42,7 +55,7 @@ console.log("0.84.2");
     fs.writeFileSync(path.join(targetDir, "settings.json"), JSON.stringify({ keep: true, compaction: { enabled: false } }), { mode: 0o600 });
     fs.writeFileSync(path.join(targetDir, "unrelated.txt"), "must-survive", { mode: 0o600 });
   }
-  const env = { HOME: root, PATH: `${bin}:/usr/bin:/bin`, PI_CODING_AGENT_DIR: source, LARKIN_PI_PROBE_LOG: probeLog };
+  const env = { HOME: root, PATH: `${bin}:/usr/bin:/bin`, PI_CODING_AGENT_DIR: source };
   return { root, source, config, targetDir, agent, env, auth, models, probeLog };
 }
 
@@ -56,8 +69,14 @@ test("profile apply does not inherit a later ambient package root when the plan 
   const later = path.join(f.root, "later-root");
   fs.mkdirSync(path.join(later, "dist", "modes", "interactive", "theme"), { recursive: true });
   fs.writeFileSync(path.join(later, "dist", "modes", "interactive", "theme", "dark.json"), "{}\n");
-  const previous = process.env.PI_PACKAGE_DIR;
-  const previousProbeLog = process.env.LARKIN_PI_PROBE_LOG;
+  const previous = {
+    PI_PACKAGE_DIR: process.env.PI_PACKAGE_DIR,
+    PI_CODING_AGENT_DIR: process.env.PI_CODING_AGENT_DIR,
+    PI_OFFLINE: process.env.PI_OFFLINE,
+    PI_SKIP_VERSION_CHECK: process.env.PI_SKIP_VERSION_CHECK,
+    LARKIN_PI_DISTRIBUTION: process.env.LARKIN_PI_DISTRIBUTION,
+    LARKIN_CONFIG_DIR: process.env.LARKIN_CONFIG_DIR,
+  };
   try {
     fs.writeFileSync(f.probeLog, "");
     const plan = migration.preparePiProfileMigration({ ...f.env, PI_PACKAGE_DIR: minimal }, f.config, f.agent, "external");
@@ -65,21 +84,60 @@ test("profile apply does not inherit a later ambient package root when the plan 
     const prepareProbes = fs.readFileSync(f.probeLog, "utf8").trim().split("\n").filter(Boolean).map(JSON.parse);
     assert.ok(prepareProbes.length >= 1);
     assert.equal(prepareProbes.every((row) => row.packageDir == null), true, JSON.stringify(prepareProbes));
-    process.env.PI_PACKAGE_DIR = later;
-    process.env.LARKIN_PI_PROBE_LOG = f.probeLog;
+    process.env.PI_CODING_AGENT_DIR = "/tmp/polluted-agent";
+    process.env.PI_OFFLINE = "1";
+    process.env.PI_SKIP_VERSION_CHECK = "1";
+    process.env.LARKIN_PI_DISTRIBUTION = "builtin";
+    process.env.LARKIN_CONFIG_DIR = "/tmp/polluted-config";
     fs.writeFileSync(f.probeLog, "");
     migration.applyPiProfileMigration(plan);
     const applyProbes = fs.readFileSync(f.probeLog, "utf8").trim().split("\n").filter(Boolean).map(JSON.parse);
-    assert.ok(applyProbes.length >= 1);
-    assert.equal(applyProbes.every((row) => row.packageDir == null), true, JSON.stringify(applyProbes));
+    assert.equal(applyProbes.length, 1, JSON.stringify(applyProbes));
+    assert.equal(applyProbes[0].packageDir, null);
+    assert.equal(applyProbes[0].codingAgentDir, null);
+    assert.equal(applyProbes[0].offline, null);
+    assert.equal(applyProbes[0].skipVersion, null);
+    assert.equal(applyProbes[0].distribution, null);
+    assert.equal(applyProbes[0].configDir, null);
+    assert.equal(applyProbes[0].command, "pi");
+    assert.equal(fs.realpathSync(applyProbes[0].cwd), fs.realpathSync(plan.state.sourceDir));
+    assert.equal(applyProbes[0].path, plan.sourceEnvironment.PATH);
     assert.equal(fs.existsSync(path.join(f.targetDir, "auth.json")), true);
   } finally {
-    if (previous === undefined) delete process.env.PI_PACKAGE_DIR;
-    else process.env.PI_PACKAGE_DIR = previous;
-    if (previousProbeLog === undefined) delete process.env.LARKIN_PI_PROBE_LOG;
-    else process.env.LARKIN_PI_PROBE_LOG = previousProbeLog;
+    for (const [key, value] of Object.entries(previous)) {
+      if (value === undefined) delete process.env[key];
+      else process.env[key] = value;
+    }
     clean(f);
   }
+});
+
+test("profile apply rejects symlink retarget and theme content mutation", () => {
+  const f = fixture();
+  const pkg = path.join(f.root, "planned-root");
+  const alt = path.join(f.root, "alternate-root");
+  fs.mkdirSync(path.join(pkg, "dist", "modes", "interactive", "theme"), { recursive: true });
+  fs.writeFileSync(path.join(pkg, "dist", "modes", "interactive", "theme", "dark.json"), "{}\n");
+  fs.mkdirSync(path.join(alt, "dist", "modes", "interactive", "theme"), { recursive: true });
+  fs.writeFileSync(path.join(alt, "dist", "modes", "interactive", "theme", "dark.json"), "{\"alt\":true}\n");
+  try {
+    const plan = migration.preparePiProfileMigration({ ...f.env, PI_PACKAGE_DIR: pkg }, f.config, f.agent, "external");
+    fs.rmSync(pkg, { recursive: true, force: true });
+    fs.symlinkSync(alt, pkg);
+    assert.throws(() => migration.applyPiProfileMigration(plan), /package root changed/);
+    assert.equal(fs.existsSync(path.join(f.targetDir, "auth.json")), false);
+  } finally { clean(f); }
+  const g = fixture();
+  const live = path.join(g.root, "live-root");
+  fs.mkdirSync(path.join(live, "dist", "modes", "interactive", "theme"), { recursive: true });
+  const theme = path.join(live, "dist", "modes", "interactive", "theme", "dark.json");
+  fs.writeFileSync(theme, "{}\n");
+  try {
+    const plan = migration.preparePiProfileMigration({ ...g.env, PI_PACKAGE_DIR: live }, g.config, g.agent, "external");
+    fs.writeFileSync(theme, "{\"mutated\":true}\n");
+    assert.throws(() => migration.applyPiProfileMigration(plan), /package root changed/);
+    assert.equal(fs.existsSync(path.join(g.targetDir, "auth.json")), false);
+  } finally { clean(g); }
 });
 
 test("profile apply fails closed when the planned package root becomes stale", () => {

--- a/test/unit/runtime/pi-profile-migration.test.mjs
+++ b/test/unit/runtime/pi-profile-migration.test.mjs
@@ -20,7 +20,13 @@ function fixture({ target = false } = {}) {
   fs.mkdirSync(bin, { recursive: true, mode: 0o700 });
   fs.mkdirSync(config, { recursive: true, mode: 0o700 });
   const version = path.join(bin, "pi");
-  fs.writeFileSync(version, `#!${process.execPath}\nconsole.log("0.84.2")\n`, { mode: 0o700 });
+  const probeLog = path.join(root, "pi-version.ndjson");
+  fs.writeFileSync(probeLog, "");
+  fs.writeFileSync(version, `#!${process.execPath}
+const fs = require("node:fs");
+try { if (process.env.LARKIN_PI_PROBE_LOG) fs.appendFileSync(process.env.LARKIN_PI_PROBE_LOG, JSON.stringify({ packageDir: process.env.PI_PACKAGE_DIR || null }) + "\\n"); } catch {}
+console.log("0.84.2");
+`, { mode: 0o700 });
   fs.chmodSync(version, 0o700);
   const auth = Buffer.from('{"fixture":{"type":"api_key","key":"PRIVATE_FIXTURE_SECRET"}}\n');
   const models = Buffer.from('{"providers":{"fixture":{"models":[{"id":"fixture-model","contextWindow":272000}]}}}\n');
@@ -36,8 +42,8 @@ function fixture({ target = false } = {}) {
     fs.writeFileSync(path.join(targetDir, "settings.json"), JSON.stringify({ keep: true, compaction: { enabled: false } }), { mode: 0o600 });
     fs.writeFileSync(path.join(targetDir, "unrelated.txt"), "must-survive", { mode: 0o600 });
   }
-  const env = { HOME: root, PATH: `${bin}:/usr/bin:/bin`, PI_CODING_AGENT_DIR: source };
-  return { root, source, config, targetDir, agent, env, auth, models };
+  const env = { HOME: root, PATH: `${bin}:/usr/bin:/bin`, PI_CODING_AGENT_DIR: source, LARKIN_PI_PROBE_LOG: probeLog };
+  return { root, source, config, targetDir, agent, env, auth, models, probeLog };
 }
 
 function clean(f) { fs.rmSync(f.root, { recursive: true, force: true }); }
@@ -51,17 +57,43 @@ test("profile apply does not inherit a later ambient package root when the plan 
   fs.mkdirSync(path.join(later, "dist", "modes", "interactive", "theme"), { recursive: true });
   fs.writeFileSync(path.join(later, "dist", "modes", "interactive", "theme", "dark.json"), "{}\n");
   const previous = process.env.PI_PACKAGE_DIR;
+  const previousProbeLog = process.env.LARKIN_PI_PROBE_LOG;
   try {
+    fs.writeFileSync(f.probeLog, "");
     const plan = migration.preparePiProfileMigration({ ...f.env, PI_PACKAGE_DIR: minimal }, f.config, f.agent, "external");
     assert.equal(plan.sourceEnvironment.PI_PACKAGE_DIR, undefined);
+    const prepareProbes = fs.readFileSync(f.probeLog, "utf8").trim().split("\n").filter(Boolean).map(JSON.parse);
+    assert.ok(prepareProbes.length >= 1);
+    assert.equal(prepareProbes.every((row) => row.packageDir == null), true, JSON.stringify(prepareProbes));
     process.env.PI_PACKAGE_DIR = later;
+    process.env.LARKIN_PI_PROBE_LOG = f.probeLog;
+    fs.writeFileSync(f.probeLog, "");
     migration.applyPiProfileMigration(plan);
+    const applyProbes = fs.readFileSync(f.probeLog, "utf8").trim().split("\n").filter(Boolean).map(JSON.parse);
+    assert.ok(applyProbes.length >= 1);
+    assert.equal(applyProbes.every((row) => row.packageDir == null), true, JSON.stringify(applyProbes));
     assert.equal(fs.existsSync(path.join(f.targetDir, "auth.json")), true);
   } finally {
     if (previous === undefined) delete process.env.PI_PACKAGE_DIR;
     else process.env.PI_PACKAGE_DIR = previous;
+    if (previousProbeLog === undefined) delete process.env.LARKIN_PI_PROBE_LOG;
+    else process.env.LARKIN_PI_PROBE_LOG = previousProbeLog;
     clean(f);
   }
+});
+
+test("profile apply fails closed when the planned package root becomes stale", () => {
+  const f = fixture();
+  const pkg = path.join(f.root, "planned-root");
+  fs.mkdirSync(path.join(pkg, "dist", "modes", "interactive", "theme"), { recursive: true });
+  fs.writeFileSync(path.join(pkg, "dist", "modes", "interactive", "theme", "dark.json"), "{}\n");
+  try {
+    const plan = migration.preparePiProfileMigration({ ...f.env, PI_PACKAGE_DIR: pkg }, f.config, f.agent, "external");
+    assert.equal(plan.sourceEnvironment.PI_PACKAGE_DIR, fs.realpathSync(pkg));
+    fs.rmSync(pkg, { recursive: true, force: true });
+    assert.throws(() => migration.applyPiProfileMigration(plan), /package root changed/);
+    assert.equal(fs.existsSync(path.join(f.targetDir, "auth.json")), false);
+  } finally { clean(f); }
 });
 
 test("profile migration plan persists a canonical external package root", () => {

--- a/test/unit/runtime/pi-profile-migration.test.mjs
+++ b/test/unit/runtime/pi-profile-migration.test.mjs
@@ -139,8 +139,10 @@ test("prepare/apply/rollback probes ignore a later ambient package root", () => 
     fs.writeFileSync(f.probeLog, "");
     migration.rollbackPiProfileMigration(plan.state);
     const rollbackProbes = readProbes();
+    assert.ok(rollbackProbes.length > 0, JSON.stringify(rollbackProbes));
     assert.equal(rollbackProbes.every((row) => !String(row.packageDir || "").includes("later-valid")), true, JSON.stringify(rollbackProbes));
-    assert.equal(fs.existsSync(path.join(f.targetDir, "auth.json")), false);
+    assert.equal(fs.realpathSync(rollbackProbes[0].packageDir), fs.realpathSync(planned));
+    assert.equal(fs.existsSync(f.targetDir), false);
     assert.equal(fs.existsSync(lock), false);
   } finally {
     if (previous === undefined) delete process.env.PI_PACKAGE_DIR;

--- a/test/unit/runtime/pi-profile-migration.test.mjs
+++ b/test/unit/runtime/pi-profile-migration.test.mjs
@@ -112,6 +112,43 @@ test("profile apply does not inherit a later ambient package root when the plan 
   }
 });
 
+test("prepare/apply/rollback probes ignore a later ambient package root", () => {
+  const f = fixture();
+  const planned = path.join(f.root, "planned-root");
+  const later = path.join(f.root, "later-valid");
+  for (const root of [planned, later]) {
+    fs.mkdirSync(path.join(root, "dist", "modes", "interactive", "theme"), { recursive: true });
+    fs.writeFileSync(path.join(root, "dist", "modes", "interactive", "theme", "dark.json"), `${JSON.stringify({ root: path.basename(root) })}\n`);
+  }
+  const previous = process.env.PI_PACKAGE_DIR;
+  const lock = path.join(f.config, "providers", "pi", `${f.agent}.larkin-pi-import.lock`);
+  const readProbes = () => fs.readFileSync(f.probeLog, "utf8").trim().split("\n").filter(Boolean).map(JSON.parse);
+  try {
+    fs.writeFileSync(f.probeLog, "");
+    const plan = migration.preparePiProfileMigration({ ...f.env, PI_PACKAGE_DIR: planned }, f.config, f.agent, "external");
+    const prepareProbes = readProbes();
+    assert.equal(prepareProbes.length, 1, JSON.stringify(prepareProbes));
+    assert.equal(fs.realpathSync(prepareProbes[0].packageDir), fs.realpathSync(planned));
+    process.env.PI_PACKAGE_DIR = later;
+    fs.writeFileSync(f.probeLog, "");
+    migration.applyPiProfileMigration(plan);
+    const applyProbes = readProbes();
+    assert.equal(applyProbes.length, 1, JSON.stringify(applyProbes));
+    assert.equal(fs.realpathSync(applyProbes[0].packageDir), fs.realpathSync(planned));
+    assert.equal(applyProbes[0].packageDir.includes("later-valid"), false);
+    fs.writeFileSync(f.probeLog, "");
+    migration.rollbackPiProfileMigration(plan.state);
+    const rollbackProbes = readProbes();
+    assert.equal(rollbackProbes.every((row) => !String(row.packageDir || "").includes("later-valid")), true, JSON.stringify(rollbackProbes));
+    assert.equal(fs.existsSync(path.join(f.targetDir, "auth.json")), false);
+    assert.equal(fs.existsSync(lock), false);
+  } finally {
+    if (previous === undefined) delete process.env.PI_PACKAGE_DIR;
+    else process.env.PI_PACKAGE_DIR = previous;
+    clean(f);
+  }
+});
+
 test("profile apply rejects symlink retarget and theme content mutation", () => {
   const f = fixture();
   const pkg = path.join(f.root, "planned-root");

--- a/test/unit/runtime/pi-profile-migration.test.mjs
+++ b/test/unit/runtime/pi-profile-migration.test.mjs
@@ -42,6 +42,17 @@ function fixture({ target = false } = {}) {
 
 function clean(f) { fs.rmSync(f.root, { recursive: true, force: true }); }
 
+test("profile migration plan persists a canonical external package root", () => {
+  const f = fixture();
+  const pkg = path.join(f.root, "nix", "store", "hash-pi");
+  fs.mkdirSync(path.join(pkg, "dist", "modes", "interactive", "theme"), { recursive: true });
+  fs.writeFileSync(path.join(pkg, "dist", "modes", "interactive", "theme", "dark.json"), "{}\n");
+  try {
+    const plan = migration.preparePiProfileMigration({ ...f.env, PI_PACKAGE_DIR: pkg }, f.config, f.agent, "external");
+    assert.equal(plan.sourceEnvironment.PI_PACKAGE_DIR, fs.realpathSync(pkg));
+  } finally { clean(f); }
+});
+
  test("imports only auth/models/settings, preserves provider bytes, owns modes, and rolls back an absent target", () => {
   const f = fixture();
   try {

--- a/test/unit/runtime/runtime-adapters.test.mjs
+++ b/test/unit/runtime/runtime-adapters.test.mjs
@@ -816,9 +816,8 @@ test("inherited builtin PI_PACKAGE_DIR does not drop production extension versio
       if (sessionLaunch.args[index] === "-e") extensionPaths.push(sessionLaunch.args[index + 1]);
     }
     assert.equal(extensionPaths.length, 2, JSON.stringify(sessionLaunch.args));
-    assert.ok(extensionPaths.some((entry) => String(entry).includes("pi-subagents")), JSON.stringify(extensionPaths));
-    assert.ok(extensionPaths.some((entry) => String(entry).includes("pi-bash-timeout")), JSON.stringify(extensionPaths));
-    assert.ok(extensionPaths.every((entry) => fs.existsSync(entry)), JSON.stringify(extensionPaths));
+    assert.deepEqual(extensionPaths.map((entry) => path.basename(entry)).sort(), ["pi-bash-timeout.bundle.js", "pi-subagents.bundle.js"]);
+    assert.ok(extensionPaths.every((entry) => fs.statSync(entry).isFile()), JSON.stringify(extensionPaths));
     assert.equal(session.effectiveModel, "test-provider/test-model");
   } finally {
     await session?.close("inherited extension probe test complete").catch(() => {});

--- a/test/unit/runtime/runtime-adapters.test.mjs
+++ b/test/unit/runtime/runtime-adapters.test.mjs
@@ -809,6 +809,10 @@ test("inherited builtin PI_PACKAGE_DIR does not drop production extension versio
     const versions = rows.filter((row) => row.kind === "argv" && row.args.includes("--version"));
     assert.ok(versions.length >= 1, JSON.stringify(rows));
     assert.equal(versions.every((row) => row.packageDir == null), true, JSON.stringify(versions));
+    const sessionLaunch = rows.find((row) => row.kind === "argv" && row.args.includes("--session-dir"));
+    assert.ok(sessionLaunch, JSON.stringify(rows));
+    const extensionArgs = sessionLaunch.args.filter((arg) => arg === "-e");
+    assert.equal(extensionArgs.length, 2, JSON.stringify(sessionLaunch.args));
     assert.equal(session.effectiveModel, "test-provider/test-model");
   } finally {
     await session?.close("inherited extension probe test complete").catch(() => {});

--- a/test/unit/runtime/runtime-adapters.test.mjs
+++ b/test/unit/runtime/runtime-adapters.test.mjs
@@ -69,8 +69,15 @@ const log = process.env.LARKIN_PI_TEST_LOG;
 const probe = args.includes("--no-session");
 let stateRequests = 0;
 const record = (value) => fs.appendFileSync(log + "." + process.pid, JSON.stringify(value) + "\\n");
-record({ kind: "argv", probe, args });
-if (args.includes("--version")) { process.stdout.write("0.84.2\\n"); process.exit(0); }
+record({ kind: "argv", probe, args, packageDir: process.env.PI_PACKAGE_DIR || null });
+if (args.includes("--version")) {
+  if (process.env.PI_PACKAGE_DIR) {
+    const theme = process.env.PI_PACKAGE_DIR + "/dist/modes/interactive/theme/dark.json";
+    if (!fs.existsSync(theme)) process.exit(1);
+  }
+  process.stdout.write("0.84.2\\n");
+  process.exit(0);
+}
 const respond = (request, data) => process.stdout.write(JSON.stringify({ type: "response", id: request.id, command: request.type, success: true, data }) + "\\n");
 const state = () => {
   stateRequests += 1;
@@ -776,6 +783,35 @@ test.each(["external", "builtin"])("%s Pi launches one shared append standing-pr
     await session.close("test complete");
   } finally {
     fs.rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("inherited builtin PI_PACKAGE_DIR does not drop production extension version probes", async () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "larkin-pi-inherited-ext-"));
+  const packageDir = path.join(root, ".larkin-official-pi-package");
+  fs.mkdirSync(path.join(packageDir, "theme"), { recursive: true });
+  fs.writeFileSync(path.join(packageDir, "theme", "dark.json"), "{}\n");
+  const { command, commandArgs, log } = makeProductionPiCommand(root);
+  const input = create({
+    workspaceDir: path.join(root, "workspace"), stateDir: path.join(root, "state"), model: "test-provider/test-model",
+    env: { LARKIN_PI_TEST_LOG: log },
+  });
+  fs.mkdirSync(input.workspaceDir, { recursive: true });
+  let session;
+  try {
+    const adapter = createNativeRuntimeAdapter("pi", {
+      piCommand: command, piCommandArgs: commandArgs,
+      env: { PI_PACKAGE_DIR: packageDir, LARKIN_PI_TEST_LOG: log },
+      piRpcClientOptions: { requestTimeoutMs: 1_000, shutdownGraceMs: 100 },
+    });
+    session = await adapter.createSession(input);
+    const rows = readProductionPiLog(log);
+    const versions = rows.filter((row) => row.kind === "argv" && row.args.includes("--version"));
+    assert.ok(versions.length >= 1, JSON.stringify(rows));
+    assert.equal(versions.every((row) => row.packageDir == null), true, JSON.stringify(versions));
+    assert.equal(session.effectiveModel, "test-provider/test-model");
+  } finally {
+    await session?.close("inherited extension probe test complete").catch(() => {});
   }
 });
 

--- a/test/unit/runtime/runtime-adapters.test.mjs
+++ b/test/unit/runtime/runtime-adapters.test.mjs
@@ -5,6 +5,8 @@ import os from "node:os";
 import path from "node:path";
 import { PassThrough } from "node:stream";
 import { afterEach, test } from "bun:test";
+import { fileURLToPath } from "node:url";
+const ADAPTERS_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../../..");
 import { ContextPromptBuilder } from "../../../dist/agent/context-prompt.mjs";
 import { resolveAgentCliExecutable } from "../../../dist/agent/agent-cli-capabilities.mjs";
 import {
@@ -816,11 +818,15 @@ test("inherited builtin PI_PACKAGE_DIR does not drop production extension versio
       if (sessionLaunch.args[index] === "-e") extensionPaths.push(sessionLaunch.args[index + 1]);
     }
     assert.equal(extensionPaths.length, 2, JSON.stringify(sessionLaunch.args));
-    assert.deepEqual(extensionPaths.map((entry) => path.basename(entry)).sort(), ["pi-bash-timeout.bundle.js", "pi-subagents.bundle.js"]);
-    assert.ok(extensionPaths.every((entry) => fs.statSync(entry).isFile()), JSON.stringify(extensionPaths));
+    const expected = [
+      path.join(ADAPTERS_ROOT, "dist", "runtime", "pi-bash-timeout.bundle.js"),
+      path.join(ADAPTERS_ROOT, "dist", "runtime", "pi-subagents.bundle.js"),
+    ].map((entry) => fs.realpathSync(entry)).sort();
+    assert.deepEqual(extensionPaths.map((entry) => fs.realpathSync(entry)).sort(), expected);
     assert.equal(session.effectiveModel, "test-provider/test-model");
   } finally {
     await session?.close("inherited extension probe test complete").catch(() => {});
+    fs.rmSync(root, { recursive: true, force: true });
   }
 });
 

--- a/test/unit/runtime/runtime-adapters.test.mjs
+++ b/test/unit/runtime/runtime-adapters.test.mjs
@@ -738,8 +738,9 @@ test.each(["external", "builtin"])("%s Pi launches one shared append standing-pr
     const sessionFile = path.join(sessionDir, `${input.resumeSessionId}.jsonl`);
     fs.writeFileSync(sessionFile, `${JSON.stringify({ type: "session", id: input.resumeSessionId })}\n`);
     const piCommand = "/fixture/external-pi";
+    const inheritedPackageDir = path.join(root, ".larkin-official-pi-package");
     const pending = createNativeRuntimeAdapter("pi", {
-      env: { LARKIN_PI_COMMAND: piCommand },
+      env: { LARKIN_PI_COMMAND: piCommand, PI_PACKAGE_DIR: inheritedPackageDir },
       resolvePiProcessExtensionArgs: () => [],
       spawn: (command, args, options) => { launch = { command, args: [...args], options }; return child; },
     }).createSession(input);
@@ -764,11 +765,13 @@ test.each(["external", "builtin"])("%s Pi launches one shared append standing-pr
       assert.equal(launch.command, piCommand);
       assert.deepEqual(launch.args.slice(0, 2), ["--mode", "rpc"]);
       assert.equal(launch.options.env.LARKIN_PI_DISTRIBUTION, undefined);
+      assert.equal(launch.options.env.PI_PACKAGE_DIR, undefined);
     } else {
       assert.ok(launch.args.includes("__internal") && launch.args.includes("pi-rpc"));
       assert.equal(launch.args.includes("-e"), false, "builtin extensions are passed inline by binary-entry");
       assert.equal(launch.options.env.LARKIN_PI_DISTRIBUTION, "builtin");
       assert.equal(launch.options.env.PI_TELEMETRY, "0");
+      assert.equal(launch.options.env.PI_PACKAGE_DIR, inheritedPackageDir);
     }
     await session.close("test complete");
   } finally {

--- a/test/unit/runtime/runtime-adapters.test.mjs
+++ b/test/unit/runtime/runtime-adapters.test.mjs
@@ -811,8 +811,14 @@ test("inherited builtin PI_PACKAGE_DIR does not drop production extension versio
     assert.equal(versions.every((row) => row.packageDir == null), true, JSON.stringify(versions));
     const sessionLaunch = rows.find((row) => row.kind === "argv" && row.args.includes("--session-dir"));
     assert.ok(sessionLaunch, JSON.stringify(rows));
-    const extensionArgs = sessionLaunch.args.filter((arg) => arg === "-e");
-    assert.equal(extensionArgs.length, 2, JSON.stringify(sessionLaunch.args));
+    const extensionPaths = [];
+    for (let index = 0; index < sessionLaunch.args.length; index += 1) {
+      if (sessionLaunch.args[index] === "-e") extensionPaths.push(sessionLaunch.args[index + 1]);
+    }
+    assert.equal(extensionPaths.length, 2, JSON.stringify(sessionLaunch.args));
+    assert.ok(extensionPaths.some((entry) => String(entry).includes("pi-subagents")), JSON.stringify(extensionPaths));
+    assert.ok(extensionPaths.some((entry) => String(entry).includes("pi-bash-timeout")), JSON.stringify(extensionPaths));
+    assert.ok(extensionPaths.every((entry) => fs.existsSync(entry)), JSON.stringify(extensionPaths));
     assert.equal(session.effectiveModel, "test-provider/test-model");
   } finally {
     await session?.close("inherited extension probe test complete").catch(() => {});

--- a/test/unit/runtime/runtime-readiness.test.mjs
+++ b/test/unit/runtime/runtime-readiness.test.mjs
@@ -95,7 +95,9 @@ test("external Pi readiness keeps a real package root and strips minimal or brok
     const rows = fs.readFileSync(marker, "utf8").trim().split("\n").filter(Boolean).map(JSON.parse);
     const realRows = rows.filter((row) => row.packageDir && row.packageDir.includes("nix-store-pi"));
     const dirtyRows = rows.filter((row) => row.packageDir && (String(row.packageDir).includes(".larkin-official-pi-package") || String(row.packageDir).includes("broken-link")));
-    assert.ok(realRows.length >= 1, JSON.stringify(rows));
+    assert.ok(realRows.some((row) => row.args.includes("--version")), JSON.stringify(rows));
+    assert.ok(realRows.some((row) => row.args.includes("--mode") && row.args.includes("rpc")), JSON.stringify(rows));
+    assert.ok(realRows.length >= 2, JSON.stringify(rows));
     assert.equal(dirtyRows.length, 0, JSON.stringify(rows));
   } finally {
     fs.rmSync(root, { recursive: true, force: true });

--- a/test/unit/runtime/runtime-readiness.test.mjs
+++ b/test/unit/runtime/runtime-readiness.test.mjs
@@ -1,4 +1,7 @@
 import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
 import { test } from "bun:test";
 import { classifyRuntimePrerequisite, probeNativeRuntimeReadiness } from "../../../dist/runtime/runtime-readiness.mjs";
 
@@ -25,4 +28,76 @@ for (const message of ["get_state timeout after 5000ms", "unexpected EOF", "TLS 
 test("readiness keeps unknown failures unavailable and reserves incompatible for proven protocol failures", () => {
   assert.equal(classifyRuntimePrerequisite("pi", new Error("opaque probe failure")).state, "unavailable");
   assert.equal(classifyRuntimePrerequisite("pi", new Error("RPC protocol version mismatch")).state, "incompatible");
+});
+
+function writeReadinessPi(root, { failIfDirty = false } = {}) {
+  const marker = path.join(root, "readiness-pi.ndjson");
+  const script = path.join(root, "readiness-pi.mjs");
+  fs.writeFileSync(marker, "");
+  fs.writeFileSync(script, `
+import fs from "node:fs";
+import path from "node:path";
+import readline from "node:readline";
+const marker = ${JSON.stringify(marker)};
+const args = process.argv.slice(2);
+fs.appendFileSync(marker, JSON.stringify({ args, packageDir: process.env.PI_PACKAGE_DIR || null }) + "\\n");
+if (args.includes("--version")) {
+  if (${failIfDirty ? "true" : "false"} && process.env.PI_PACKAGE_DIR) {
+    const theme = path.join(process.env.PI_PACKAGE_DIR, "dist/modes/interactive/theme/dark.json");
+    try { if (!fs.statSync(theme).isFile()) process.exit(1); } catch { process.exit(1); }
+  }
+  process.stdout.write("0.84.2\\n");
+  process.exit(0);
+}
+const model = { provider: "plain", id: "chat", name: "Chat", reasoning: false, contextWindow: 32000 };
+const rl = readline.createInterface({ input: process.stdin });
+rl.on("line", (line) => {
+  const request = JSON.parse(line);
+  const data = request.type === "get_available_models" ? { models: [model] } : { model, thinkingLevel: "off" };
+  process.stdout.write(JSON.stringify({ id: request.id, type: "response", command: request.type, success: true, data }) + "\\n");
+});
+`);
+  return { script, marker };
+}
+
+function writeThemeRoot(root, name) {
+  const dir = path.join(root, name);
+  fs.mkdirSync(path.join(dir, "dist", "modes", "interactive", "theme"), { recursive: true });
+  fs.writeFileSync(path.join(dir, "dist", "modes", "interactive", "theme", "dark.json"), "{}\n");
+  return dir;
+}
+
+test("external Pi readiness keeps a real package root and strips minimal or broken roots", async () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "larkin-readiness-pkg-"));
+  const { script, marker } = writeReadinessPi(root);
+  const real = writeThemeRoot(root, "nix-store-pi");
+  const minimal = path.join(root, ".larkin-official-pi-package");
+  fs.mkdirSync(path.join(minimal, "theme"), { recursive: true });
+  fs.writeFileSync(path.join(minimal, "theme", "dark.json"), "{}\n");
+  const broken = path.join(root, "broken-link");
+  fs.symlinkSync(path.join(root, "missing-target"), broken);
+  try {
+    const ready = await probeNativeRuntimeReadiness({
+      runtime: "pi", cwd: root, command: process.execPath, commandArgs: [script],
+      env: { PI_PACKAGE_DIR: real, LARKIN_PI_DISTRIBUTION: "external" },
+    });
+    assert.equal(ready.state, "ready", JSON.stringify(ready));
+    const strippedMinimal = await probeNativeRuntimeReadiness({
+      runtime: "pi", cwd: root, command: process.execPath, commandArgs: [script],
+      env: { PI_PACKAGE_DIR: minimal, LARKIN_PI_DISTRIBUTION: "external" },
+    });
+    assert.equal(strippedMinimal.state, "ready", JSON.stringify(strippedMinimal));
+    const strippedBroken = await probeNativeRuntimeReadiness({
+      runtime: "pi", cwd: root, command: process.execPath, commandArgs: [script],
+      env: { PI_PACKAGE_DIR: broken, LARKIN_PI_DISTRIBUTION: "external" },
+    });
+    assert.equal(strippedBroken.state, "ready", JSON.stringify(strippedBroken));
+    const rows = fs.readFileSync(marker, "utf8").trim().split("\n").filter(Boolean).map(JSON.parse);
+    const realRows = rows.filter((row) => row.packageDir && row.packageDir.includes("nix-store-pi"));
+    const dirtyRows = rows.filter((row) => row.packageDir && (String(row.packageDir).includes(".larkin-official-pi-package") || String(row.packageDir).includes("broken-link")));
+    assert.ok(realRows.length >= 1, JSON.stringify(rows));
+    assert.equal(dirtyRows.length, 0, JSON.stringify(rows));
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
 });


### PR DESCRIPTION
## Summary
External/npm Pi (`@earendil-works/pi-coding-agent` 0.84.2) treats `PI_PACKAGE_DIR` as a Node package root and opens `dist/modes/interactive/theme/dark.json`. Larkin's builtin layout only has `theme/dark.json`. When a Host process already materialized builtin assets (or is itself a builtin-Pi agent), catalog discovery and session spawn inherited that directory and died before the RPC handshake, often as `stdin is unavailable`.

https://github.com/eddiearc/larkin/issues/156

## Root cause
`discoverPiModelCatalogUncached`, `createPiRpcBackend`, and `probeNativeRuntimeReadiness` merged `process.env`. A builtin Host therefore leaked `LARKIN_PI_DISTRIBUTION=builtin` and `PI_PACKAGE_DIR` into an external child.

## Change
- Treat a child as builtin only from explicit session/adapter overrides, not host `process.env`.
- Strip `PI_PACKAGE_DIR` (and a leaked host `LARKIN_PI_DISTRIBUTION=builtin`) for external children.
- Keep `PI_PACKAGE_DIR` for explicit builtin children and preserve `PI_CODING_AGENT_DIR`.

## Tests
- Helper: host builtin is ignored unless an override says builtin.
- Catalog: materialized builtin assets + inherited `PI_PACKAGE_DIR`; fake external Pi would ENOENT on `dist/.../theme/dark.json` if the env leaked; `get_available_models` succeeds.
- Adapter: external launch drops `PI_PACKAGE_DIR`; builtin launch keeps it.
- Focused: `pi-model-catalog` + `runtime-adapters` 80/80. Typecheck/build pass.

## Non-goals
- No merge, release, retag, or issue close.
- Does not claim a live Feishu client banner or a real overseas setup run.
- Does not change the 30s/60s wait contract or #151.

## Claim boundary
This proves the child env and RPC handshake contract. It does not prove a particular user's already-broken agent directory on disk.