### PR TITLE
fix(setup): fail closed without granted group_msg scope

### DIFF
--- a/src/setup/bot-register.ts
+++ b/src/setup/bot-register.ts
@@ -857,8 +857,11 @@ try {
   try { scopePayload = JSON.parse(scopeResult.stdout || ""); } catch { scopePayload = null; }
   const missing = missingGrantedTenantScopes(scopePayload);
   if (scopeResult.status !== 0 || missing.length > 0) {
+    const reason = scopeResult.status !== 0
+      ? `scopes API 失败 status=${scopeResult.status}`
+      : `缺 ${missing.join(", ")}`;
     throw new Error(
-      `Bot tenant scope 未就绪，缺 ${missing.join(", ") || "im:message.group_msg"}；+chat-list 成功不能当作可发群消息。请在开发者后台开通后重跑 setup，不要重建 Agent。`,
+      `Bot tenant scope 未就绪，${reason}；+chat-list 成功不能当作可发群消息。请在开发者后台开通后重跑 setup，不要重建 Agent。`,
     );
   }
   if (commentSubscription !== "preserve") {
@@ -908,6 +911,7 @@ try {
   }
 } catch (error) {
   const diagnostic = errorMessage(error);
+  if (diagnostic.startsWith("Bot tenant scope 未就绪")) die(diagnostic);
   if (diagnostic.startsWith("document comment application subscription")
       || diagnostic.startsWith("document comment local verified-state persistence")) say(`! ${diagnostic}`);
   die("Agent lark-channel binding/凭证校验失败或评论订阅核验失败；安全本地状态与权威 bot 凭证已保留，请检查身份授权后重跑 larkin setup");

--- a/src/setup/bot-register.ts
+++ b/src/setup/bot-register.ts
@@ -44,6 +44,7 @@ import {
   type LarkinTenant,
 } from "../feishu/platform-hosts.js";
 import { authorizationUrlFailureMessage, presentAuthorizationUrl } from "./setup-authorization-url.js";
+import { missingGrantedTenantScopes } from "./tenant-scope-grant.js";
 // qrcode-terminal does not publish TypeScript declarations.
 // @ts-expect-error bundled CommonJS dependency
 import qrcodePackage from "qrcode-terminal";
@@ -847,6 +848,19 @@ try {
     await wait(delay);
   }
   if (!verified) throw new Error("Bot identity verification failed");
+  const scopeResult = await runIdentityProcess(
+    official.command,
+    [...official.argsPrefix, "api", "GET", "/open-apis/application/v6/scopes"],
+    cliEnv,
+  );
+  let scopePayload: unknown;
+  try { scopePayload = JSON.parse(scopeResult.stdout || ""); } catch { scopePayload = null; }
+  const missing = missingGrantedTenantScopes(scopePayload);
+  if (scopeResult.status !== 0 || missing.length > 0) {
+    throw new Error(
+      `Bot tenant scope 未就绪，缺 ${missing.join(", ") || "im:message.group_msg"}；+chat-list 成功不能当作可发群消息。请在开发者后台开通后重跑 setup，不要重建 Agent。`,
+    );
+  }
   if (commentSubscription !== "preserve") {
     const reconciled = await applyDocumentCommentSubscription({
       mode: commentSubscription as "none" | DocumentCommentSubscriptionDimension,

--- a/src/setup/bot-register.ts
+++ b/src/setup/bot-register.ts
@@ -83,11 +83,13 @@ const testFixture = process.env.LARKIN_TEST_BOT_REGISTER_MODULE
     resolveOfficialLarkCli?: typeof resolveOfficialLarkCli;
     spawn?: typeof systemSpawn;
     wait?: (milliseconds: number) => Promise<void>;
+    collectSetupAgentChoice?: () => Promise<SetupAgentChoice | null>;
   }
   : null;
 const registerApp: RegisterApp = testFixture?.registerApp ?? channelRegisterApp as unknown as RegisterApp;
 const qrcode = testFixture?.qrcode ?? qrcodePackage;
 const spawnSync = testFixture?.spawnSync ?? systemSpawnSync;
+const spawnChild = testFixture?.spawn ?? systemSpawn;
 const synchronizeAgentProfile = testFixture?.syncAgentProfile ?? syncAgentProfile;
 const resolveOfficialCli = testFixture?.resolveOfficialLarkCli ?? resolveOfficialLarkCli;
 const wait = testFixture?.wait ?? ((milliseconds: number) => new Promise<void>((resolve) => setTimeout(resolve, milliseconds)));
@@ -361,7 +363,7 @@ async function runBindProcess(command: string, args: readonly string[]): Promise
     return spawnSync(command, [...args], { env: process.env, stdio: "inherit" }).status;
   }
   return await new Promise<number | null>((resolve, reject) => {
-    const child = systemSpawn(command, [...args], { env: process.env, stdio: "inherit" });
+    const child = spawnChild(command, [...args], { env: process.env, stdio: "inherit" });
     trackPendingChild(child);
     let killTimer: NodeJS.Timeout | null = null;
     const abort = (): void => {
@@ -392,7 +394,7 @@ async function runBoundedCliProcess(command: string, args: readonly string[], en
     return { status: result.status, stdout: result.stdout || "", stderr: result.stderr || "" };
   }
   return await new Promise<{ status: number | null; stdout: string; stderr: string }>((resolve, reject) => {
-    const child = systemSpawn(command, [...args], { env, stdio: ["ignore", "pipe", "pipe"] });
+    const child = spawnChild(command, [...args], { env, stdio: ["ignore", "pipe", "pipe"] });
     trackPendingChild(child);
     let stdout = "";
     let stderr = "";
@@ -662,12 +664,13 @@ const documentCommentSubscription: DocumentCommentSubscriptionCapability = comme
     ? { mode: "none", status: "safe-default", source: "setup-default", updatedAt: requestedAt }
     : priorSubscription;
 
-if (!flag("--runtime") && (!testFixture || process.env.LARKIN_TEST_ENABLE_AGENT_CHOICE === "1")) {
+const injectedAgentChoice = testFixture?.collectSetupAgentChoice;
+if (!flag("--runtime") && (!testFixture || injectedAgentChoice || process.env.LARKIN_TEST_ENABLE_AGENT_CHOICE === "1")) {
   const existing = larkinConfig.loadConfig(process.env).config.agents[id];
   // The official resolver performs a synchronous login-shell probe. Resolve it
   // exactly once before the credential heartbeat lock becomes active.
   resolvedSetupOfficialCli = resolveOfficialCli({ env: process.env });
-  const questioner = terminalSetupQuestioner();
+  const questioner = injectedAgentChoice ? { ask: async () => "", secret: async () => "" } : terminalSetupQuestioner();
   // One setup-owned transaction starts before status/logout and remains active
   // through selection, login, bind, readiness, and the final setup commit.
   pendingPiAuthTransaction = beginBuiltinPiCredentialTransaction(CFG_DIR, id);
@@ -678,35 +681,41 @@ if (!flag("--runtime") && (!testFixture || process.env.LARKIN_TEST_ENABLE_AGENT_
     report: (message: string) => say(message),
   };
   try {
-    const requested = await collectSetupAgentChoice(questioner, existing, authServices);
-    const choice = await recoverUnavailableExternalPi(requested, questioner, () => probeNativeRuntimeReadiness({
-      runtime: "pi", agentId: id, cwd: path.join(CFG_DIR, "agents", id), env: process.env,
-    }), (message) => say(`! ${message}`), authServices);
+    const requested = injectedAgentChoice
+      ? await injectedAgentChoice()
+      : await collectSetupAgentChoice(questioner, existing, authServices);
+    const choice = injectedAgentChoice
+      ? requested
+      : await recoverUnavailableExternalPi(requested, questioner, () => probeNativeRuntimeReadiness({
+        runtime: "pi", agentId: id, cwd: path.join(CFG_DIR, "agents", id), env: process.env,
+      }), (message) => say(`! ${message}`), authServices);
     if (choice) {
       let serializedChoice: SetupAgentChoice & { authCompleted?: true; readinessCompleted?: true } = choice;
       if (choice.runtime === "pi" && choice.distribution === "builtin") {
-        const official = choice.preset === "official" ? choice as OfficialPiAuthSelection : null;
-        const configured = official ? null : configureBuiltinPiProviderModel(CFG_DIR, id, choice as BuiltinPiProviderSetupSelection);
-        const providerId = official?.providerId || configured!.provider;
-        const authType = official?.authType || "api_key";
-        let piRuntime: Awaited<ReturnType<typeof createOfficialPiModelRuntime>>;
-        try {
-          say(`正在通过捆绑官方 Pi 登录 ${providerId}（${authType}）…`);
-          piRuntime = await createOfficialPiModelRuntime(CFG_DIR, id);
-          await runOfficialPiLogin(piRuntime, providerId, authType,
-            createOfficialPiAuthInteraction({ questioner, report: (message) => say(message), openUrl: openBrowser }));
-        } catch {
-          pendingPiAuthTransaction.rollback();
-          pendingPiAuthTransaction = null;
-          throw new Error(`官方 Pi ${providerId} 登录失败或已取消；credential/config 未修改`);
-        }
-        if (process.env.LARKIN_TEST_SKIP_BUILTIN_PI_PROVIDER_TURN !== "1") {
-          say("正在验证内置 Pi provider（受控单轮，不发送飞书（Lark）消息）…");
-          try { await verifyOfficialPiProviderTurn(piRuntime, choice.model); }
-          catch {
+        if (!injectedAgentChoice) {
+          const official = choice.preset === "official" ? choice as OfficialPiAuthSelection : null;
+          const configured = official ? null : configureBuiltinPiProviderModel(CFG_DIR, id, choice as BuiltinPiProviderSetupSelection);
+          const providerId = official?.providerId || configured!.provider;
+          const authType = official?.authType || "api_key";
+          let piRuntime: Awaited<ReturnType<typeof createOfficialPiModelRuntime>>;
+          try {
+            say(`正在通过捆绑官方 Pi 登录 ${providerId}（${authType}）…`);
+            piRuntime = await createOfficialPiModelRuntime(CFG_DIR, id);
+            await runOfficialPiLogin(piRuntime, providerId, authType,
+              createOfficialPiAuthInteraction({ questioner, report: (message) => say(message), openUrl: openBrowser }));
+          } catch {
             pendingPiAuthTransaction.rollback();
             pendingPiAuthTransaction = null;
-            throw new Error(`官方 Pi ${providerId} readiness 失败；credential/config 未修改`);
+            throw new Error(`官方 Pi ${providerId} 登录失败或已取消；credential/config 未修改`);
+          }
+          if (process.env.LARKIN_TEST_SKIP_BUILTIN_PI_PROVIDER_TURN !== "1") {
+            say("正在验证内置 Pi provider（受控单轮，不发送飞书（Lark）消息）…");
+            try { await verifyOfficialPiProviderTurn(piRuntime, choice.model); }
+            catch {
+              pendingPiAuthTransaction.rollback();
+              pendingPiAuthTransaction = null;
+              throw new Error(`官方 Pi ${providerId} readiness 失败；credential/config 未修改`);
+            }
           }
         }
         serializedChoice = { ...choice, authCompleted: true, readinessCompleted: true };

--- a/src/setup/grant-scopes.ts
+++ b/src/setup/grant-scopes.ts
@@ -11,6 +11,7 @@ import * as larkinConfig from "../platform/config.js";
 import { managedOfficialLarkCli } from "../app/agent-lark-cli-workspace.js";
 import { loadValidatedBotCredential } from "./run-credential-preflight.js";
 import { parseLarkinTenant, registerAppAccountsHost, type LarkinTenant } from "../feishu/platform-hosts.js";
+import { presentAuthorizationUrl } from "./setup-authorization-url.js";
 // qrcode-terminal does not publish TypeScript declarations.
 // @ts-expect-error bundled CommonJS dependency
 import qrcodePackage from "qrcode-terminal";
@@ -132,14 +133,22 @@ export async function main(): Promise<void> {
     },
     onQRCodeReady: (info) => {
       const minutes = Math.max(1, Math.round(info.expireIn / 60));
+      const official = resolveManagedOfficialCli(selected, process.env);
+      const presented = presentAuthorizationUrl(info.url, {
+        tenant: TENANT,
+        larkCliVersion: official.command.version,
+      });
+      if (TENANT === "lark" && /\/page\/launcher(?:\?|$)/.test(presented)) {
+        throw new Error("Lark 租户拒绝把 /page/launcher 交给浏览器");
+      }
       log("\n请用飞书（Lark）扫码或打开链接，确认给应用增补权限：\n");
-      qrcode.generate(info.url, { small: true });
-      log(`\n链接: ${info.url}\n有效期约 ${minutes} 分钟（⚠️ 需本进程保持轮询，否则 user_code 立即失效）\n`);
+      qrcode.generate(presented, { small: true });
+      log(`\n链接: ${presented}\n有效期约 ${minutes} 分钟（⚠️ 需本进程保持轮询，否则 user_code 立即失效）\n`);
       if (URL_FILE) {
-        try { fs.writeFileSync(URL_FILE, info.url); }
+        try { fs.writeFileSync(URL_FILE, presented); }
         catch (error) { log(`[grant] 写 url-file 失败: ${error instanceof Error ? error.message : String(error)}`); }
       }
-      sendUrlToChat(info.url, minutes);
+      sendUrlToChat(presented, minutes);
     },
     onStatusChange: (info) => log(`[grant] 状态: ${info.status}`),
     domain: registerAppAccountsHost(TENANT),

--- a/src/setup/tenant-scope-grant.ts
+++ b/src/setup/tenant-scope-grant.ts
@@ -1,0 +1,22 @@
+/** Tenant scopes the freshness gate needs on the Bot application. */
+export const FRESHNESS_REQUIRED_TENANT_SCOPES = ["im:message.group_msg"] as const;
+
+interface ScopeRow {
+  scope_name?: unknown;
+  grant_status?: unknown;
+}
+
+function asRows(payload: unknown): ScopeRow[] {
+  if (!payload || typeof payload !== "object") return [];
+  const root = payload as { data?: { scopes?: unknown }; scopes?: unknown };
+  const raw = Array.isArray(root.data?.scopes) ? root.data.scopes
+    : Array.isArray(root.scopes) ? root.scopes
+    : [];
+  return raw.filter((row): row is ScopeRow => !!row && typeof row === "object");
+}
+
+/** grant_status 1 is granted on GET /open-apis/application/v6/scopes. */
+export function missingGrantedTenantScopes(payload: unknown, required: readonly string[] = FRESHNESS_REQUIRED_TENANT_SCOPES): string[] {
+  const rows = asRows(payload);
+  return required.filter((name) => !rows.some((row) => row.scope_name === name && row.grant_status === 1));
+}

--- a/test/integration/app/strict-production-cutover.test.mjs
+++ b/test/integration/app/strict-production-cutover.test.mjs
@@ -342,6 +342,68 @@ for (const [mode, needle] of [
   });
 }
 
+test("scope failure keeps canonical config and retry succeeds after grant", { timeout: 25_000 }, () => {
+  const temp = fs.mkdtempSync(path.join(os.tmpdir(), "larkin-strict-register-scope-retry-"));
+  try {
+    const root = path.join(temp, "root");
+    const resultFile = path.join(root, ".setup-result-123.json");
+    fs.mkdirSync(root, { recursive: true });
+    const denied = registerPreload(temp, "scope-denied");
+    const first = spawnSync(process.execPath, ["--preload", denied.loader, path.join(ROOT, "dist/setup/bot-register.mjs"), "--auto", "--result-file", resultFile], {
+      cwd: ROOT,
+      encoding: "utf8",
+      timeout: TRANSIENT_VERIFY_CHILD_TIMEOUT_MS,
+      env: {
+        ...process.env,
+        HOME: path.join(temp, "home"),
+        LARKIN_CONFIG_DIR: root,
+        CALL_MARKER: path.join(temp, "calls-denied.ndjson"),
+        BIND_MARKER: path.join(temp, "bound-denied"),
+        FAST_RETRY_TIMER: "1",
+        LARKIN_TEST_BOT_REGISTER_MODULE: denied.preload,
+        BUN_OPTIONS: [process.env.BUN_OPTIONS, `--preload=${denied.preload}`].filter(Boolean).join(" "),
+      },
+    });
+    assert.notEqual(first.status, 0, first.stderr || first.stdout);
+    assert.equal(fs.existsSync(resultFile), false);
+    const configAfterFail = JSON.parse(fs.readFileSync(path.join(root, "config.json"), "utf8"));
+    assert.equal(configAfterFail.activeAgent, APP);
+    assert.equal(configAfterFail.agents[APP].runtime, "codex");
+    assert.equal(configAfterFail.agents[APP].model, "gpt");
+    assert.equal(configAfterFail.mentionPolicy, "require");
+    const credential = JSON.parse(fs.readFileSync(path.join(root, "bots", `${APP}.json`), "utf8"));
+    assert.equal(credential.appId, APP);
+    assert.equal(credential.appSecret, "canary-secret");
+    const workspace = path.join(root, "lark-cli-config");
+    assert.equal(fs.existsSync(`${workspace}.quarantine`), false);
+    const granted = registerPreload(temp, "ok");
+    const second = spawnSync(process.execPath, ["--preload", granted.loader, path.join(ROOT, "dist/setup/bot-register.mjs"), "--auto", "--result-file", resultFile], {
+      cwd: ROOT,
+      encoding: "utf8",
+      timeout: TRANSIENT_VERIFY_CHILD_TIMEOUT_MS,
+      env: {
+        ...process.env,
+        HOME: path.join(temp, "home"),
+        LARKIN_CONFIG_DIR: root,
+        CALL_MARKER: path.join(temp, "calls-granted.ndjson"),
+        BIND_MARKER: path.join(temp, "bound-granted"),
+        FAST_RETRY_TIMER: "1",
+        LARKIN_TEST_BOT_REGISTER_MODULE: granted.preload,
+        BUN_OPTIONS: [process.env.BUN_OPTIONS, `--preload=${granted.preload}`].filter(Boolean).join(" "),
+      },
+    });
+    assert.equal(second.status, 0, second.stderr || second.stdout);
+    assert.equal(fs.existsSync(resultFile), true);
+    const configAfterRetry = JSON.parse(fs.readFileSync(path.join(root, "config.json"), "utf8"));
+    assert.equal(configAfterRetry.activeAgent, APP);
+    assert.equal(configAfterRetry.agents[APP].runtime, "codex");
+    const runSource = fs.readFileSync(path.join(ROOT, "src/app/run.ts"), "utf8");
+    const runtimeSource = fs.readFileSync(path.join(ROOT, "src/app/runtime-process.ts"), "utf8");
+    const attachSource = fs.readFileSync(path.join(ROOT, "src/app/runtime-agent-config.ts"), "utf8");
+    assert.doesNotMatch(attachSource + runSource + runtimeSource, /\.lark-cli-config\.quarantine-/);
+  } finally { fs.rmSync(temp, { recursive: true, force: true }); }
+});
+
 test("bot-register bounds transient Bot verification retries and preserves authoritative binding state", { timeout: TRANSIENT_VERIFY_TEST_TIMEOUT_MS }, () => {
   const temp = fs.mkdtempSync(path.join(os.tmpdir(), "larkin-strict-register-transient-exhaust-"));
   try {

--- a/test/integration/app/strict-production-cutover.test.mjs
+++ b/test/integration/app/strict-production-cutover.test.mjs
@@ -8,6 +8,7 @@ import { fileURLToPath } from "node:url";
 
 const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..", "..", "..");
 const APP = "cli_strictA1";
+const GRANTED_SCOPES_STDOUT = JSON.stringify({ data: { scopes: [{ scope_name: "im:message.group_msg", grant_status: 1 }] } });
 const TRANSIENT_VERIFY_CHILD_TIMEOUT_MS = 10_000;
 const TRANSIENT_VERIFY_TEST_TIMEOUT_MS = 15_000;
 
@@ -33,7 +34,7 @@ function writeCredential(root, value, mode = 0o600) {
 
 function successfulRunPreload(temp) {
   const preload = path.join(temp, "successful-run.cjs");
-  fs.writeFileSync(preload, `const cp=require("node:child_process"),fs=require("node:fs"),original=cp.spawnSync,originalLstat=fs.lstatSync,{EventEmitter}=require("node:events"); fs.lstatSync=function(file,...args){const stat=originalLstat.call(this,file,...args);if(process.env.FAKE_UID_PATH&&String(file)===process.env.FAKE_UID_PATH)return new Proxy(stat,{get(target,prop){if(prop==="uid")return target.uid+1;const value=Reflect.get(target,prop,target);return typeof value==="function"?value.bind(target):value}});return stat};cp.spawnSync=(command,args,options)=>{if(command!=="lark-cli")return original(command,args,options);if(args.includes("+chat-list"))return {status:0,stdout:JSON.stringify({ok:true,identity:"bot"}),stderr:""};return {status:0,stdout:"",stderr:""}};cp.spawn=()=>{fs.writeFileSync(process.env.SPAWN_MARKER,"yes");const child=new EventEmitter();child.pid=process.pid+1000;child.kill=()=>true;queueMicrotask(()=>child.emit("exit",0));return child};require("node:module").syncBuiltinESMExports();`);
+  fs.writeFileSync(preload, `const cp=require("node:child_process"),fs=require("node:fs"),original=cp.spawnSync,originalLstat=fs.lstatSync,{EventEmitter}=require("node:events"); fs.lstatSync=function(file,...args){const stat=originalLstat.call(this,file,...args);if(process.env.FAKE_UID_PATH&&String(file)===process.env.FAKE_UID_PATH)return new Proxy(stat,{get(target,prop){if(prop==="uid")return target.uid+1;const value=Reflect.get(target,prop,target);return typeof value==="function"?value.bind(target):value}});return stat};cp.spawnSync=(command,args,options)=>{if(command!=="lark-cli")return original(command,args,options);if(args.includes("+chat-list"))return {status:0,stdout:JSON.stringify({ok:true,identity:"bot"}),stderr:""};if(args.some((a)=>String(a).includes("application/v6/scopes")))return {status:0,stdout:${JSON.stringify(GRANTED_SCOPES_STDOUT)},stderr:""};return {status:0,stdout:"",stderr:""}};cp.spawn=()=>{fs.writeFileSync(process.env.SPAWN_MARKER,"yes");const child=new EventEmitter();child.pid=process.pid+1000;child.kill=()=>true;queueMicrotask(()=>child.emit("exit",0));return child};require("node:module").syncBuiltinESMExports();`);
   return preload;
 }
 
@@ -62,6 +63,7 @@ test("bot credential verification pins lark-cli identity explicitly to bot", () 
   const register = fs.readFileSync(path.join(ROOT, "src/setup/bot-register.ts"), "utf8");
   const bind = fs.readFileSync(path.join(ROOT, "src/setup/setup-bind.ts"), "utf8");
   assert.match(register, /\[\.\.\.official\.argsPrefix, "im", "\+chat-list", "--as", "bot"\]/);
+  assert.match(register, /application\/v6\/scopes/);
   assert.match(register, /synchronizeAgentProfile\(agent/);
   assert.match(bind, /\["--profile", profile\.name, "im", "\+chat-list", "--as", "bot", "--json"\]/);
   assert.match(bind, /不要求名字等于 App ID/);
@@ -77,7 +79,7 @@ test("run fails closed for missing or malformed App-ID bot credentials before da
     fs.writeFileSync(preload, `
 const cp = require("node:child_process"); const {EventEmitter}=require("node:events"); const fs=require("node:fs");
 cp.spawn = function(){ fs.writeFileSync(process.env.SPAWN_MARKER,"spawned"); const c=new EventEmitter(); c.pid=424242; c.kill=()=>{}; process.nextTick(()=>c.emit("exit",0)); return c; };
-cp.spawnSync = function(command,args){ if(command==="lark-cli" && args.includes("+chat-list")) return {status:0,stdout:JSON.stringify({ok:true,identity:"bot"}),stderr:""}; return {status:0,stdout:"",stderr:""}; };
+cp.spawnSync = function(command,args){ if(command==="lark-cli" && args.includes("+chat-list")) return {status:0,stdout:JSON.stringify({ok:true,identity:"bot"}),stderr:""}; if(command==="lark-cli" && args.some((a)=>String(a).includes("application/v6/scopes"))) return {status:0,stdout:${JSON.stringify(GRANTED_SCOPES_STDOUT)},stderr:""}; return {status:0,stdout:"",stderr:""}; };
 require("node:module").syncBuiltinESMExports();
 module.exports={
   channelPackage:{createLarkChannel(){ return {on(){},dispatcher:{register(){}},connect(){return Promise.reject(new Error("unauthorized secret"));},disconnect(){return new Promise(()=>{});},rawClient:null,botIdentity:null}; }},
@@ -210,8 +212,10 @@ function registerPreload(temp, mode, returnedId = APP, returnedSecret = "canary-
   fs.writeFileSync(qrcodeMock, `export default {generate(){}};`);
   fs.writeFileSync(preload, `
 const cp=require("node:child_process"); const fs=require("node:fs"),path=require("node:path"); let verifyCalls=0;
+globalThis.fetch=async()=>{throw new Error("blocked test fetch")};
 cp.spawnSync=function(command,args,options={}){
   fs.appendFileSync(process.env.CALL_MARKER,JSON.stringify({command,args,larkConfigDir:options.env?.LARKSUITE_CLI_CONFIG_DIR,hasHermesHome:Object.hasOwn(options.env||{},"HERMES_HOME"),hasOpenClawHome:Object.hasOwn(options.env||{},"OPENCLAW_HOME"),hasLarkChannel:Object.keys(options.env||{}).some(key=>key==="LARK_CHANNEL"||key.startsWith("LARK_CHANNEL_")),secretViaStdin:options.input==="canary-secret"})+"\\n");
+  if(command==="lark-cli" && args.some((a)=>String(a).includes("application/v6/scopes"))) return {status:0,stdout:${JSON.stringify(GRANTED_SCOPES_STDOUT)},stderr:""};
   if(command==="lark-cli" && args.includes("+chat-list")) { verifyCalls++; if((${JSON.stringify(mode)}==="sync-transient"&&verifyCalls<3)||${JSON.stringify(mode)}==="sync-transient-exhaust")return {status:3,stdout:"",stderr:JSON.stringify({ok:false,error:{subtype:"invalid_client",code:20048,message:"canary-secret must never be printed"}})};if(${JSON.stringify(mode)}==="sync-network"&&verifyCalls<2)return {status:1,stdout:"",stderr:"TypeError: fetch failed; cause: EAI_AGAIN canary-secret"};if(${JSON.stringify(mode)}==="sync-agent-context")return {status:1,stdout:"",stderr:JSON.stringify({ok:false,error:{subtype:"not_configured",message:"workspace is not configured canary-secret"}})};return {status:0,stdout:${JSON.stringify(mode === "verify-fail" ? JSON.stringify({ ok: false, identity: "bot" }) : JSON.stringify({ ok: true, identity: "bot", data: { chats: [] } }))},stderr:""}; }
   if(command===process.execPath){ fs.writeFileSync(process.env.BIND_MARKER,"bound"); if(${JSON.stringify(mode)}!=="bind-fail"){const root=process.env.LARKIN_CONFIG_DIR;fs.writeFileSync(path.join(root,"config.json"),JSON.stringify({version:4,serverId:"strict-register",activeAgent:${JSON.stringify(returnedId)},mentionPolicy:"require",agents:{[${JSON.stringify(returnedId)}]:{runtime:"codex",model:"gpt"}}}),{mode:0o600});} return {status:${mode === "bind-fail" ? 1 : 0},stdout:"",stderr:"bind failed"}; }
   return {status:0,stdout:"",stderr:""};
@@ -291,7 +295,7 @@ for (const [mode, expectedCalls, expectedStatus] of [["sync-network", 2, 0], ["s
   });
 }
 
-test("bot-register bounds transient Bot verification retries and preserves authoritative binding state", { timeout: 10_000 }, () => {
+test("bot-register bounds transient Bot verification retries and preserves authoritative binding state", { timeout: TRANSIENT_VERIFY_TEST_TIMEOUT_MS }, () => {
   const temp = fs.mkdtempSync(path.join(os.tmpdir(), "larkin-strict-register-transient-exhaust-"));
   try {
     const root = path.join(temp, "root");
@@ -306,7 +310,7 @@ test("bot-register bounds transient Bot verification retries and preserves autho
     const result = spawnSync(process.execPath, ["--preload", loader, path.join(ROOT, "dist/setup/bot-register.mjs"), "--auto", "--result-file", resultFile], {
       cwd: ROOT,
       encoding: "utf8",
-      timeout: 5_000,
+      timeout: TRANSIENT_VERIFY_CHILD_TIMEOUT_MS,
       env: {
         ...process.env,
         HOME: path.join(temp, "home"),
@@ -335,7 +339,7 @@ test("bot-register bounds transient Bot verification retries and preserves autho
   } finally { fs.rmSync(temp, { recursive: true, force: true }); }
 });
 
-test("bot-register rejects an unsafe returned App ID before any local or lark-cli write", () => {
+test("bot-register rejects an unsafe returned App ID before any local or lark-cli write", { timeout: TRANSIENT_VERIFY_TEST_TIMEOUT_MS }, () => {
   const temp = fs.mkdtempSync(path.join(os.tmpdir(), "larkin-strict-register-app-id-"));
   try {
     const root = path.join(temp, "root");
@@ -353,7 +357,7 @@ test("bot-register rejects an unsafe returned App ID before any local or lark-cl
   } finally { fs.rmSync(temp, { recursive: true, force: true }); }
 });
 
-test("bot-register rejects a non-string returned secret before lark-cli or local writes", () => {
+test("bot-register rejects a non-string returned secret before lark-cli or local writes", { timeout: TRANSIENT_VERIFY_TEST_TIMEOUT_MS }, () => {
   const temp = fs.mkdtempSync(path.join(os.tmpdir(), "larkin-strict-register-secret-type-"));
   try {
     const root = path.join(temp, "root");
@@ -370,7 +374,7 @@ test("bot-register rejects a non-string returned secret before lark-cli or local
   } finally { fs.rmSync(temp, { recursive: true, force: true }); }
 });
 
-test("bot-register rejects the removed explicit App ID option before registration or local writes", () => {
+test("bot-register rejects the removed explicit App ID option before registration or local writes", { timeout: TRANSIENT_VERIFY_TEST_TIMEOUT_MS }, () => {
   const temp = fs.mkdtempSync(path.join(os.tmpdir(), "larkin-strict-register-target-"));
   try {
     const root = path.join(temp, "root");
@@ -390,7 +394,7 @@ test("bot-register rejects the removed explicit App ID option before registratio
   } finally { fs.rmSync(temp, { recursive: true, force: true }); }
 });
 
-test("bot-register rejects result-file paths outside the config root before registration", () => {
+test("bot-register rejects result-file paths outside the config root before registration", { timeout: TRANSIENT_VERIFY_TEST_TIMEOUT_MS }, () => {
   const temp = fs.mkdtempSync(path.join(os.tmpdir(), "larkin-strict-register-result-path-"));
   try {
     const root = path.join(temp, "root");
@@ -462,7 +466,7 @@ for (const existing of [false, true]) {
   });
 }
 
-test("bot-register result publication failure preserves successful binding and authoritative credential", () => {
+test("bot-register result publication failure preserves successful binding and authoritative credential", { timeout: TRANSIENT_VERIFY_TEST_TIMEOUT_MS }, () => {
   const temp = fs.mkdtempSync(path.join(os.tmpdir(), "larkin-strict-register-result-"));
   try {
     const root = path.join(temp, "root");
@@ -488,7 +492,7 @@ test("bot-register result publication failure preserves successful binding and a
 });
 
 for (const mode of ["sync-fail", "verify-fail"]) {
-  test(`bot-register ${mode} preserves the authoritative credential and Agent binding for recovery`, { timeout: 10_000 }, () => {
+  test(`bot-register ${mode} preserves the authoritative credential and Agent binding for recovery`, { timeout: TRANSIENT_VERIFY_TEST_TIMEOUT_MS }, () => {
     const temp = fs.mkdtempSync(path.join(os.tmpdir(), `larkin-strict-register-${mode}-`));
     try {
       const root = path.join(temp, "root");

--- a/test/integration/app/strict-production-cutover.test.mjs
+++ b/test/integration/app/strict-production-cutover.test.mjs
@@ -215,7 +215,12 @@ const cp=require("node:child_process"); const fs=require("node:fs"),path=require
 globalThis.fetch=async()=>{throw new Error("blocked test fetch")};
 cp.spawnSync=function(command,args,options={}){
   fs.appendFileSync(process.env.CALL_MARKER,JSON.stringify({command,args,larkConfigDir:options.env?.LARKSUITE_CLI_CONFIG_DIR,hasHermesHome:Object.hasOwn(options.env||{},"HERMES_HOME"),hasOpenClawHome:Object.hasOwn(options.env||{},"OPENCLAW_HOME"),hasLarkChannel:Object.keys(options.env||{}).some(key=>key==="LARK_CHANNEL"||key.startsWith("LARK_CHANNEL_")),secretViaStdin:options.input==="canary-secret"})+"\\n");
-  if(command==="lark-cli" && args.some((a)=>String(a).includes("application/v6/scopes"))) return {status:0,stdout:${JSON.stringify(GRANTED_SCOPES_STDOUT)},stderr:""};
+  if(command==="lark-cli" && args.some((a)=>String(a).includes("application/v6/scopes"))) {
+    if(${JSON.stringify(mode)}==="scope-denied") return {status:0,stdout:JSON.stringify({data:{scopes:[{scope_name:"im:message.group_msg",grant_status:0}]}}),stderr:""};
+    if(${JSON.stringify(mode)}==="scope-network") return {status:1,stdout:"",stderr:"fetch failed"};
+    if(${JSON.stringify(mode)}==="scope-malformed") return {status:0,stdout:"{",stderr:""};
+    return {status:0,stdout:${JSON.stringify(GRANTED_SCOPES_STDOUT)},stderr:""};
+  }
   if(command==="lark-cli" && args.includes("+chat-list")) { verifyCalls++; if((${JSON.stringify(mode)}==="sync-transient"&&verifyCalls<3)||${JSON.stringify(mode)}==="sync-transient-exhaust")return {status:3,stdout:"",stderr:JSON.stringify({ok:false,error:{subtype:"invalid_client",code:20048,message:"canary-secret must never be printed"}})};if(${JSON.stringify(mode)}==="sync-network"&&verifyCalls<2)return {status:1,stdout:"",stderr:"TypeError: fetch failed; cause: EAI_AGAIN canary-secret"};if(${JSON.stringify(mode)}==="sync-agent-context")return {status:1,stdout:"",stderr:JSON.stringify({ok:false,error:{subtype:"not_configured",message:"workspace is not configured canary-secret"}})};return {status:0,stdout:${JSON.stringify(mode === "verify-fail" ? JSON.stringify({ ok: false, identity: "bot" }) : JSON.stringify({ ok: true, identity: "bot", data: { chats: [] } }))},stderr:""}; }
   if(command===process.execPath){ fs.writeFileSync(process.env.BIND_MARKER,"bound"); if(${JSON.stringify(mode)}!=="bind-fail"){const root=process.env.LARKIN_CONFIG_DIR;fs.writeFileSync(path.join(root,"config.json"),JSON.stringify({version:4,serverId:"strict-register",activeAgent:${JSON.stringify(returnedId)},mentionPolicy:"require",agents:{[${JSON.stringify(returnedId)}]:{runtime:"codex",model:"gpt"}}}),{mode:0o600});} return {status:${mode === "bind-fail" ? 1 : 0},stdout:"",stderr:"bind failed"}; }
   return {status:0,stdout:"",stderr:""};
@@ -291,6 +296,48 @@ for (const [mode, expectedCalls, expectedStatus] of [["sync-network", 2, 0], ["s
       assert.equal(fs.existsSync(bindMarker), true);
       assert.doesNotMatch(result.stderr + result.stdout, /canary-secret/);
       if (mode === "sync-agent-context") assert.match(result.stderr, /lark-channel binding\/凭证校验失败/i);
+    } finally { fs.rmSync(temp, { recursive: true, force: true }); }
+  });
+}
+
+for (const [mode, needle] of [
+  ["scope-denied", /缺 im:message\.group_msg/],
+  ["scope-network", /scopes API 失败/],
+  ["scope-malformed", /缺 im:message\.group_msg/],
+]) {
+  test(`bot-register fail-closes ${mode} and keeps the actionable scope diagnostic`, { timeout: TRANSIENT_VERIFY_TEST_TIMEOUT_MS }, () => {
+    const temp = fs.mkdtempSync(path.join(os.tmpdir(), `larkin-strict-register-${mode}-`));
+    try {
+      const root = path.join(temp, "root");
+      const callMarker = path.join(temp, "calls.ndjson");
+      const bindMarker = path.join(temp, "bound");
+      const resultFile = path.join(root, ".setup-result-123.json");
+      fs.mkdirSync(root, { recursive: true });
+      const { preload, loader } = registerPreload(temp, mode);
+      const result = spawnSync(process.execPath, ["--preload", loader, path.join(ROOT, "dist/setup/bot-register.mjs"), "--auto", "--result-file", resultFile], {
+        cwd: ROOT,
+        encoding: "utf8",
+        timeout: TRANSIENT_VERIFY_CHILD_TIMEOUT_MS,
+        env: {
+          ...process.env,
+          HOME: path.join(temp, "home"),
+          LARKIN_CONFIG_DIR: root,
+          CALL_MARKER: callMarker,
+          BIND_MARKER: bindMarker,
+          FAST_RETRY_TIMER: "1",
+          LARKIN_TEST_BOT_REGISTER_MODULE: preload,
+          BUN_OPTIONS: [process.env.BUN_OPTIONS, `--preload=${preload}`].filter(Boolean).join(" "),
+        },
+      });
+      const text = `${result.stderr || ""}\n${result.stdout || ""}`;
+      assert.notEqual(result.status, 0, text);
+      assert.match(text, needle);
+      assert.match(text, /开发者后台/);
+      assert.match(text, /不要重建 Agent/);
+      assert.doesNotMatch(text, /身份授权\/评论订阅核验失败/);
+      assert.equal(fs.existsSync(resultFile), false);
+      assert.equal(fs.existsSync(bindMarker), true);
+      assert.equal(fs.existsSync(path.join(root, "bots", `${APP}.json`)), true);
     } finally { fs.rmSync(temp, { recursive: true, force: true }); }
   });
 }

--- a/test/integration/app/strict-production-cutover.test.mjs
+++ b/test/integration/app/strict-production-cutover.test.mjs
@@ -335,6 +335,10 @@ for (const [mode, needle] of [
       assert.match(text, /开发者后台/);
       assert.match(text, /不要重建 Agent/);
       assert.doesNotMatch(text, /身份授权\/评论订阅核验失败/);
+      assert.doesNotMatch(text, /canary-secret/);
+      assert.doesNotMatch(text, /grant_status/);
+      assert.doesNotMatch(text, /fetch failed/);
+      assert.doesNotMatch(text, /"scopes"/);
       assert.equal(fs.existsSync(resultFile), false);
       assert.equal(fs.existsSync(bindMarker), true);
       assert.equal(fs.existsSync(path.join(root, "bots", `${APP}.json`)), true);
@@ -348,6 +352,9 @@ test("scope failure keeps canonical config and retry succeeds after grant", { ti
     const root = path.join(temp, "root");
     const resultFile = path.join(root, ".setup-result-123.json");
     fs.mkdirSync(root, { recursive: true });
+    const configFile = path.join(root, "config.json");
+    const priorConfig = Buffer.from(`${JSON.stringify(storedConfig())}\n`);
+    fs.writeFileSync(configFile, priorConfig, { mode: 0o600 });
     const denied = registerPreload(temp, "scope-denied");
     const first = spawnSync(process.execPath, ["--preload", denied.loader, path.join(ROOT, "dist/setup/bot-register.mjs"), "--auto", "--result-file", resultFile], {
       cwd: ROOT,
@@ -365,12 +372,18 @@ test("scope failure keeps canonical config and retry succeeds after grant", { ti
       },
     });
     assert.notEqual(first.status, 0, first.stderr || first.stdout);
+    const firstText = `${first.stderr || ""}\n${first.stdout || ""}`;
+    assert.doesNotMatch(firstText, /canary-secret/);
+    assert.doesNotMatch(firstText, /grant_status/);
+    assert.doesNotMatch(firstText, /"scopes"/);
     assert.equal(fs.existsSync(resultFile), false);
-    const configAfterFail = JSON.parse(fs.readFileSync(path.join(root, "config.json"), "utf8"));
-    assert.equal(configAfterFail.activeAgent, APP);
-    assert.equal(configAfterFail.agents[APP].runtime, "codex");
-    assert.equal(configAfterFail.agents[APP].model, "gpt");
-    assert.equal(configAfterFail.mentionPolicy, "require");
+    const expectedFailedConfig = Buffer.from(JSON.stringify({
+      version: 4, serverId: "strict-register", activeAgent: APP, mentionPolicy: "require",
+      agents: { [APP]: { runtime: "codex", model: "gpt" } },
+    }));
+    const configAfterFail = fs.readFileSync(configFile);
+    assert.notEqual(Buffer.compare(configAfterFail, priorConfig), 0);
+    assert.equal(Buffer.compare(configAfterFail, expectedFailedConfig), 0);
     const credential = JSON.parse(fs.readFileSync(path.join(root, "bots", `${APP}.json`), "utf8"));
     assert.equal(credential.appId, APP);
     assert.equal(credential.appSecret, "canary-secret");
@@ -394,9 +407,7 @@ test("scope failure keeps canonical config and retry succeeds after grant", { ti
     });
     assert.equal(second.status, 0, second.stderr || second.stdout);
     assert.equal(fs.existsSync(resultFile), true);
-    const configAfterRetry = JSON.parse(fs.readFileSync(path.join(root, "config.json"), "utf8"));
-    assert.equal(configAfterRetry.activeAgent, APP);
-    assert.equal(configAfterRetry.agents[APP].runtime, "codex");
+    assert.equal(Buffer.compare(fs.readFileSync(configFile), expectedFailedConfig), 0);
     const runSource = fs.readFileSync(path.join(ROOT, "src/app/run.ts"), "utf8");
     const runtimeSource = fs.readFileSync(path.join(ROOT, "src/app/runtime-process.ts"), "utf8");
     const attachSource = fs.readFileSync(path.join(ROOT, "src/app/runtime-agent-config.ts"), "utf8");

--- a/test/integration/build/standalone-setup-workflow.test.mjs
+++ b/test/integration/build/standalone-setup-workflow.test.mjs
@@ -83,6 +83,8 @@ elif printf '%s\n' "$*" | grep -q '+chat-list'; then
       exit 1
     fi
     printf '%s\n' '{"ok":true,"identity":"bot","data":{"chats":[]}}'
+elif printf '%s\n' "$*" | grep -q 'application/v6/scopes'; then
+  printf '%s\n' '{"data":{"scopes":[{"scope_name":"im:message.group_msg","grant_status":1}]}}'
 else
   printf '%s\n' '{"ok":true}'
 fi

--- a/test/integration/setup/bot-register-scope-pi-transaction.test.mjs
+++ b/test/integration/setup/bot-register-scope-pi-transaction.test.mjs
@@ -1,0 +1,179 @@
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { test } from "bun:test";
+import { fileURLToPath } from "node:url";
+
+const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../../..");
+const APP = "cli_scopePiTxnA1";
+const ORIGINAL_AUTH = `${JSON.stringify({ original: { type: "api_key", key: "original-key" } }, null, 2)}\n`;
+const ORIGINAL_MODELS = `${JSON.stringify({ providers: { original: { baseUrl: "http://127.0.0.1:1" } } }, null, 2)}\n`;
+const SETUP_AUTH = `${JSON.stringify({
+  original: { type: "api_key", key: "original-key" },
+  setup: { type: "api_key", key: "setup-key" },
+}, null, 2)}\n`;
+const DENIED_SCOPES = JSON.stringify({ data: { scopes: [{ scope_name: "im:message.group_msg", grant_status: 0 }] } });
+const GRANTED_SCOPES = JSON.stringify({ data: { scopes: [{ scope_name: "im:message.group_msg", grant_status: 1 }] } });
+
+function walkQuarantine(root) {
+  const hits = [];
+  const walk = (dir) => {
+    let entries = [];
+    try { entries = fs.readdirSync(dir, { withFileTypes: true }); } catch { return; }
+    for (const entry of entries) {
+      const next = path.join(dir, entry.name);
+      if (/quarantine/i.test(entry.name)) hits.push(next);
+      if (entry.isDirectory()) walk(next);
+    }
+  };
+  walk(root);
+  return hits;
+}
+
+function writePiOriginal(root) {
+  const dir = path.join(root, "providers", "pi", APP);
+  fs.mkdirSync(dir, { recursive: true, mode: 0o700 });
+  fs.chmodSync(dir, 0o700);
+  fs.writeFileSync(path.join(dir, "auth.json"), ORIGINAL_AUTH, { mode: 0o600 });
+  fs.writeFileSync(path.join(dir, "models.json"), ORIGINAL_MODELS, { mode: 0o600 });
+  fs.writeFileSync(path.join(dir, "models-store.json"), "{}\n", { mode: 0o600 });
+}
+
+function writeFixture(temp, scopesStdout, scopesStatus = 0) {
+  const fixture = path.join(temp, "fixture.cjs");
+  fs.writeFileSync(fixture, `const fs = require("node:fs");
+const path = require("node:path");
+const { EventEmitter } = require("node:events");
+const { PassThrough } = require("node:stream");
+function fakeChild(status, stdout) {
+  const child = new EventEmitter();
+  child.stdout = new PassThrough();
+  child.stderr = new PassThrough();
+  child.kill = () => true;
+  child.pid = 1;
+  queueMicrotask(() => {
+    child.stdout.end(stdout || "");
+    child.stderr.end("");
+    child.emit("exit", status);
+  });
+  return child;
+}
+function writeBoundConfig() {
+  const root = process.env.LARKIN_CONFIG_DIR;
+  fs.mkdirSync(path.join(root, "agents", ${JSON.stringify(APP)}), { recursive: true, mode: 0o700 });
+  fs.writeFileSync(path.join(root, "config.json"), JSON.stringify({
+    version: 4, serverId: "scope-pi", activeAgent: ${JSON.stringify(APP)}, mentionPolicy: "require",
+    agents: { [${JSON.stringify(APP)}]: { runtime: "pi", model: "larkin-custom/fixture-model", piDistribution: "builtin" } },
+  }) + "\\n", { mode: 0o600 });
+}
+module.exports = {
+  registerApp: async () => ({ client_id: ${JSON.stringify(APP)}, client_secret: "canary-secret", user_info: { tenant_brand: "feishu", open_id: "ou_owner" } }),
+  qrcode: { generate() {} },
+  resolveOfficialLarkCli: () => ({ command: "lark-cli", argsPrefix: [], version: "1.0.80" }),
+  wait: async () => {},
+  spawn(command, args) {
+    if (args.includes("+chat-list")) return fakeChild(0, JSON.stringify({ ok: true, identity: "bot" }));
+    if (args.some((a) => String(a).includes("application/v6/scopes"))) return fakeChild(${scopesStatus}, ${JSON.stringify(scopesStdout)});
+    if (args.includes("setup-bind")) { writeBoundConfig(); return fakeChild(0, ""); }
+    return fakeChild(0, "");
+  },
+  spawnSync(command, args) {
+    if (command === "lark-cli" && args.includes("+chat-list")) return { status: 0, stdout: JSON.stringify({ ok: true, identity: "bot" }), stderr: "" };
+    if (args.some((a) => String(a).includes("application/v6/scopes"))) {
+      return { status: ${scopesStatus}, stdout: ${JSON.stringify(scopesStdout)}, stderr: "" };
+    }
+    if (args.includes("setup-bind")) { writeBoundConfig(); return { status: 0, stdout: "", stderr: "" }; }
+    return { status: 0, stdout: "", stderr: "" };
+  },
+  syncAgentProfile(agent) {
+    const source = path.join(agent.stateDir, "lark-channel-source");
+    const workspace = path.join(agent.larkConfigDir, "lark-channel");
+    fs.mkdirSync(source, { recursive: true, mode: 0o700 });
+    fs.mkdirSync(workspace, { recursive: true, mode: 0o700 });
+    fs.writeFileSync(path.join(source, "config.json"), "{}", { mode: 0o600 });
+    fs.writeFileSync(path.join(workspace, "config.json"), "{}", { mode: 0o600 });
+  },
+  async collectSetupAgentChoice() {
+    const dir = path.join(process.env.LARKIN_CONFIG_DIR, "providers", "pi", ${JSON.stringify(APP)});
+    fs.mkdirSync(dir, { recursive: true, mode: 0o700 });
+    fs.chmodSync(dir, 0o700);
+    fs.writeFileSync(path.join(dir, "auth.json"), ${JSON.stringify(SETUP_AUTH)}, { mode: 0o600 });
+    fs.writeFileSync(path.join(dir, "models.json"), ${JSON.stringify(SETUP_AUTH)}, { mode: 0o600 });
+    return { runtime: "pi", distribution: "builtin", preset: "custom", baseUrl: "http://127.0.0.1:9", model: "fixture-model" };
+  },
+};
+`);
+  return fixture;
+}
+
+function runRegister(root, temp, fixture, resultFile) {
+  return spawnSync(process.execPath, [path.join(ROOT, "dist/setup/bot-register.mjs"), "--auto", "--result-file", resultFile], {
+    cwd: ROOT,
+    encoding: "utf8",
+    timeout: 15_000,
+    env: {
+      ...process.env,
+      HOME: path.join(temp, "home"),
+      LARKIN_CONFIG_DIR: root,
+      LARKIN_HOME: root,
+      LARKSUITE_CLI_CONFIG_DIR: path.join(root, "lark-cli"),
+      LARKIN_TEST_BOT_REGISTER_MODULE: fixture,
+      LARKIN_TEST_ASYNC_IDENTITY: "1",
+    },
+  });
+}
+
+test("injected agent-choice enters Pi transaction and rolls back on scope failure", { timeout: 20_000 }, () => {
+  const temp = fs.mkdtempSync(path.join(os.tmpdir(), "larkin-scope-pi-txn-"));
+  const root = path.join(temp, "root");
+  fs.mkdirSync(root, { recursive: true, mode: 0o700 });
+  writePiOriginal(root);
+  const authBefore = fs.readFileSync(path.join(root, "providers", "pi", APP, "auth.json"));
+  const modelsBefore = fs.readFileSync(path.join(root, "providers", "pi", APP, "models.json"));
+  const configBefore = fs.existsSync(path.join(root, "config.json")) ? fs.readFileSync(path.join(root, "config.json")) : null;
+  const resultFile = path.join(root, ".setup-result-123.json");
+  const fixture = writeFixture(temp, DENIED_SCOPES);
+  try {
+    const result = runRegister(root, temp, fixture, resultFile);
+    const text = `${result.stderr || ""}\n${result.stdout || ""}`;
+    assert.notEqual(result.status, 0, text);
+    assert.match(text, /缺 im:message\.group_msg/);
+    assert.equal(fs.existsSync(resultFile), false);
+    assert.deepEqual(fs.readFileSync(path.join(root, "providers", "pi", APP, "auth.json")), authBefore);
+    assert.deepEqual(fs.readFileSync(path.join(root, "providers", "pi", APP, "models.json")), modelsBefore);
+    assert.equal(walkQuarantine(root).length, 0);
+    const configAfter = fs.readFileSync(path.join(root, "config.json"));
+    if (configBefore) assert.notEqual(Buffer.compare(configAfter, configBefore), 0);
+    const parsed = JSON.parse(configAfter.toString("utf8"));
+    assert.equal(parsed.activeAgent, APP);
+    assert.equal(parsed.agents[APP].runtime, "pi");
+    assert.equal(JSON.parse(fs.readFileSync(path.join(root, "bots", `${APP}.json`), "utf8")).appSecret, "canary-secret");
+  } finally {
+    fs.rmSync(temp, { recursive: true, force: true });
+  }
+});
+
+test("injected agent-choice retries after grant and keeps Pi setup credential", { timeout: 20_000 }, () => {
+  const temp = fs.mkdtempSync(path.join(os.tmpdir(), "larkin-scope-pi-retry-"));
+  const root = path.join(temp, "root");
+  fs.mkdirSync(root, { recursive: true, mode: 0o700 });
+  writePiOriginal(root);
+  const resultFile = path.join(root, ".setup-result-123.json");
+  try {
+    const denied = writeFixture(temp, DENIED_SCOPES);
+    const first = runRegister(root, temp, denied, resultFile);
+    assert.notEqual(first.status, 0, first.stderr || first.stdout);
+    assert.equal(fs.existsSync(resultFile), false);
+    const granted = writeFixture(temp, GRANTED_SCOPES);
+    const second = runRegister(root, temp, granted, resultFile);
+    assert.equal(second.status, 0, second.stderr || second.stdout);
+    assert.equal(fs.existsSync(resultFile), true);
+    const auth = JSON.parse(fs.readFileSync(path.join(root, "providers", "pi", APP, "auth.json"), "utf8"));
+    assert.equal(auth.setup.key, "setup-key");
+    assert.equal(walkQuarantine(root).length, 0);
+  } finally {
+    fs.rmSync(temp, { recursive: true, force: true });
+  }
+});

--- a/test/integration/setup/bot-register-scope-pi-transaction.test.mjs
+++ b/test/integration/setup/bot-register-scope-pi-transaction.test.mjs
@@ -140,6 +140,9 @@ test("injected agent-choice enters Pi transaction and rolls back on scope failur
     const text = `${result.stderr || ""}\n${result.stdout || ""}`;
     assert.notEqual(result.status, 0, text);
     assert.match(text, /缺 im:message\.group_msg/);
+    assert.doesNotMatch(text, /canary-secret/);
+    assert.doesNotMatch(text, /grant_status/);
+    assert.doesNotMatch(text, /"scopes"/);
     assert.equal(fs.existsSync(resultFile), false);
     assert.deepEqual(fs.readFileSync(path.join(root, "providers", "pi", APP, "auth.json")), authBefore);
     assert.deepEqual(fs.readFileSync(path.join(root, "providers", "pi", APP, "models.json")), modelsBefore);

--- a/test/integration/setup/setup-scope-hot-attach.test.mjs
+++ b/test/integration/setup/setup-scope-hot-attach.test.mjs
@@ -1,0 +1,144 @@
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { test } from "bun:test";
+import { fileURLToPath } from "node:url";
+
+const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../../..");
+const APP = "cli_setupHotA1";
+const STUB = `{
+  ensureOfficialLarkCliForSetup: async () => ({ command: { command: "lark-cli", argsPrefix: [], version: "1.0.80" }, installed: false }),
+  OFFICIAL_LARK_CLI_VERSION: "1.0.80",
+  OFFICIAL_LARK_CLI_INSTALL: "npm install --global @larksuite/cli@1.0.80",
+  formatOfficialLarkCliConsent: () => ({ lines: [], question: "" }),
+  probeOfficialLarkCli: () => ({ state: "ready", command: { command: "lark-cli", argsPrefix: [], version: "1.0.80" } }),
+}`;
+
+function writePreload(temp) {
+  const preload = path.join(temp, "preload.cjs");
+  fs.writeFileSync(preload, `
+const Module = require("node:module");
+const cp = require("node:child_process");
+const fs = require("node:fs");
+const path = require("node:path");
+const { EventEmitter } = require("node:events");
+const originalLoad = Module._load;
+const originalSpawn = cp.spawn;
+function fakeChild(code) {
+  const child = new EventEmitter();
+  child.pid = 42;
+  child.kill = () => true;
+  child.stdout = null;
+  child.stderr = null;
+  queueMicrotask(() => child.emit("exit", code, null));
+  return child;
+}
+Module._load = function(request, parent, isMain) {
+  if (String(request).includes("official-lark-cli")) {
+    return ${STUB};
+  }
+  return originalLoad.call(this, request, parent, isMain);
+};
+if (typeof Bun !== "undefined" && typeof Bun.plugin === "function") {
+  Bun.plugin({
+    name: "setup-scope-hot-attach-stubs",
+    setup(build) {
+      build.onLoad({ filter: /official-lark-cli/ }, () => ({
+        contents: ${JSON.stringify(`
+export async function ensureOfficialLarkCliForSetup() {
+  return { command: { command: "lark-cli", argsPrefix: [], version: "1.0.80" }, installed: false };
+}
+export const OFFICIAL_LARK_CLI_VERSION = "1.0.80";
+export const OFFICIAL_LARK_CLI_INSTALL = "npm install --global @larksuite/cli@1.0.80";
+export function formatOfficialLarkCliConsent() { return { lines: [], question: "" }; }
+export function probeOfficialLarkCli() {
+  return { state: "ready", command: { command: "lark-cli", argsPrefix: [], version: "1.0.80" } };
+}
+`)},
+        loader: "js",
+      }));
+      build.onLoad({ filter: /setup-dashboard/ }, () => ({
+        contents: ${JSON.stringify(`
+export async function waitForOwnedDashboard() { return { state: "timeout" }; }
+export function openBrowser() { return false; }
+export async function openOwnedDashboardWhenReady() {
+  return { readiness: { state: "timeout" }, opened: false };
+}
+`)},
+        loader: "js",
+      }));
+    },
+  });
+}
+cp.spawn = function(command, args = [], options = {}) {
+  const list = Array.isArray(args) ? args : [];
+  fs.appendFileSync(process.env.SPAWN_LOG, JSON.stringify({ command, args: list }) + "\\n");
+  if (list.includes("bot-register")) {
+    if (process.env.FAKE_REGISTER_FAIL === "1") return fakeChild(1);
+    const idx = list.indexOf("--result-file");
+    const resultFile = list[idx + 1];
+    const root = process.env.LARKIN_CONFIG_DIR;
+    const configPath = path.join(root, "config.json");
+    fs.mkdirSync(path.join(root, "agents", ${JSON.stringify(APP)}), { recursive: true, mode: 0o700 });
+    fs.writeFileSync(configPath, JSON.stringify({
+      version: 4, serverId: "hot", mentionPolicy: "require", activeAgent: ${JSON.stringify(APP)},
+      agents: { [${JSON.stringify(APP)}]: { runtime: "pi", model: "fixture", piDistribution: "builtin" } },
+    }) + "\\n", { mode: 0o600 });
+    fs.chmodSync(configPath, 0o600);
+    fs.writeFileSync(resultFile, JSON.stringify({ agentId: ${JSON.stringify(APP)} }) + "\\n", { mode: 0o600 });
+    return fakeChild(0);
+  }
+  if (list.includes("run")) {
+    fs.appendFileSync(process.env.ATTACH_LOG, "run\\n");
+    return fakeChild(0);
+  }
+  return originalSpawn.call(this, command, args, options);
+};
+require("node:module").syncBuiltinESMExports();
+`);
+  return preload;
+}
+
+function runSetup(root, temp, fail) {
+  const preload = writePreload(temp);
+  return spawnSync(process.execPath, ["--preload", preload, path.join(ROOT, "dist/app/setup.mjs"), "--provider", "openai", "--api-key", "k", "--model", "gpt-4o"], {
+    cwd: ROOT,
+    encoding: "utf8",
+    timeout: 15_000,
+    env: {
+      ...process.env,
+      HOME: path.join(temp, "home"),
+      LARKIN_CONFIG_DIR: root,
+      LARKIN_HOME: root,
+      LARKIN_INTERNAL_DISPATCH: "0",
+      LARKIN_BUN_TEST_RUNNER: "1",
+      SPAWN_LOG: path.join(temp, "spawn.ndjson"),
+      ATTACH_LOG: path.join(temp, "attach.log"),
+      FAKE_REGISTER_FAIL: fail ? "1" : "0",
+      BUN_OPTIONS: [process.env.BUN_OPTIONS, `--preload=${preload}`].filter(Boolean).join(" "),
+    },
+  });
+}
+
+test("public setup does not hot-attach on bot-register failure and attaches once after retry", { timeout: 20_000 }, () => {
+  const temp = fs.mkdtempSync(path.join(os.tmpdir(), "larkin-setup-hot-"));
+  const root = path.join(temp, "root");
+  fs.mkdirSync(root, { recursive: true, mode: 0o700 });
+  const configPath = path.join(root, "config.json");
+  try {
+    const first = runSetup(root, temp, true);
+    assert.notEqual(first.status, 0, first.stderr || first.stdout);
+    assert.equal(fs.existsSync(configPath), false);
+    assert.equal(fs.existsSync(path.join(temp, "attach.log")), false);
+    const second = runSetup(root, temp, false);
+    assert.equal(second.status, 0, second.stderr || second.stdout);
+    const parsed = JSON.parse(fs.readFileSync(configPath, "utf8"));
+    assert.equal(parsed.activeAgent, APP);
+    const attach = fs.existsSync(path.join(temp, "attach.log")) ? fs.readFileSync(path.join(temp, "attach.log"), "utf8") : "";
+    assert.equal(attach.trim().split("\n").filter(Boolean).length, 1);
+  } finally {
+    fs.rmSync(temp, { recursive: true, force: true });
+  }
+});

--- a/test/integration/setup/setup-scope-hot-attach.test.mjs
+++ b/test/integration/setup/setup-scope-hot-attach.test.mjs
@@ -113,7 +113,6 @@ function runSetup(root, temp, fail) {
       LARKIN_CONFIG_DIR: root,
       LARKIN_HOME: root,
       LARKIN_INTERNAL_DISPATCH: "0",
-      LARKIN_BUN_TEST_RUNNER: "1",
       SPAWN_LOG: path.join(temp, "spawn.ndjson"),
       ATTACH_LOG: path.join(temp, "attach.log"),
       FAKE_REGISTER_FAIL: fail ? "1" : "0",

--- a/test/unit/setup/bot-register-tenant-urls.test.mjs
+++ b/test/unit/setup/bot-register-tenant-urls.test.mjs
@@ -15,7 +15,7 @@ function assertLarkinRegisterAddons(addons) {
   assert.equal(addons == null, false);
   assert.deepEqual(addons.events.items.tenant, EXPECTED_TENANT_EVENTS);
   assert.deepEqual(addons.callbacks.items, EXPECTED_CALLBACKS);
-  for (const scope of ["im:message", "im:message:send_as_bot", "drive:drive", "docs:document.comment:create", "docs:document.comment:read"]) {
+  for (const scope of ["im:message", "im:message:send_as_bot", "im:message.group_msg", "drive:drive", "docs:document.comment:create", "docs:document.comment:read"]) {
     assert.equal(addons.scopes.tenant.includes(scope), true, `missing tenant scope ${scope}`);
   }
 }

--- a/test/unit/setup/grant-scopes-tenant-urls.test.mjs
+++ b/test/unit/setup/grant-scopes-tenant-urls.test.mjs
@@ -9,7 +9,7 @@ import { test } from "bun:test";
 const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../../..");
 const ENTRY = path.join(ROOT, "dist/setup/grant-scopes.mjs");
 
-function runGrant({ tenant = "feishu", extraArgs = [] } = {}) {
+function runGrant({ tenant = "feishu", extraArgs = [], extraEnv = {} } = {}) {
   const temp = fs.mkdtempSync(path.join(os.tmpdir(), "larkin-grant-tenant-"));
   const root = path.join(temp, "root");
   const app = "cli_grantTenantA1";
@@ -31,7 +31,7 @@ module.exports = {
       appId: opts.appId,
       domain: opts.domain,
     }));
-    opts.onQRCodeReady({ url: "https://" + opts.domain + "/oauth/grant", expireIn: 60 });
+    opts.onQRCodeReady({ url: process.env.GRANT_READY_URL || ("https://" + opts.domain + "/oauth/grant"), expireIn: 60 });
     return { client_id: opts.appId };
   },
   qrcode: { generate() {} },
@@ -51,6 +51,7 @@ module.exports = {
       LARKIN_TEST_GRANT_SCOPES_MODULE: fixture,
       REGISTER_MARKER: marker,
       LARKIN_AGENT_ID: undefined,
+      ...extraEnv,
     },
   });
   return { temp, marker, result };
@@ -76,6 +77,28 @@ test("explicit --tenant lark uses the official Lark accounts host", () => {
     assert.equal(opts.domain, "accounts.larksuite.com");
     assert.doesNotMatch(JSON.stringify(opts), /feishu\.cn/);
   } finally { fs.rmSync(temp, { recursive: true, force: true }); }
+});
+
+test("--tenant lark rewrites launcher to /page/cli and keeps addons", () => {
+  const urlFile = path.join(os.tmpdir(), `larkin-grant-url-${process.pid}.txt`);
+  const { temp, result } = runGrant({
+    tenant: "lark",
+    extraArgs: ["--tenant", "lark", "--url-file", urlFile],
+    extraEnv: {
+      GRANT_READY_URL: "https://open.larksuite.com/page/launcher?user_code=YKDY-TZ7Q&from=sdk&addons=H4sI",
+    },
+  });
+  try {
+    assert.equal(result.status, 0, result.stderr);
+    const presented = fs.readFileSync(urlFile, "utf8");
+    assert.match(presented, /^https:\/\/open\.larksuite\.com\/page\/cli\?/);
+    assert.match(presented, /user_code=YKDY-TZ7Q/);
+    assert.match(presented, /[?&]addons=H4sI/);
+    assert.doesNotMatch(presented, /\/page\/launcher/);
+  } finally {
+    fs.rmSync(temp, { recursive: true, force: true });
+    try { fs.rmSync(urlFile, { force: true }); } catch { /* ignore */ }
+  }
 });
 
 test("Feishu credential / default still uses accounts.feishu.cn", () => {

--- a/test/unit/setup/tenant-scope-grant.test.mjs
+++ b/test/unit/setup/tenant-scope-grant.test.mjs
@@ -1,0 +1,16 @@
+import assert from "node:assert/strict";
+import { test } from "bun:test";
+import { missingGrantedTenantScopes } from "../../../src/setup/tenant-scope-grant.ts";
+
+test("missingGrantedTenantScopes requires grant_status 1 for group_msg", () => {
+  assert.deepEqual(missingGrantedTenantScopes({ data: { scopes: [] } }), ["im:message.group_msg"]);
+  assert.deepEqual(missingGrantedTenantScopes({
+    data: { scopes: [{ scope_name: "im:message.group_msg", grant_status: 0 }] },
+  }), ["im:message.group_msg"]);
+  assert.deepEqual(missingGrantedTenantScopes({
+    data: { scopes: [
+      { scope_name: "im:message:readonly", grant_status: 1 },
+      { scope_name: "im:message.group_msg", grant_status: 1 },
+    ] },
+  }), []);
+});

--- a/test/unit/setup/tenant-scope-grant.test.mjs
+++ b/test/unit/setup/tenant-scope-grant.test.mjs
@@ -13,4 +13,10 @@ test("missingGrantedTenantScopes requires grant_status 1 for group_msg", () => {
       { scope_name: "im:message.group_msg", grant_status: 1 },
     ] },
   }), []);
+  assert.deepEqual(missingGrantedTenantScopes(null), ["im:message.group_msg"]);
+  assert.deepEqual(missingGrantedTenantScopes("{not-json"), ["im:message.group_msg"]);
+  assert.deepEqual(missingGrantedTenantScopes({ data: {} }), ["im:message.group_msg"]);
+  assert.deepEqual(missingGrantedTenantScopes({
+    data: { scopes: [{ grant_status: 1 }] },
+  }), ["im:message.group_msg"]);
 });


### PR DESCRIPTION
## Summary

https://github.com/eddiearc/larkin/issues/160

`+chat-list` only proves Bot identity, not group history read. After identity verification, setup now requires `im:message.group_msg` with `grant_status=1` on `GET /open-apis/application/v6/scopes`. Missing that scope fails setup instead of greening.

`grant-scopes --tenant lark` rewrites `/page/launcher` to `/page/cli` and keeps `addons=`, matching setup.

## Non-goals

- Does not auto-approve tenant scopes that need review.
- Does not rebuild Agents or use `--as user` as a workaround.
- Live Lark tenant approval is not claimed from unit tests.

## Tests

- `missingGrantedTenantScopes` requires `grant_status=1`.
- Lark grant-scopes presents `/page/cli` with `addons`, not launcher.
- Register addons list includes `im:message.group_msg`.

## Unproven

- Live International Lark setup after this change (E4). Fixture covers URL rewrite and grant_status parsing only.