### PR TITLE
test(agent): give Windows time to evict reminder anchors

### DIFF
--- a/test/unit/agent/host-reminder-orchestrator.test.mjs
+++ b/test/unit/agent/host-reminder-orchestrator.test.mjs
@@ -223,7 +223,10 @@ test("thread reminder fire carries the thread target and remains exactly-once", 
 });
 
 test("fire pins evicted thread and document-comment anchors for protected outbound routing", {
-  timeout: 60_000,
+  // Windows 11 gate measured 130461ms for 2 × 2048 fsyncing inbox appends that
+  // evict the source from the 2048-entry message index. This is durable-store
+  // I/O, not a leaked handle; keep the real eviction path and wait for it.
+  timeout: 180_000,
 }, () => {
   for (const route of [
     { anchor: "om_evicted_thread", target: "thread:oc_evicted:omt_topic", kind: undefined },

--- a/test/unit/agent/host-reminder-orchestrator.test.mjs
+++ b/test/unit/agent/host-reminder-orchestrator.test.mjs
@@ -223,10 +223,10 @@ test("thread reminder fire carries the thread target and remains exactly-once", 
 });
 
 test("fire pins evicted thread and document-comment anchors for protected outbound routing", {
-  // Windows 11 gate measured 130461ms for 2 × 2048 fsyncing inbox appends that
-  // evict the source from the 2048-entry message index. This is durable-store
-  // I/O, not a leaked handle; keep the real eviction path and wait for it.
-  timeout: 180_000,
+  // Windows 11 gate measured 130461ms then 164158ms for 2 × 2048 fsyncing inbox
+  // appends that evict the source from the 2048-entry message index. This is
+  // durable-store I/O, not a leaked handle; keep the real eviction path.
+  timeout: 240_000,
 }, () => {
   for (const route of [
     { anchor: "om_evicted_thread", target: "thread:oc_evicted:omt_topic", kind: undefined },


### PR DESCRIPTION
## Summary

Windows 11 gate times out in `fire pins evicted thread and document-comment anchors for protected outbound routing` after 60s. The same test spent **130461ms** on the last observed run before Bun reported the 60s timeout.

https://github.com/eddiearc/larkin/issues/158
https://github.com/eddiearc/larkin/actions/runs/32980066989/job/98214407458

## Root cause

The test must evict the source from the 2048-entry `inboxState.messages` index, then prove fire rebinds `delivery_anchors`. That requires 2 × 2048 real `appendNdjson("inbox")` calls, each fsyncing inbox + rewriting `inboxState`. On Windows this is durable I/O, not a leaked handle or hung assertion.

## Scope

- Raise this test timeout from 60s to 180s, with the measured 130s evidence in the comment.

## Non-goals

- Do not change inbox cap, fsync policy, or reminder routing.
- Do not claim Windows standalone smoke or a green Windows gate until this exact head’s gate finishes.
- Do not fold #156 / #157 / #117.

## Tests

- Local Darwin: `bun test --max-concurrency 1 test/unit/agent/host-reminder-orchestrator.test.mjs` → 27/27. The target test took 13649ms.
- Windows gate on this head is the E4 proof. Not claimed here.

## Unproven

- Whether 180s is enough on a loaded Windows runner. If it still times out, that is a new measurement, not a reason to change production eviction.