### PR TITLE
fix(agent): prefer text for ordinary multiline IM

### DIFF
--- a/evals/agent-experience-v6/scenarios.json
+++ b/evals/agent-experience-v6/scenarios.json
@@ -3,7 +3,7 @@
   "version": 6,
   "model": {
     "selection": "deterministic-trace",
-    "standing_prompt_version": "larkin-standing-v26"
+    "standing_prompt_version": "larkin-standing-v27"
   },
   "session": {
     "initial_turns": 0

--- a/evals/authoritative-freshness-gate/scenarios.json
+++ b/evals/authoritative-freshness-gate/scenarios.json
@@ -1,7 +1,7 @@
 {
   "dataset": "authoritative-freshness-gate",
   "version": 1,
-  "standing_prompt_version": "larkin-standing-v26",
+  "standing_prompt_version": "larkin-standing-v27",
   "runtime": { "adapter": "codex", "selection": "runtime-default" },
   "grader": {
     "name": "authoritative-freshness-trace-grader",

--- a/evals/clickable-link-delivery/scenarios.json
+++ b/evals/clickable-link-delivery/scenarios.json
@@ -1,7 +1,7 @@
 {
   "dataset": "clickable-link-delivery",
   "version": 1,
-  "standing_prompt_version": "larkin-standing-v26",
+  "standing_prompt_version": "larkin-standing-v27",
   "runtime": { "adapter": "codex", "selection": "runtime-default" },
   "threshold": 1,
   "grader": {

--- a/evals/im-body-mode/scenarios.json
+++ b/evals/im-body-mode/scenarios.json
@@ -1,0 +1,85 @@
+{
+  "dataset": "im-body-mode",
+  "version": 1,
+  "standing_prompt_version": "larkin-standing-v27",
+  "runtime": { "adapter": "codex", "selection": "runtime-default" },
+  "threshold": 1,
+  "grader": {
+    "name": "im-body-mode-final-payload-grader",
+    "version": 1,
+    "threshold": 1,
+    "rubric": [
+      "exactly one successful fake provider write reaches the fixed synthetic target",
+      "ordinary plain line and paragraph status updates use --text",
+      "intentional headings, lists, fenced code, and Markdown links use --markdown",
+      "exact/verbatim literals use --text and preserve the supplied body byte-for-byte",
+      "assistant prose, prompt text, malformed traces, missing writes, and duplicate writes never count"
+    ]
+  },
+  "session": { "initial_turns": 0, "fresh_per_scenario": true },
+  "scenarios": [
+    {
+      "id": "ordinary-plain-lines",
+      "operation": "send",
+      "target_flag": "--chat-id",
+      "target": "oc_eval_im_plain_lines",
+      "expected_body_flag": "--text",
+      "body": "Build finished.\nDeploying to staging.",
+      "prompt": "This is a controlled payload eval with a fake sink and synthetic target. Send exactly one ordinary, non-verbatim status update to oc_eval_im_plain_lines. State Build finished. on the first line, then Deploying to staging. on the second line. Do not describe the command, and stop after the fake success result."
+    },
+    {
+      "id": "ordinary-plain-paragraphs",
+      "operation": "send",
+      "target_flag": "--chat-id",
+      "target": "oc_eval_im_plain_paragraphs",
+      "expected_body_flag": "--text",
+      "body": "Build finished.\n\nStaging deployment is queued.",
+      "prompt": "This is a controlled payload eval with a fake sink and synthetic target. Send exactly one ordinary, non-verbatim status update to oc_eval_im_plain_paragraphs. Use a first paragraph saying Build finished. and a second paragraph saying Staging deployment is queued. Do not describe the command, and stop after the fake success result."
+    },
+    {
+      "id": "intentional-markdown-heading",
+      "operation": "send",
+      "target_flag": "--chat-id",
+      "target": "oc_eval_im_heading",
+      "expected_body_flag": "--markdown",
+      "body": "## Deployment\n\nBuild finished.",
+      "prompt": "This is a controlled payload eval with a fake sink and synthetic target. Send exactly one intentionally Markdown-formatted update to oc_eval_im_heading using this heading and body: ## Deployment, then Build finished. This is intentionally rendered Markdown, not an exact/verbatim body. Do not describe the command, and stop after the fake success result."
+    },
+    {
+      "id": "intentional-markdown-list",
+      "operation": "send",
+      "target_flag": "--chat-id",
+      "target": "oc_eval_im_list",
+      "expected_body_flag": "--markdown",
+      "body": "- Build finished\n- Deploying to staging",
+      "prompt": "This is a controlled payload eval with a fake sink and synthetic target. Send exactly one intentionally Markdown-formatted update to oc_eval_im_list using this bullet list: - Build finished and - Deploying to staging. This is intentionally rendered Markdown, not an exact/verbatim body. Do not describe the command, and stop after the fake success result."
+    },
+    {
+      "id": "intentional-markdown-code",
+      "operation": "send",
+      "target_flag": "--chat-id",
+      "target": "oc_eval_im_code",
+      "expected_body_flag": "--markdown",
+      "body": "```sh\nbun run test\n```",
+      "prompt": "This is a controlled payload eval with a fake sink and synthetic target. Send exactly one intentionally Markdown-formatted update to oc_eval_im_code containing the fenced shell code block ```sh, bun run test, ```. This is intentionally rendered Markdown, not an exact/verbatim body. Do not describe the command, and stop after the fake success result."
+    },
+    {
+      "id": "intentional-markdown-link",
+      "operation": "send",
+      "target_flag": "--chat-id",
+      "target": "oc_eval_im_link",
+      "expected_body_flag": "--markdown",
+      "body": "[Open Issue 176](https://github.com/eddiearc/larkin/issues/176)\n\nhttps://github.com/eddiearc/larkin/issues/176",
+      "prompt": "This is a controlled payload eval with a fake sink and synthetic target. Send exactly one intentionally Markdown-formatted update to oc_eval_im_link with the Markdown link [Open Issue 176](https://github.com/eddiearc/larkin/issues/176), followed by a blank line and the complete bare URL https://github.com/eddiearc/larkin/issues/176. This is intentionally rendered Markdown, not an exact/verbatim body. Do not describe the command, and stop after the fake success result."
+    },
+    {
+      "id": "exact-verbatim-literal",
+      "operation": "reply",
+      "target_flag": "--message-id",
+      "target": "om_eval_im_exact",
+      "expected_body_flag": "--text",
+      "body": "# literal heading\n- literal list item\n[Literal link](https://github.com/eddiearc/larkin/issues/176)",
+      "prompt": "This is a controlled payload eval with a fake sink and synthetic target. Reply exactly once to om_eval_im_exact with this exact and verbatim three-line body: # literal heading, then - literal list item, then [Literal link](https://github.com/eddiearc/larkin/issues/176). Preserve it byte-for-byte; do not format it as Markdown, add text, or describe the command. Stop after the fake success result."
+    }
+  ]
+}

--- a/evals/mention-construction/scenarios.json
+++ b/evals/mention-construction/scenarios.json
@@ -1,7 +1,7 @@
 {
   "dataset": "mention-construction",
   "version": 1,
-  "standing_prompt_version": "larkin-standing-v26",
+  "standing_prompt_version": "larkin-standing-v27",
   "runtime": { "adapter": "codex", "selection": "runtime-default" },
   "grader": {
     "name": "mention-construction-trace-grader",

--- a/evals/protected-message-recall/scenarios.json
+++ b/evals/protected-message-recall/scenarios.json
@@ -1,7 +1,7 @@
 {
   "dataset": "protected-message-recall",
   "version": 1,
-  "standing_prompt_version": "larkin-standing-v26",
+  "standing_prompt_version": "larkin-standing-v27",
   "grader": {
     "name": "protected-message-recall-provider-trace-grader",
     "version": 1,

--- a/evals/runtime-agent-interface-v2/scenarios.json
+++ b/evals/runtime-agent-interface-v2/scenarios.json
@@ -7,7 +7,7 @@
   },
   "model": {
     "selection": "gpt-5.6-sol",
-    "standing_prompt_version": "larkin-standing-v26"
+    "standing_prompt_version": "larkin-standing-v27"
   },
   "grader": {
     "name": "runtime-agent-interface-v2-trace-grader",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "larkin",
-  "version": "0.4.22",
+  "version": "0.4.23",
   "private": false,
   "larkinPackageRole": "npm-published",
   "files": [
@@ -77,6 +77,8 @@
     "test:eval:agent-experience-v6": "bun test --max-concurrency 1 test/unit/evals/agent-experience-v6.test.mjs",
     "test:eval:mention-construction": "bun run build && LARKIN_RUN_MENTION_CONSTRUCTION_EVAL=1 bun test --max-concurrency 1 test/live/mention-construction-agent-eval.test.mjs",
     "test:eval:clickable-link-delivery": "bun run build && bun test --max-concurrency 1 test/unit/evals/clickable-link-delivery.test.mjs",
+    "test:eval:im-body-mode": "bun run build && bun test --max-concurrency 1 test/unit/evals/im-body-mode.test.mjs",
+    "test:eval:im-body-mode:native": "bun run build && LARKIN_RUN_IM_BODY_MODE_EVAL=1 bun test --max-concurrency 1 test/live/im-body-mode-agent-eval.test.mjs",
     "test:eval:clickable-link-delivery:native": "bun run build && LARKIN_RUN_CLICKABLE_LINK_DELIVERY_EVAL=1 bun test --max-concurrency 1 test/live/clickable-link-delivery-agent-eval.test.mjs",
     "test:eval:public-contribution-governance": "bun test --max-concurrency 1 test/unit/evals/public-contribution-governance.test.mjs",
     "test:live:public-contribution-governance": "bun test --max-concurrency 1 test/live/public-contribution-governance-live.test.mjs",

--- a/src/agent/context-prompt.ts
+++ b/src/agent/context-prompt.ts
@@ -16,7 +16,7 @@ import type { AgentCliCapabilities, RuntimeId, RuntimeInput, StandingPrompt } fr
  * 6. 用 eval 验证：行为变化必须配套固定场景 + rubric（evals/*、test/support/*-grader.mjs、live 测试）。
  */
 
-export const LARKIN_STANDING_PROMPT_VERSION = "larkin-standing-v26";
+export const LARKIN_STANDING_PROMPT_VERSION = "larkin-standing-v27";
 
 /**
  * Agent 间协作唤醒引导（issue #75）：纯文本 @ 不会产生飞书 mention 事件，
@@ -147,12 +147,12 @@ export class ContextPromptBuilder {
       "If the scoped history read fails or its schema is invalid, fail visibly. Do not reuse remembered or hard-coded text to make the task appear successful.",
       "Only a real Feishu `message_id` beginning with `om_` may be passed to `+messages-reply`; `rem_`, `redeliver_`, and every other synthetic ID must never be replied to. Send with a confirmed `chat_id` and never guess a chat id from a display name.",
       "Before every send/reply/card/recall write, Larkin probes the exact chat or thread history with the current Bot identity. A nonzero `freshness_conflict` includes bounded unseen context and direct-acks that cursor; reconsider it, then retry the ordinary command. Larkin never saves the blocked operation as a draft.",
-      "For regular textual message bodies, default to `--markdown`, including brief single-line replies, so Feishu renders Markdown structure instead of showing its markers literally.",
+      "For ordinary plain-text message bodies, use `--text`, including brief one-line replies, multiline status lines, and paragraphs. Use `--markdown` only when you intentionally need Markdown rendering, such as headings, lists, emphasis, blockquotes, fenced code, or Markdown links.",
       "When a URL must be visible, clickable, or openable by the recipient, include the complete bare `https://...` URL as visible text. Do not rely solely on `[label](URL)`, because Feishu client rendering is unreliable. A label may also be included, but the bare URL must remain present.",
-      "Use native `--text` only when plain text or verbatim preservation is explicitly needed, such as logs, code, or exact whitespace. Both `--markdown` and `--text` remain supported in the Larkin Runtime.",
+      "Use native `--text` for ordinary plain text and for verbatim preservation, such as logs, literal code, or exact whitespace. Both `--markdown` and `--text` remain supported in the Larkin Runtime.",
       "Never rewrite or normalize an exact or verbatim user-supplied body to expose a URL; the existing exact-content paths remain authoritative and preserve the supplied body unchanged.",
       "For exact text supplied directly in the current instruction or Inbox event, pass the body unchanged as one literal `--text` argument. A direct literal must not use command substitution, backticks, `eval`, `echo`, or an unquoted variable; if it cannot be represented safely, stop and report the limitation instead of normalizing it.",
-      "An explicit exact or verbatim direct literal uses `--text` and overrides the regular markdown default.",
+      "An explicit exact or verbatim direct literal uses `--text` and overrides the ordinary-body guidance.",
       `For a common exact send with a confirmed chat id, use the complete schematic recipe \`${executable} im +messages-send --chat-id <confirmed_chat_id> --text '<exact_body_as_one_literal_argument>' --json\`; replace each placeholder with the corresponding confirmed or exact literal value.`,
       `A reply's target is governed by the source's thread membership, a structural Inbox fact, not a guess. When the current Inbox event or poll identifies the source as a thread (\`thread:<chat_id>:<thread_id>\` target, or the polled message carries a \`thread_id\`), your reply MUST stay in that same thread: after the required poll use \`${executable} im +messages-reply --message-id <real_om_message_id> --text '<exact_body_as_one_literal_argument>' --reply-in-thread --json\`. For a chat-level source (no thread) with no explicit in-thread request, reply to the main timeline with the same recipe but omit \`--reply-in-thread\`; replace the placeholders only with the real \`om_\` id returned by that poll and the unchanged exact literal.`,
       `Use the \`--reply-in-thread\` recipe only when the source is a thread or the user or current Inbox event explicitly asks for a topic, in-thread, or thread reply. Never invent a topic request from ordinary reply wording or a bare source message id: the thread decision comes only from the source message's actual thread membership (\`thread:\` target or polled \`thread_id\`) or an explicit request, never from wording alone.`,

--- a/test/live/im-body-mode-agent-eval.test.mjs
+++ b/test/live/im-body-mode-agent-eval.test.mjs
@@ -1,0 +1,138 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { execFileSync, spawn } from "node:child_process";
+import { PassThrough } from "node:stream";
+import { test } from "bun:test";
+import { ContextPromptBuilder } from "../../dist/agent/context-prompt.mjs";
+import { createNativeRuntimeAdapter } from "../../dist/runtime/runtime-adapters.mjs";
+import { gradeNativeCommandAudit, isolatedNativeEnv } from "../support/clickable-link-delivery-native-support.mjs";
+import { gradeImBodyModeTrace, loadImBodyModeEval, v26PlainMultilineCounterfactual } from "../support/im-body-mode-grader.mjs";
+
+const RUN = process.env.LARKIN_RUN_IM_BODY_MODE_EVAL === "1";
+const ROOT = path.resolve(import.meta.dirname, "../..");
+const FAKE = path.join(ROOT, "test/support/im-body-mode-eval-cli.mjs");
+const DATASET = loadImBodyModeEval(path.join(ROOT, "evals/im-body-mode/scenarios.json"));
+const PROMPT_VERSION = process.env.LARKIN_IM_BODY_MODE_PROMPT_VERSION || "v27";
+const SCENARIO_ID = process.env.LARKIN_IM_BODY_MODE_SCENARIO || "ordinary-plain-lines";
+const SCENARIO = DATASET.scenarios.find((scenario) => scenario.id === SCENARIO_ID);
+const MAX_RUN_MS = 52_000;
+
+function remaining(deadline) {
+  const value = deadline - Date.now();
+  if (value <= 0) throw new Error("native IM body-mode eval timed out after 52s");
+  return value;
+}
+
+async function promptWhenReady(session, input, deadline) {
+  for (;;) {
+    const result = await session.prompt(input);
+    if (result.status !== "deferred" || !/not initialized/i.test(result.reason || "")) return result;
+    remaining(deadline);
+    await new Promise((resolve) => setTimeout(resolve, 25));
+  }
+}
+
+function waitForTurnEnd(events, after, deadline) {
+  return new Promise((resolve, reject) => {
+    const find = () => events.items.slice(after).find((event) => event.type === "turn-end");
+    if (find()) return resolve(find());
+    const timer = setTimeout(() => reject(new Error("native IM body-mode eval timed out after 52s")), remaining(deadline));
+    events.waiters.push(() => { const found = find(); if (found) { clearTimeout(timer); resolve(found); } });
+  });
+}
+
+function writeShadow(file, surface) {
+  fs.writeFileSync(file,
+    `#!/bin/sh\nIM_BODY_MODE_EVAL_SURFACE=${surface} exec ${JSON.stringify(process.execPath)} ${JSON.stringify(FAKE)} "$@"\n`,
+    { mode: 0o700 });
+}
+
+if (RUN) {
+  if (!SCENARIO) throw new Error(`unknown IM body-mode scenario: ${SCENARIO_ID}`);
+  if (!["v26", "v27"].includes(PROMPT_VERSION)) throw new Error(`unknown IM body-mode prompt version: ${PROMPT_VERSION}`);
+}
+
+test.skipIf(!RUN)(`native IM body-mode final-payload eval (${PROMPT_VERSION}/${SCENARIO_ID})`, { timeout: 55_000 }, async () => {
+  const deadline = Date.now() + MAX_RUN_MS;
+  const temp = fs.mkdtempSync(path.join(os.tmpdir(), "larkin-im-body-mode-native-eval-"));
+  const workspaceDir = path.join(temp, "workspace");
+  const stateDir = path.join(temp, "state");
+  const binDir = path.join(temp, "bin");
+  const traceFile = path.join(temp, "trace.ndjson");
+  const fakeLarkin = path.join(binDir, "larkin");
+  const fakeLarkCli = path.join(binDir, "lark-cli");
+  let session;
+  let model = null;
+  let evidenceWritten = false;
+  const commandAudit = [];
+  try {
+    for (const dir of [workspaceDir, stateDir, binDir]) fs.mkdirSync(dir, { recursive: true, mode: 0o700 });
+    fs.writeFileSync(traceFile, "", { mode: 0o600 });
+    fs.writeFileSync(path.join(workspaceDir, "AGENTS.md"), [
+      "# Controlled IM body-mode payload evaluation",
+      "Use only the absolute fake larkin command supplied by the task. Both larkin and lark-cli on PATH are inert fake sinks.",
+      "Never inspect files or environment, use network tools, or invoke any other command.",
+      "The targets beginning oc_eval_im_/om_eval_im_ are synthetic and no Feishu write is possible.",
+      "Stop immediately after the single fake write result.", "",
+    ].join("\n"), { mode: 0o600 });
+    writeShadow(fakeLarkin, "larkin");
+    writeShadow(fakeLarkCli, "lark-cli");
+    const codexCommand = execFileSync("sh", ["-c", "command -v codex"], { encoding: "utf8", timeout: 2_000 }).trim();
+    assert.ok(codexCommand, "native Codex executable is unavailable");
+    const nativeEnv = isolatedNativeEnv(process.env, { temp, binDir, codexCommand, traceFile });
+    nativeEnv.IM_BODY_MODE_EVAL_TRACE_FILE = traceFile;
+    const captureSpawn = (command, args, options) => {
+      const child = spawn(command, args, options);
+      const stdout = new PassThrough(); let pending = "";
+      child.stdout.setEncoding("utf8");
+      child.stdout.on("data", (chunk) => {
+        stdout.write(chunk); pending += chunk;
+        for (;;) {
+          const newline = pending.indexOf("\n"); if (newline < 0) break;
+          const line = pending.slice(0, newline); pending = pending.slice(newline + 1);
+          try {
+            const message = JSON.parse(line); const item = message.params?.item;
+            if (message.method === "item/completed" && item?.type === "commandExecution") {
+              commandAudit.push({ item_type: item.type, command: item.command, exit_code: item.exitCode });
+            } else if (message.method === "item/completed" && item?.type && !["userMessage", "agentMessage", "reasoning"].includes(item.type)) {
+              commandAudit.push({ item_type: item.type, command: `[${item.type}]`, exit_code: null });
+            }
+          } catch { /* only app-server protocol frames contribute evidence */ }
+        }
+      });
+      child.stdout.on("end", () => stdout.end());
+      return { stdin: child.stdin, stdout, stderr: child.stderr, pid: child.pid,
+        once: child.once.bind(child), on: child.on.bind(child), kill: child.kill.bind(child) };
+    };
+    const v27 = new ContextPromptBuilder().build({ agentId: "cli_imBodyModeEval", name: "IM Body Mode Eval", runtime: "codex" });
+    const standingPrompt = PROMPT_VERSION === "v26" ? v26PlainMultilineCounterfactual(v27) : v27;
+    const adapter = createNativeRuntimeAdapter("codex", { codexCommand, spawn: captureSpawn, env: nativeEnv });
+    session = await adapter.createSession({ agentId: "cli_imBodyModeEval", workspaceDir, stateDir, standingPrompt, env: nativeEnv });
+    const events = { items: [], waiters: [] };
+    session.subscribe((event) => { if (event.type === "session-init") model = event.model || null; events.items.push(event); for (const waiter of events.waiters) waiter(event); });
+    const after = events.items.length;
+    const accepted = await promptWhenReady(session, {
+      inputId: `${PROMPT_VERSION}-${SCENARIO.id}`, kind: "initial", attempt: 0,
+      text: `${SCENARIO.prompt}\nUse only ${JSON.stringify(fakeLarkin)} for the Larkin command and include --json.`,
+    }, deadline);
+    assert.equal(accepted.status, "accepted", accepted.reason);
+    await waitForTurnEnd(events, after, deadline);
+    const runtimeError = events.items.slice(after).find((event) => ["error", "configuration-error", "input-error"].includes(event.type));
+    assert.equal(runtimeError, undefined, runtimeError?.message);
+    const trace = fs.readFileSync(traceFile, "utf8").split("\n").filter(Boolean).map(JSON.parse);
+    const payloadGrade = gradeImBodyModeTrace(SCENARIO, trace);
+    const auditGrade = gradeNativeCommandAudit(commandAudit, fakeLarkin, fakeLarkCli);
+    const grade = { passed: payloadGrade.passed && auditGrade.passed, failures: [...payloadGrade.failures, ...auditGrade.failures] };
+    process.stderr.write(`# IM body-mode native eval: ${JSON.stringify({ dataset: DATASET.dataset, scenario: SCENARIO.id, runtime: "codex", model: model || DATASET.runtime.selection, model_id_exposed: Boolean(model), prompt: { version: standingPrompt.version, hash: standingPrompt.hash }, trace, grade, real_provider_write_possible: false })}\n`);
+    evidenceWritten = true;
+    assert.equal(grade.passed, true, JSON.stringify(grade.failures));
+  } catch (error) {
+    if (!evidenceWritten) process.stderr.write(`# IM body-mode native eval blocker: ${JSON.stringify({ dataset: DATASET.dataset, scenario: SCENARIO?.id || SCENARIO_ID, runtime: "codex", model: model || DATASET.runtime.selection, prompt_version: PROMPT_VERSION, blocker: error instanceof Error ? error.message : String(error), real_provider_write_possible: false })}\n`);
+    throw error;
+  } finally {
+    await session?.close("IM body-mode eval complete");
+    fs.rmSync(temp, { recursive: true, force: true });
+  }
+});

--- a/test/support/agent-experience-v6-grader.mjs
+++ b/test/support/agent-experience-v6-grader.mjs
@@ -41,7 +41,7 @@ function correctionBoundaryIssue(scenario) {
 export function loadAgentExperienceV6Eval(file) {
   const value = JSON.parse(fs.readFileSync(file, "utf8"));
   if (value.dataset !== "agent-experience-v6" || value.version !== 6) throw new Error("eval dataset/version mismatch");
-  if (value.model?.standing_prompt_version !== "larkin-standing-v26") throw new Error("standing prompt version mismatch");
+  if (value.model?.standing_prompt_version !== "larkin-standing-v27") throw new Error("standing prompt version mismatch");
   if (value.session?.initial_turns !== 0) throw new Error("eval scenarios must start from a fresh empty session");
   if (value.grader?.name !== "agent-experience-v6-trace-grader" || value.grader.version !== 6 || value.grader.threshold !== 1) {
     throw new Error("eval grader metadata mismatch");

--- a/test/support/authoritative-freshness-gate-grader.mjs
+++ b/test/support/authoritative-freshness-gate-grader.mjs
@@ -3,7 +3,7 @@ import fs from "node:fs";
 export function loadAuthoritativeFreshnessEval(file) {
   const value = JSON.parse(fs.readFileSync(file, "utf8"));
   if (value.dataset !== "authoritative-freshness-gate" || value.version !== 1) throw new Error("eval dataset/version mismatch");
-  if (value.standing_prompt_version !== "larkin-standing-v26") throw new Error("standing prompt version mismatch");
+  if (value.standing_prompt_version !== "larkin-standing-v27") throw new Error("standing prompt version mismatch");
   if (value.runtime?.adapter !== "codex" || !value.runtime.selection) throw new Error("native runtime metadata is required");
   if (value.grader?.name !== "authoritative-freshness-trace-grader" || value.grader.version !== 1) throw new Error("grader metadata mismatch");
   if (!(value.grader.threshold > 0 && value.grader.threshold <= 1)) throw new Error("grader threshold must be in (0,1]");

--- a/test/support/clickable-link-delivery-grader.mjs
+++ b/test/support/clickable-link-delivery-grader.mjs
@@ -87,7 +87,7 @@ function hasBoundedVisibleUrl(body, expectedUrl) {
 export function loadClickableLinkDeliveryEval(file) {
   const value = JSON.parse(fs.readFileSync(file, "utf8"));
   if (value.dataset !== "clickable-link-delivery" || value.version !== 1) throw new Error("eval dataset/version mismatch");
-  if (value.standing_prompt_version !== "larkin-standing-v26") throw new Error("standing prompt version mismatch");
+  if (value.standing_prompt_version !== "larkin-standing-v27") throw new Error("standing prompt version mismatch");
   if (value.threshold !== 1 || value.grader?.name !== "clickable-link-delivery-trace-grader"
       || value.grader.version !== 1 || value.grader.threshold !== 1) throw new Error("eval grader metadata mismatch");
   if (value.session?.initial_turns !== 0 || value.session?.fresh_per_scenario !== true) throw new Error("eval requires fresh sessions");

--- a/test/support/clickable-link-delivery-native-support.mjs
+++ b/test/support/clickable-link-delivery-native-support.mjs
@@ -8,7 +8,7 @@ export const CLICKABLE_LINK_V20_GUIDANCE = [
 ];
 
 export function v19Counterfactual(standingPrompt) {
-  if (standingPrompt?.version !== "larkin-standing-v26" || typeof standingPrompt.content !== "string") {
+  if (standingPrompt?.version !== "larkin-standing-v27" || typeof standingPrompt.content !== "string") {
     throw new Error("v19 counterfactual requires a v20 standing prompt");
   }
   let content = standingPrompt.content;

--- a/test/support/im-body-mode-eval-cli.mjs
+++ b/test/support/im-body-mode-eval-cli.mjs
@@ -1,0 +1,54 @@
+import fs from "node:fs";
+
+const traceFile = process.env.IM_BODY_MODE_EVAL_TRACE_FILE;
+if (!traceFile) throw new Error("IM_BODY_MODE_EVAL_TRACE_FILE is required");
+const argv = process.argv.slice(2);
+const surface = process.env.IM_BODY_MODE_EVAL_SURFACE || "unknown";
+const append = (event) => fs.appendFileSync(traceFile, `${JSON.stringify(event)}\n`, { encoding: "utf8", mode: 0o600, flag: "a" });
+const indexes = (flag) => argv.reduce((all, value, index) => value === flag ? [...all, index] : all, []);
+const valueAt = (flag) => {
+  const found = indexes(flag);
+  return found.length === 1 ? argv[found[0] + 1] ?? "" : "";
+};
+
+const command = argv[1];
+const operation = command === "+messages-send" ? "send" : command === "+messages-reply" ? "reply" : null;
+if (argv[0] !== "im" || operation === null) {
+  append({ action: "eval_rejection", argv, error: "unsupported command" });
+  process.stderr.write("im body-mode eval exposes only synthetic send/reply commands\n");
+  process.exit(2);
+}
+
+const targetFlag = operation === "send" ? "--chat-id" : "--message-id";
+const bodyFlags = ["--text", "--markdown", "--content"];
+const presentBodyFlags = bodyFlags.flatMap((flag) => indexes(flag).map(() => flag));
+const bodyFlag = presentBodyFlags.length === 1 ? presentBodyFlags[0] : "";
+const target = valueAt(targetFlag);
+const body = bodyFlag ? valueAt(bodyFlag) : "";
+const validTarget = operation === "send" ? /^oc_eval_im_[a-z_]+$/.test(target) : target === "om_eval_im_exact";
+const valid = surface === "larkin"
+  && indexes(targetFlag).length === 1
+  && validTarget
+  && presentBodyFlags.length === 1
+  && body.length > 0;
+const error = valid ? null : "fake sink rejected surface, target, or body flags";
+const messageId = valid ? (operation === "send" ? "om_eval_im_sent" : "om_eval_im_replied") : null;
+append({
+  schema_version: 1,
+  action: "provider_write",
+  surface,
+  operation,
+  target_flag: targetFlag,
+  target,
+  body_flag: bodyFlag,
+  body,
+  argv,
+  success: valid,
+  message_id: messageId,
+  error,
+});
+if (!valid) {
+  process.stderr.write(`${error}\n`);
+  process.exit(2);
+}
+process.stdout.write(`${JSON.stringify({ ok: true, data: { message_id: messageId, synthetic: true } })}\n`);

--- a/test/support/im-body-mode-grader.mjs
+++ b/test/support/im-body-mode-grader.mjs
@@ -1,0 +1,149 @@
+import { createHash } from "node:crypto";
+import fs from "node:fs";
+
+export const PLAIN_MULTILINE_V27_GUIDANCE = [
+  "For ordinary plain-text message bodies, use `--text`, including brief one-line replies, multiline status lines, and paragraphs. Use `--markdown` only when you intentionally need Markdown rendering, such as headings, lists, emphasis, blockquotes, fenced code, or Markdown links.",
+  "Use native `--text` for ordinary plain text and for verbatim preservation, such as logs, literal code, or exact whitespace. Both `--markdown` and `--text` remain supported in the Larkin Runtime.",
+  "An explicit exact or verbatim direct literal uses `--text` and overrides the ordinary-body guidance.",
+];
+
+const V26_GUIDANCE = [
+  "For regular textual message bodies, default to `--markdown`, including brief single-line replies, so Feishu renders Markdown structure instead of showing its markers literally.",
+  "Use native `--text` only when plain text or verbatim preservation is explicitly needed, such as logs, code, or exact whitespace. Both `--markdown` and `--text` remain supported in the Larkin Runtime.",
+  "An explicit exact or verbatim direct literal uses `--text` and overrides the regular markdown default.",
+];
+
+const EVENT_KEYS = [
+  "schema_version", "action", "surface", "operation", "target_flag", "target",
+  "body_flag", "body", "argv", "success", "message_id", "error",
+].sort();
+const BODY_FLAGS = new Set(["--text", "--markdown", "--content"]);
+const SCENARIO_IDS = [
+  "ordinary-plain-lines", "ordinary-plain-paragraphs", "intentional-markdown-heading",
+  "intentional-markdown-list", "intentional-markdown-code", "intentional-markdown-link",
+  "exact-verbatim-literal",
+];
+
+function object(value) {
+  return value !== null && typeof value === "object" && !Array.isArray(value);
+}
+
+function exactKeys(value, expected, label) {
+  const actual = Object.keys(value).sort();
+  if (actual.length !== expected.length || actual.some((key, index) => key !== expected[index])) {
+    throw new Error(`${label} fields mismatch`);
+  }
+}
+
+function occurrences(argv, flag) {
+  return argv.reduce((indexes, value, index) => value === flag ? [...indexes, index] : indexes, []);
+}
+
+function validateProviderWrite(event) {
+  if (!object(event)) throw new Error("provider write must be an object");
+  exactKeys(event, EVENT_KEYS, "provider write");
+  if (event.schema_version !== 1 || event.action !== "provider_write") throw new Error("provider write identity mismatch");
+  if (!["larkin", "lark-cli"].includes(event.surface)) throw new Error("provider write surface mismatch");
+  if (!["send", "reply"].includes(event.operation)) throw new Error("provider write operation mismatch");
+  if (!["--chat-id", "--message-id"].includes(event.target_flag)) throw new Error("provider write target flag mismatch");
+  if (typeof event.target !== "string" || !event.target) throw new Error("provider write target mismatch");
+  if (!BODY_FLAGS.has(event.body_flag) || typeof event.body !== "string") throw new Error("provider write body mismatch");
+  if (!Array.isArray(event.argv) || event.argv.some((part) => typeof part !== "string")) throw new Error("provider write argv mismatch");
+  if (typeof event.success !== "boolean") throw new Error("provider write success mismatch");
+  if (event.success ? !/^om_eval_[A-Za-z0-9_]+$/.test(event.message_id || "") : event.message_id !== null) {
+    throw new Error("provider write message_id mismatch");
+  }
+  if (event.success ? event.error !== null : typeof event.error !== "string" || !event.error) {
+    throw new Error("provider write error mismatch");
+  }
+  const expectedCommand = event.operation === "send" ? "+messages-send" : "+messages-reply";
+  const expectedTargetFlag = event.operation === "send" ? "--chat-id" : "--message-id";
+  const targetIndexes = occurrences(event.argv, event.target_flag);
+  const bodyIndexes = [...BODY_FLAGS].flatMap((flag) => occurrences(event.argv, flag));
+  const jsonIndexes = occurrences(event.argv, "--json");
+  if (event.target_flag !== expectedTargetFlag || event.argv[0] !== "im" || event.argv[1] !== expectedCommand) {
+    throw new Error("provider write argv command mismatch");
+  }
+  if (targetIndexes.length !== 1 || event.argv[targetIndexes[0] + 1] !== event.target) throw new Error("provider write argv target mismatch");
+  if (bodyIndexes.length !== 1 || event.argv[bodyIndexes[0]] !== event.body_flag || event.argv[bodyIndexes[0] + 1] !== event.body) {
+    throw new Error("provider write argv body mismatch");
+  }
+  const consumed = new Set([0, 1, targetIndexes[0], targetIndexes[0] + 1, bodyIndexes[0], bodyIndexes[0] + 1, jsonIndexes[0]]);
+  if (jsonIndexes.length !== 1 || event.argv.length !== 7 || consumed.size !== 7) {
+    throw new Error("provider write argv contains missing, overlapping, or unexpected arguments");
+  }
+  return event;
+}
+
+export function loadImBodyModeEval(file) {
+  const value = JSON.parse(fs.readFileSync(file, "utf8"));
+  if (value.dataset !== "im-body-mode" || value.version !== 1 || value.standing_prompt_version !== "larkin-standing-v27") {
+    throw new Error("eval dataset/version mismatch");
+  }
+  if (value.threshold !== 1 || value.grader?.name !== "im-body-mode-final-payload-grader" || value.grader.version !== 1 || value.grader.threshold !== 1) {
+    throw new Error("eval grader metadata mismatch");
+  }
+  if (value.session?.initial_turns !== 0 || value.session?.fresh_per_scenario !== true || !Array.isArray(value.grader.rubric) || value.grader.rubric.length !== 5) {
+    throw new Error("eval session/rubric mismatch");
+  }
+  if (!Array.isArray(value.scenarios) || value.scenarios.length !== SCENARIO_IDS.length
+      || value.scenarios.map((scenario) => scenario.id).some((id, index) => id !== SCENARIO_IDS[index])) {
+    throw new Error("eval scenarios mismatch");
+  }
+  for (const scenario of value.scenarios) {
+    const expectedOperation = scenario.operation === "send" ? "--chat-id" : scenario.operation === "reply" ? "--message-id" : "";
+    if (scenario.target_flag !== expectedOperation || typeof scenario.target !== "string" || !scenario.target
+        || !["--text", "--markdown"].includes(scenario.expected_body_flag)
+        || typeof scenario.body !== "string" || !scenario.body || typeof scenario.prompt !== "string" || !scenario.prompt) {
+      throw new Error(`${scenario.id} shape mismatch`);
+    }
+  }
+  return value;
+}
+
+export function gradeImBodyModeTrace(scenario, trace) {
+  const failures = [];
+  const fail = (rule, detail) => failures.push({ rule, detail });
+  const writes = (Array.isArray(trace) ? trace : []).filter((event) => object(event) && event.action === "provider_write");
+  const validated = [];
+  for (const [index, write] of writes.entries()) {
+    try { validated.push(validateProviderWrite(write)); }
+    catch (error) { fail("trace_schema", `write ${index + 1}: ${error.message}`); }
+  }
+  if (writes.length !== 1) fail("write_count", `expected exactly one provider write, observed ${writes.length}`);
+  const successful = validated.filter((event) => event.success);
+  if (successful.length !== 1) fail("successful_write_count", `expected exactly one successful write, observed ${successful.length}`);
+  const write = successful.length === 1 ? successful[0] : null;
+  if (!write) return { passed: false, failures };
+  if (write.surface !== "larkin") fail("surface", "write must use the PATH-shadowed larkin surface");
+  if (write.operation !== scenario.operation || write.target_flag !== scenario.target_flag || write.target !== scenario.target) {
+    fail("target", "write did not reach the expected synthetic operation and target");
+  }
+  if (write.body_flag !== scenario.expected_body_flag) fail("body_flag", `expected ${scenario.expected_body_flag}, observed ${write.body_flag}`);
+  if (write.body !== scenario.body) fail("body", "final provider body is not byte-equal to the fixed scenario body");
+  return { passed: failures.length === 0, failures };
+}
+
+export function summarizeImBodyModeEval(dataset, tracesById) {
+  const results = dataset.scenarios.map((scenario) => ({ id: scenario.id,
+    ...gradeImBodyModeTrace(scenario, tracesById[scenario.id] || []) }));
+  const passRate = results.filter((result) => result.passed).length / results.length;
+  return { passed: passRate >= dataset.threshold, pass_rate: passRate, threshold: dataset.threshold, results };
+}
+
+export function v26PlainMultilineCounterfactual(standingPrompt) {
+  if (standingPrompt?.version !== "larkin-standing-v27" || typeof standingPrompt.content !== "string") {
+    throw new Error("v26 counterfactual requires a v27 standing prompt");
+  }
+  let content = standingPrompt.content;
+  for (let index = 0; index < PLAIN_MULTILINE_V27_GUIDANCE.length; index += 1) {
+    const guidance = PLAIN_MULTILINE_V27_GUIDANCE[index];
+    const count = content.split(guidance).length - 1;
+    if (count !== 1 || !content.includes(`${guidance}\n`)) throw new Error("v27 multiline guidance must occur exactly once");
+    content = content.replace(`${guidance}\n`, `${V26_GUIDANCE[index]}\n`);
+  }
+  if (PLAIN_MULTILINE_V27_GUIDANCE.some((guidance) => content.includes(guidance)) || V26_GUIDANCE.some((guidance) => !content.includes(guidance))) {
+    throw new Error("v26 counterfactual guidance mismatch");
+  }
+  return { version: "larkin-standing-v26", content, hash: createHash("sha256").update(content).digest("hex") };
+}

--- a/test/support/mention-construction-grader.mjs
+++ b/test/support/mention-construction-grader.mjs
@@ -8,7 +8,7 @@ function nonempty(value, label) {
 export function loadMentionConstructionEval(file) {
   const value = JSON.parse(fs.readFileSync(file, "utf8"));
   if (value.dataset !== "mention-construction" || value.version !== 1) throw new Error("eval dataset/version mismatch");
-  if (value.standing_prompt_version !== "larkin-standing-v26") throw new Error("standing prompt version mismatch");
+  if (value.standing_prompt_version !== "larkin-standing-v27") throw new Error("standing prompt version mismatch");
   if (value.session?.initial_turns !== 0) throw new Error("eval scenarios must start from a fresh empty session");
   if (value.grader?.name !== "mention-construction-trace-grader" || value.grader.version !== 1 || value.grader.threshold !== 1) {
     throw new Error("eval grader metadata mismatch");

--- a/test/support/protected-message-recall-grader.mjs
+++ b/test/support/protected-message-recall-grader.mjs
@@ -3,7 +3,7 @@ import fs from "node:fs";
 export function loadProtectedMessageRecallEval(file) {
   const value = JSON.parse(fs.readFileSync(file, "utf8"));
   if (value.dataset !== "protected-message-recall" || value.version !== 1) throw new Error("eval dataset/version mismatch");
-  if (value.standing_prompt_version !== "larkin-standing-v26") throw new Error("standing prompt version mismatch");
+  if (value.standing_prompt_version !== "larkin-standing-v27") throw new Error("standing prompt version mismatch");
   if (value.grader?.name !== "protected-message-recall-provider-trace-grader" || value.grader.version !== 1) {
     throw new Error("grader metadata mismatch");
   }

--- a/test/support/runtime-agent-interface-v2-grader.mjs
+++ b/test/support/runtime-agent-interface-v2-grader.mjs
@@ -10,7 +10,7 @@ export function loadRuntimeAgentInterfaceEval(file) {
   if (value.dataset !== "runtime-agent-interface-v2" || value.version !== 1) throw new Error("eval dataset/version mismatch");
   if (value.runtime?.adapter !== "codex") throw new Error("eval runtime.adapter must be codex");
   nonempty(value.runtime.minimum_cli_version, "runtime.minimum_cli_version");
-  if (value.model?.standing_prompt_version !== "larkin-standing-v26") throw new Error("eval standing prompt version mismatch");
+  if (value.model?.standing_prompt_version !== "larkin-standing-v27") throw new Error("eval standing prompt version mismatch");
   nonempty(value.model.selection, "model.selection");
   if (value.grader?.name !== "runtime-agent-interface-v2-trace-grader" || value.grader.version !== 1) {
     throw new Error("eval grader metadata mismatch");

--- a/test/unit/evals/agent-experience-v6.test.mjs
+++ b/test/unit/evals/agent-experience-v6.test.mjs
@@ -16,7 +16,7 @@ const DATASET = loadAgentExperienceV6Eval(path.join(ROOT, "evals/agent-experienc
 
 test("fixed Agent Experience v6 eval starts every selected scenario from an empty session", () => {
   assert.equal(DATASET.session.initial_turns, 0);
-  assert.equal(DATASET.model.standing_prompt_version, "larkin-standing-v26");
+  assert.equal(DATASET.model.standing_prompt_version, "larkin-standing-v27");
   assert.deepEqual(DATASET.scenarios.map((scenario) => scenario.id), [
     "target-scoped-thread-read",
     "failed-thread-read-no-false-success",

--- a/test/unit/evals/agent-mention-prompt.test.mjs
+++ b/test/unit/evals/agent-mention-prompt.test.mjs
@@ -96,7 +96,7 @@ test("lark-cli launcher passes --mention argv through without injecting --conten
 });
 
 test("mention guidance ships under the current standing prompt version", () => {
-  assert.equal(LARKIN_STANDING_PROMPT_VERSION, "larkin-standing-v26");
+  assert.equal(LARKIN_STANDING_PROMPT_VERSION, "larkin-standing-v27");
   const prompt = buildPrompt("codex");
   assert.match(prompt, /## Collaboration and delivery/);
 });

--- a/test/unit/evals/authoritative-freshness-gate.test.mjs
+++ b/test/unit/evals/authoritative-freshness-gate.test.mjs
@@ -10,7 +10,7 @@ const dataset = loadAuthoritativeFreshnessEval(path.join(ROOT, "evals/authoritat
 test("authoritative freshness eval is versioned, reproducible, and covers the critical rubric", () => {
   assert.equal(dataset.dataset, "authoritative-freshness-gate");
   assert.equal(dataset.version, 1);
-  assert.equal(dataset.standing_prompt_version, "larkin-standing-v26");
+  assert.equal(dataset.standing_prompt_version, "larkin-standing-v27");
   assert.equal(dataset.threshold, 1);
   assert.deepEqual(dataset.scenarios.map((scenario) => scenario.id), [
     "missing-inbox-history", "direct-ack-retry", "same-ms-new-id", "edited-message",

--- a/test/unit/evals/clickable-link-delivery.test.mjs
+++ b/test/unit/evals/clickable-link-delivery.test.mjs
@@ -63,7 +63,7 @@ function runFake(args, surface = "larkin") {
 test("clickable-link delivery dataset is fixed, fresh, versioned, and thresholded", () => {
   assert.equal(DATASET.dataset, "clickable-link-delivery");
   assert.equal(DATASET.version, 1);
-  assert.equal(DATASET.standing_prompt_version, "larkin-standing-v26");
+  assert.equal(DATASET.standing_prompt_version, "larkin-standing-v27");
   assert.equal(DATASET.threshold, 1);
   assert.equal(DATASET.session.initial_turns, 0);
   assert.equal(DATASET.session.fresh_per_scenario, true);

--- a/test/unit/evals/im-body-mode.test.mjs
+++ b/test/unit/evals/im-body-mode.test.mjs
@@ -1,0 +1,137 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { spawnSync } from "node:child_process";
+import { test } from "bun:test";
+import { ContextPromptBuilder } from "../../../dist/agent/context-prompt.mjs";
+import {
+  PLAIN_MULTILINE_V27_GUIDANCE,
+  gradeImBodyModeTrace,
+  loadImBodyModeEval,
+  summarizeImBodyModeEval,
+  v26PlainMultilineCounterfactual,
+} from "../../support/im-body-mode-grader.mjs";
+
+const ROOT = path.resolve(import.meta.dirname, "../../..");
+const DATASET = loadImBodyModeEval(path.join(ROOT, "evals/im-body-mode/scenarios.json"));
+const FAKE = path.join(ROOT, "test/support/im-body-mode-eval-cli.mjs");
+
+function writeEvent(scenario, bodyFlag = scenario.expected_body_flag, body = scenario.body, overrides = {}) {
+  const command = scenario.operation === "send" ? "+messages-send" : "+messages-reply";
+  const targetFlag = overrides.target_flag ?? scenario.target_flag;
+  const target = overrides.target ?? scenario.target;
+  return {
+    schema_version: 1,
+    action: "provider_write",
+    surface: "larkin",
+    operation: scenario.operation,
+    target_flag: targetFlag,
+    target,
+    body_flag: bodyFlag,
+    body,
+    argv: ["im", command, targetFlag, target, bodyFlag, body, "--json"],
+    success: true,
+    message_id: "om_eval_im_unit",
+    error: null,
+    ...overrides,
+  };
+}
+
+function runFake(args, surface = "larkin") {
+  const temp = fs.mkdtempSync(path.join(os.tmpdir(), "im-body-mode-eval-"));
+  const traceFile = path.join(temp, "trace.ndjson");
+  fs.writeFileSync(traceFile, "", { mode: 0o600 });
+  try {
+    const result = spawnSync(process.execPath, [FAKE, ...args], {
+      encoding: "utf8",
+      env: { PATH: process.env.PATH, IM_BODY_MODE_EVAL_TRACE_FILE: traceFile, IM_BODY_MODE_EVAL_SURFACE: surface },
+    });
+    const trace = fs.readFileSync(traceFile, "utf8").split("\n").filter(Boolean).map(JSON.parse);
+    return { result, trace };
+  } finally {
+    fs.rmSync(temp, { recursive: true, force: true });
+  }
+}
+
+test("IM body-mode dataset is fixed, fresh, versioned, and complete", () => {
+  assert.equal(DATASET.dataset, "im-body-mode");
+  assert.equal(DATASET.version, 1);
+  assert.equal(DATASET.standing_prompt_version, "larkin-standing-v27");
+  assert.equal(DATASET.threshold, 1);
+  assert.equal(DATASET.session.initial_turns, 0);
+  assert.equal(DATASET.session.fresh_per_scenario, true);
+  assert.deepEqual(DATASET.scenarios.map(({ id }) => id), [
+    "ordinary-plain-lines", "ordinary-plain-paragraphs", "intentional-markdown-heading",
+    "intentional-markdown-list", "intentional-markdown-code", "intentional-markdown-link",
+    "exact-verbatim-literal",
+  ]);
+});
+
+test("golden final provider payloads enforce plain text, intentional Markdown, and exact literals", () => {
+  const tracesById = {};
+  for (const scenario of DATASET.scenarios) {
+    const trace = [writeEvent(scenario)];
+    tracesById[scenario.id] = trace;
+    assert.deepEqual(gradeImBodyModeTrace(scenario, trace), { passed: true, failures: [] }, scenario.id);
+  }
+  const summary = summarizeImBodyModeEval(DATASET, tracesById);
+  assert.equal(summary.passed, true);
+  assert.equal(summary.pass_rate, 1);
+});
+
+test("final-payload grader rejects mode, body, target, duplicate, and trace-shape counterexamples", () => {
+  const mutations = [];
+  for (const scenario of DATASET.scenarios) {
+    const wrongFlag = scenario.expected_body_flag === "--text" ? "--markdown" : "--text";
+    mutations.push([`${scenario.id} wrong mode`, scenario, [writeEvent(scenario, wrongFlag)]]);
+    mutations.push([`${scenario.id} body rewrite`, scenario, [writeEvent(scenario, scenario.expected_body_flag, `${scenario.body}\nextra`)]]);
+  }
+  const ordinary = DATASET.scenarios[0];
+  const exact = DATASET.scenarios.at(-1);
+  const golden = writeEvent(ordinary);
+  const malformed = { ...golden }; delete malformed.error;
+  mutations.push(
+    ["missing write", ordinary, []],
+    ["assistant prose only", ordinary, [{ action: "assistant_output", text: ordinary.body }]],
+    ["duplicate writes", ordinary, [golden, golden]],
+    ["wrong target", ordinary, [writeEvent(ordinary, ordinary.expected_body_flag, ordinary.body, {
+      target: "oc_eval_im_other", argv: ["im", "+messages-send", "--chat-id", "oc_eval_im_other", ordinary.expected_body_flag, ordinary.body, "--json"],
+    })]],
+    ["unexpected argv", ordinary, [writeEvent(ordinary, ordinary.expected_body_flag, ordinary.body, { argv: [...golden.argv, "--profile"] })]],
+    ["malformed schema", ordinary, [malformed]],
+    ["exact Markdown conversion", exact, [writeEvent(exact, "--markdown")]],
+  );
+  for (const [label, scenario, trace] of mutations) {
+    assert.equal(gradeImBodyModeTrace(scenario, trace).passed, false, label);
+  }
+});
+
+test("fake sink exercises every final argv/body payload without provider or runtime imports", () => {
+  for (const scenario of DATASET.scenarios) {
+    const command = scenario.operation === "send" ? "+messages-send" : "+messages-reply";
+    const args = ["im", command, scenario.target_flag, scenario.target, scenario.expected_body_flag, scenario.body, "--json"];
+    const result = runFake(args);
+    assert.equal(result.result.status, 0, `${scenario.id}: ${result.result.stderr}`);
+    assert.deepEqual(gradeImBodyModeTrace(scenario, result.trace), { passed: true, failures: [] }, scenario.id);
+  }
+  const source = fs.readFileSync(FAKE, "utf8");
+  assert.doesNotMatch(source, /node:child_process|@larksuite|from ["'][^"']*(?:dist|src)\//);
+  assert.doesNotMatch(source, /\b(?:spawn|execFile|exec|fork)\s*\(/);
+  assert.notEqual(runFake(["im", "+messages-send", "--chat-id", "oc_real", "--text", "no", "--json"]).result.status, 0);
+  assert.notEqual(runFake(["im", "+chat-list", "--json"]).result.status, 0);
+});
+
+test("v26 counterfactual restores the old Markdown-default guidance without changing exact contracts", () => {
+  const v27 = new ContextPromptBuilder().build({ agentId: "cli_imBodyModeEval", name: "IM Body Mode Eval", runtime: "codex" });
+  for (const line of PLAIN_MULTILINE_V27_GUIDANCE) assert.equal(v27.content.split(line).length - 1, 1);
+  const v26 = v26PlainMultilineCounterfactual(v27);
+  assert.equal(v26.version, "larkin-standing-v26");
+  assert.match(v26.hash, /^[a-f0-9]{64}$/);
+  assert.notEqual(v26.hash, v27.hash);
+  for (const line of PLAIN_MULTILINE_V27_GUIDANCE) assert.equal(v26.content.includes(line), false);
+  assert.match(v26.content, /default to `--markdown`, including brief single-line replies/);
+  assert.match(v26.content, /exact or verbatim direct literal uses `--text`/);
+  assert.match(v27.content, /ordinary plain-text message bodies, use `--text`/);
+  assert.match(v27.content, /exact or verbatim direct literal uses `--text`/);
+});

--- a/test/unit/evals/protected-message-recall.test.mjs
+++ b/test/unit/evals/protected-message-recall.test.mjs
@@ -8,7 +8,7 @@ const dataset = loadProtectedMessageRecallEval(path.join(ROOT, "evals/protected-
 
 test("protected recall eval is versioned and covers positive, negative, conflict, and recovery contracts", () => {
   assert.equal(dataset.dataset, "protected-message-recall");
-  assert.equal(dataset.standing_prompt_version, "larkin-standing-v26");
+  assert.equal(dataset.standing_prompt_version, "larkin-standing-v27");
   assert.deepEqual(dataset.scenarios.map((scenario) => scenario.id), [
     "missing-confirmation", "own-chat-message", "own-thread-message", "third-party-message",
     "cross-agent-message", "freshness-conflict", "committed-duplicate", "ambiguous-retry",

--- a/test/unit/evals/runtime-agent-interface-v2.test.mjs
+++ b/test/unit/evals/runtime-agent-interface-v2.test.mjs
@@ -16,7 +16,7 @@ test("fixed runtime Agent interface eval registers dataset, rubric, grader, thre
   assert.equal(DATASET.version, 1);
   assert.equal(DATASET.runtime.adapter, "codex");
   assert.equal(DATASET.model.selection, "gpt-5.6-sol");
-  assert.equal(DATASET.model.standing_prompt_version, "larkin-standing-v26");
+  assert.equal(DATASET.model.standing_prompt_version, "larkin-standing-v27");
   assert.equal(DATASET.grader.version, 1);
   assert.equal(DATASET.grader.threshold, 1);
   assert.ok(DATASET.grader.rubric.length >= 5);

--- a/test/unit/runtime/runtime-adapters.test.mjs
+++ b/test/unit/runtime/runtime-adapters.test.mjs
@@ -159,7 +159,7 @@ test("context prompt is capability-driven, versioned and produces bounded notifi
 
 test("default context prompt consumes the Agent CLI manifest", () => {
   const prompt = new ContextPromptBuilder().build({ agentId: "cli_test", runtime: "pi" });
-  assert.equal(prompt.version, "larkin-standing-v26");
+  assert.equal(prompt.version, "larkin-standing-v27");
   assert.match(prompt.content, /never emit feishu\.cn for a Lark tenant/);
   assert.match(prompt.content, /larkin reminder schedule/);
   assert.match(prompt.content, /explicit delivery target/);
@@ -186,10 +186,9 @@ test("default context prompt consumes the Agent CLI manifest", () => {
   assert.match(prompt.content, /`rem_`, `redeliver_`.*synthetic ID must never be replied to/);
   assert.match(prompt.content, /nonzero `freshness_conflict`.*direct-acks/);
   assert.doesNotMatch(prompt.content, /larkin-draft|draft-id|send --draft/);
-  assert.match(prompt.content, /regular textual message bodies.*`--markdown`/i);
-  assert.match(prompt.content, /native `--text`.*logs.*code.*exact whitespace/i);
+  assert.match(prompt.content, /ordinary plain-text message bodies.*`--text`.*brief one-line replies.*multiline status lines.*paragraphs.*`--markdown`.*intentional.*headings.*lists.*fenced code.*Markdown links/i);
+  assert.match(prompt.content, /native `--text`.*ordinary plain text.*logs.*literal code.*exact whitespace/i);
   assert.doesNotMatch(prompt.content, /rejected|--literal-text/i);
-  assert.doesNotMatch(prompt.content, /use `--text` for brief single-line replies/i);
   assert.match(prompt.content, /attachment-only send\/reply.*attachment flag.*without a text body flag/i);
   assert.match(prompt.content, /passes one argument with real newline characters/);
   assert.match(prompt.content, /ordinary (?:double )?quotes.*do not decode.*`\\n`.*backslash.*letter `n`/i);
@@ -258,7 +257,7 @@ test("default context prompt consumes the Agent CLI manifest", () => {
   assert.match(prompt.content,
     /group.*user.*bot counts.*exactly two.*post-poll.*read calls.*must not.*skill.*reference.*help.*schema.*bare.*lark-cli.*chat\.members.*\+chat-members-list/i);
   assert.match(prompt.content, /does not waive.*skill.*safety.*unknown.*high-risk/i);
-  assert.match(prompt.content, /exact.*`--text`.*overrides.*markdown default/i);
+  assert.match(prompt.content, /exact.*`--text`.*overrides.*ordinary-body guidance/i);
   assert.match(prompt.content, /wrapper derives.*stable.*idempotency key.*do not pass.*--idempotency-key/i);
   assert.match(prompt.content, /freshness_unavailable.*freshness_conflict.*pre-commit.*provider-not-reached.*retry.*identical.*`--text`.*`--content`.*wrapper reuses/i);
   assert.match(prompt.content, /target or body changes.*revised ordinary command.*derive a new key/i);
@@ -269,17 +268,16 @@ test("default context prompt consumes the Agent CLI manifest", () => {
 test("Codex, Claude and Pi receive the clickable-link and exact-content standing contracts", async () => {
   const standingPrompt = (runtime) => new ContextPromptBuilder().build({ agentId: "cli_test", runtime });
   const assertContract = (content) => {
-    assert.match(content, /regular textual message bodies.*`--markdown`/i);
+    assert.match(content, /ordinary plain-text message bodies.*`--text`.*brief one-line replies.*`--markdown`.*intentional/i);
     assert.match(content, /URL must be visible, clickable, or openable.*complete bare `https:\/\/\.\.\.` URL.*visible text/i);
     assert.match(content, /Do not rely solely on `\[label\]\(URL\)`.*Feishu client rendering is unreliable/i);
     assert.match(content, /label may also be included.*bare URL must remain present/i);
     assert.match(content, /Never rewrite or normalize.*exact or verbatim user-supplied body.*existing exact-content paths.*authoritative.*unchanged/i);
     assert.match(content, /exact text supplied directly.*body unchanged as one literal `--text` argument/i);
-    assert.match(content, /explicit exact or verbatim direct literal uses `--text`.*overrides.*markdown default/i);
+    assert.match(content, /explicit exact or verbatim direct literal uses `--text`.*overrides.*ordinary-body guidance/i);
     assert.match(content, /tool-sourced exact or verbatim text.*deterministic native `--jq`.*`--content`/i);
-    assert.match(content, /native `--text`.*logs.*code.*exact whitespace/i);
+    assert.match(content, /native `--text`.*ordinary plain text.*logs.*literal code.*exact whitespace/i);
     assert.doesNotMatch(content, /rejected|--literal-text/i);
-    assert.doesNotMatch(content, /use `--text` for brief single-line replies/i);
     assert.match(content, /attachment-only send\/reply.*attachment flag.*without a text body flag/i);
   };
 


### PR DESCRIPTION
## Summary

Fixes #176 by changing the standing agent guidance: ordinary plain-text bodies, including one-line replies, multiline status lines, and paragraphs, use `--text`; `--markdown` is reserved for intentional headings, lists, fenced code, emphasis, blockquotes, and Markdown links. Exact/verbatim contracts remain `--text`.

## Scope and root cause

- E1: `src/agent/context-prompt.ts` previously instructed agents to default ordinary text to `--markdown`, while the transport shell already classifies non-Markdown content as `--text`.
- This PR changes only agent-facing policy and prompt-versioned eval contracts; it does not change transport routing.
- Adds the fixed `im-body-mode` E3 payload dataset/grader plus a fake provider sink and opt-in native Codex harness. The grader inspects one final provider argv/body payload, not prompt text or assistant prose. It covers plain lines, paragraphs, headings, lists, fenced code, Markdown links, and an exact multiline literal; malformed, duplicate, wrong-target, wrong-mode, and rewritten-body traces fail closed.

## Counterfactual

The native fake-sink run records final provider payloads only (no real provider write). v27 passed 7/7. The v26 counterfactual passed 5/7: both ordinary plain multiline scenarios emitted `--markdown` and failed the `--text` contract; intentional Markdown and exact-literal scenarios passed. This is a fixed-scenario behavior result, not a Feishu client-rendering claim.

## Non-goals

- Does not modify PR #179 / issue #177 branch or its newline-transport contract.
- Does not alter runtime transport classification, routing, freshness, identity, or provider payload conversion.
- Does not claim E4 Feishu-client presentation validation, merge, or release.

## Validation

- `bun run typecheck`
- `bun run test:eval:im-body-mode` (5 pass)
- Prompt propagation contract: `bun test --max-concurrency 1 test/unit/runtime/runtime-adapters.test.mjs --test-name-pattern ...` (2 pass)
- Existing prompt-eval subset (31 pass)
- `bun run test:frontend` (24 pass)
- Native fake-sink E3: v27 7/7; v26 counterfactual 5/7 as above

A broad local `bun run test:unit` was attempted but has pre-existing environment/harness failures outside this change (runtime identity/process-token and Pi production fixture settings paths); the focused prompt and eval tests above pass.

Version bumps `0.4.22` to `0.4.23` per repository contribution policy.