### PR TITLE
fix(runtime): keep serving Inbox after idle compact and land depth-1 session refs

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "larkin",
-  "version": "0.4.24",
+  "version": "0.4.25",
   "private": false,
   "larkinPackageRole": "npm-published",
   "files": [

--- a/src/agent/context-prompt.ts
+++ b/src/agent/context-prompt.ts
@@ -35,10 +35,19 @@ const FEISHU_IM_COMMAND_GROUPS = [
   ["Chats", ["im +chat-list", "im +chat-search", "im chats get"]],
 ] as const;
 
+/** Depth-1 archive of the session closed by the latest replacement. Older archives stay on disk. */
+export interface PreviousSessionRef {
+  sessionId: string;
+  file: string | null;
+  closedAt: string;
+  reason: string;
+}
+
 export interface ContextPromptInput {
   agent: { id: string; name?: string; description?: string };
   runtime: RuntimeId;
   cli: AgentCliCapabilities;
+  previousSession?: PreviousSessionRef | null;
 }
 
 function clean(value: string): string {
@@ -46,12 +55,30 @@ function clean(value: string): string {
 }
 
 export class ContextPromptBuilder {
-  build(input: { agentId: string; name?: string; description?: string; runtime: RuntimeId; cli?: AgentCliCapabilities }): StandingPrompt {
+  build(input: { agentId: string; name?: string; description?: string; runtime: RuntimeId; cli?: AgentCliCapabilities;
+    previousSession?: PreviousSessionRef | null }): StandingPrompt {
     return this.buildStandingPrompt({
       agent: { id: input.agentId, name: input.name, description: input.description },
       runtime: input.runtime,
       cli: input.cli ?? agentCliPromptCapabilities(),
+      previousSession: input.previousSession ?? null,
     });
+  }
+
+  /** Rendered only for the single most recent predecessor; never a chain. */
+  private previousSessionSection(previous: PreviousSessionRef | null | undefined): string[] {
+    if (!previous) return [];
+    const location = previous.file
+      ? `\`${clean(previous.file)}\``
+      : `session id \`${clean(previous.sessionId)}\` in the Runtime session directory`;
+    return [
+      "",
+      "## Previous session archive",
+      "",
+      `The session before this one was closed (${clean(previous.reason)}, ${clean(previous.closedAt)}). Its archive is ${location}.`,
+      "Consult it only when the user refers to earlier context. Do not load it whole: use `tail` or `rg` on the file for the relevant part.",
+      "Older archives are kept on disk and are intentionally not referenced here.",
+    ];
   }
 
   buildInboxNotice(input: { busy: boolean; count?: number; deliveryId?: string; target?: string; wakeReason?: string }): string {
@@ -71,6 +98,7 @@ export class ContextPromptBuilder {
       `You are the persistent Larkin agent **${identity}** (agent id: \`${input.agent.id}\`) running on ${input.runtime}.`,
       `Your authoritative self identity is **${identity}** (agent id: \`${input.agent.id}\`). Do not call \`${command("profile show")}\` merely to learn your identity.`,
       input.agent.description ? `Identity context: ${clean(input.agent.description)}` : "",
+      ...this.previousSessionSection(input.previousSession),
       "",
       "## Message handling",
       "",

--- a/src/feishu/host-shell.ts
+++ b/src/feishu/host-shell.ts
@@ -24,6 +24,7 @@ import { inboxAuditRegistryFile, observeInboxAuditTarget } from "../agent/missed
 import { HostChannelBusiness } from "./host-channel-business.js";
 import { HostInteractionOrchestrator } from "./interaction-orchestrator.js";
 import { targetFor, type FeishuInboundEvent } from "./message-policy.js";
+import type { PreviousSessionRef } from "../agent/context-prompt.js";
 import type { RuntimeHost, RuntimeHostEvent, RuntimeSessionRecoveryResult } from "../runtime/runtime-host.js";
 import { providerAuthenticationFailureReadiness, RuntimePrerequisiteError } from "../runtime/runtime-readiness.js";
 import { readDocumentCommentSubscription, verifyCallbackProbe, type EffectiveDocumentCommentSubscription } from "../platform/callback-capability.js";
@@ -62,7 +63,11 @@ interface ConfiguredAgent {
   botName?: string | null;
 }
 
-interface AgentState { agentId?: string; sessions: Record<string, string> }
+interface AgentState {
+  agentId?: string;
+  sessions: Record<string, string>;
+  previousSessions?: Record<string, PreviousSessionRef>;
+}
 interface PendingDocumentComment {
   messageId: string;
   fileToken: string;
@@ -309,7 +314,16 @@ export function createHostShell({
   };
   const agentStates = new Map<string, AgentStateRecord>();
   const saveAgentState = (record: AgentStateRecord): void => {
-    try { record.store.writeJson("agentState", record.state); }
+    try {
+      const latest = record.store.readJson<Partial<AgentState>>("agentState", {});
+      if (isRecord(latest.previousSessions)) {
+        record.state.previousSessions = {
+          ...latest.previousSessions,
+          ...(record.state.previousSessions ?? {}),
+        };
+      }
+      record.store.writeJson("agentState", record.state);
+    }
     catch (error) { log(`agent-state 写失败: ${errorMessage(error)}`); }
   };
   const initializeAgentState = (agent: ConfiguredAgent): AgentStateRecord => {
@@ -319,7 +333,11 @@ export function createHostShell({
     let state: AgentState;
     try {
       const loaded = store.readJson<Partial<AgentState>>("agentState", {});
-      state = { ...loaded, sessions: isRecord(loaded.sessions) ? loaded.sessions as Record<string, string> : {} };
+      state = {
+        ...loaded,
+        sessions: isRecord(loaded.sessions) ? loaded.sessions as Record<string, string> : {},
+        ...(isRecord(loaded.previousSessions) ? { previousSessions: loaded.previousSessions as AgentState["previousSessions"] } : {}),
+      };
     } catch { state = { sessions: {} }; }
     state.agentId = agent.agentId;
     const record = { store, state };
@@ -1285,11 +1303,19 @@ export function createHostShell({
     }
     if (message.type === "session") {
       const record = agentStates.get(agent.agentId);
-      if (record && record.state.sessions[message.runtime] !== message.sessionId) {
-        if (message.sessionId) record.state.sessions[message.runtime] = message.sessionId;
-        else delete record.state.sessions[message.runtime];
-        saveAgentState(record);
-        log(`持久化 agent=${agent.name} runtime=${message.runtime} sessionId=${message.sessionId}`);
+      if (record) {
+        const sessionChanged = record.state.sessions[message.runtime] !== message.sessionId;
+        if (sessionChanged) {
+          if (message.sessionId) record.state.sessions[message.runtime] = message.sessionId;
+          else delete record.state.sessions[message.runtime];
+        }
+        if (message.previousSession) {
+          record.state.previousSessions = { ...(record.state.previousSessions ?? {}), [message.runtime]: message.previousSession };
+        }
+        if (sessionChanged || message.previousSession) {
+          saveAgentState(record);
+          log(`持久化 agent=${agent.name} runtime=${message.runtime} sessionId=${message.sessionId}`);
+        }
       }
       hostState.updateStatus(agent, projectSessionStatus(hostState.readStatus(agent), message.runtime, message.sessionId, message.launchId, new Date(), {
         ...(message.model ? { model: message.model } : {}),
@@ -1524,6 +1550,7 @@ export function createHostShell({
         await runtimeHost.start(agents.map((agent) => ({
           ...agent,
           sessionId: agentStates.get(agent.agentId)?.state.sessions[agent.runtime] || null,
+          previousSession: agentStates.get(agent.agentId)?.state.previousSessions?.[agent.runtime] ?? null,
         })));
         reminder.startSync();
         inboxAudit.start();

--- a/src/runtime/runtime-adapters.ts
+++ b/src/runtime/runtime-adapters.ts
@@ -72,6 +72,7 @@ interface ProcessLike {
 export interface PiSessionProcessLike {
   readonly policyManaged?: boolean;
   readonly sessionId?: string | null;
+  readonly sessionFile?: string | null;
   readonly model?: { provider: string; id: string; reasoning?: boolean; thinkingLevelMap?: Record<string, unknown> };
   readonly thinkingLevel?: string;
   prompt(text: string): Promise<unknown>;
@@ -549,6 +550,7 @@ class PiSession extends EventSession {
     }));
   }
   get sessionId(): string | null { return this.sdk.sessionId ?? null; }
+  get sessionFile(): string | null { return this.sdk.sessionFile ?? null; }
   get effectiveModel(): string | null { return this.sdk.model ? `${this.sdk.model.provider}/${this.sdk.model.id}` : null; }
   get effectiveReasoningEffort(): string | null { return this.sdk.thinkingLevel ?? null; }
   async prompt(input: RuntimeInput): Promise<RuntimeInputResult> { return this.enqueue(input, () => this.sdk.prompt(input.text)); }
@@ -991,12 +993,14 @@ function writePrivateAtomic(file: string, content: string): void {
 class PiRpcBackend implements PiSessionProcessLike {
   readonly policyManaged: boolean;
   sessionId: string | null;
+  sessionFile: string | null;
   model?: { provider: string; id: string; reasoning?: boolean; thinkingLevelMap?: Record<string, unknown> };
   thinkingLevel?: string;
   constructor(private readonly client: PiRpcClient, state: PiRpcState,
     private readonly policy?: { model: string; contextWindow: number; ownedPiDirectory: string }) {
     this.policyManaged = Boolean(policy);
     this.sessionId = state.sessionId ?? null;
+    this.sessionFile = typeof state.sessionFile === "string" && state.sessionFile ? state.sessionFile : null;
     if (state.model?.provider && state.model.id) this.model = {
       provider: state.model.provider, id: state.model.id,
       ...(state.model.reasoning !== undefined ? { reasoning: state.model.reasoning } : {}),
@@ -1016,12 +1020,20 @@ class PiRpcBackend implements PiSessionProcessLike {
     if (effectiveModel !== this.policy.model || state.model?.contextWindow !== this.policy.contextWindow) {
       throw new Error("Pi model or context window changed after startup; compaction policy is no longer safe");
     }
-    const ownedSettings = readOwnedPiSettings(this.policy.ownedPiDirectory);
-    assertEffectivePiCompactionSettings({ contextWindow: state.model?.contextWindow, compaction: {
-      enabled: state.autoCompactionEnabled,
-      reserveTokens: ownedSettings.compaction?.reserveTokens,
-      keepRecentTokens: ownedSettings.compaction?.keepRecentTokens,
-    } });
+    if (typeof state.sessionFile === "string" && state.sessionFile) this.sessionFile = state.sessionFile;
+    if (typeof state.sessionId === "string" && state.sessionId) this.sessionId = state.sessionId;
+    // Use the live process handshake, not a disk re-read of owned settings.json.
+    // Disk reserveTokens can drift after startup; that must not reject prompt.
+    const handshake = state.compactionCapabilities;
+    if (typeof handshake?.reserveTokens === "number" && typeof handshake?.keepRecentTokens === "number") {
+      assertEffectivePiCompactionSettings({ contextWindow: state.model?.contextWindow, compaction: {
+        enabled: state.autoCompactionEnabled,
+        reserveTokens: handshake.reserveTokens,
+        keepRecentTokens: handshake.keepRecentTokens,
+      } });
+      return;
+    }
+    if (state.autoCompactionEnabled !== true) throw new Error("Pi native compaction must be enabled");
   }
   getState(): Promise<Record<string, unknown>> { return this.client.request("get_state"); }
   dispose(): Promise<void> { return this.client.close(); }

--- a/src/runtime/runtime-contracts.ts
+++ b/src/runtime/runtime-contracts.ts
@@ -75,6 +75,8 @@ export interface RuntimeSessionCreate {
 
 export interface RuntimeSession {
   readonly sessionId: string | null;
+  /** On-disk archive of this session when the Runtime exposes one (Pi jsonl). */
+  readonly sessionFile?: string | null;
   readonly effectiveModel?: string | null;
   readonly effectiveReasoningEffort?: string | null;
   prompt(input: RuntimeInput): Promise<RuntimeInputResult>;

--- a/src/runtime/runtime-host.ts
+++ b/src/runtime/runtime-host.ts
@@ -595,17 +595,10 @@ export function createRuntimeHost(options: {
       && agent.piProactiveCompactionGeneration === agent.generation
       && agent.piProactiveCompactionSession === agent.session
       ? agent.piProactiveCompaction : null;
-    if (proactive && await proactive === "failed") {
-      return { status: "deferred", deliveryId: record.deliveryId, reason: "Pi proactive compaction failed for the current session generation" };
-    }
-    if (agent.adapter.id === "pi" && agent.piProactiveCompactionFailedGeneration === agent.generation) {
-      return { status: "deferred", deliveryId: record.deliveryId, reason: "Pi proactive compaction failed for the current session generation" };
-    }
+    if (proactive) await proactive;
     if (agent.adapter.id === "pi" && !busy && !agent.busy && !agent.turnInProgress && agent.session) {
       const idleGate = proactivelyCompactPiAtIdle(agent, agent.session);
-      if (idleGate && await idleGate === "failed") {
-        return { status: "deferred", deliveryId: record.deliveryId, reason: "Pi proactive compaction failed for the current session generation" };
-      }
+      if (idleGate) await idleGate;
     }
     agent.submitting = true;
     if (!busy) agent.busy = true; // Reserve the turn before prompt() can yield.
@@ -670,13 +663,12 @@ export function createRuntimeHost(options: {
       && agent.piProactiveCompactionGeneration === agent.generation
       && agent.piProactiveCompactionSession === agent.session
       ? agent.piProactiveCompaction : null;
-    if (proactive && await proactive === "failed") return;
+    if (proactive) await proactive;
     if (agent.submitting || agent.starting) { agent.retryAfterSubmit = true; return; }
-    if (agent.adapter.id === "pi" && agent.piProactiveCompactionFailedGeneration === agent.generation) return;
     if (agent.busy || agent.turnInProgress || !agent.session) return;
     if (agent.adapter.id === "pi") {
       const idleGate = proactivelyCompactPiAtIdle(agent, agent.session);
-      if (idleGate && await idleGate === "failed") return;
+      if (idleGate) await idleGate;
     }
     const record = [...agent.records.values()].find((candidate) => candidate.status === "pending" || candidate.status === "submitting");
     if (record) await submit(agent, record, false);
@@ -867,11 +859,10 @@ export function createRuntimeHost(options: {
       && agent.piProactiveCompactionGeneration === agent.generation
       && agent.piProactiveCompactionSession === agent.session
       ? agent.piProactiveCompaction : null;
-    if (proactive && await proactive === "failed") return;
-    if (agent.adapter.id === "pi" && agent.piProactiveCompactionFailedGeneration === agent.generation) return;
+    if (proactive) await proactive;
     if (agent.adapter.id === "pi" && !agent.busy && !agent.turnInProgress && agent.session) {
       const idleGate = proactivelyCompactPiAtIdle(agent, agent.session);
-      if (idleGate && await idleGate === "failed") return;
+      if (idleGate) await idleGate;
     }
     if (agent.stopped || agent.busy || agent.turnInProgress || agent.submitting) return;
     if (agent.backgroundCompletionInFlight || !agent.backgroundCompletionQueue.length) return;
@@ -1046,7 +1037,7 @@ export function createRuntimeHost(options: {
       void ensureSession(agent).then(async () => {
         const session = agent.session;
         const proactive = session ? proactivelyCompactPiAtIdle(agent, session) : null;
-        if (proactive && await proactive === "failed") return;
+        if (proactive) await proactive;
         reconcileSubagentLedger(agent, { forceMissing: true, missingReason: "pi session gone" });
         enqueueUndeliveredTerminalWakes(agent);
         await retryPending(agent);
@@ -1253,8 +1244,6 @@ export function createRuntimeHost(options: {
     })();
     const tracked = task.catch((error): "failed" => {
       agent.piProactiveCompactionFailedGeneration = generation;
-      emit({ type: "agent-status", agentId: agent.config.agentId, status: "error",
-        error: "Pi proactive compaction failed; the current session generation is degraded" });
       log("Pi proactive compaction failed", String(error));
       return "failed";
     }).finally(() => {
@@ -1376,9 +1365,7 @@ export function createRuntimeHost(options: {
         emit({ type: "agent-status", agentId: agent.config.agentId, status: "active", readiness: agent.readiness });
       }
       const proactive = proactivelyCompactPiAtIdle(agent, session);
-      void (proactive ?? Promise.resolve("noop" as const)).then((outcome) => {
-        if (outcome !== "failed") return retryPending(agent);
-      });
+      void (proactive ?? Promise.resolve("noop" as const)).then(() => retryPending(agent));
       queueMicrotask(() => { void scanAndPromoteAcceptedInboxUpdates(agent); });
     } else if (event.type === "runtime-observation") {
       if (event.phase === "background_dispatched" && typeof event.taskId === "string" && event.taskId) {
@@ -1627,9 +1614,7 @@ export function createRuntimeHost(options: {
     await oldSession.close("Pi context fallback committed").catch((error) => log("previous Pi session close after fallback failed", String(error)));
     reconcileAfterSessionSwap(agent);
     const proactive = proactivelyCompactPiAtIdle(agent, fresh);
-    void (proactive ?? Promise.resolve("noop" as const)).then((outcome) => {
-      if (outcome !== "failed") return retryPending(agent);
-    });
+    void (proactive ?? Promise.resolve("noop" as const)).then(() => retryPending(agent));
     return { generationChanged: true, sessionChanged: oldSessionId !== fresh.sessionId, turns: 0,
       runtimeReady: true, pendingCount: remainingPendingCount, rearmedCount,
       replayStatus: remainingPendingCount > 0 ? "pending" : "consumed", sessionId: fresh.sessionId };
@@ -1939,9 +1924,7 @@ export function createRuntimeHost(options: {
           .catch((error) => log("previous runtime close after context-window recovery failed", String(error)));
         reconcileAfterSessionSwap(agent);
         const proactive = proactivelyCompactPiAtIdle(agent, fresh);
-        void (proactive ?? Promise.resolve("noop" as const)).then((outcome) => {
-          if (outcome !== "failed") return retryPending(agent);
-        });
+        void (proactive ?? Promise.resolve("noop" as const)).then(() => retryPending(agent));
         return { generationChanged: true, sessionChanged: oldSessionId !== fresh.sessionId, turns: 0,
           runtimeReady: true, pendingCount: rearmed.remainingPendingCount, rearmedCount: rearmed.rearmedCount,
           replayStatus: rearmed.remainingPendingCount > 0 ? "pending" : "consumed", sessionId: fresh.sessionId };
@@ -2045,9 +2028,9 @@ export function createRuntimeHost(options: {
           await recoverStalePiCompaction(agent);
           const startupSession = agent.session;
           const proactive = startupSession ? proactivelyCompactPiAtIdle(agent, startupSession) : null;
-          const proactiveOutcome = proactive ? await proactive : "noop" as const;
+          if (proactive) await proactive;
           activeCount += 1;
-          if (proactiveOutcome !== "failed") await retryPending(agent);
+          await retryPending(agent);
         } catch (error) {
           const reason = error instanceof Error ? error.message : String(error);
           const transient = error instanceof RuntimePrerequisiteError && error.readiness.state === "unavailable";

--- a/src/runtime/runtime-host.ts
+++ b/src/runtime/runtime-host.ts
@@ -6,7 +6,7 @@ import { auditReminderDelivery } from "../agent/reminder-delivery-audit.js";
 import { isCanonicalInboxTarget, targetKeyOfInboxEnvelope } from "../agent/inbox-projection.js";
 import type { ContextOverflowRearmResult, InboxDeliverySourceResolution } from "../agent/agent-state-store.js";
 import { SpanKind } from "@opentelemetry/api";
-import type { ContextPromptBuilder } from "../agent/context-prompt.js";
+import type { ContextPromptBuilder, PreviousSessionRef } from "../agent/context-prompt.js";
 import type {
   NormalizedRuntimeEvent, RuntimeAdapter, RuntimeInput, RuntimeInputResult, RuntimeSession,
 } from "./runtime-contracts.js";
@@ -51,6 +51,7 @@ export interface AgentRuntimeConfig {
   runtime: string; model: string; effort?: string | null; workspaceDir: string;
   piDistribution?: "external" | "builtin";
   stateDir?: string; sessionId?: string | null;
+  previousSession?: PreviousSessionRef | null;
   larkConfigDir?: string;
   feishuAppId?: string;
 }
@@ -65,9 +66,9 @@ export interface DeliveryRecord {
 }
 interface DeliveryFile { version: 1; records: DeliveryRecord[] }
 interface DeliveryStateStore {
-  readJson<T>(key: "runtimeDeliveries", fallback: T): T;
+  readJson<T>(key: "runtimeDeliveries" | "agentState", fallback: T): T;
   readNdjson?<T>(key: "inbox"): T[];
-  writeJson(key: "runtimeDeliveries", value: unknown): void;
+  writeJson(key: "runtimeDeliveries" | "agentState", value: unknown): void;
   withInboxTransaction<T>(operation: () => T): T;
   resolveInboxDeliverySource?(messageId: string): InboxDeliverySourceResolution;
   paths?: { reminders: string };
@@ -85,7 +86,8 @@ interface DeliveryStateStore {
 
 export type RuntimeHostEvent =
   | { type: "agent-status"; agentId: string; status: "active" | "inactive" | "error"; error?: string; readiness?: RuntimeReadiness }
-  | { type: "session"; agentId: string; runtime: string; sessionId: string | null; launchId: string; model?: string; reasoningEffort?: string }
+  | { type: "session"; agentId: string; runtime: string; sessionId: string | null; launchId: string; model?: string; reasoningEffort?: string;
+    previousSession?: PreviousSessionRef | null }
   | { type: "activity"; agentId: string; activity: string; activityKind?: string; detailKind?: string; isHeartbeat?: boolean }
   | { type: "delivery"; agentId: string; deliveryId: string; messageId: string; status: "accepted" | "consumed" | "deferred" | "error"; reason?: string }
   | { type: "runtime"; agentId: string; event: NormalizedRuntimeEvent };
@@ -113,6 +115,7 @@ interface ManagedAgent {
   piProactiveCompactionGeneration: number | null;
   piProactiveCompactionSession: RuntimeSession | null;
   piProactiveCompactionFailedGeneration: number | null;
+  previousSession: PreviousSessionRef | null;
   readiness: RuntimeReadiness | null;
   turnInProgress: boolean; turnHadFailure: boolean; turnHadAuthenticatedOutput: boolean; authFailureActive: boolean;
   /** Delivery ids already promoted from accepted inbox_update to a wake while idle. */
@@ -189,6 +192,56 @@ const BACKGROUND_COMPLETION_IMMEDIATE_RETRY_LIMIT = 5;
 const DEFAULT_SUBAGENT_RECONCILE_INTERVAL_MS = 15_000;
 const now = (): string => new Date().toISOString();
 const isActiveDelivery = (status: DeliveryStatus): boolean => ["pending", "submitting", "accepted"].includes(status);
+
+const previousSessionRefFor = (session: RuntimeSession, reason: string): PreviousSessionRef | null => session.sessionId
+  ? { sessionId: session.sessionId, file: session.sessionFile ?? null, closedAt: new Date().toISOString(), reason }
+  : null;
+
+function parsePreviousSessionRef(value: unknown): PreviousSessionRef | null {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return null;
+  const record = value as Record<string, unknown>;
+  if (typeof record.sessionId !== "string" || !record.sessionId) return null;
+  if (typeof record.closedAt !== "string" || typeof record.reason !== "string") return null;
+  return {
+    sessionId: record.sessionId,
+    file: typeof record.file === "string" && record.file ? record.file : null,
+    closedAt: record.closedAt,
+    reason: record.reason,
+  };
+}
+
+function loadPersistedPreviousSession(config: AgentRuntimeConfig, store?: DeliveryStateStore): PreviousSessionRef | null {
+  const fromConfig = parsePreviousSessionRef(config.previousSession);
+  if (fromConfig) return fromConfig;
+  if (!store) return null;
+  try {
+    const state = store.readJson<{ previousSessions?: Record<string, unknown> }>("agentState", {});
+    return parsePreviousSessionRef(state.previousSessions?.[config.runtime]);
+  } catch {
+    return null;
+  }
+}
+
+function persistPreviousSession(agent: ManagedAgent, previous: PreviousSessionRef | null): void {
+  agent.previousSession = previous;
+  agent.config.previousSession = previous;
+  const store = agent.stateStore;
+  if (!store) return;
+  try {
+    const current = store.readJson<Record<string, unknown>>("agentState", { sessions: {} });
+    // Delivery-ledger mocks ignore the JSON key and would be clobbered by this write.
+    if (Array.isArray((current as { records?: unknown }).records) && !("sessions" in current)) return;
+    const previousSessions = current.previousSessions && typeof current.previousSessions === "object"
+      && !Array.isArray(current.previousSessions)
+      ? { ...(current.previousSessions as Record<string, unknown>) }
+      : {};
+    if (previous) previousSessions[agent.adapter.id] = previous;
+    else delete previousSessions[agent.adapter.id];
+    store.writeJson("agentState", { ...current, previousSessions });
+  } catch {
+    // In-memory ref still holds for this process; restart will miss it only if this write failed.
+  }
+}
 type ReplayFailureCode = "canonical_inbox_row_missing" | "canonical_inbox_malformed" | "duplicate_message_id"
   | "inbox_state_conflict" | "delivery_target_conflict" | "structured_target_invalid"
   | "structured_target_missing" | "wake_reason_conflict";
@@ -1476,7 +1529,7 @@ export function createRuntimeHost(options: {
     const standingPrompt = options.promptBuilder.build({
       agentId: agent.config.agentId, name: agent.config.displayName || agent.config.name,
       description: agent.config.description || "", runtime: agent.adapter.id,
-      cli: agentCliPromptCapabilities("larkin"),
+      cli: agentCliPromptCapabilities("larkin"), previousSession: agent.previousSession,
     });
     const generation = ++agent.generation;
     let completedSession: RuntimeSession | null = null;
@@ -1530,9 +1583,11 @@ export function createRuntimeHost(options: {
     const readiness = agent.adapter.probe ? await agent.adapter.probe({ agentId: agent.config.agentId,
       workspaceDir: agent.config.workspaceDir, stateDir: agent.config.stateDir, env: probeEnv }) : { runtime: "pi" as const, state: "ready" as const };
     if (readiness.state !== "ready") throw new RuntimeSessionRecoveryError("recovery_staged_not_committed", "Pi context fallback readiness failed");
+    const previousRef = previousSessionRefFor(oldSession, "context-window overflow");
     const standingPrompt = options.promptBuilder.build({
       agentId: agent.config.agentId, name: agent.config.displayName || agent.config.name,
       description: agent.config.description || "", runtime: agent.adapter.id, cli: agentCliPromptCapabilities("larkin"),
+      previousSession: previousRef,
     });
     let fresh: RuntimeSession;
     try {
@@ -1558,6 +1613,7 @@ export function createRuntimeHost(options: {
     const oldConfigSessionId = agent.config.sessionId;
     const oldReadiness = agent.readiness;
     const oldDisabledReason = agent.disabledReason;
+    const oldPreviousSession = agent.previousSession;
     const oldRecord = { ...record, input: { ...record.input } };
     let durableRollback: (() => void) | null = null;
     let rearmedCount = 1;
@@ -1572,6 +1628,7 @@ export function createRuntimeHost(options: {
       agent.launchId = crypto.randomUUID();
       agent.config.sessionId = null;
       agent.session = fresh;
+      persistPreviousSession(agent, previousRef);
       agent.readiness = readiness;
       agent.disabledReason = null;
       for (const candidate of agent.records.values()) {
@@ -1596,6 +1653,7 @@ export function createRuntimeHost(options: {
       agent.launchId = oldLaunchId;
       agent.config.sessionId = oldConfigSessionId;
       agent.session = oldSession;
+      persistPreviousSession(agent, oldPreviousSession);
       agent.readiness = oldReadiness;
       agent.disabledReason = oldDisabledReason;
       Object.assign(record, oldRecord);
@@ -1607,7 +1665,8 @@ export function createRuntimeHost(options: {
       agent.config.sessionId = fresh.sessionId;
       emit({ type: "session", agentId, runtime: agent.adapter.id, sessionId: fresh.sessionId, launchId: agent.launchId,
         ...(fresh.effectiveModel ? { model: fresh.effectiveModel } : {}),
-        ...(fresh.effectiveReasoningEffort ? { reasoningEffort: fresh.effectiveReasoningEffort } : {}) });
+        ...(fresh.effectiveReasoningEffort ? { reasoningEffort: fresh.effectiveReasoningEffort } : {}),
+        ...(agent.previousSession ? { previousSession: agent.previousSession } : {}) });
     }
     emit({ type: "agent-status", agentId, status: "active", readiness });
     agent.piSessionOwner = probeEnv[PI_SUBAGENT_SESSION_OWNER_ENV];
@@ -1647,7 +1706,7 @@ export function createRuntimeHost(options: {
       const standingPrompt = options.promptBuilder.build({
         agentId: config.agentId, name: config.displayName || config.name,
         description: config.description || "", runtime: adapter.id,
-        cli: agentCliPromptCapabilities("larkin"),
+        cli: agentCliPromptCapabilities("larkin"), previousSession: previous.previousSession,
       });
       const session = await adapter.createSession({
         agentId: config.agentId, model: config.model, reasoningEffort: config.effort || null,
@@ -1741,10 +1800,11 @@ export function createRuntimeHost(options: {
           LARKIN_CLAUDE_COMMAND: process.env.LARKIN_CLAUDE_COMMAND, ...probeEnv } })
         : { runtime: agent.adapter.id, state: "ready" as const };
       if (readiness.state !== "ready") throw new RuntimePrerequisiteError(readiness);
+      const previousRef = previousSessionRefFor(oldSession, "operator reset");
       const standingPrompt = options.promptBuilder.build({
         agentId: agent.config.agentId, name: agent.config.displayName || agent.config.name,
         description: agent.config.description || "", runtime: agent.adapter.id,
-        cli: agentCliPromptCapabilities("larkin"),
+        cli: agentCliPromptCapabilities("larkin"), previousSession: previousRef,
       });
       const create = agent.adapter.createSession({
         agentId: agent.config.agentId, model: agent.config.model, reasoningEffort: agent.config.effort || null,
@@ -1768,6 +1828,7 @@ export function createRuntimeHost(options: {
         agent.launchId = crypto.randomUUID();
         agent.config.sessionId = null;
         agent.session = fresh;
+        persistPreviousSession(agent, previousRef);
         agent.readiness = readiness;
         agent.disabledReason = null;
       };
@@ -1783,7 +1844,8 @@ export function createRuntimeHost(options: {
         agent.config.sessionId = fresh.sessionId;
         emit({ type: "session", agentId, runtime: agent.adapter.id, sessionId: fresh.sessionId, launchId: agent.launchId,
           ...(fresh.effectiveModel ? { model: fresh.effectiveModel } : {}),
-          ...(fresh.effectiveReasoningEffort ? { reasoningEffort: fresh.effectiveReasoningEffort } : {}) });
+          ...(fresh.effectiveReasoningEffort ? { reasoningEffort: fresh.effectiveReasoningEffort } : {}),
+          ...(agent.previousSession ? { previousSession: agent.previousSession } : {}) });
       }
       emit({ type: "agent-status", agentId, status: "active", readiness });
       agent.piSessionOwner = probeEnv[PI_SUBAGENT_SESSION_OWNER_ENV];
@@ -1836,10 +1898,12 @@ export function createRuntimeHost(options: {
         throw new RuntimeSessionRecoveryError("recovery_staged_not_committed", "Runtime readiness probe failed");
       }
       if (readiness.state !== "ready") throw new RuntimePrerequisiteError(readiness);
+      const previousRef = previousSessionRefFor(oldSession, "context-window recovery");
+      const oldPreviousSession = agent.previousSession;
       const standingPrompt = options.promptBuilder.build({
         agentId: agent.config.agentId, name: agent.config.displayName || agent.config.name,
         description: agent.config.description || "", runtime: agent.adapter.id,
-        cli: agentCliPromptCapabilities("larkin"),
+        cli: agentCliPromptCapabilities("larkin"), previousSession: previousRef,
       });
       let fresh: RuntimeSession;
       try {
@@ -1874,6 +1938,7 @@ export function createRuntimeHost(options: {
         agent.generation = oldGeneration;
         agent.launchId = oldLaunchId;
         agent.config.sessionId = oldConfigSessionId;
+        persistPreviousSession(agent, oldPreviousSession);
         agent.readiness = oldReadiness;
         agent.disabledReason = oldDisabledReason;
         agent.records = new Map(oldRecords);
@@ -1901,6 +1966,7 @@ export function createRuntimeHost(options: {
           agent.launchId = crypto.randomUUID();
           agent.config.sessionId = null;
           agent.session = fresh;
+          persistPreviousSession(agent, previousRef);
           agent.readiness = readiness;
           agent.disabledReason = null;
           for (const record of agent.records.values()) {
@@ -1915,7 +1981,8 @@ export function createRuntimeHost(options: {
           agent.config.sessionId = fresh.sessionId;
           emit({ type: "session", agentId, runtime: agent.adapter.id, sessionId: fresh.sessionId, launchId: agent.launchId,
             ...(fresh.effectiveModel ? { model: fresh.effectiveModel } : {}),
-            ...(fresh.effectiveReasoningEffort ? { reasoningEffort: fresh.effectiveReasoningEffort } : {}) });
+            ...(fresh.effectiveReasoningEffort ? { reasoningEffort: fresh.effectiveReasoningEffort } : {}),
+            ...(agent.previousSession ? { previousSession: agent.previousSession } : {}) });
         }
         emit({ type: "agent-status", agentId, status: "active", readiness });
         durableRollback = null;
@@ -1988,7 +2055,8 @@ export function createRuntimeHost(options: {
             }) : undefined,
           compactionMachines: new Map(), compactionRecoveryInFlight: new Set(), piOverflowCompactionFailed: new Set(),
           piProactiveCompaction: null, piProactiveCompactionGeneration: null, piProactiveCompactionSession: null,
-          piProactiveCompactionFailedGeneration: null, readiness: null,
+          piProactiveCompactionFailedGeneration: null,
+          previousSession: loadPersistedPreviousSession(config, stateStore), readiness: null,
           turnInProgress: false, turnHadFailure: false, turnHadAuthenticatedOutput: false, authFailureActive: false,
           promotedInboxUpdateIds: new Set(),
           backgroundCompletionQueue: [], backgroundCompletionKeys: new Set(),

--- a/test/unit/runtime/runtime-adapters.test.mjs
+++ b/test/unit/runtime/runtime-adapters.test.mjs
@@ -157,9 +157,26 @@ test("context prompt is capability-driven, versioned and produces bounded notifi
   assert.equal(update.deliveryId, "delivery-1");
 });
 
+test("context prompt references only the supplied previous session archive", () => {
+  const prompt = new ContextPromptBuilder().build({
+    agentId: "cli_test", runtime: "pi",
+    previousSession: {
+      sessionId: "gen-1", file: "/tmp/pi-sessions/gen-1.jsonl",
+      closedAt: "2026-09-03T00:00:00.000Z", reason: "context-window overflow",
+    },
+  });
+  assert.match(prompt.content, /## Previous session archive/);
+  assert.match(prompt.content, /`\/tmp\/pi-sessions\/gen-1\.jsonl`/);
+  assert.match(prompt.content, /Do not load it whole: use `tail` or `rg`/);
+  assert.match(prompt.content, /Older archives are kept on disk and are intentionally not referenced here/);
+  assert.doesNotMatch(prompt.content, /gen-0/);
+  assert.equal((prompt.content.match(/## Previous session archive/g) ?? []).length, 1);
+});
+
 test("default context prompt consumes the Agent CLI manifest", () => {
   const prompt = new ContextPromptBuilder().build({ agentId: "cli_test", runtime: "pi" });
   assert.equal(prompt.version, "larkin-standing-v28");
+  assert.doesNotMatch(prompt.content, /## Previous session archive/);
   assert.match(prompt.content, /never emit feishu\.cn for a Lark tenant/);
   assert.match(prompt.content, /larkin reminder schedule/);
   assert.match(prompt.content, /explicit delivery target/);
@@ -1086,7 +1103,7 @@ test.each(["context-revalidate", "model-revalidate", "auto-revalidate"])("produc
   }
 });
 
-test.each(["reserveTokens", "keepRecentTokens"])("production Pi backend rejects owned %s drift before prompt or compact submission", async (field) => {
+test.each(["reserveTokens", "keepRecentTokens"])("production Pi backend accepts prompt when owned %s drifts after startup", async (field) => {
   const root = fs.mkdtempSync(path.join(os.tmpdir(), `larkin-pi-production-owned-${field}-`));
   const { command, commandArgs, log } = makeProductionPiCommand(root);
   const input = create({
@@ -1106,11 +1123,10 @@ test.each(["reserveTokens", "keepRecentTokens"])("production Pi backend rejects 
     settings.compaction[field] = field === "reserveTokens" ? 49_999 : 19_999;
     fs.writeFileSync(settingsFile, JSON.stringify(settings));
     const promptResult = await session.prompt({ inputId: `owned-${field}-prompt`, kind: "user", text: "prompt", attempt: 0 });
-    assert.equal(promptResult.status, "rejected");
-    assert.match(promptResult.reason, /must be exactly/);
-    await assert.rejects(session.compact(), /must be exactly/);
+    assert.equal(promptResult.status, "accepted", "disk settings drift must not reject prompt");
+    await session.compact();
     const rows = readProductionPiLog(log);
-    assert.equal(rows.some((row) => row.kind === "request" && !row.probe && ["prompt", "compact", "steer"].includes(row.type)), false);
+    assert.equal(rows.some((row) => row.kind === "request" && !row.probe && row.type === "prompt"), true);
   } finally {
     await session.close("production owned settings test complete").catch(() => {});
   }

--- a/test/unit/runtime/runtime-host.test.mjs
+++ b/test/unit/runtime/runtime-host.test.mjs
@@ -918,6 +918,7 @@ test("RuntimeHost context-overflow recovery stages no-resume, rearms exact recor
     assert.equal(result.rearmedCount, 4);
     assert.equal(result.replayStatus, "pending", "the Inbox remains durable until the normal Runtime poll consumes it");
     assert.equal(sessions[1].input.resumeSessionId, null);
+    assert.match(sessions[1].input.standingPrompt.content, /## Previous session archive[\s\S]*session id `old-context-session`/);
     assert.deepEqual(sessions[0].session.closes, ["context-window recovery committed"]);
     await new Promise((resolve) => setTimeout(resolve, 10));
     const ledger = store.readJson("runtimeDeliveries", { records: [] });
@@ -3173,6 +3174,110 @@ test("RuntimeHost keeps exhausted terminal wakes pending so a restart can requeu
     assert.equal(host2.getDispatchedSubagent("cli_piExhaustedDropA1", "task-exhausted-drop-1")?.wakeState, "pending");
   } finally {
     await host2.shutdown("done");
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("RuntimeHost overflow replacement references only the immediately previous archive (depth=1)", async () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "larkin-depth1-overflow-"));
+  const agentId = "cli_depth1OverflowA1";
+  const raw = createAgentStateStore(root, agentId);
+  const overflowRecord = (deliveryId, messageId) => ({
+    deliveryId, messageId, status: "error", retryable: false,
+    reason: "Your input exceeds the context window of this model. Please adjust your input and try again.",
+    errorCategory: "context_window",
+    input: { inputId: `input-${deliveryId}`, deliveryId, kind: "wake", text: "redacted", attempt: 0 },
+    updatedAt: "before",
+  });
+  raw.appendNdjson("inbox", { message_id: "om_depth1_1", chat_id: "oc_depth1", content: "first" });
+  raw.writeJson("runtimeDeliveries", { version: 1, records: [overflowRecord("d-depth1-1", "om_depth1_1")] });
+  const sessions = [];
+  let compactCalls = 0;
+  const adapter = { id: "pi", capabilities: {}, async createSession(input) {
+    const session = new FakeSession();
+    session.sessionId = input.resumeSessionId || `gen-${sessions.length}`;
+    session.sessionFile = `/tmp/pi-sessions/${session.sessionId}.jsonl`;
+    session.compact = async () => { compactCalls += 1; };
+    sessions.push({ session, input });
+    return session;
+  } };
+  const startHost = () => createRuntimeHost({
+    adapterFor: () => adapter, promptBuilder: new ContextPromptBuilder(), stateStoreFor: () => raw,
+  });
+  const hostA = startHost();
+  try {
+    await hostA.start([{ agentId, name: "depth1", runtime: "pi", model: "model", workspaceDir: "/tmp", stateDir: root }]);
+    assert.doesNotMatch(sessions[0].input.standingPrompt.content, /Previous session archive/, "gen-0 has no predecessor");
+    await hostA.recoverContextOverflow(agentId, "d-depth1-1", "overflow 1");
+    const prompt1 = sessions[1].input.standingPrompt.content;
+    assert.match(prompt1, /## Previous session archive/);
+    assert.match(prompt1, /`\/tmp\/pi-sessions\/gen-0\.jsonl`/);
+    assert.match(prompt1, /Do not load it whole/);
+    assert.equal(sessions[1].input.resumeSessionId, null);
+    assert.equal(raw.readJson("agentState", {}).previousSessions.pi.file, "/tmp/pi-sessions/gen-0.jsonl");
+  } finally {
+    await hostA.shutdown("done");
+  }
+
+  fs.writeFileSync(raw.paths.inbox, `${JSON.stringify({ message_id: "om_depth1_2", chat_id: "oc_depth1", content: "second" })}\n`);
+  raw.writeJson("runtimeDeliveries", { version: 1, records: [overflowRecord("d-depth1-2", "om_depth1_2")] });
+  const hostB = startHost();
+  try {
+    await hostB.start([{ agentId, name: "depth1", runtime: "pi", model: "model", workspaceDir: "/tmp", stateDir: root, sessionId: "gen-1" }]);
+    await hostB.recoverContextOverflow(agentId, "d-depth1-2", "overflow 2");
+    const prompt2 = sessions.at(-1).input.standingPrompt.content;
+    assert.match(prompt2, /`\/tmp\/pi-sessions\/gen-1\.jsonl`/, "second overflow points at gen-1");
+    assert.doesNotMatch(prompt2, /gen-0\.jsonl/, "second overflow must not reference gen-0");
+    assert.equal((prompt2.match(/## Previous session archive/g) ?? []).length, 1);
+    assert.equal(compactCalls, 0, "replacement itself must not compact");
+  } finally {
+    await hostB.shutdown("done");
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("RuntimeHost persists the depth-1 previous archive across reset and start() rebuild", async () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "larkin-depth1-persist-"));
+  const agentId = "cli_depth1PersistA1";
+  const store = createAgentStateStore(root, agentId);
+  const sessions = [];
+  let compactCalls = 0;
+  const adapter = { id: "pi", capabilities: {}, async createSession(input) {
+    const index = sessions.length;
+    const session = new FakeSession();
+    session.sessionId = `gen-${index}`;
+    session.sessionFile = `/tmp/pi-sessions/gen-${index}.jsonl`;
+    session.compact = async () => { compactCalls += 1; };
+    sessions.push({ session, input });
+    return session;
+  } };
+  const host = createRuntimeHost({ adapterFor: () => adapter, promptBuilder: new ContextPromptBuilder(), stateStoreFor: () => store });
+  try {
+    await host.start([{ agentId, name: "persist", runtime: "pi", model: "model", workspaceDir: "/tmp", stateDir: root }]);
+    await host.resetSession(agentId);
+    await host.resetSession(agentId);
+    const prompt2 = sessions[2].input.standingPrompt.content;
+    assert.match(prompt2, /`\/tmp\/pi-sessions\/gen-1\.jsonl`/);
+    assert.doesNotMatch(prompt2, /gen-0\.jsonl/);
+    assert.equal((prompt2.match(/## Previous session archive/g) ?? []).length, 1);
+    assert.equal(compactCalls, 0);
+    const persisted = store.readJson("agentState", {});
+    assert.equal(persisted.previousSessions.pi.file, "/tmp/pi-sessions/gen-1.jsonl");
+    assert.equal(persisted.previousSessions.pi.sessionId, "gen-1");
+  } finally {
+    await host.shutdown("done");
+  }
+
+  const restarted = createRuntimeHost({ adapterFor: () => adapter, promptBuilder: new ContextPromptBuilder(), stateStoreFor: () => store });
+  try {
+    await restarted.start([{ agentId, name: "persist", runtime: "pi", model: "model", workspaceDir: "/tmp", stateDir: root, sessionId: "gen-2" }]);
+    const rebuilt = sessions[3].input.standingPrompt.content;
+    assert.match(rebuilt, /`\/tmp\/pi-sessions\/gen-1\.jsonl`/, "start() rebuild must reload previousSession from agent-state");
+    assert.doesNotMatch(rebuilt, /gen-0\.jsonl/);
+    assert.equal((rebuilt.match(/## Previous session archive/g) ?? []).length, 1);
+    assert.equal(sessions[3].input.resumeSessionId, "gen-2");
+  } finally {
+    await restarted.shutdown("done");
     fs.rmSync(root, { recursive: true, force: true });
   }
 });

--- a/test/unit/runtime/runtime-host.test.mjs
+++ b/test/unit/runtime/runtime-host.test.mjs
@@ -229,15 +229,17 @@ test("RuntimeHost bounds proactive compact failure without retry or session rese
     await host.start([{ agentId: "cli_piProactiveFailureA1", name: "failure", runtime: "pi", model: "model", workspaceDir: "/tmp", stateDir: root }]);
     session.emit({ type: "turn-end" });
     session.emit({ type: "turn-end" });
-    await new Promise((resolve) => setTimeout(resolve, 30));
+    const compactDeadline = Date.now() + 1_000;
+    while (session.compactCalls < 1 && Date.now() < compactDeadline) await new Promise((resolve) => setTimeout(resolve, 5));
     assert.equal(session.compactCalls, 1);
     assert.equal(session.closes.length, 0, "proactive failure must not reset the session");
     const receipt = await host.deliver("cli_piProactiveFailureA1", {
       message_id: "om_pi_proactive_failure", chat_id: "oc_pi_proactive_failure", content: "pending",
     });
-    assert.equal(receipt.status, "deferred");
-    assert.equal(session.prompts.length, 0, "degraded generation must not submit pending work");
-    assert.equal(store.readJson("runtimeDeliveries", { records: [] }).records[0].status, "pending");
+    assert.equal(receipt.status, "accepted");
+    assert.ok(session.prompts.length >= 1, "idle compact failure must still submit pending work");
+    assert.equal(session.compactCalls, 1, "failed generation must not retry compact");
+    assert.equal(session.closes.length, 0, "later deliveries must keep the same session");
   } finally {
     await host.shutdown("done");
     fs.rmSync(root, { recursive: true, force: true });


### PR DESCRIPTION
## Summary
- Idle Pi compact failure no longer marks the generation incompatible or defers all later Inbox deliveries. Compact is still attempted at most once per generation; the current session is not reset.
- Session replacement (overflow auto / `recoverSession` / `resetSession`) writes **only** the immediately previous archive into the standing prompt (depth=1, no chain). The ref is persisted in `agent-state.json` so `start()` rebuild after daemon restart still has it. Swap does not compact, summarize, or read jsonl contents.
- `validatePolicy` uses the live Pi handshake. Drifted owned `settings.json` reserveTokens/keepRecentTokens no longer reject prompt.
- Version stays `0.4.25` (already bumped).

Fixes #184

## Test plan
- [x] `bun run build`
- [x] `bun test test/unit/runtime/runtime-host.test.mjs` (idle compact failure still accepts/prompts; two overflows reference only the previous archive; reset+restart reloads agent-state; recoverSession carries the ref)
- [x] `bun test test/unit/runtime/runtime-adapters.test.mjs` (owned settings drift accepts prompt)
- [x] `host-runtime-lifecycle` + `host-hot-agent-attach`
- [ ] CI `bun run test`
- Live 2dan install/status remains post-merge; this PR does not bootout or move jsonl.