### PR TITLE
feat(agent): protect bot-owned message recall

### DIFF
--- a/evals/agent-experience-v6/scenarios.json
+++ b/evals/agent-experience-v6/scenarios.json
@@ -3,7 +3,7 @@
   "version": 6,
   "model": {
     "selection": "deterministic-trace",
-    "standing_prompt_version": "larkin-standing-v25"
+    "standing_prompt_version": "larkin-standing-v26"
   },
   "session": {
     "initial_turns": 0

--- a/evals/authoritative-freshness-gate/scenarios.json
+++ b/evals/authoritative-freshness-gate/scenarios.json
@@ -1,7 +1,7 @@
 {
   "dataset": "authoritative-freshness-gate",
   "version": 1,
-  "standing_prompt_version": "larkin-standing-v25",
+  "standing_prompt_version": "larkin-standing-v26",
   "runtime": { "adapter": "codex", "selection": "runtime-default" },
   "grader": {
     "name": "authoritative-freshness-trace-grader",

--- a/evals/clickable-link-delivery/scenarios.json
+++ b/evals/clickable-link-delivery/scenarios.json
@@ -1,7 +1,7 @@
 {
   "dataset": "clickable-link-delivery",
   "version": 1,
-  "standing_prompt_version": "larkin-standing-v25",
+  "standing_prompt_version": "larkin-standing-v26",
   "runtime": { "adapter": "codex", "selection": "runtime-default" },
   "threshold": 1,
   "grader": {

--- a/evals/mention-construction/scenarios.json
+++ b/evals/mention-construction/scenarios.json
@@ -1,7 +1,7 @@
 {
   "dataset": "mention-construction",
   "version": 1,
-  "standing_prompt_version": "larkin-standing-v25",
+  "standing_prompt_version": "larkin-standing-v26",
   "runtime": { "adapter": "codex", "selection": "runtime-default" },
   "grader": {
     "name": "mention-construction-trace-grader",

--- a/evals/protected-message-recall/scenarios.json
+++ b/evals/protected-message-recall/scenarios.json
@@ -1,0 +1,29 @@
+{
+  "dataset": "protected-message-recall",
+  "version": 1,
+  "standing_prompt_version": "larkin-standing-v26",
+  "grader": {
+    "name": "protected-message-recall-provider-trace-grader",
+    "version": 1,
+    "threshold": 1.0,
+    "rubric": [
+      "explicit --yes confirmation is required before any provider read or mutation",
+      "the original sender must be the current Runtime Bot",
+      "the exact chat or thread is authoritatively probed before recall",
+      "rejected and freshness-conflict cases never invoke provider delete",
+      "accepted recall preserves the native messages delete argv under locked Bot identity",
+      "committed and ambiguous outcomes cannot cause a second provider delete"
+    ]
+  },
+  "threshold": 1,
+  "scenarios": [
+    { "id": "missing-confirmation", "expected_exit": 2, "lookup_calls": 0, "probe_calls": 0, "provider_delete_calls": 0 },
+    { "id": "own-chat-message", "expected_exit": 0, "lookup_calls": 1, "probe_calls": 1, "provider_delete_calls": 1, "target_kind": "chat", "target_id": "oc_recall" },
+    { "id": "own-thread-message", "expected_exit": 0, "lookup_calls": 1, "probe_calls": 1, "provider_delete_calls": 1, "target_kind": "thread", "target_id": "omt_recall" },
+    { "id": "third-party-message", "expected_exit": 2, "lookup_calls": 1, "probe_calls": 0, "provider_delete_calls": 0 },
+    { "id": "cross-agent-message", "expected_exit": 2, "lookup_calls": 1, "probe_calls": 0, "provider_delete_calls": 0 },
+    { "id": "freshness-conflict", "expected_exit": 3, "lookup_calls": 1, "probe_calls": 1, "provider_delete_calls": 0, "target_kind": "chat", "target_id": "oc_recall" },
+    { "id": "committed-duplicate", "expected_exit": 0, "lookup_calls": 0, "probe_calls": 0, "provider_delete_calls": 0 },
+    { "id": "ambiguous-retry", "expected_exit": 2, "lookup_calls": 0, "probe_calls": 0, "provider_delete_calls": 0 }
+  ]
+}

--- a/evals/runtime-agent-interface-v2/scenarios.json
+++ b/evals/runtime-agent-interface-v2/scenarios.json
@@ -7,7 +7,7 @@
   },
   "model": {
     "selection": "gpt-5.6-sol",
-    "standing_prompt_version": "larkin-standing-v25"
+    "standing_prompt_version": "larkin-standing-v26"
   },
   "grader": {
     "name": "runtime-agent-interface-v2-trace-grader",

--- a/package.json
+++ b/package.json
@@ -73,6 +73,7 @@
     "test:eval:pi-bash-timeout": "bun run build && bun test --max-concurrency 1 test/live/pi-bash-timeout-live.test.mjs",
     "test:eval:runtime-agent-interface-v2": "bun test --max-concurrency 1 test/unit/evals/runtime-agent-interface-v2.test.mjs",
     "test:eval:authoritative-freshness-gate": "bun test --max-concurrency 1 test/unit/evals/authoritative-freshness-gate.test.mjs",
+    "test:eval:protected-message-recall": "bun run build && bun test --max-concurrency 1 test/unit/evals/protected-message-recall.test.mjs test/unit/app/lark-cli-launcher.test.mjs",
     "test:eval:agent-experience-v6": "bun test --max-concurrency 1 test/unit/evals/agent-experience-v6.test.mjs",
     "test:eval:mention-construction": "bun run build && LARKIN_RUN_MENTION_CONSTRUCTION_EVAL=1 bun test --max-concurrency 1 test/live/mention-construction-agent-eval.test.mjs",
     "test:eval:clickable-link-delivery": "bun run build && bun test --max-concurrency 1 test/unit/evals/clickable-link-delivery.test.mjs",

--- a/src/agent/context-prompt.ts
+++ b/src/agent/context-prompt.ts
@@ -16,7 +16,7 @@ import type { AgentCliCapabilities, RuntimeId, RuntimeInput, StandingPrompt } fr
  * 6. 用 eval 验证：行为变化必须配套固定场景 + rubric（evals/*、test/support/*-grader.mjs、live 测试）。
  */
 
-export const LARKIN_STANDING_PROMPT_VERSION = "larkin-standing-v25";
+export const LARKIN_STANDING_PROMPT_VERSION = "larkin-standing-v26";
 
 /**
  * Agent 间协作唤醒引导（issue #75）：纯文本 @ 不会产生飞书 mention 事件，
@@ -31,7 +31,7 @@ export const AGENT_MENTION_GUIDANCE: readonly string[] = [
 ];
 
 const FEISHU_IM_COMMAND_GROUPS = [
-  ["Messages", ["im +messages-send", "im +messages-reply", "im +chat-messages-list", "im +threads-messages-list", "im +messages-mget"]],
+  ["Messages", ["im +messages-send", "im +messages-reply", "im messages delete", "im +chat-messages-list", "im +threads-messages-list", "im +messages-mget"]],
   ["Chats", ["im +chat-list", "im +chat-search", "im chats get"]],
 ] as const;
 
@@ -146,7 +146,7 @@ export class ContextPromptBuilder {
       "Successful history response messages are always at `data.messages`. Never use a chat-wide fallback for a thread target, never merge stderr with `2>&1` before parsing JSON, and never truncate structured output before parsing it.",
       "If the scoped history read fails or its schema is invalid, fail visibly. Do not reuse remembered or hard-coded text to make the task appear successful.",
       "Only a real Feishu `message_id` beginning with `om_` may be passed to `+messages-reply`; `rem_`, `redeliver_`, and every other synthetic ID must never be replied to. Send with a confirmed `chat_id` and never guess a chat id from a display name.",
-      "Before every send/reply/card write, Larkin probes the exact chat or thread history with the current Bot identity. A nonzero `freshness_conflict` includes bounded unseen context and direct-acks that cursor; reconsider it, then retry the ordinary command. Larkin never saves the blocked message body as a draft.",
+      "Before every send/reply/card/recall write, Larkin probes the exact chat or thread history with the current Bot identity. A nonzero `freshness_conflict` includes bounded unseen context and direct-acks that cursor; reconsider it, then retry the ordinary command. Larkin never saves the blocked operation as a draft.",
       "For regular textual message bodies, default to `--markdown`, including brief single-line replies, so Feishu renders Markdown structure instead of showing its markers literally.",
       "When a URL must be visible, clickable, or openable by the recipient, include the complete bare `https://...` URL as visible text. Do not rely solely on `[label](URL)`, because Feishu client rendering is unreliable. A label may also be included, but the bare URL must remain present.",
       "Use native `--text` only when plain text or verbatim preservation is explicitly needed, such as logs, code, or exact whitespace. Both `--markdown` and `--text` remain supported in the Larkin Runtime.",
@@ -172,6 +172,7 @@ export class ContextPromptBuilder {
       "For the known canonical Inbox poll, scoped chat/thread history, and exact send/reply recipes specified here, execute them directly; you must not read or re-read a skill file or reference merely to rediscover or confirm their command syntax.",
       `For a task that starts from an exact group name and asks for user and bot counts, after the required Inbox poll use this known canonical two-read recipe directly: first run \`${executable} im +chat-search --query '<exact_group_name>' --json\`, require one result with an exact name match and confirm its \`oc_\` chat id, then run \`${executable} im chats get --chat-id <confirmed_oc_chat_id> --json\` and answer from its \`user_count\` and \`bot_count\`. This group user/bot counts recipe uses exactly two post-poll business read calls; you must not read or re-read a skill or reference, open help or schema, invoke bare \`lark-cli\`, call \`chat.members\` or \`+chat-members-list\`, fall back to \`+chat-list\`, or add shell filters or output truncation. If the exact name is not a unique visible match, the chat id is not confirmed, or either count is missing, fail visibly without another discovery path or a guess.`,
       "This narrow direct-recipe rule does not waive required skill safety gates, authorization, identity, freshness, or other safety checks. Unknown commands or high-risk operations still require the applicable skill/reference guidance or help.",
+      `To recall a message after the required explicit user approval, use \`${executable} im messages delete --message-id <bot-owned_om_id> --yes --json\`. Runtime verifies the original sender is this exact Bot, derives the exact chat/thread target, probes freshness before provider commit, and refuses cross-Agent or third-party messages. A \`committed=true\` or \`duplicate=true\` result must not be retried; an ambiguous result fails closed and requires user inspection. Never use generic API or bare \`lark-cli\` to bypass recall protection.`,
       "The Larkin wrapper derives the stable per-intent idempotency key; do not pass `--idempotency-key` in an ordinary send or reply recipe. A successful write result carrying `duplicate: true` means the provider returned the earlier delivery for the same derived key: the message was already delivered and no new message was created. Do not resend the same command after a `duplicate: true` result; treat the message as delivered. To deliberately send identical content again as a fresh intent (e.g., a new reminder), pass an explicit new `--idempotency-key`, which the wrapper respects instead of deriving its own.",
       "Both `freshness_unavailable` and `freshness_conflict` are pre-commit, provider-not-reached results. If a retry is warranted for an unchanged exact operation, rerun the identical safe ordinary command: `--text` for a direct literal or the same deterministic `--content` dataflow for a tool source. The wrapper reuses its derived key. If the target or body changes after reconsideration, run the revised ordinary command and let the wrapper derive a new key. A result with `committed=true` must not be repeated; ambiguous termination follows the existing wrapper same-key recovery contract.",
       "For multiline `--markdown` or `--text` content in zsh or bash, prefer shell ANSI-C quoting so the command passes one argument with real newline characters: `--markdown $'First line\\nSecond line'` or `--text $'First line\\nSecond line'`. Putting `\"First line\\nSecond line\"` in ordinary double quotes is wrong: ordinary quotes do not decode `\\n`, so lark-cli and Feishu receive a backslash followed by the letter `n`. A literal multiline argument containing real newline characters is also valid. If ANSI-C-quoted content contains an apostrophe, use a safe shell single-quote splice or the literal-newline form; never use `eval`, `echo`, a temporary file, or unsafe variable interpolation to construct the body.",

--- a/src/app/lark-cli.ts
+++ b/src/app/lark-cli.ts
@@ -45,7 +45,7 @@ function portableSignalCode(signal: NodeJS.Signals): number {
 
 export type LarkCliCommandDecision =
   | { kind: "passthrough" }
-  | { kind: "guarded"; operation: "send" | "reply" | "card" | "urgent-app" }
+  | { kind: "guarded"; operation: "send" | "reply" | "card" | "urgent-app" | "recall" }
   | { kind: "comment-reply" }
   | { kind: "denied"; reason: string };
 
@@ -229,6 +229,11 @@ export function classifyLarkCliCommand(argv: readonly string[]): LarkCliCommandD
       ? (parsed.commandArgv.includes("--dry-run") || parsed.help ? { kind: "passthrough" } : { kind: "guarded", operation: "urgent-app" })
       : noncanonicalProtectedDecision();
   }
+  if (exactPath(parsed.commandArgv, ["im", "messages", "delete"])) {
+    return uniqueProtectedOperation(protectedPaths, "raw-delete")
+      ? (parsed.commandArgv.includes("--dry-run") || parsed.help ? { kind: "passthrough" } : { kind: "guarded", operation: "recall" })
+      : noncanonicalProtectedDecision();
+  }
   if (exactPath(parsed.commandArgv, ["im", "messages", "patch"]) || exactPath(parsed.commandArgv, ["im", "messages", "update"])) {
     const expected = parsed.commandArgv[2] === "patch" ? "card-patch" : "card-update";
     return uniqueProtectedOperation(protectedPaths, expected)
@@ -241,7 +246,7 @@ export function classifyLarkCliCommand(argv: readonly string[]): LarkCliCommandD
       ? { kind: "denied", reason: "该原始 IM 写入口会旁路 target freshness；请使用 +messages-send/+messages-reply" }
       : noncanonicalProtectedDecision();
   }
-  if (["forward", "merge_forward", "delete", "urgent_phone", "urgent_sms"]
+  if (["forward", "merge_forward", "urgent_phone", "urgent_sms"]
     .some((operation) => exactPath(parsed.commandArgv, ["im", "messages", operation]))) {
     const expected = `raw-${parsed.commandArgv[2]}` as ProtectedOperation;
     return uniqueProtectedOperation(protectedPaths, expected)
@@ -512,6 +517,59 @@ function guardedTarget(decision: Extract<LarkCliCommandDecision, { kind: "guarde
   return feishuImTarget(target);
 }
 
+type RecallLedgerEntry = {
+  status: "deleting" | "deleted" | "failed";
+  target: string;
+  updated_at: string;
+};
+type RecallLedgerState = {
+  version: 1;
+  cursors?: Record<string, { generation: string; cursor: FeishuImCursor }>;
+  message_recalls?: Record<string, RecallLedgerEntry>;
+};
+
+function recallLedgerEntry(store: AgentStateStore, messageId: string): RecallLedgerEntry | null {
+  const state = store.readJson<RecallLedgerState>("freshnessState", { version: 1, cursors: {} });
+  const entry = state.message_recalls?.[messageId];
+  return entry && typeof entry === "object" ? entry : null;
+}
+
+function claimRecall(store: AgentStateStore, messageId: string, target: string): "ready" | "deleted" | "ambiguous" {
+  return store.mutateJson<RecallLedgerState, "ready" | "deleted" | "ambiguous">(
+    "freshnessState", { version: 1, cursors: {} }, (state) => {
+      state.message_recalls ??= {};
+      const prior = state.message_recalls[messageId];
+      if (prior?.status === "deleted") return "deleted";
+      if (prior?.status === "deleting") return "ambiguous";
+      state.message_recalls[messageId] = { status: "deleting", target, updated_at: new Date().toISOString() };
+      return "ready";
+    },
+  );
+}
+
+function finalizeFailedRecall(store: AgentStateStore, messageId: string, target: string): void {
+  store.mutateJson<RecallLedgerState, void>("freshnessState", { version: 1, cursors: {} }, (state) => {
+    state.message_recalls ??= {};
+    state.message_recalls[messageId] = { status: "failed", target, updated_at: new Date().toISOString() };
+  });
+}
+
+function finalizeSuccessfulRecall(
+  store: AgentStateStore,
+  messageId: string,
+  target: string,
+  cursor: FeishuImCursor | null,
+  generation: string,
+): void {
+  store.mutateJson<RecallLedgerState, void>("freshnessState", { version: 1, cursors: {} }, (state) => {
+    state.cursors ??= {};
+    if (cursor) state.cursors[target] = { generation, cursor };
+    else delete state.cursors[target];
+    state.message_recalls ??= {};
+    state.message_recalls[messageId] = { status: "deleted", target, updated_at: new Date().toISOString() };
+  });
+}
+
 function uniqueRawFlagValue(argv: readonly string[], flag: string): string | null {
   const nativeArgv = nativeArgvBeforeBoundary(argv);
   const values: string[] = [];
@@ -526,6 +584,53 @@ function uniqueRawFlagValue(argv: readonly string[], flag: string): string | nul
   }
   if (values.length > 1) throw new Error(`Runtime im messages urgent_app 不允许重复 ${flag}；官方 CLI 会采用最后一次赋值`);
   return values[0] || null;
+}
+
+function assertRecallSyntax(argv: readonly string[]): string {
+  const messageId = policyFlagValue(argv, "--message-id");
+  if (!messageId || !/^om_[A-Za-z0-9_-]+$/.test(messageId)) {
+    throw new Error("Runtime im messages delete 只接受真实 Feishu om_ message_id");
+  }
+  const yesCount = nativeArgvBeforeBoundary(argv).filter((argument) => argument === "--yes").length;
+  if (yesCount !== 1) throw new Error("Runtime im messages delete 必须且只能指定一次 --yes 显式确认");
+  if (policyFlagValue(argv, "--idempotency-key")) {
+    throw new Error("Runtime im messages delete 不接受 provider idempotency key；Runtime 使用本地 recall ledger 防止重复提交");
+  }
+  return messageId;
+}
+
+function resolveOwnedRecallTarget(
+  messageId: string,
+  feishuAppId: string,
+  env: Env,
+  io: LarkCliIo,
+  dependencies: LarkCliLauncherDependencies,
+): { target: FreshnessTarget; message: FeishuImMessage } {
+  const result = callNative([
+    "im", "+messages-mget", "--message-ids", messageId, "--no-reactions", "--json", "--as", "bot",
+  ], env, io, dependencies);
+  if (result.error) throw new Error(`recall message lookup failed: ${result.error.message}`);
+  if (result.status !== 0) throw new Error(`recall message lookup exited ${result.status ?? "without status"}: ${result.stderr || "no details"}`);
+  let value: unknown;
+  try { value = JSON.parse(result.stdout || ""); } catch { throw new Error("recall message lookup returned non-JSON output"); }
+  const root = value as { ok?: unknown; identity?: unknown; data?: { messages?: unknown } } | null;
+  if (!root || root.ok !== true || !root.data) throw new Error("recall message lookup returned an unsuccessful payload");
+  if (root.identity !== "bot") throw new Error("recall message lookup did not confirm Bot identity");
+  if (!Array.isArray(root.data.messages)) throw new Error("recall message lookup omitted messages");
+  const matches = root.data.messages.filter((row) => row && typeof row === "object" && !Array.isArray(row)
+    && (row as { message_id?: unknown }).message_id === messageId) as FeishuImMessage[];
+  if (matches.length !== 1) throw new Error(`无法唯一确认 ${messageId} 的原始消息；禁止旁路 recall ownership`);
+  const message = matches[0]!;
+  if (typeof message.chat_id !== "string" || !message.chat_id) {
+    throw new Error(`无法从官方 +messages-mget 确认 ${messageId} 的 chat；禁止旁路 recall freshness`);
+  }
+  if (!isOwnBotMessage(message, feishuAppId)) {
+    throw new Error("Runtime im messages delete 只能撤回当前 Runtime Bot 自己发出的消息；拒绝跨 Agent 或第三方消息");
+  }
+  const target = typeof message.thread_id === "string" && message.thread_id
+    ? feishuImTarget(`thread:${message.chat_id}:${message.thread_id}`)
+    : feishuImTarget(`chat:${message.chat_id}`);
+  return { target, message };
 }
 
 function resolveUrgentAppTarget(
@@ -569,9 +674,10 @@ function botArgv(argv: readonly string[], intentId: string, decision?: Extract<L
   const insertion = boundary < 0 ? next.length : boundary;
   const injected: string[] = [];
   if (!parsed.flags.has("--as")) injected.push("--as", "bot");
-  if (decision?.operation !== "urgent-app" && !parsed.flags.has("--idempotency-key")) injected.push("--idempotency-key", intentId);
+  const supportsProviderIdempotency = decision?.operation !== "urgent-app" && decision?.operation !== "recall";
+  if (supportsProviderIdempotency && !parsed.flags.has("--idempotency-key")) injected.push("--idempotency-key", intentId);
   next.splice(insertion, 0, ...injected);
-  if (decision?.operation !== "urgent-app") return next;
+  if (supportsProviderIdempotency) return next;
   const rewritten: string[] = [];
   for (let index = 0; index < next.length; index += 1) {
     const argument = next[index];
@@ -765,7 +871,7 @@ function emitFreshnessError(io: LarkCliIo, input: {
     target: input.target,
     ...(input.current ? { current_cursor: input.current } : {}),
     ...(input.messages ? { unseen_messages: input.messages } : {}),
-    next: "Reconsider the returned context, then retry the ordinary send/reply/card command; history is probed again before every write.",
+    next: "Reconsider the returned context, then retry the ordinary send/reply/card/recall command; history is probed again before every write.",
   })}\n`);
 }
 
@@ -964,6 +1070,18 @@ function emitDuplicatedWrite(
   return 0;
 }
 
+function emitDuplicatedRecall(io: LarkCliIo, messageId: string, target: string): number {
+  io.stdout(`${JSON.stringify({
+    ok: true,
+    identity: "bot",
+    committed: true,
+    duplicate: true,
+    message_id: messageId,
+    target,
+  })}\n`);
+  return 0;
+}
+
 function emitCommittedUnverified(
   result: SpawnSyncReturns<string>,
   io: LarkCliIo,
@@ -1053,10 +1171,19 @@ export function runLarkCli(
   }
   if (decision.kind === "passthrough") return passthroughWithObservation(effectiveArgv, privateEnv, io, nativeDependencies, store);
   try {
+    const recallMessageId = decision.operation === "recall" ? assertRecallSyntax(effectiveArgv) : null;
+    const priorRecall = recallMessageId ? recallLedgerEntry(store, recallMessageId) : null;
+    if (priorRecall?.status === "deleted") return emitDuplicatedRecall(io, recallMessageId!, priorRecall.target);
+    if (priorRecall?.status === "deleting") {
+      throw new Error("message recall 上次 provider 结果不明确，已 fail-closed 以避免重复撤回；请由用户检查原会话");
+    }
+    const recall = recallMessageId
+      ? resolveOwnedRecallTarget(recallMessageId, agent.feishuAppId, privateEnv, io, nativeDependencies)
+      : null;
     const urgent = decision.operation === "urgent-app"
       ? resolveUrgentAppTarget(effectiveArgv, privateEnv, io, nativeDependencies)
       : null;
-    const target = urgent?.target ?? guardedTarget(decision, effectiveArgv, store);
+    const target = recall?.target ?? urgent?.target ?? guardedTarget(decision, effectiveArgv, store);
     const targetKey = serializeFeishuImTarget(target);
     const generation = freshnessGeneration(privateEnv);
     const seen = store.readFreshnessCursor<FeishuImCursor>(targetKey, generation);
@@ -1073,6 +1200,24 @@ export function runLarkCli(
       emitFreshnessError(io, { subtype: "freshness_conflict", target: targetKey, current: gated.current, messages: gated.context });
       store.mergeFreshnessCursor(targetKey, gated.current, mergeFeishuImCursor, generation);
       return 3;
+    }
+    if (decision.operation === "recall") {
+      const claim = claimRecall(store, recallMessageId!, targetKey);
+      if (claim === "deleted") return emitDuplicatedRecall(io, recallMessageId!, targetKey);
+      if (claim === "ambiguous") {
+        throw new Error("message recall 上次 provider 结果不明确，已 fail-closed 以避免重复撤回；请由用户检查原会话");
+      }
+      const recallWrite = callNative(botArgv(effectiveArgv, "", decision), privateEnv, io, nativeDependencies);
+      if (!recallWrite.error && recallWrite.status === 0) {
+        const predictedSnapshot = {
+          messages: gated.snapshot.messages.filter((message) => message.message_id !== recallMessageId),
+        };
+        const predictedCursor = feishuImFreshnessAdapter.cursor(predictedSnapshot);
+        finalizeSuccessfulRecall(store, recallMessageId!, targetKey, predictedCursor, generation);
+      } else if (definitiveProviderRejection(recallWrite)) {
+        finalizeFailedRecall(store, recallMessageId!, targetKey);
+      }
+      return emitNativeResult(recallWrite, io);
     }
     if (decision.operation === "urgent-app") {
       const userIds = assertUrgentAppPreconditions(effectiveArgv, urgent!.message, target, agent.feishuAppId);

--- a/test/support/agent-experience-v6-grader.mjs
+++ b/test/support/agent-experience-v6-grader.mjs
@@ -41,7 +41,7 @@ function correctionBoundaryIssue(scenario) {
 export function loadAgentExperienceV6Eval(file) {
   const value = JSON.parse(fs.readFileSync(file, "utf8"));
   if (value.dataset !== "agent-experience-v6" || value.version !== 6) throw new Error("eval dataset/version mismatch");
-  if (value.model?.standing_prompt_version !== "larkin-standing-v25") throw new Error("standing prompt version mismatch");
+  if (value.model?.standing_prompt_version !== "larkin-standing-v26") throw new Error("standing prompt version mismatch");
   if (value.session?.initial_turns !== 0) throw new Error("eval scenarios must start from a fresh empty session");
   if (value.grader?.name !== "agent-experience-v6-trace-grader" || value.grader.version !== 6 || value.grader.threshold !== 1) {
     throw new Error("eval grader metadata mismatch");

--- a/test/support/authoritative-freshness-gate-grader.mjs
+++ b/test/support/authoritative-freshness-gate-grader.mjs
@@ -3,7 +3,7 @@ import fs from "node:fs";
 export function loadAuthoritativeFreshnessEval(file) {
   const value = JSON.parse(fs.readFileSync(file, "utf8"));
   if (value.dataset !== "authoritative-freshness-gate" || value.version !== 1) throw new Error("eval dataset/version mismatch");
-  if (value.standing_prompt_version !== "larkin-standing-v25") throw new Error("standing prompt version mismatch");
+  if (value.standing_prompt_version !== "larkin-standing-v26") throw new Error("standing prompt version mismatch");
   if (value.runtime?.adapter !== "codex" || !value.runtime.selection) throw new Error("native runtime metadata is required");
   if (value.grader?.name !== "authoritative-freshness-trace-grader" || value.grader.version !== 1) throw new Error("grader metadata mismatch");
   if (!(value.grader.threshold > 0 && value.grader.threshold <= 1)) throw new Error("grader threshold must be in (0,1]");

--- a/test/support/clickable-link-delivery-grader.mjs
+++ b/test/support/clickable-link-delivery-grader.mjs
@@ -87,7 +87,7 @@ function hasBoundedVisibleUrl(body, expectedUrl) {
 export function loadClickableLinkDeliveryEval(file) {
   const value = JSON.parse(fs.readFileSync(file, "utf8"));
   if (value.dataset !== "clickable-link-delivery" || value.version !== 1) throw new Error("eval dataset/version mismatch");
-  if (value.standing_prompt_version !== "larkin-standing-v25") throw new Error("standing prompt version mismatch");
+  if (value.standing_prompt_version !== "larkin-standing-v26") throw new Error("standing prompt version mismatch");
   if (value.threshold !== 1 || value.grader?.name !== "clickable-link-delivery-trace-grader"
       || value.grader.version !== 1 || value.grader.threshold !== 1) throw new Error("eval grader metadata mismatch");
   if (value.session?.initial_turns !== 0 || value.session?.fresh_per_scenario !== true) throw new Error("eval requires fresh sessions");

--- a/test/support/clickable-link-delivery-native-support.mjs
+++ b/test/support/clickable-link-delivery-native-support.mjs
@@ -8,7 +8,7 @@ export const CLICKABLE_LINK_V20_GUIDANCE = [
 ];
 
 export function v19Counterfactual(standingPrompt) {
-  if (standingPrompt?.version !== "larkin-standing-v25" || typeof standingPrompt.content !== "string") {
+  if (standingPrompt?.version !== "larkin-standing-v26" || typeof standingPrompt.content !== "string") {
     throw new Error("v19 counterfactual requires a v20 standing prompt");
   }
   let content = standingPrompt.content;

--- a/test/support/mention-construction-grader.mjs
+++ b/test/support/mention-construction-grader.mjs
@@ -8,7 +8,7 @@ function nonempty(value, label) {
 export function loadMentionConstructionEval(file) {
   const value = JSON.parse(fs.readFileSync(file, "utf8"));
   if (value.dataset !== "mention-construction" || value.version !== 1) throw new Error("eval dataset/version mismatch");
-  if (value.standing_prompt_version !== "larkin-standing-v25") throw new Error("standing prompt version mismatch");
+  if (value.standing_prompt_version !== "larkin-standing-v26") throw new Error("standing prompt version mismatch");
   if (value.session?.initial_turns !== 0) throw new Error("eval scenarios must start from a fresh empty session");
   if (value.grader?.name !== "mention-construction-trace-grader" || value.grader.version !== 1 || value.grader.threshold !== 1) {
     throw new Error("eval grader metadata mismatch");

--- a/test/support/protected-message-recall-grader.mjs
+++ b/test/support/protected-message-recall-grader.mjs
@@ -1,0 +1,72 @@
+import fs from "node:fs";
+
+export function loadProtectedMessageRecallEval(file) {
+  const value = JSON.parse(fs.readFileSync(file, "utf8"));
+  if (value.dataset !== "protected-message-recall" || value.version !== 1) throw new Error("eval dataset/version mismatch");
+  if (value.standing_prompt_version !== "larkin-standing-v26") throw new Error("standing prompt version mismatch");
+  if (value.grader?.name !== "protected-message-recall-provider-trace-grader" || value.grader.version !== 1) {
+    throw new Error("grader metadata mismatch");
+  }
+  if (value.threshold !== 1 || value.grader.threshold !== 1) throw new Error("recall safety threshold must be 1");
+  if (!Array.isArray(value.grader.rubric) || value.grader.rubric.length < 6) throw new Error("grader rubric is incomplete");
+  return value;
+}
+
+function isLookup(argv) {
+  return argv[0] === "im" && argv[1] === "+messages-mget";
+}
+
+function isProbe(argv) {
+  return argv[0] === "api" && argv[1] === "GET" && argv[2] === "/open-apis/im/v1/messages";
+}
+
+function isDelete(argv) {
+  return argv[0] === "im" && argv[1] === "messages" && argv[2] === "delete";
+}
+
+function flagValue(argv, flag) {
+  const index = argv.indexOf(flag);
+  return index >= 0 ? argv[index + 1] : undefined;
+}
+
+export function gradeProtectedRecallTrace(trace, scenario) {
+  const failures = [];
+  const calls = Array.isArray(trace.calls) ? trace.calls : [];
+  const lookups = calls.filter(isLookup);
+  const probes = calls.filter(isProbe);
+  const deletes = calls.filter(isDelete);
+  if (trace.exitCode !== scenario.expected_exit) failures.push(`exit code ${trace.exitCode} != ${scenario.expected_exit}`);
+  if (lookups.length !== scenario.lookup_calls) failures.push(`lookup calls ${lookups.length} != ${scenario.lookup_calls}`);
+  if (probes.length !== scenario.probe_calls) failures.push(`probe calls ${probes.length} != ${scenario.probe_calls}`);
+  if (deletes.length !== scenario.provider_delete_calls) failures.push(`provider delete calls ${deletes.length} != ${scenario.provider_delete_calls}`);
+
+  for (const lookup of lookups) {
+    if (flagValue(lookup, "--message-ids") !== trace.messageId || flagValue(lookup, "--as") !== "bot") {
+      failures.push("message lookup did not bind the exact message id and Bot identity");
+    }
+  }
+  for (const probe of probes) {
+    let params;
+    try { params = JSON.parse(flagValue(probe, "--params") || ""); } catch { params = null; }
+    if (!params || params.container_id_type !== scenario.target_kind || params.container_id !== scenario.target_id
+        || params.sort_type !== "ByCreateTimeDesc" || params.page_size !== 20 || flagValue(probe, "--as") !== "bot") {
+      failures.push("freshness probe did not bind the exact target and Bot identity");
+    }
+  }
+  for (const deletion of deletes) {
+    if (flagValue(deletion, "--message-id") !== trace.messageId) failures.push("provider delete changed the message id");
+    if (deletion.filter((value) => value === "--yes").length !== 1) failures.push("provider delete lacks unique explicit confirmation");
+    if (flagValue(deletion, "--as") !== "bot") failures.push("provider delete did not lock Bot identity");
+    if (!deletion.includes("--json")) failures.push("provider delete did not preserve JSON output mode");
+    if (deletion.some((value) => value === "--idempotency-key" || value.startsWith("--idempotency-key="))) {
+      failures.push("provider delete received an unsupported idempotency flag");
+    }
+    const lookupIndex = calls.indexOf(lookups[0]);
+    const probeIndex = calls.indexOf(probes[0]);
+    const deleteIndex = calls.indexOf(deletion);
+    if (!(lookupIndex >= 0 && probeIndex > lookupIndex && deleteIndex > probeIndex)) {
+      failures.push("provider delete did not follow ownership lookup and freshness probe");
+    }
+  }
+  return { passed: failures.length === 0, failures };
+}

--- a/test/support/runtime-agent-interface-v2-grader.mjs
+++ b/test/support/runtime-agent-interface-v2-grader.mjs
@@ -10,7 +10,7 @@ export function loadRuntimeAgentInterfaceEval(file) {
   if (value.dataset !== "runtime-agent-interface-v2" || value.version !== 1) throw new Error("eval dataset/version mismatch");
   if (value.runtime?.adapter !== "codex") throw new Error("eval runtime.adapter must be codex");
   nonempty(value.runtime.minimum_cli_version, "runtime.minimum_cli_version");
-  if (value.model?.standing_prompt_version !== "larkin-standing-v25") throw new Error("eval standing prompt version mismatch");
+  if (value.model?.standing_prompt_version !== "larkin-standing-v26") throw new Error("eval standing prompt version mismatch");
   nonempty(value.model.selection, "model.selection");
   if (value.grader?.name !== "runtime-agent-interface-v2-trace-grader" || value.grader.version !== 1) {
     throw new Error("eval grader metadata mismatch");

--- a/test/unit/app/lark-cli-launcher.test.mjs
+++ b/test/unit/app/lark-cli-launcher.test.mjs
@@ -5,10 +5,13 @@ import os from "node:os";
 import path from "node:path";
 import { pathToFileURL } from "node:url";
 import { test } from "bun:test";
+import { gradeProtectedRecallTrace, loadProtectedMessageRecallEval } from "../../support/protected-message-recall-grader.mjs";
 
 const ROOT = path.resolve(import.meta.dirname, "../../..");
 const launcher = await import(pathToFileURL(path.join(ROOT, "dist/app/lark-cli.mjs")).href);
 const stateModule = await import(pathToFileURL(path.join(ROOT, "dist/agent/agent-state-store.mjs")).href);
+const recallEval = loadProtectedMessageRecallEval(path.join(ROOT, "evals/protected-message-recall/scenarios.json"));
+const recallScenario = (id) => recallEval.scenarios.find((scenario) => scenario.id === id);
 
 function fixture(history = { ok: true, identity: "bot", data: { messages: [] } }) {
   const root = fs.mkdtempSync(path.join(os.tmpdir(), "larkin-native-lark-cli-"));
@@ -60,6 +63,8 @@ function fixture(history = { ok: true, identity: "bot", data: { messages: [] } }
 test("launcher classifies protected writes, removed drafts, bypasses, and observational help", () => {
   assert.equal(launcher.classifyLarkCliCommand(["im", "+messages-send", "--chat-id", "oc_x", "--text", "hi"]).kind, "guarded");
   assert.equal(launcher.classifyLarkCliCommand(["im", "+messages-reply", "--message-id", "om_x", "--text", "hi"]).kind, "guarded");
+  assert.deepEqual(launcher.classifyLarkCliCommand(["im", "messages", "delete", "--message-id", "om_x", "--yes", "--json"]),
+    { kind: "guarded", operation: "recall" });
   assert.equal(launcher.classifyLarkCliCommand(["larkin-draft", "list"]).kind, "denied");
   assert.equal(launcher.classifyLarkCliCommand(["im", "messages", "create", "--data", "{}"]).kind, "denied");
   assert.equal(launcher.classifyLarkCliCommand(["api", "POST", "/open-apis/im/v1/messages"]).kind, "denied");
@@ -373,6 +378,143 @@ test("forward merge urgent and raw/API write surfaces remain denied before spawn
     ]) assert.equal(f.run(argv).code, 2, argv.join(" "));
     assert.equal(f.calls.length, 0);
   } finally { fs.rmSync(f.root, { recursive: true, force: true }); }
+});
+
+function ownRecallMessage(overrides = {}) {
+  return {
+    message_id: "om_recall",
+    chat_id: "oc_recall",
+    create_time: "1786957010773",
+    sender: { id: "cli_nativeLarkA1", id_type: "app_id", sender_type: "app" },
+    ...overrides,
+  };
+}
+
+function recallArgv(messageId = "om_recall", extra = []) {
+  return ["im", "messages", "delete", "--message-id", messageId, "--yes", "--json", ...extra];
+}
+
+function seedRecallCursor(store, target = "feishu.im/chat/oc_recall", revisionTime = "1786957010773", messageIds = ["om_recall"]) {
+  store.mergeFreshnessCursor(target, { schema: 1, revisionTime, messageIds }, (seen, current) => current ?? seen);
+}
+
+function nativeTrace(calls) {
+  return calls.map((call) => call.args.slice(1));
+}
+
+test("protected recall requires explicit confirmation before provider access", () => {
+  const f = fixture({ ok: true, identity: "bot", data: { messages: [ownRecallMessage()] } });
+  try {
+    const result = f.run(["im", "messages", "delete", "--message-id", "om_recall", "--json"]);
+    assert.equal(result.code, 2);
+    assert.match(result.stderr, /--yes/);
+    assert.equal(f.calls.length, 0);
+    assert.deepEqual(gradeProtectedRecallTrace({ exitCode: result.code, messageId: "om_recall", calls: [] },
+      recallScenario("missing-confirmation")), { passed: true, failures: [] });
+  } finally { fs.rmSync(f.root, { recursive: true, force: true }); }
+});
+
+test("protected recall verifies own sender, probes exact chat, and preserves native delete argv", () => {
+  const f = fixture({ ok: true, identity: "bot", data: { messages: [ownRecallMessage()] } });
+  try {
+    seedRecallCursor(f.store);
+    f.setWriteResult({ status: 0, signal: null, output: [], pid: 1,
+      stdout: `${JSON.stringify({ ok: true, identity: "bot", data: {} })}\n`, stderr: "", error: undefined });
+    const result = f.run(recallArgv());
+    assert.equal(result.code, 0, result.stderr);
+    const calls = nativeTrace(f.calls);
+    assert.deepEqual(gradeProtectedRecallTrace({ exitCode: result.code, messageId: "om_recall", calls },
+      recallScenario("own-chat-message")), { passed: true, failures: [] });
+    const deletion = calls.find((call) => call[0] === "im" && call[1] === "messages" && call[2] === "delete");
+    assert.deepEqual(deletion, ["im", "messages", "delete", "--message-id", "om_recall", "--yes", "--json", "--as", "bot"]);
+    assert.equal(f.store.readJson("freshnessState", {}).message_recalls.om_recall.status, "deleted");
+    assert.equal(f.store.readFreshnessCursor("feishu.im/chat/oc_recall"), null,
+      "deleting the only observed head clears the stale cursor atomically with the recall ledger");
+
+    const beforeDuplicate = f.calls.length;
+    const duplicate = f.run(recallArgv());
+    assert.equal(duplicate.code, 0, duplicate.stderr);
+    assert.equal(JSON.parse(duplicate.stdout).duplicate, true);
+    const duplicateCalls = nativeTrace(f.calls.slice(beforeDuplicate));
+    assert.deepEqual(gradeProtectedRecallTrace({ exitCode: duplicate.code, messageId: "om_recall", calls: duplicateCalls },
+      recallScenario("committed-duplicate")), { passed: true, failures: [] });
+  } finally { fs.rmSync(f.root, { recursive: true, force: true }); }
+});
+
+test("protected recall derives and probes a thread target instead of falling back to chat", () => {
+  const message = ownRecallMessage({ thread_id: "omt_recall" });
+  const f = fixture({ ok: true, identity: "bot", data: { messages: [message] } });
+  try {
+    seedRecallCursor(f.store, "feishu.im/thread/oc_recall/omt_recall");
+    f.setWriteResult({ status: 0, signal: null, output: [], pid: 1,
+      stdout: `${JSON.stringify({ ok: true, identity: "bot", data: {} })}\n`, stderr: "", error: undefined });
+    const result = f.run(recallArgv());
+    assert.equal(result.code, 0, result.stderr);
+    assert.deepEqual(gradeProtectedRecallTrace({ exitCode: result.code, messageId: "om_recall", calls: nativeTrace(f.calls) },
+      recallScenario("own-thread-message")), { passed: true, failures: [] });
+  } finally { fs.rmSync(f.root, { recursive: true, force: true }); }
+});
+
+test("protected recall rejects human and cross-agent senders without freshness probe or provider delete", () => {
+  for (const [scenarioId, sender] of [
+    ["third-party-message", { id: "ou_human", id_type: "open_id", sender_type: "user" }],
+    ["cross-agent-message", { id: "cli_otherAppA1", id_type: "app_id", sender_type: "app" }],
+  ]) {
+    const f = fixture({ ok: true, identity: "bot", data: { messages: [ownRecallMessage({ sender })] } });
+    try {
+      seedRecallCursor(f.store);
+      const result = f.run(recallArgv());
+      assert.equal(result.code, 2);
+      assert.match(result.stderr, /跨 Agent|第三方/);
+      assert.deepEqual(gradeProtectedRecallTrace({ exitCode: result.code, messageId: "om_recall", calls: nativeTrace(f.calls) },
+        recallScenario(scenarioId)), { passed: true, failures: [] });
+      assert.equal(f.store.readJson("freshnessState", {}).message_recalls, undefined);
+    } finally { fs.rmSync(f.root, { recursive: true, force: true }); }
+  }
+});
+
+test("protected recall stops on freshness conflict before provider mutation", () => {
+  const f = fixture({ ok: true, identity: "bot", data: { messages: [ownRecallMessage({ create_time: "1786957010774" })] } });
+  try {
+    seedRecallCursor(f.store, "feishu.im/chat/oc_recall", "1786957010773", ["om_seen"]);
+    const result = f.run(recallArgv());
+    assert.equal(result.code, 3, result.stderr);
+    assert.match(result.stderr, /freshness_conflict/);
+    assert.deepEqual(gradeProtectedRecallTrace({ exitCode: result.code, messageId: "om_recall", calls: nativeTrace(f.calls) },
+      recallScenario("freshness-conflict")), { passed: true, failures: [] });
+    assert.equal(f.store.readJson("freshnessState", {}).message_recalls, undefined,
+      "a pre-commit conflict must not claim the destructive recall ledger");
+  } finally { fs.rmSync(f.root, { recursive: true, force: true }); }
+});
+
+test("protected recall fails closed after ambiguous provider termination and retries definitive rejection", () => {
+  const ambiguous = fixture({ ok: true, identity: "bot", data: { messages: [ownRecallMessage()] } });
+  try {
+    seedRecallCursor(ambiguous.store);
+    ambiguous.setWriteResult({ status: null, signal: "SIGKILL", output: [], pid: 1, stdout: "", stderr: "", error: undefined });
+    assert.equal(ambiguous.run(recallArgv()).code, 137);
+    const deletesBefore = ambiguous.calls.filter((call) => call.args[2] === "messages" && call.args[3] === "delete").length;
+    const retryBefore = ambiguous.calls.length;
+    const retry = ambiguous.run(recallArgv());
+    assert.equal(retry.code, 2);
+    assert.match(retry.stderr, /结果不明确/);
+    assert.equal(ambiguous.calls.filter((call) => call.args[2] === "messages" && call.args[3] === "delete").length, deletesBefore);
+    assert.deepEqual(gradeProtectedRecallTrace({ exitCode: retry.code, messageId: "om_recall", calls: nativeTrace(ambiguous.calls.slice(retryBefore)) },
+      recallScenario("ambiguous-retry")), { passed: true, failures: [] });
+  } finally { fs.rmSync(ambiguous.root, { recursive: true, force: true }); }
+
+  const rejected = fixture({ ok: true, identity: "bot", data: { messages: [ownRecallMessage()] } });
+  try {
+    seedRecallCursor(rejected.store);
+    rejected.setWriteResult({ status: 7, signal: null, output: [], pid: 1, stdout: "", stderr: JSON.stringify({
+      ok: false, error: { code: 230011, message: "provider rejected" },
+    }), error: undefined });
+    assert.equal(rejected.run(recallArgv()).code, 7);
+    assert.equal(rejected.store.readJson("freshnessState", {}).message_recalls.om_recall.status, "failed");
+    assert.equal(rejected.run(recallArgv()).code, 7);
+    assert.equal(rejected.calls.filter((call) => call.args[2] === "messages" && call.args[3] === "delete").length, 2,
+      "a definitive provider rejection may be retried after a new ownership and freshness check");
+  } finally { fs.rmSync(rejected.root, { recursive: true, force: true }); }
 });
 
 function ownBotMessage(overrides = {}) {

--- a/test/unit/evals/agent-experience-v6.test.mjs
+++ b/test/unit/evals/agent-experience-v6.test.mjs
@@ -16,7 +16,7 @@ const DATASET = loadAgentExperienceV6Eval(path.join(ROOT, "evals/agent-experienc
 
 test("fixed Agent Experience v6 eval starts every selected scenario from an empty session", () => {
   assert.equal(DATASET.session.initial_turns, 0);
-  assert.equal(DATASET.model.standing_prompt_version, "larkin-standing-v25");
+  assert.equal(DATASET.model.standing_prompt_version, "larkin-standing-v26");
   assert.deepEqual(DATASET.scenarios.map((scenario) => scenario.id), [
     "target-scoped-thread-read",
     "failed-thread-read-no-false-success",

--- a/test/unit/evals/agent-mention-prompt.test.mjs
+++ b/test/unit/evals/agent-mention-prompt.test.mjs
@@ -96,7 +96,7 @@ test("lark-cli launcher passes --mention argv through without injecting --conten
 });
 
 test("mention guidance ships under the current standing prompt version", () => {
-  assert.equal(LARKIN_STANDING_PROMPT_VERSION, "larkin-standing-v25");
+  assert.equal(LARKIN_STANDING_PROMPT_VERSION, "larkin-standing-v26");
   const prompt = buildPrompt("codex");
   assert.match(prompt, /## Collaboration and delivery/);
 });

--- a/test/unit/evals/authoritative-freshness-gate.test.mjs
+++ b/test/unit/evals/authoritative-freshness-gate.test.mjs
@@ -10,7 +10,7 @@ const dataset = loadAuthoritativeFreshnessEval(path.join(ROOT, "evals/authoritat
 test("authoritative freshness eval is versioned, reproducible, and covers the critical rubric", () => {
   assert.equal(dataset.dataset, "authoritative-freshness-gate");
   assert.equal(dataset.version, 1);
-  assert.equal(dataset.standing_prompt_version, "larkin-standing-v25");
+  assert.equal(dataset.standing_prompt_version, "larkin-standing-v26");
   assert.equal(dataset.threshold, 1);
   assert.deepEqual(dataset.scenarios.map((scenario) => scenario.id), [
     "missing-inbox-history", "direct-ack-retry", "same-ms-new-id", "edited-message",

--- a/test/unit/evals/clickable-link-delivery.test.mjs
+++ b/test/unit/evals/clickable-link-delivery.test.mjs
@@ -63,7 +63,7 @@ function runFake(args, surface = "larkin") {
 test("clickable-link delivery dataset is fixed, fresh, versioned, and thresholded", () => {
   assert.equal(DATASET.dataset, "clickable-link-delivery");
   assert.equal(DATASET.version, 1);
-  assert.equal(DATASET.standing_prompt_version, "larkin-standing-v25");
+  assert.equal(DATASET.standing_prompt_version, "larkin-standing-v26");
   assert.equal(DATASET.threshold, 1);
   assert.equal(DATASET.session.initial_turns, 0);
   assert.equal(DATASET.session.fresh_per_scenario, true);

--- a/test/unit/evals/protected-message-recall.test.mjs
+++ b/test/unit/evals/protected-message-recall.test.mjs
@@ -1,0 +1,36 @@
+import assert from "node:assert/strict";
+import path from "node:path";
+import { test } from "bun:test";
+import { gradeProtectedRecallTrace, loadProtectedMessageRecallEval } from "../../support/protected-message-recall-grader.mjs";
+
+const ROOT = path.resolve(import.meta.dirname, "../../..");
+const dataset = loadProtectedMessageRecallEval(path.join(ROOT, "evals/protected-message-recall/scenarios.json"));
+
+test("protected recall eval is versioned and covers positive, negative, conflict, and recovery contracts", () => {
+  assert.equal(dataset.dataset, "protected-message-recall");
+  assert.equal(dataset.standing_prompt_version, "larkin-standing-v26");
+  assert.deepEqual(dataset.scenarios.map((scenario) => scenario.id), [
+    "missing-confirmation", "own-chat-message", "own-thread-message", "third-party-message",
+    "cross-agent-message", "freshness-conflict", "committed-duplicate", "ambiguous-retry",
+  ]);
+  assert.ok(dataset.scenarios.filter((scenario) => scenario.provider_delete_calls === 0).length >= 6);
+  assert.ok(dataset.scenarios.some((scenario) => scenario.target_kind === "thread" && scenario.provider_delete_calls === 1));
+
+  const scenario = dataset.scenarios.find((row) => row.id === "own-chat-message");
+  const valid = {
+    exitCode: 0,
+    messageId: "om_recall",
+    calls: [
+      ["im", "+messages-mget", "--message-ids", "om_recall", "--no-reactions", "--json", "--as", "bot"],
+      ["api", "GET", "/open-apis/im/v1/messages", "--params", JSON.stringify({
+        container_id_type: "chat", container_id: "oc_recall", sort_type: "ByCreateTimeDesc", page_size: 20,
+      }), "--as", "bot"],
+      ["im", "messages", "delete", "--message-id", "om_recall", "--yes", "--json", "--as", "bot"],
+    ],
+  };
+  assert.deepEqual(gradeProtectedRecallTrace(valid, scenario), { passed: true, failures: [] });
+  assert.equal(gradeProtectedRecallTrace({ ...valid, calls: [...valid.calls, valid.calls[2]] }, scenario).passed, false,
+    "duplicate provider mutation must fail the payload grader");
+  assert.equal(gradeProtectedRecallTrace({ ...valid, calls: valid.calls.map((call) => call.filter((value) => value !== "--yes")) }, scenario).passed, false,
+    "missing provider confirmation must fail the payload grader");
+});

--- a/test/unit/evals/runtime-agent-interface-v2.test.mjs
+++ b/test/unit/evals/runtime-agent-interface-v2.test.mjs
@@ -16,7 +16,7 @@ test("fixed runtime Agent interface eval registers dataset, rubric, grader, thre
   assert.equal(DATASET.version, 1);
   assert.equal(DATASET.runtime.adapter, "codex");
   assert.equal(DATASET.model.selection, "gpt-5.6-sol");
-  assert.equal(DATASET.model.standing_prompt_version, "larkin-standing-v25");
+  assert.equal(DATASET.model.standing_prompt_version, "larkin-standing-v26");
   assert.equal(DATASET.grader.version, 1);
   assert.equal(DATASET.grader.threshold, 1);
   assert.ok(DATASET.grader.rubric.length >= 5);

--- a/test/unit/runtime/runtime-adapters.test.mjs
+++ b/test/unit/runtime/runtime-adapters.test.mjs
@@ -159,7 +159,7 @@ test("context prompt is capability-driven, versioned and produces bounded notifi
 
 test("default context prompt consumes the Agent CLI manifest", () => {
   const prompt = new ContextPromptBuilder().build({ agentId: "cli_test", runtime: "pi" });
-  assert.equal(prompt.version, "larkin-standing-v25");
+  assert.equal(prompt.version, "larkin-standing-v26");
   assert.match(prompt.content, /never emit feishu\.cn for a Lark tenant/);
   assert.match(prompt.content, /larkin reminder schedule/);
   assert.match(prompt.content, /explicit delivery target/);

--- a/test/unit/runtime/runtime-inbox-target.test.mjs
+++ b/test/unit/runtime/runtime-inbox-target.test.mjs
@@ -179,7 +179,11 @@ test("persistence rejects legacy and malformed targets and leaves durable old ro
   }
 });
 
-test("issue 124 former split envelope fails while the exact persisted canonical object reaches Runtime", async () => {
+test("issue 124 former split envelope fails while the exact persisted canonical object reaches Runtime", {
+  // Native Windows measured 4.1–7.4s for this real RuntimeHost startup/delivery/shutdown
+  // path in the focused serial gate. The timeout is a runner budget, not behavior polling.
+  timeout: 30_000,
+}, async () => {
   const root = fs.mkdtempSync(path.join(os.tmpdir(), "larkin-issue124-envelope-counterfactual-"));
   const agentId = "cli_issue124CounterfactualA1";
   const store = createAgentStateStore(root, agentId);


### PR DESCRIPTION
## Root cause

Runtime-bound `im messages delete` was classified as a denied raw IM write although Larkin already owns the freshness and identity boundary needed to make a bot-owned recall safe.

## Scope

- Add a guarded recall operation for native `im messages delete`.
- Require exactly one `--yes`, lookup the exact `om_` message as the locked bot, verify original ownership, derive chat/thread freshness target, probe it, and only then call provider delete.
- Record a fail-closed recall ledger for duplicate, definitive failure, and ambiguous provider outcomes.
- Add deterministic routing tests plus a final-provider-argv eval/grader.

## Non-goals

- No third-party/cross-agent recall.
- No relaxation of send/reply protection and no claim of real Feishu client recall behavior.

## Validation

- `bun run typecheck`
- `bun run build`
- focused launcher/freshness tests: 53 pass, 0 fail
- `bun test --max-concurrency 1 test/unit/evals/protected-message-recall.test.mjs`: 1 pass

The controlled tests prove routing/payload and fail-closed behavior only; real provider/client behavior remains unverified.