### PR TITLE
chore(release): bump Larkin to 0.4.24

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "larkin",
-  "version": "0.4.23",
+  "version": "0.4.24",
   "private": false,
   "larkinPackageRole": "npm-published",
   "files": [


### PR DESCRIPTION
## Summary
- Bump the npm package manifest from `0.4.23` to `0.4.24` via the canonical `version:bump` script.
- Base is `f7c4adb`, which already includes #182.

## Scope
- Metadata-only version bump (`package.json`).
- No product-logic changes, release trigger, binary installation, or runtime/LaunchAgent changes.

## Validation
- `bun run release:check-version v0.4.24`
- `bun test --max-concurrency 1 test/unit/platform/versioning.test.mjs`
- `bun run typecheck`
- `bun run licenses:check`