### PR TITLE
fix(agent): keep require policy on inbox audit and make heartbeat configurable

### DIFF
--- a/src/agent/config-cli-contract.ts
+++ b/src/agent/config-cli-contract.ts
@@ -1,4 +1,4 @@
-export const CONFIG_CLI_OPERATIONS = Object.freeze(["show", "runtime", "model", "effort", "mention", "apply"] as const);
+export const CONFIG_CLI_OPERATIONS = Object.freeze(["show", "runtime", "model", "effort", "mention", "inbox-audit", "apply"] as const);
 
 export const CONFIG_CLI_USAGE = Object.freeze([
   "larkin config show [--agent <App ID>] [--chat <oc_id>] [--json]",
@@ -8,6 +8,8 @@ export const CONFIG_CLI_USAGE = Object.freeze([
   "larkin config mention global <require|free>",
   "larkin config mention agent <inherit|require|free> [--agent <App ID>]",
   "larkin config mention chat <oc_id> <inherit|require|free> [--agent <App ID>]",
+  "larkin config inbox-audit global <on|off> [--interval <15m|1h>]",
+  "larkin config inbox-audit agent <inherit|on|off> [--agent <App ID>] [--interval <15m|inherit>]",
   "larkin config apply [--agent <App ID>]",
 ]);
 

--- a/src/agent/inbox-audit-heartbeat.ts
+++ b/src/agent/inbox-audit-heartbeat.ts
@@ -7,67 +7,85 @@ interface AuditStateStore {
   appendCanonicalInboxOnce(value: unknown): { status: "appended" | "duplicate_pending" | "duplicate_consumed"; envelope: unknown };
 }
 interface AuditRuntime { deliver(agentId: string, envelope: object): Promise<unknown> | unknown }
+export interface InboxAuditSchedule { enabled: boolean; intervalMs: number }
 type Timer = ReturnType<typeof setTimeout>;
 
-/** One Host-owned timer fans a targetless internal wake to each active Agent. */
+function safeIntervalMs(intervalMs: number): number {
+  if (!Number.isSafeInteger(intervalMs) || intervalMs < 1) throw new Error("inbox audit cadence must be a positive integer");
+  return intervalMs;
+}
+
+/** One Host-owned timer per Agent; disabled Agents are re-armed without a model wake. */
 export class InboxAuditHeartbeat {
-  private timer: Timer | null = null;
+  private readonly timers = new Map<string, Timer>();
   private running = false;
   private sequence = 0;
-  private readonly cadenceMs: number;
 
   constructor(private readonly options: {
     agents: readonly AuditAgent[];
     stateStore(agent: AuditAgent): AuditStateStore;
     runtimeHost: AuditRuntime;
     log?: (...parts: unknown[]) => void;
-    cadenceMs?: number;
     setTimer?: typeof setTimeout;
     clearTimer?: typeof clearTimeout;
     now?: () => number;
+    schedule(agent: AuditAgent): InboxAuditSchedule;
+    /** Skip model wake when audit is disabled or there is no pending originally-wake=true work. */
+    shouldDispatch(agent: AuditAgent): boolean;
   }) {
-    this.cadenceMs = options.cadenceMs ?? INBOX_AUDIT_CADENCE_MS;
-    if (!Number.isSafeInteger(this.cadenceMs) || this.cadenceMs < 1) throw new Error("inbox audit cadence must be a positive integer");
+    for (const agent of options.agents) safeIntervalMs(options.schedule(agent).intervalMs);
   }
 
   start(): void {
     if (this.running) return;
     this.running = true;
-    this.schedule();
+    for (const agent of this.options.agents) this.arm(agent);
   }
 
   stop(): void {
     this.running = false;
-    if (this.timer) (this.options.clearTimer ?? clearTimeout)(this.timer);
-    this.timer = null;
+    const clearTimer = this.options.clearTimer ?? clearTimeout;
+    for (const timer of this.timers.values()) clearTimer(timer);
+    this.timers.clear();
   }
 
-  private schedule(): void {
-    if (!this.running || this.timer) return;
-    this.timer = (this.options.setTimer ?? setTimeout)(() => {
-      this.timer = null;
-      return this.fire().finally(() => { if (this.running) this.schedule(); });
-    }, this.cadenceMs);
-    this.timer.unref?.();
+  private arm(agent: AuditAgent): void {
+    if (!this.running || this.timers.has(agent.agentId)) return;
+    let intervalMs = INBOX_AUDIT_CADENCE_MS;
+    try { intervalMs = safeIntervalMs(this.options.schedule(agent).intervalMs); }
+    catch (error) {
+      this.options.log?.(`inbox audit schedule failed agent=${agent.agentId}: ${error instanceof Error ? error.message : String(error)}`);
+    }
+    const timer = (this.options.setTimer ?? setTimeout)(() => {
+      this.timers.delete(agent.agentId);
+      return this.fire(agent).finally(() => { if (this.running) this.arm(agent); });
+    }, intervalMs);
+    timer.unref?.();
+    this.timers.set(agent.agentId, timer);
   }
 
-  private async fire(): Promise<void> {
+  private async fire(agent: AuditAgent): Promise<void> {
+    try {
+      const schedule = this.options.schedule(agent);
+      if (!schedule.enabled || !this.options.shouldDispatch(agent)) return;
+    } catch (error) {
+      this.options.log?.(`inbox audit schedule failed agent=${agent.agentId}: ${error instanceof Error ? error.message : String(error)}`);
+      return;
+    }
     const now = this.options.now ?? Date.now;
-    for (const agent of this.options.agents) {
-      const message_id = `rem_inbox_audit_${now()}_${++this.sequence}_${agent.agentId}`;
-      const envelope = {
-        kind: "reminder",
-        message_id,
-        target: RUNTIME_REMINDER_TARGET,
-        wake: true,
-        content: "Internal inbox audit wake. Poll runtime:reminder, then run larkin inbox audit --json. No finding stays silent.",
-      };
-      try {
-        const appended = this.options.stateStore(agent).appendCanonicalInboxOnce(envelope);
-        if (appended.status === "appended") await this.options.runtimeHost.deliver(agent.agentId, appended.envelope as object);
-      } catch (error) {
-        this.options.log?.(`inbox audit heartbeat failed agent=${agent.agentId}: ${error instanceof Error ? error.message : String(error)}`);
-      }
+    const message_id = `rem_inbox_audit_${now()}_${++this.sequence}_${agent.agentId}`;
+    const envelope = {
+      kind: "reminder",
+      message_id,
+      target: RUNTIME_REMINDER_TARGET,
+      wake: true,
+      content: "Internal inbox audit wake. Poll runtime:reminder, then run larkin inbox audit --json. No finding stays silent.",
+    };
+    try {
+      const appended = this.options.stateStore(agent).appendCanonicalInboxOnce(envelope);
+      if (appended.status === "appended") await this.options.runtimeHost.deliver(agent.agentId, appended.envelope as object);
+    } catch (error) {
+      this.options.log?.(`inbox audit heartbeat failed agent=${agent.agentId}: ${error instanceof Error ? error.message : String(error)}`);
     }
   }
 }

--- a/src/agent/missed-outbound-scan.ts
+++ b/src/agent/missed-outbound-scan.ts
@@ -8,8 +8,7 @@ import * as path from "node:path";
  * or deleted automatically.
  */
 export const INBOX_AUDIT_LEGACY_MIGRATION_NON_GOAL = "New versions no longer create missed-outbound loops; existing indistinguishable historical loops are not migrated or deleted automatically.";
-// Audits return every retained target. Storage remains bounded so a heartbeat
-// cannot accumulate an unbounded work list.
+// Pending audits are bounded so a heartbeat cannot accumulate an unbounded work list.
 export const MAX_INBOX_AUDIT_TARGETS = 96;
 const MAX_STORED_TARGETS = MAX_INBOX_AUDIT_TARGETS;
 const CHAT = /^oc_[A-Za-z0-9]+$/;
@@ -22,8 +21,14 @@ export interface InboxAuditTarget {
   observed_at: string;
 }
 
-interface StoredTarget extends InboxAuditTarget { agent_id: string }
-interface AuditRegistry { version: 1; targets: StoredTarget[] }
+type AuditStatus = "pending" | "completed";
+interface StoredTarget extends InboxAuditTarget {
+  agent_id: string;
+  status: AuditStatus;
+  completed_at?: string;
+  completed_anchor?: string;
+}
+interface AuditRegistry { version: 2; targets: StoredTarget[] }
 
 export function inboxAuditRegistryFile(larkinHome: string): string {
   return path.join(larkinHome, "inbox-audit.json");
@@ -37,15 +42,22 @@ function parseTarget(event: { chat_id?: string; thread_id?: string | null; messa
   return { target: threadId ? `thread:${chatId}:${threadId}` : `chat:${chatId}`, anchor };
 }
 
+function emptyRegistry(): AuditRegistry {
+  return { version: 2, targets: [] };
+}
+
 function load(file: string): AuditRegistry {
-  let value: Partial<AuditRegistry>;
-  try { value = JSON.parse(fs.readFileSync(file, "utf8")) as Partial<AuditRegistry>; }
+  let value: { version?: unknown; targets?: unknown };
+  try { value = JSON.parse(fs.readFileSync(file, "utf8")) as { version?: unknown; targets?: unknown }; }
   catch (error) {
-    if ((error as NodeJS.ErrnoException).code === "ENOENT") return { version: 1, targets: [] };
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") return emptyRegistry();
     throw error;
   }
-  if (value?.version !== 1 || !Array.isArray(value.targets)) return { version: 1, targets: [] };
-  return { version: 1, targets: value.targets.flatMap((row): StoredTarget[] => {
+  // v1 rows were recorded without wake eligibility, so they cannot prove a
+  // missed originally-wake=true outbound. Discard rather than re-scan them.
+  if (value?.version === 1) return emptyRegistry();
+  if (value?.version !== 2 || !Array.isArray(value.targets)) return emptyRegistry();
+  return { version: 2, targets: value.targets.flatMap((row): StoredTarget[] => {
     if (!row || typeof row !== "object") return [];
     const candidate = row as Partial<StoredTarget>;
     if (typeof candidate.target !== "string" || typeof candidate.anchor !== "string") return [];
@@ -54,9 +66,18 @@ function load(file: string): AuditRegistry {
       thread_id: candidate.target.startsWith("thread:") ? candidate.target.split(":")[2] : null,
       message_id: candidate.anchor,
     });
-    return typeof candidate.agent_id === "string" && candidate.agent_id && parsed && candidate.target === parsed.target
-      && typeof candidate.observed_at === "string" && Number.isFinite(Date.parse(candidate.observed_at))
-      ? [{ agent_id: candidate.agent_id, ...parsed, observed_at: candidate.observed_at }] : [];
+    const status = candidate.status === "completed" ? "completed" : candidate.status === "pending" ? "pending" : null;
+    if (!status || typeof candidate.agent_id !== "string" || !candidate.agent_id || !parsed || candidate.target !== parsed.target) return [];
+    if (typeof candidate.observed_at !== "string" || !Number.isFinite(Date.parse(candidate.observed_at))) return [];
+    const completed_at = typeof candidate.completed_at === "string" && Number.isFinite(Date.parse(candidate.completed_at))
+      ? candidate.completed_at : undefined;
+    const completed_anchor = typeof candidate.completed_anchor === "string" && ANCHOR.test(candidate.completed_anchor)
+      ? candidate.completed_anchor : undefined;
+    return [{
+      agent_id: candidate.agent_id, ...parsed, observed_at: candidate.observed_at, status,
+      ...(completed_at ? { completed_at } : {}),
+      ...(completed_anchor ? { completed_anchor } : {}),
+    }];
   }) };
 }
 
@@ -68,22 +89,28 @@ function save(file: string, registry: AuditRegistry): void {
   fs.chmodSync(file, 0o600);
 }
 
-/** Record only an authoritative human group/topic source; DMs and bots are ignored. */
+/**
+ * Record only an originally wake=true human group/topic source.
+ * Unmentioned require-policy traffic, DMs, and bots stay out of the audit work list.
+ */
 export function observeInboxAuditTarget(file: string, agentId: string, event: {
   chat_id?: string;
   chat_type?: string;
   thread_id?: string | null;
   message_id?: string;
+  wake?: boolean;
   _sender_is_bot?: boolean;
   _scan_authority?: boolean;
 }, now = new Date()): boolean {
-  if (event._scan_authority !== true || event._sender_is_bot !== false || event.chat_type !== "group") return false;
+  if (event.wake !== true || event._scan_authority !== true || event._sender_is_bot !== false || event.chat_type !== "group") return false;
   const parsed = parseTarget(event);
   if (!parsed) return false;
   const registry = load(file);
+  const existing = registry.targets.find((row) => row.agent_id === agentId && row.target === parsed.target);
+  if (existing?.status === "completed" && existing.anchor === parsed.anchor) return false;
   const observed_at = now.toISOString();
   registry.targets = registry.targets.filter((row) => row.agent_id !== agentId || row.target !== parsed.target);
-  registry.targets.unshift({ agent_id: agentId, ...parsed, observed_at });
+  registry.targets.unshift({ agent_id: agentId, ...parsed, observed_at, status: "pending" });
   registry.targets = registry.targets.slice(0, MAX_STORED_TARGETS);
   save(file, registry);
   return true;
@@ -96,19 +123,45 @@ function instruction(target: InboxAuditTarget): string {
   return `${history} If a real missed outbound finding requires a response, use the existing guarded larkin im reply path anchored at ${target.anchor}; otherwise stay silent.`;
 }
 
-/** Content-free, bounded audit work list consumed by the Agent CLI. */
+function pendingRows(file: string, agentId: string): StoredTarget[] {
+  return load(file).targets.filter((row) => row.agent_id === agentId && row.status === "pending")
+    .sort((left, right) => right.observed_at.localeCompare(left.observed_at));
+}
+
+export function hasPendingInboxAuditTargets(file: string, agentId: string): boolean {
+  return pendingRows(file, agentId).length > 0;
+}
+
+/** Content-free, bounded pending audit work list. Completed/reported targets are omitted. */
 export function readInboxAuditTargets(file: string, agentId: string): {
   version: 1;
   targets: Array<InboxAuditTarget & { instruction: string }>;
   has_more: boolean;
   no_finding: "stay_silent";
 } {
-  const rows = load(file).targets.filter((row) => row.agent_id === agentId)
-    .sort((left, right) => right.observed_at.localeCompare(left.observed_at));
+  const rows = pendingRows(file, agentId);
   return {
     version: 1,
-    targets: rows.slice(0, MAX_INBOX_AUDIT_TARGETS).map(({ agent_id: _agentId, ...target }) => ({ ...target, instruction: instruction(target) })),
+    targets: rows.slice(0, MAX_INBOX_AUDIT_TARGETS).map(({
+      agent_id: _agentId, status: _status, completed_at: _completedAt, completed_anchor: _completedAnchor, ...target
+    }) => ({ ...target, instruction: instruction(target) })),
     has_more: rows.length > MAX_INBOX_AUDIT_TARGETS,
     no_finding: "stay_silent",
   };
+}
+
+/** Mark currently pending targets for this Agent as completed so later audits do not repeat them. */
+export function completeInboxAuditTargets(file: string, agentId: string, now = new Date()): number {
+  const registry = load(file);
+  const completed_at = now.toISOString();
+  let count = 0;
+  for (const row of registry.targets) {
+    if (row.agent_id !== agentId || row.status !== "pending") continue;
+    row.status = "completed";
+    row.completed_at = completed_at;
+    row.completed_anchor = row.anchor;
+    count += 1;
+  }
+  if (count) save(file, registry);
+  return count;
 }

--- a/src/app/agent-cli.ts
+++ b/src/app/agent-cli.ts
@@ -8,7 +8,7 @@ import * as path from "node:path";
 import { createAgentStateStore, type AgentStateStore } from "../agent/agent-state-store.js";
 import * as larkinConfig from "../platform/config.js";
 import { projectInboxCheck, projectInboxEvents, type InboxEnvelope } from "../agent/inbox-projection.js";
-import { inboxAuditRegistryFile, readInboxAuditTargets } from "../agent/missed-outbound-scan.js";
+import { completeInboxAuditTargets, inboxAuditRegistryFile, readInboxAuditTargets } from "../agent/missed-outbound-scan.js";
 import { createReminderRoutes } from "../agent/reminder-routes.js";
 import { InteractionStateMachine } from "../agent/interaction-state-machine.js";
 import { issueCallbackProbe, readCallbackCapability } from "../platform/callback-capability.js";
@@ -175,7 +175,7 @@ function agentConfigRequest(
   const [operation = "show", ...rest] = argv;
   const authority = { kind: "agent" as const, agentId: agent.agentId };
   const options = parseOptions(rest, new Set(["--json"]));
-  const unknownFlags = [...options.values.keys()].filter((flag) => !["--agent", "--chat", "--model"].includes(flag));
+  const unknownFlags = [...options.values.keys()].filter((flag) => !["--agent", "--chat", "--model", "--interval"].includes(flag));
   if (unknownFlags.length) throw new Error(`config 不支持参数：${unknownFlags.join(", ")}；运行 larkin config --help`);
   const assertOnlyFlags = (valueFlags: readonly string[], booleanFlags: readonly string[] = []): void => {
     const allowedValues = new Set(valueFlags);
@@ -237,6 +237,20 @@ function agentConfigRequest(
     } else if (scope === "chat" && options.positionals.length === 3 && first?.startsWith("oc_") && ["inherit", "require", "free"].includes(second || "")) {
       mutation = { kind: "set-chat-mention", agentId: targetId, chatId: first, value: second as larkinConfig.MentionPolicyOverride };
     } else throw new Error("用法: larkin config mention global <require|free> | mention agent <inherit|require|free> | mention chat <oc_id> <inherit|require|free> [--agent <App ID>]");
+  } else if (operation === "inbox-audit") {
+    const [scope, first] = options.positionals;
+    if (scope === "global") assertOnlyFlags(["--interval"]);
+    else if (scope === "agent") assertOnlyFlags(["--agent", "--interval"]);
+    else assertOnlyFlags([]);
+    if (options.positionals.length !== 2) {
+      throw new Error("用法: larkin config inbox-audit global <on|off> [--interval <15m|1h>] | inbox-audit agent <inherit|on|off> [--agent <App ID>] [--interval <15m|inherit>]");
+    }
+    mutation = larkinConfig.inboxAuditMutationFromCli({
+      scope: scope || "",
+      enabled: first,
+      interval: options.values.get("--interval"),
+      agentId: targetId,
+    });
   } else if (operation === "apply") {
     assertOnlyFlags(["--agent"]);
     if (options.positionals.length) throw new Error("用法: larkin config apply [--agent <App ID>]");
@@ -246,7 +260,7 @@ function agentConfigRequest(
       larkinConfig.markConfigApplied(env, targetId, expectedSignature);
       return { ok: true, agentId: targetId, applyState: "applied", result };
     }).catch((error) => { throw new Error(`配置已保存但未应用：${error instanceof Error ? error.message : String(error)}`); });
-  } else throw new Error("config 只支持 show/runtime/model/effort/mention/apply；运行 larkin config --help");
+  } else throw new Error("config 只支持 show/runtime/model/effort/mention/inbox-audit/apply；运行 larkin config --help");
   const result = larkinConfig.mutateConfig(env, mutation, authority);
   return { ok: true, revision: result.revision, persisted: true, applyState: result.applyState, changedScope: result.changedScope };
 }
@@ -493,7 +507,10 @@ export function runAgentCli(
         if (options.positionals.length || options.values.size || options.booleans.size > 1) {
           throw new Error("inbox audit 只接受 --json");
         }
-        emitJson(io, readInboxAuditTargets(inboxAuditRegistryFile(config.larkinHome), agent.agentId));
+        const file = inboxAuditRegistryFile(config.larkinHome);
+        const audit = readInboxAuditTargets(file, agent.agentId);
+        completeInboxAuditTargets(file, agent.agentId);
+        emitJson(io, audit);
         return 0;
       }
       if (options.positionals.length || [...options.values.keys()].some((flag) => !["--target", "--limit"].includes(flag))) {

--- a/src/app/agent-config.ts
+++ b/src/app/agent-config.ts
@@ -56,6 +56,8 @@ type ConfigMutation =
   | { kind: "set-global-mention"; value: "require" | "free" }
   | { kind: "set-agent-mention"; agentId: string; value: "inherit" | "require" | "free" }
   | { kind: "set-chat-mention"; agentId: string; chatId: string; value: "inherit" | "require" | "free" }
+  | { kind: "set-global-inbox-audit"; enabled?: boolean; intervalMs?: number }
+  | { kind: "set-agent-inbox-audit"; agentId: string; enabled?: boolean | "inherit"; intervalMs?: number | "inherit" }
   | { kind: "set-agent-runtime"; agentId: string; runtime: string; model?: string }
   | { kind: "set-agent-model"; agentId: string; model: string }
   | { kind: "set-agent-effort"; agentId: string; effort: string | null };
@@ -139,12 +141,12 @@ const die = (message: string): never => {
 };
 
 if (!kind || !["agents", "model", "runtime", "effort", "pi-distribution", "chats", "config"].includes(kind)) {
-  die("用法: larkin agents | larkin config <show|mention|apply> | larkin model [<id>] | larkin runtime [<id>] [--model <id>] | larkin pi-distribution [show|builtin|external] | larkin effort [<level>|clear] | larkin chats [free|strict <oc_id>]");
+  die("用法: larkin agents | larkin config <show|mention|inbox-audit|apply> | larkin model [<id>] | larkin runtime [<id>] [--model <id>] | larkin pi-distribution [show|builtin|external] | larkin effort [<level>|clear] | larkin chats [free|strict <oc_id>]");
 }
 
 const allowedValueFlags: Record<string, ReadonlySet<string>> = {
   agents: new Set(), model: new Set(["--agent"]), runtime: new Set(["--agent", "--model"]),
-  effort: new Set(["--agent"]), "pi-distribution": new Set(["--agent", "--snapshot"]), chats: new Set(["--agent"]), config: new Set(["--agent", "--chat"]),
+  effort: new Set(["--agent"]), "pi-distribution": new Set(["--agent", "--snapshot"]), chats: new Set(["--agent"]), config: new Set(["--agent", "--chat", "--interval"]),
 };
 const allowedBooleanFlags: Record<string, ReadonlySet<string>> = {
   agents: new Set(["--json"]), model: new Set(), runtime: new Set(), effort: new Set(), "pi-distribution": new Set(["--import-external-profile"]), chats: new Set(), config: new Set(["--json"]),
@@ -172,6 +174,7 @@ for (let index = 0; index < rest.length; index += 1) {
 const flagAgent = parsedValues.get("--agent");
 const flagModel = parsedValues.get("--model");
 const flagChat = parsedValues.get("--chat");
+const flagInterval = parsedValues.get("--interval");
 const flagJson = parsedBooleans.has("--json");
 const importExternalProfile = parsedBooleans.has("--import-external-profile");
 const value = positionals[0];
@@ -218,11 +221,17 @@ if (kind === "agents") {
   } else if (operation === "mention" && scope === "chat") {
     assertOnlyFlags(["--agent"]);
     if (positionals.length !== 4) die("用法: larkin config mention chat <oc_id> <inherit|require|free> [--agent <App ID>]");
+  } else if (operation === "inbox-audit" && scope === "global") {
+    assertOnlyFlags(["--interval"]);
+    if (positionals.length !== 3) die("用法: larkin config inbox-audit global <on|off> [--interval <15m|1h>]");
+  } else if (operation === "inbox-audit" && scope === "agent") {
+    assertOnlyFlags(["--agent", "--interval"]);
+    if (positionals.length !== 3) die("用法: larkin config inbox-audit agent <inherit|on|off> [--agent <App ID>] [--interval <15m|inherit>]");
   } else if (operation === "apply") {
     assertOnlyFlags(["--agent"]);
     if (positionals.length !== 1) die("用法: larkin config apply [--agent <App ID>]");
   } else {
-    die("config 只支持 show/mention/apply；运行 larkin config --help");
+    die("config 只支持 show/mention/inbox-audit/apply；运行 larkin config --help");
   }
 }
 
@@ -391,11 +400,15 @@ if (kind === "config") {
     if (flagJson) say(JSON.stringify(view, null, 2));
     else {
       say(`全局群消息策略=${String(view.mentionPolicy)}（free 会唤醒所有继承它的 Agent）`);
+      const inboxAudit = view.inboxAudit as { enabled?: boolean; intervalMs?: number } | undefined;
+      say(`全局 Inbox Audit=${inboxAudit?.enabled ? "on" : "off"} interval=${larkinConfig.formatInboxAuditInterval(Number(inboxAudit?.intervalMs || larkinConfig.DEFAULT_INBOX_AUDIT_INTERVAL_MS))}（默认关闭；未 @ 的 require 群消息不会进入审计）`);
       for (const item of view.agents as Array<Record<string, unknown>>) {
         const mention = item.mention as { override: string; chat?: { chatId: string; override: string; effective: string; source: string } };
+        const agentAudit = item.inboxAudit as { override?: { enabled?: string; intervalMs?: number | "inherit" }; effective?: { enabled?: boolean; intervalMs?: number } };
         const apply = item.apply as { applyState?: string };
-        say(`agent=${item.agentId} runtime=${item.runtime} model=${item.model} effort=${item.effort || "default"} mention=${mention.override} apply=${apply.applyState || "unknown"}`);
+        say(`agent=${item.agentId} runtime=${item.runtime} model=${item.model} effort=${item.effort || "default"} mention=${mention.override} inbox-audit=${agentAudit?.override?.enabled || "inherit"} apply=${apply.applyState || "unknown"}`);
         if (mention.chat) say(`  chat=${mention.chat.chatId} override=${mention.chat.override} effective=${mention.chat.effective} source=${mention.chat.source}`);
+        if (agentAudit?.effective) say(`  inbox-audit effective=${agentAudit.effective.enabled ? "on" : "off"} interval=${larkinConfig.formatInboxAuditInterval(Number(agentAudit.effective.intervalMs || larkinConfig.DEFAULT_INBOX_AUDIT_INTERVAL_MS))}`);
       }
     }
     process.exit(0);
@@ -417,6 +430,18 @@ if (kind === "config") {
     say(JSON.stringify({ ok: true, revision: result.revision, persisted: result.persisted, applyState: result.applyState, changedScope: result.changedScope }, null, 2));
     process.exit(0);
   }
+  if (operation === "inbox-audit") {
+    try {
+      const result = larkinConfig.mutateConfig(process.env, larkinConfig.inboxAuditMutationFromCli({
+        scope: scope || "",
+        enabled: first,
+        interval: flagInterval,
+        agentId: scope === "agent" ? requireTarget() : (selected || keys[0] || ""),
+      }), authority);
+      say(JSON.stringify({ ok: true, revision: result.revision, persisted: result.persisted, applyState: result.applyState, changedScope: result.changedScope }, null, 2));
+    } catch (error) { die(error instanceof Error ? error.message : String(error)); }
+    process.exit(0);
+  }
   if (operation === "apply") {
     const agentId = requireTarget();
     const expectedSignature = larkinConfig.runtimeConfigSignature(config, agentId);
@@ -433,7 +458,7 @@ if (kind === "config") {
     } catch (error) { die(`配置已保存但未应用：${error instanceof Error ? error.message : String(error)}`); }
     process.exit(0);
   }
-  die("config 只支持 show/mention/apply");
+  die("config 只支持 show/mention/inbox-audit/apply");
 }
 let key = flagAgent;
 if (!key && runtimeAgentId) key = runtimeAgentId;

--- a/src/app/cli.ts
+++ b/src/app/cli.ts
@@ -83,6 +83,7 @@ Examples:
   larkin config show --agent cli_x --chat oc_x --json
   larkin config runtime pi --agent cli_x --model default
   larkin config mention chat oc_x free --agent cli_x
+  larkin config inbox-audit global on --interval 15m
 
 Credentials, internal paths, serverId, activeAgent, and raw config are never exposed here.`,
   session: `Usage: larkin session reset --agent <App ID> --json [--wait-ready <seconds>]

--- a/src/feishu/host-shell.ts
+++ b/src/feishu/host-shell.ts
@@ -19,15 +19,15 @@ import {
 import { ProcessingEyeOrchestrator } from "./host-processing-eye.js";
 import { projectInboxEnvelope, targetKeyOfInboxEnvelope } from "../agent/inbox-projection.js";
 import { HostReminderOrchestrator } from "../agent/host-reminder-orchestrator.js";
-import { InboxAuditHeartbeat } from "../agent/inbox-audit-heartbeat.js";
-import { inboxAuditRegistryFile, observeInboxAuditTarget } from "../agent/missed-outbound-scan.js";
+import { InboxAuditHeartbeat, INBOX_AUDIT_CADENCE_MS } from "../agent/inbox-audit-heartbeat.js";
+import { hasPendingInboxAuditTargets, inboxAuditRegistryFile, observeInboxAuditTarget } from "../agent/missed-outbound-scan.js";
 import { HostChannelBusiness } from "./host-channel-business.js";
 import { HostInteractionOrchestrator } from "./interaction-orchestrator.js";
 import { targetFor, type FeishuInboundEvent } from "./message-policy.js";
 import type { RuntimeHost, RuntimeHostEvent, RuntimeSessionRecoveryResult } from "../runtime/runtime-host.js";
 import { providerAuthenticationFailureReadiness, RuntimePrerequisiteError } from "../runtime/runtime-readiness.js";
 import { readDocumentCommentSubscription, verifyCallbackProbe, type EffectiveDocumentCommentSubscription } from "../platform/callback-capability.js";
-import { loadConfig, resolveMentionPolicy } from "../platform/config.js";
+import { loadConfig, resolveInboxAuditSchedule, resolveMentionPolicy } from "../platform/config.js";
 import { processCommandToken } from "../app/internal-command.js";
 import { managedOfficialLarkCli } from "../app/agent-lark-cli-workspace.js";
 import { isChannelReconnecting, isRuntimeReadinessCurrent } from "../app/agent-readiness.js";
@@ -416,13 +416,27 @@ export function createHostShell({
   };
   for (const agent of agents) prepareAgentState(agent);
   const reminder = new HostReminderOrchestrator({ agents, stateStore, envelopeProjector, deliveryTarget: runtimeHost, log });
+  const auditRegistry = inboxAuditRegistryFile(larkinHome);
   const inboxAudit = new InboxAuditHeartbeat({
     agents,
     stateStore,
     runtimeHost,
     log,
+    schedule(agent) {
+      try { return resolveInboxAuditSchedule(loadConfig(env).config, agent.agentId); }
+      catch (error) {
+        log(`inbox audit schedule 读取失败 agent=${agent.agentId}: ${errorMessage(error)}`);
+        return { enabled: false, intervalMs: INBOX_AUDIT_CADENCE_MS };
+      }
+    },
+    shouldDispatch(agent) {
+      try { return hasPendingInboxAuditTargets(auditRegistry, agent.agentId); }
+      catch (error) {
+        log(`inbox audit pending 读取失败 agent=${agent.agentId}: ${errorMessage(error)}`);
+        return false;
+      }
+    },
   });
-  const auditRegistry = inboxAuditRegistryFile(larkinHome);
   const seenEventIds = new Set<string>();
   const inFlightEventIds = new Set<string>();
   const onFeishuMessage = async (agent: ConfiguredAgent, event: FeishuInboundEvent, options?: { wake?: boolean }): Promise<void> => {
@@ -458,7 +472,7 @@ export function createHostShell({
         // append/dedupe decision is durable. Agent model-seen state is untouched.
         if (event.event_id) seenEventIds.add(eventKey);
         try {
-          observeInboxAuditTarget(auditRegistry, agent.agentId, event);
+          observeInboxAuditTarget(auditRegistry, agent.agentId, { ...event, wake });
         } catch (error) {
           log(`inbox audit target 未持久化: ${(error as Error).message}`);
         }

--- a/src/platform/config.ts
+++ b/src/platform/config.ts
@@ -22,6 +22,21 @@ type Obj = Record<string, unknown>;
 export type { RuntimeModels } from "../runtime/runtime-model-catalog.js";
 export type MentionPolicy = "require" | "free";
 export type MentionPolicyOverride = MentionPolicy | "inherit";
+export type InboxAuditEnabledOverride = boolean | "inherit";
+export type InboxAuditIntervalOverride = number | "inherit";
+
+export interface InboxAuditSettings {
+  enabled?: boolean;
+  intervalMs?: number;
+}
+export interface InboxAuditResolved {
+  enabled: boolean;
+  intervalMs: number;
+}
+
+export const DEFAULT_INBOX_AUDIT_INTERVAL_MS = 15 * 60_000;
+export const MIN_INBOX_AUDIT_INTERVAL_MS = 60_000;
+export const MAX_INBOX_AUDIT_INTERVAL_MS = 24 * 60 * 60_000;
 
 export interface StoredAgent {
   runtime: string;
@@ -30,6 +45,7 @@ export interface StoredAgent {
   effort?: string;
   mentionPolicy?: MentionPolicy;
   chatMentionPolicies?: Record<string, MentionPolicy>;
+  inboxAudit?: InboxAuditSettings;
   createdAt?: string;
 }
 
@@ -50,6 +66,7 @@ export interface HydratedConfig {
   version: 4;
   serverId: string | null;
   mentionPolicy: MentionPolicy;
+  inboxAudit?: InboxAuditResolved;
   configDir: string;
   larkinHome: string;
   larkConfigDir: string;
@@ -62,6 +79,8 @@ export type ConfigMutation =
   | { kind: "set-global-mention"; value: MentionPolicy }
   | { kind: "set-agent-mention"; agentId: string; value: MentionPolicyOverride }
   | { kind: "set-chat-mention"; agentId: string; chatId: string; value: MentionPolicyOverride }
+  | { kind: "set-global-inbox-audit"; enabled?: boolean; intervalMs?: number }
+  | { kind: "set-agent-inbox-audit"; agentId: string; enabled?: InboxAuditEnabledOverride; intervalMs?: InboxAuditIntervalOverride }
   | { kind: "set-agent-runtime"; agentId: string; runtime: string; model?: string }
   | { kind: "set-agent-pi-distribution"; agentId: string; distribution: "builtin" | "external" }
   | { kind: "set-agent-model"; agentId: string; model: string }
@@ -83,8 +102,10 @@ interface ConfigApplyFile { version: 1; persistedRevision: string; agents: Recor
 
 const TOP_FIELDS_V3 = new Set(["version", "serverId", "activeAgent", "agents"]);
 const TOP_FIELDS_V4 = new Set(["version", "serverId", "mentionPolicy", "activeAgent", "agents"]);
+const OPTIONAL_TOP_FIELDS_V4 = new Set(["inboxAudit"]);
 const AGENT_FIELDS_V3 = new Set(["runtime", "model", "effort", "noMentionChats", "createdAt"]);
-const AGENT_FIELDS_V4 = new Set(["runtime", "model", "piDistribution", "effort", "mentionPolicy", "chatMentionPolicies", "createdAt"]);
+const AGENT_FIELDS_V4 = new Set(["runtime", "model", "piDistribution", "effort", "mentionPolicy", "chatMentionPolicies", "inboxAudit", "createdAt"]);
+const INBOX_AUDIT_FIELDS = new Set(["enabled", "intervalMs"]);
 const APP_ID = /^cli_[A-Za-z0-9]+$/;
 const CHAT_ID = /^oc_[A-Za-z0-9_-]+$/;
 const PI_EFFORTS = new Set(["off", "minimal", "low", "medium", "high", "xhigh", "max"]);
@@ -150,6 +171,88 @@ function assertPolicy(value: unknown, label: string): asserts value is MentionPo
   if (value !== "require" && value !== "free") throw new Error(`${label} 只允许 require/free`);
 }
 
+export function assertInboxAuditInterval(value: unknown, label = "inbox-audit interval"): asserts value is number {
+  if (typeof value !== "number" || !Number.isSafeInteger(value) || value < MIN_INBOX_AUDIT_INTERVAL_MS || value > MAX_INBOX_AUDIT_INTERVAL_MS) {
+    throw new Error(`${label} 必须是 ${MIN_INBOX_AUDIT_INTERVAL_MS}–${MAX_INBOX_AUDIT_INTERVAL_MS} 毫秒`);
+  }
+}
+
+export function parseInboxAuditInterval(value: string): number {
+  if (typeof value !== "string" || !value) throw new Error("inbox-audit interval 不能为空");
+  let milliseconds: number;
+  if (/^[1-9]\d*$/.test(value)) milliseconds = Number(value);
+  else {
+    const match = /^([1-9]\d*)(m|h)$/.exec(value);
+    if (!match) throw new Error("inbox-audit interval 只允许 15m/1h 或 60000–86400000 毫秒");
+    milliseconds = Number(match[1]) * (match[2] === "h" ? 3_600_000 : 60_000);
+  }
+  assertInboxAuditInterval(milliseconds);
+  return milliseconds;
+}
+
+export function formatInboxAuditInterval(intervalMs: number): string {
+  if (intervalMs % 3_600_000 === 0) return `${intervalMs / 3_600_000}h`;
+  if (intervalMs % 60_000 === 0) return `${intervalMs / 60_000}m`;
+  return `${intervalMs}ms`;
+}
+
+function parseStoredInboxAudit(value: unknown, label: string): InboxAuditSettings {
+  if (!isPlainObject(value)) throw new Error(`${label} 必须是普通 object`);
+  assertAllowedFields(value, INBOX_AUDIT_FIELDS, label);
+  const settings: InboxAuditSettings = {};
+  if (Object.hasOwn(value, "enabled")) {
+    if (typeof value.enabled !== "boolean") throw new Error(`${label}.enabled 必须是 boolean`);
+    settings.enabled = value.enabled;
+  }
+  if (Object.hasOwn(value, "intervalMs")) {
+    assertInboxAuditInterval(value.intervalMs, `${label}.intervalMs`);
+    settings.intervalMs = value.intervalMs;
+  }
+  return settings;
+}
+
+function resolvedInboxAudit(settings: InboxAuditSettings | undefined): InboxAuditResolved {
+  return {
+    enabled: settings?.enabled ?? false,
+    intervalMs: settings?.intervalMs ?? DEFAULT_INBOX_AUDIT_INTERVAL_MS,
+  };
+}
+
+export function inboxAuditMutationFromCli(input: {
+  scope: string;
+  enabled: string | undefined;
+  interval: string | undefined;
+  agentId: string;
+}): ConfigMutation {
+  if (input.scope === "global") {
+    if (input.enabled !== "on" && input.enabled !== "off") {
+      throw new Error("用法: larkin config inbox-audit global <on|off> [--interval <15m|1h>]");
+    }
+    const mutation: Extract<ConfigMutation, { kind: "set-global-inbox-audit" }> = {
+      kind: "set-global-inbox-audit", enabled: input.enabled === "on",
+    };
+    if (input.interval !== undefined) {
+      if (input.interval === "inherit") throw new Error("全局 inbox-audit 不支持 interval=inherit");
+      mutation.intervalMs = parseInboxAuditInterval(input.interval);
+    }
+    return mutation;
+  }
+  if (input.scope === "agent") {
+    if (input.enabled !== "on" && input.enabled !== "off" && input.enabled !== "inherit") {
+      throw new Error("用法: larkin config inbox-audit agent <inherit|on|off> [--agent <App ID>] [--interval <15m|inherit>]");
+    }
+    const mutation: Extract<ConfigMutation, { kind: "set-agent-inbox-audit" }> = {
+      kind: "set-agent-inbox-audit", agentId: input.agentId,
+      enabled: input.enabled === "inherit" ? "inherit" : input.enabled === "on",
+    };
+    if (input.interval !== undefined) {
+      mutation.intervalMs = input.interval === "inherit" ? "inherit" : parseInboxAuditInterval(input.interval);
+    }
+    return mutation;
+  }
+  throw new Error("inbox-audit scope 只支持 global/agent");
+}
+
 function assertModel(runtime: string, model: string): void {
   if (model === "default") return;
   const safe = runtime === "pi" ? PI_MODEL.test(model)
@@ -188,6 +291,7 @@ function validateStoredAgent(key: string, agent: unknown, version: 3 | 4): asser
     }
   }
   if (version === 4 && Object.hasOwn(agent, "mentionPolicy")) assertPolicy(agent.mentionPolicy, `Agent ${key}.mentionPolicy`);
+  if (version === 4 && Object.hasOwn(agent, "inboxAudit")) parseStoredInboxAudit(agent.inboxAudit, `Agent ${key}.inboxAudit`);
   if (version === 4 && Object.hasOwn(agent, "chatMentionPolicies")) {
     if (!isPlainObject(agent.chatMentionPolicies)) throw new Error(`Agent ${key}.chatMentionPolicies 必须是普通 object`);
     for (const [chatId, policy] of Object.entries(agent.chatMentionPolicies)) {
@@ -213,6 +317,7 @@ function hydratedStoredAgent(key: string, agent: Obj, version: 3 | 4): StoredAge
     ...(agent.piDistribution === "external" || agent.piDistribution === "builtin" ? { piDistribution: agent.piDistribution } : {}),
     ...(typeof agent.effort === "string" ? { effort: agent.effort } : {}),
     ...(version === 4 && (agent.mentionPolicy === "require" || agent.mentionPolicy === "free") ? { mentionPolicy: agent.mentionPolicy } : {}),
+    ...(version === 4 && Object.hasOwn(agent, "inboxAudit") ? { inboxAudit: parseStoredInboxAudit(agent.inboxAudit, `Agent ${key}.inboxAudit`) } : {}),
     ...(Object.keys(chatMentionPolicies).length ? { chatMentionPolicies, noMentionChats: Object.entries(chatMentionPolicies).filter(([, policy]) => policy === "free").map(([chatId]) => chatId) } : {}),
     ...(typeof agent.createdAt === "string" ? { createdAt: agent.createdAt } : {}),
   };
@@ -228,6 +333,7 @@ export function hydrateAgent(key: string, agent: StoredAgent & { noMentionChats?
     larkConfigDir: path.join(layout.agentStateDir(key), "lark-cli-config"),
     ...(agent.effort ? { effort: agent.effort } : {}),
     ...(agent.mentionPolicy ? { mentionPolicy: agent.mentionPolicy } : {}),
+    ...(agent.inboxAudit ? { inboxAudit: { ...agent.inboxAudit } } : {}),
     ...(agent.chatMentionPolicies ? { chatMentionPolicies: { ...agent.chatMentionPolicies } } : {}),
     ...(agent.noMentionChats ? { noMentionChats: [...agent.noMentionChats] } : {}),
     ...(agent.createdAt ? { createdAt: agent.createdAt } : {}),
@@ -244,7 +350,7 @@ export function normalizeConfig(raw: unknown, configDir: string, { mint }: { min
   const version = raw.version;
   if (version !== 3 && version !== 4) throw new Error("不支持该配置格式：larkin 只接受 version=3/4");
   const topFields = version === 3 ? TOP_FIELDS_V3 : TOP_FIELDS_V4;
-  assertAllowedFields(raw, topFields, "config");
+  assertAllowedFields(raw, version === 4 ? new Set([...TOP_FIELDS_V4, ...OPTIONAL_TOP_FIELDS_V4]) : topFields, "config");
   for (const field of topFields) if (!Object.hasOwn(raw, field)) throw new Error(`config 缺少必需字段 ${field}`);
   if (typeof raw.serverId !== "string" || !raw.serverId) throw new Error("config.serverId 必须是非空字符串");
   if (version === 4) assertPolicy(raw.mentionPolicy, "config.mentionPolicy");
@@ -254,8 +360,12 @@ export function normalizeConfig(raw: unknown, configDir: string, { mint }: { min
   if (raw.activeAgent !== null && !Object.hasOwn(raw.agents, raw.activeAgent)) throw new Error(`config.activeAgent 指向不存在的 Agent：${raw.activeAgent}`);
   const agents: Record<string, HydratedAgent> = {};
   for (const [key, agent] of Object.entries(raw.agents)) agents[key] = hydrateAgent(key, hydratedStoredAgent(key, agent as Obj, version), layout.root);
+  const inboxAudit = version === 4 && Object.hasOwn(raw, "inboxAudit")
+    ? resolvedInboxAudit(parseStoredInboxAudit(raw.inboxAudit, "config.inboxAudit"))
+    : undefined;
   return {
     version: 4, serverId: raw.serverId, mentionPolicy: version === 4 ? raw.mentionPolicy as MentionPolicy : "require",
+    ...(inboxAudit ? { inboxAudit } : {}),
     configDir: layout.configDir, larkinHome: layout.larkinHome, larkConfigDir: resolveLarkConfigDir({}, layout.root), activeAgent: raw.activeAgent as string | null, agents,
   };
 }
@@ -336,14 +446,23 @@ export function selectAgent(config: HydratedConfig, env: Env = process.env): Hyd
   return agents[config.activeAgent];
 }
 
-export function toStored(config: HydratedConfig): { version: 4; serverId: string | null; mentionPolicy: MentionPolicy; activeAgent: string | null; agents: Record<string, StoredAgent> } {
-  const out = { version: 4 as const, serverId: config.serverId, mentionPolicy: config.mentionPolicy, activeAgent: config.activeAgent, agents: {} as Record<string, StoredAgent> };
+export function toStored(config: HydratedConfig): {
+  version: 4; serverId: string | null; mentionPolicy: MentionPolicy; inboxAudit?: InboxAuditResolved;
+  activeAgent: string | null; agents: Record<string, StoredAgent>;
+} {
+  const out: ReturnType<typeof toStored> = {
+    version: 4, serverId: config.serverId, mentionPolicy: config.mentionPolicy, activeAgent: config.activeAgent, agents: {},
+  };
+  if (config.inboxAudit) out.inboxAudit = { enabled: config.inboxAudit.enabled, intervalMs: config.inboxAudit.intervalMs };
   for (const [key, agent] of Object.entries(config.agents || {})) {
     const stored: StoredAgent = { runtime: agent.runtime, model: agent.model };
     if (agent.piDistribution) stored.piDistribution = agent.piDistribution;
     if (typeof agent.effort === "string" && agent.effort) stored.effort = agent.effort;
     if (agent.mentionPolicy) stored.mentionPolicy = agent.mentionPolicy;
     if (agent.chatMentionPolicies && Object.keys(agent.chatMentionPolicies).length) stored.chatMentionPolicies = { ...agent.chatMentionPolicies };
+    if (agent.inboxAudit && (agent.inboxAudit.enabled !== undefined || agent.inboxAudit.intervalMs !== undefined)) {
+      stored.inboxAudit = { ...agent.inboxAudit };
+    }
     if (typeof agent.createdAt === "string" && agent.createdAt) stored.createdAt = agent.createdAt;
     out.agents[key] = stored;
   }
@@ -370,6 +489,23 @@ export function resolveAgentGlobalMentionPolicy(config: HydratedConfig, agentId:
   return { effective: config.mentionPolicy, source: "global" };
 }
 
+export function resolveInboxAuditSchedule(config: HydratedConfig, agentId: string): InboxAuditResolved & {
+  enabledSource: "agent" | "global" | "default";
+  intervalSource: "agent" | "global" | "default";
+} {
+  const agent = config.agents[agentId];
+  if (!agent) throw new Error(`Agent 不存在：${agentId}`);
+  const enabled = agent.inboxAudit?.enabled ?? config.inboxAudit?.enabled ?? false;
+  const intervalMs = agent.inboxAudit?.intervalMs ?? config.inboxAudit?.intervalMs ?? DEFAULT_INBOX_AUDIT_INTERVAL_MS;
+  assertInboxAuditInterval(intervalMs);
+  return {
+    enabled,
+    intervalMs,
+    enabledSource: agent.inboxAudit?.enabled !== undefined ? "agent" : config.inboxAudit ? "global" : "default",
+    intervalSource: agent.inboxAudit?.intervalMs !== undefined ? "agent" : config.inboxAudit?.intervalMs !== undefined ? "global" : "default",
+  };
+}
+
 function revision(bytes: Buffer | string): string {
   return `sha256:${crypto.createHash("sha256").update(bytes).digest("hex")}`;
 }
@@ -381,6 +517,7 @@ function agentSignature(config: HydratedConfig, agentId: string): string {
   return revision(JSON.stringify({
     runtime: agent.runtime, model: agent.model, piDistribution: agent.piDistribution ?? null, effort: agent.effort ?? null,
     globalMentionPolicy: config.mentionPolicy, agentMentionPolicy: agent.mentionPolicy ?? null, chatMentionPolicies: chats,
+    globalInboxAudit: config.inboxAudit ?? null, agentInboxAudit: agent.inboxAudit ?? null,
   }));
 }
 
@@ -558,11 +695,36 @@ function applyMutation(config: HydratedConfig, mutation: ConfigMutation): { scop
     config.mentionPolicy = mutation.value;
     return { scope: "global", runtimeChange: false, affectedAgentIds: Object.keys(config.agents) };
   }
+  if (mutation.kind === "set-global-inbox-audit") {
+    if (mutation.enabled === undefined && mutation.intervalMs === undefined) throw new Error("inbox-audit 全局变更必须包含 enabled 或 interval");
+    const current = resolvedInboxAudit(config.inboxAudit);
+    if (mutation.enabled !== undefined) current.enabled = mutation.enabled;
+    if (mutation.intervalMs !== undefined) {
+      assertInboxAuditInterval(mutation.intervalMs, "全局 inbox-audit interval");
+      current.intervalMs = mutation.intervalMs;
+    }
+    config.inboxAudit = current;
+    return { scope: "global", runtimeChange: false, affectedAgentIds: Object.keys(config.agents) };
+  }
   if (!APP_ID.test(mutation.agentId) || !config.agents[mutation.agentId]) throw new Error(`Agent 不存在：${mutation.agentId}`);
   const agent = config.agents[mutation.agentId];
   if (mutation.kind === "set-agent-mention") {
     if (mutation.value === "inherit") delete agent.mentionPolicy;
     else { assertPolicy(mutation.value, "Agent mention policy"); agent.mentionPolicy = mutation.value; }
+    return { scope: "agent", agentId: mutation.agentId, runtimeChange: false, affectedAgentIds: [mutation.agentId] };
+  }
+  if (mutation.kind === "set-agent-inbox-audit") {
+    if (mutation.enabled === undefined && mutation.intervalMs === undefined) throw new Error("inbox-audit Agent 变更必须包含 enabled 或 interval");
+    const current: InboxAuditSettings = { ...(agent.inboxAudit || {}) };
+    if (mutation.enabled === "inherit") delete current.enabled;
+    else if (mutation.enabled !== undefined) current.enabled = mutation.enabled;
+    if (mutation.intervalMs === "inherit") delete current.intervalMs;
+    else if (mutation.intervalMs !== undefined) {
+      assertInboxAuditInterval(mutation.intervalMs, "Agent inbox-audit interval");
+      current.intervalMs = mutation.intervalMs;
+    }
+    if (current.enabled === undefined && current.intervalMs === undefined) delete agent.inboxAudit;
+    else agent.inboxAudit = current;
     return { scope: "agent", agentId: mutation.agentId, runtimeChange: false, affectedAgentIds: [mutation.agentId] };
   }
   if (mutation.kind === "set-chat-mention") {
@@ -965,8 +1127,24 @@ export function safeConfigView(config: HydratedConfig, onlyAgentId?: string, cha
       source: agent.mentionPolicy ? "agent" : "global",
       ...(chatId ? { chat: { chatId, override: agent.chatMentionPolicies?.[chatId] ?? "inherit", ...resolveMentionPolicy(config, agentId, chatId) } } : {}),
     },
+    inboxAudit: (() => {
+      const resolved = resolveInboxAuditSchedule(config, agentId);
+      return {
+        override: {
+          enabled: agent.inboxAudit?.enabled === undefined ? "inherit" : agent.inboxAudit.enabled ? "on" : "off",
+          intervalMs: agent.inboxAudit?.intervalMs ?? "inherit",
+        },
+        effective: { enabled: resolved.enabled, intervalMs: resolved.intervalMs },
+        source: { enabled: resolved.enabledSource, intervalMs: resolved.intervalSource },
+      };
+    })(),
     chatMentionPolicies: { ...(agent.chatMentionPolicies || {}) },
     apply: (applyState?.agents as Record<string, unknown> | undefined)?.[agentId] ?? { applyState: "unknown" },
   }));
-  return { version: 4, mentionPolicy: config.mentionPolicy, persistedRevision: applyState?.persistedRevision ?? "unknown", agents };
+  const inboxAudit = resolvedInboxAudit(config.inboxAudit);
+  return {
+    version: 4, mentionPolicy: config.mentionPolicy,
+    inboxAudit: { enabled: inboxAudit.enabled, intervalMs: inboxAudit.intervalMs },
+    persistedRevision: applyState?.persistedRevision ?? "unknown", agents,
+  };
 }

--- a/test/integration/build/standalone-binary-acceptance.test.mjs
+++ b/test/integration/build/standalone-binary-acceptance.test.mjs
@@ -159,7 +159,7 @@ readline.createInterface({ input: process.stdin }).on("line", (line) => {
     assert.match(checked(runCli(["--help"]), "standalone help").stdout, /Usage:\s*larkin <command>/);
     assert.equal(checked(runCli(["--version"]), "standalone version").stdout.trim(), `larkin ${PACKAGE.version}`);
     const configHelp = checked(runCli(["help", "config"]), "standalone config help").stdout;
-    for (const token of ["config runtime", "config model", "config effort", "config mention global", "config mention agent", "config mention chat", "config apply", "--agent", "--chat"]) {
+    for (const token of ["config runtime", "config model", "config effort", "config mention global", "config mention agent", "config mention chat", "config inbox-audit global", "config inbox-audit agent", "config apply", "--agent", "--chat", "--interval"]) {
       assert.match(configHelp, new RegExp(token), `config help missing ${token}`);
     }
     assert.equal(JSON.parse(checked(runCli(["config", "show", "--agent", appId, "--json"]), "config show").stdout).agents[0].agentId, appId);

--- a/test/unit/agent/missed-outbound-scan.test.mjs
+++ b/test/unit/agent/missed-outbound-scan.test.mjs
@@ -5,15 +5,18 @@ import path from "node:path";
 import { spawnSync } from "node:child_process";
 import { test } from "bun:test";
 import {
+  completeInboxAuditTargets,
+  hasPendingInboxAuditTargets,
   inboxAuditRegistryFile,
   MAX_INBOX_AUDIT_TARGETS,
   observeInboxAuditTarget,
   readInboxAuditTargets,
 } from "../../../src/agent/missed-outbound-scan.ts";
-import { InboxAuditHeartbeat } from "../../../src/agent/inbox-audit-heartbeat.ts";
+import { InboxAuditHeartbeat, INBOX_AUDIT_CADENCE_MS } from "../../../src/agent/inbox-audit-heartbeat.ts";
 
 const CHAT = "oc_7961b9d7be893b46520a926b90cf46eb";
 const ROUTING_SINK = path.resolve(import.meta.dirname, "../../support/inbox-audit-routing-sink.mjs");
+const WAKE = { chat_id: CHAT, chat_type: "group", wake: true, _scan_authority: true, _sender_is_bot: false };
 
 function reportFindingToControlledSink(audit, finding, traceFile) {
   const source = finding && audit.targets.find((row) => row.target === finding.target && row.anchor === finding.anchor);
@@ -27,15 +30,16 @@ function reportFindingToControlledSink(audit, finding, traceFile) {
   });
 }
 
-test("audit registry retains only authoritative human group/topic targets with their om_ anchor", () => {
+test("audit registry retains only originally wake=true human group/topic targets with their om_ anchor", () => {
   const root = fs.mkdtempSync(path.join(os.tmpdir(), "larkin-inbox-audit-"));
   try {
     const file = inboxAuditRegistryFile(root);
-    const common = { chat_id: CHAT, chat_type: "group", _scan_authority: true, _sender_is_bot: false };
-    assert.equal(observeInboxAuditTarget(file, "cli_audit", { ...common, message_id: "om_chat" }), true);
-    assert.equal(observeInboxAuditTarget(file, "cli_audit", { ...common, thread_id: "omt_topic", message_id: "om_topic" }), true);
-    assert.equal(observeInboxAuditTarget(file, "cli_audit", { ...common, chat_type: "p2p", message_id: "om_dm" }), false);
-    assert.equal(observeInboxAuditTarget(file, "cli_audit", { ...common, _sender_is_bot: true, message_id: "om_bot" }), false);
+    assert.equal(observeInboxAuditTarget(file, "cli_audit", { ...WAKE, message_id: "om_chat" }), true);
+    assert.equal(observeInboxAuditTarget(file, "cli_audit", { ...WAKE, thread_id: "omt_topic", message_id: "om_topic" }), true);
+    assert.equal(observeInboxAuditTarget(file, "cli_audit", { ...WAKE, chat_type: "p2p", message_id: "om_dm" }), false);
+    assert.equal(observeInboxAuditTarget(file, "cli_audit", { ...WAKE, _sender_is_bot: true, message_id: "om_bot" }), false);
+    assert.equal(observeInboxAuditTarget(file, "cli_audit", { ...WAKE, wake: false, message_id: "om_unmentioned" }), false, "require unmentioned traffic must not enter audit");
+    assert.equal(observeInboxAuditTarget(file, "cli_audit", { ...WAKE, wake: undefined, message_id: "om_missing_wake" }), false);
     const audit = readInboxAuditTargets(file, "cli_audit");
     assert.equal(audit.targets.length, 2);
     assert.equal(audit.targets.every((row) => row.target.startsWith("chat:") || row.target.startsWith("thread:")), true);
@@ -43,7 +47,7 @@ test("audit registry retains only authoritative human group/topic targets with t
     assert.equal(audit.targets.every((row) => /existing guarded larkin im reply/.test(row.instruction)), true);
     assert.equal(audit.no_finding, "stay_silent");
     for (let index = 0; index < MAX_INBOX_AUDIT_TARGETS + 2; index += 1) {
-      observeInboxAuditTarget(file, "cli_other", { ...common, chat_id: `oc_${index}a`, message_id: `om_other${index}` });
+      observeInboxAuditTarget(file, "cli_other", { ...WAKE, chat_id: `oc_${index}a`, message_id: `om_other${index}` });
     }
     const retained = readInboxAuditTargets(file, "cli_other");
     assert.equal(retained.targets.length, MAX_INBOX_AUDIT_TARGETS);
@@ -57,15 +61,14 @@ test("controlled audit sink routes only a concrete thread finding to its om_ anc
     const file = inboxAuditRegistryFile(root);
     const traceFile = path.join(root, "provider-writes.ndjson");
     fs.writeFileSync(traceFile, "", { mode: 0o600 });
-    const common = { chat_id: CHAT, chat_type: "group", _scan_authority: true, _sender_is_bot: false };
     assert.equal(observeInboxAuditTarget(file, "cli_audit", {
-      ...common, thread_id: "omt_auditthread", message_id: "om_audit_thread_anchor",
+      ...WAKE, thread_id: "omt_auditthread", message_id: "om_audit_thread_anchor",
     }), true);
     assert.equal(observeInboxAuditTarget(file, "cli_audit", {
-      ...common, chat_type: "p2p", message_id: "om_dm_anchor",
+      ...WAKE, chat_type: "p2p", message_id: "om_dm_anchor",
     }), false, "DM sources must not enter audit routing");
     assert.equal(observeInboxAuditTarget(file, "cli_audit", {
-      ...common, message_id: "rem_invalid_anchor",
+      ...WAKE, message_id: "rem_invalid_anchor",
     }), false, "non-om_ anchors must not enter audit routing");
 
     const audit = readInboxAuditTargets(file, "cli_audit");
@@ -85,26 +88,61 @@ test("controlled audit sink routes only a concrete thread finding to its om_ anc
   } finally { fs.rmSync(root, { recursive: true, force: true }); }
 });
 
-test("one Host timer callback delivers targetless runtime audit wakes to multiple agents", async () => {
+test("completed and v1 audit targets are not returned or re-observed", () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "larkin-inbox-audit-complete-"));
+  try {
+    const file = inboxAuditRegistryFile(root);
+    fs.writeFileSync(file, `${JSON.stringify({
+      version: 1,
+      targets: [{ agent_id: "cli_audit", target: `chat:${CHAT}`, anchor: "om_legacy", observed_at: "2026-07-20T00:00:00.000Z" }],
+    })}\n`, { mode: 0o600 });
+    assert.equal(readInboxAuditTargets(file, "cli_audit").targets.length, 0, "v1 rows cannot prove originally-wake=true and must be discarded");
+    assert.equal(observeInboxAuditTarget(file, "cli_audit", { ...WAKE, message_id: "om_pending" }), true);
+    assert.equal(hasPendingInboxAuditTargets(file, "cli_audit"), true);
+    assert.equal(completeInboxAuditTargets(file, "cli_audit", new Date("2026-07-21T00:00:00.000Z")), 1);
+    assert.equal(readInboxAuditTargets(file, "cli_audit").targets.length, 0);
+    assert.equal(hasPendingInboxAuditTargets(file, "cli_audit"), false);
+    assert.equal(observeInboxAuditTarget(file, "cli_audit", { ...WAKE, message_id: "om_pending" }), false, "same completed anchor must not reopen");
+    assert.equal(observeInboxAuditTarget(file, "cli_audit", { ...WAKE, message_id: "om_new" }), true, "a new originally-wake=true anchor may reopen the target");
+    assert.equal(readInboxAuditTargets(file, "cli_audit").targets[0].anchor, "om_new");
+    assert.equal(JSON.parse(fs.readFileSync(file, "utf8")).version, 2);
+  } finally { fs.rmSync(root, { recursive: true, force: true }); }
+});
+
+test("one Host timer per Agent skips disabled or empty audits and uses configured cadence", async () => {
   const timers = [];
   const inbox = [];
   const deliveries = [];
+  const pending = new Set(["cli_auditOne"]);
+  const schedule = {
+    cli_auditOne: { enabled: true, intervalMs: 60_000 },
+    cli_auditTwo: { enabled: true, intervalMs: 120_000 },
+    cli_auditOff: { enabled: false, intervalMs: INBOX_AUDIT_CADENCE_MS },
+  };
   const heartbeat = new InboxAuditHeartbeat({
-    agents: [{ agentId: "cli_auditOne" }, { agentId: "cli_auditTwo" }],
+    agents: [{ agentId: "cli_auditOne" }, { agentId: "cli_auditTwo" }, { agentId: "cli_auditOff" }],
     stateStore: () => ({ appendCanonicalInboxOnce(envelope) { inbox.push(envelope); return { status: "appended", envelope }; } }),
     runtimeHost: { async deliver(agentId, envelope) { deliveries.push({ agentId, envelope }); } },
     now: () => 1234,
     setTimer(callback, delay) { timers.push({ callback, delay }); return { unref() {} }; },
     clearTimer() {},
+    schedule(agent) { return schedule[agent.agentId]; },
+    shouldDispatch(agent) { return pending.has(agent.agentId); },
   });
   heartbeat.start();
   heartbeat.start();
-  assert.equal(timers.length, 1, "multiple agents still share one Host timer");
-  assert.equal(timers[0].delay, 15 * 60_000);
-  await timers[0].callback();
-  assert.equal(timers.length, 2, "callback re-arms one successor timer");
-  assert.equal(deliveries.length, 2);
-  assert.equal(inbox.every((row) => row.target === "runtime:reminder" && row.kind === "reminder"), true);
-  assert.equal(inbox.every((row) => !Object.hasOwn(row, "deliveryTarget") && !Object.hasOwn(row, "deliveryAnchor")), true);
+  assert.equal(timers.length, 3, "each Agent has its own Host timer");
+  assert.deepEqual(timers.map((timer) => timer.delay).sort((left, right) => left - right), [60_000, 120_000, INBOX_AUDIT_CADENCE_MS]);
+  await Promise.all([timers[0].callback(), timers[1].callback(), timers[2].callback()]);
+  assert.equal(deliveries.length, 1);
+  assert.equal(deliveries[0].agentId, "cli_auditOne");
+  assert.equal(inbox[0].target, "runtime:reminder");
+  assert.equal(Object.hasOwn(inbox[0], "deliveryTarget"), false);
+  assert.equal(Object.hasOwn(inbox[0], "deliveryAnchor"), false);
+  pending.delete("cli_auditOne");
+  const rearmed = timers.filter((timer) => timer.delay === 60_000);
+  assert.equal(rearmed.length, 2, "enabled Agent re-arms after fire");
+  await rearmed[1].callback();
+  assert.equal(deliveries.length, 1, "no pending originally-wake=true work must not wake the model");
   heartbeat.stop();
 });

--- a/test/unit/app/agent-cli.test.mjs
+++ b/test/unit/app/agent-cli.test.mjs
@@ -45,7 +45,7 @@ test("Agent CLI manifest is the single machine-readable public command inventory
   assert.deepEqual(cliModule.AGENT_CLI_CAPABILITIES.commands.reminder, ["schedule", "list", "snooze", "update", "cancel", "log"]);
   assert.deepEqual(cliModule.AGENT_CLI_CAPABILITIES.commands.interaction, ["callback-status", "callback-probe", "create", "get", "resolve"]);
   assert.deepEqual(cliModule.AGENT_CLI_CAPABILITIES.commands.profile, ["show"]);
-  assert.deepEqual(cliModule.AGENT_CLI_CAPABILITIES.commands.config, ["show", "runtime", "model", "effort", "mention", "apply"]);
+  assert.deepEqual(cliModule.AGENT_CLI_CAPABILITIES.commands.config, ["show", "runtime", "model", "effort", "mention", "inbox-audit", "apply"]);
   const f = fixture();
   try {
     const help = JSON.parse(f.run(["--help"]).stdout);
@@ -133,6 +133,9 @@ test("Agent config commands reject extra positionals and operation-inapplicable 
       ["mention", "chat", "oc_self", "free", "--json"],
       ["apply", "extra"],
       ["apply", "--chat", "oc_irrelevant"],
+      ["inbox-audit", "global", "on", "extra"],
+      ["inbox-audit", "global", "on", "--agent", f.agentId],
+      ["inbox-audit", "agent", "on", "--chat", "oc_irrelevant"],
     ];
     for (const args of invalidCases) {
       const rejected = f.run(["config", ...args]);
@@ -287,8 +290,8 @@ let input="";process.stdin.on("data",c=>{input+=c;for(;;){const i=input.indexOf(
 test("inbox audit returns bounded group/topic instructions without a delivery side effect", () => {
   const f = fixture();
   try {
-    fs.writeFileSync(path.join(f.root, "inbox-audit.json"), JSON.stringify({ version: 1, targets: [{
-      agent_id: f.agentId, target: "thread:oc_audit:omt_audit", anchor: "om_audit", observed_at: "2026-07-20T00:00:00.000Z",
+    fs.writeFileSync(path.join(f.root, "inbox-audit.json"), JSON.stringify({ version: 2, targets: [{
+      agent_id: f.agentId, target: "thread:oc_audit:omt_audit", anchor: "om_audit", observed_at: "2026-07-20T00:00:00.000Z", status: "pending",
     }] }), { mode: 0o600 });
     const result = f.run(["inbox", "audit", "--json"]);
     assert.equal(result.code, 0, result.stderr);
@@ -296,6 +299,9 @@ test("inbox audit returns bounded group/topic instructions without a delivery si
     assert.deepEqual(body.targets.map((row) => ({ target: row.target, anchor: row.anchor })), [{ target: "thread:oc_audit:omt_audit", anchor: "om_audit" }]);
     assert.match(body.targets[0].instruction, /threads-messages-list/);
     assert.equal(body.no_finding, "stay_silent");
+    const second = f.run(["inbox", "audit", "--json"]);
+    assert.equal(second.code, 0, second.stderr);
+    assert.deepEqual(JSON.parse(second.stdout).targets, [], "reported targets must not be scanned again");
   } finally { fs.rmSync(f.root, { recursive: true, force: true }); }
 });
 

--- a/test/unit/feishu/inbox-audit-require-host.test.mjs
+++ b/test/unit/feishu/inbox-audit-require-host.test.mjs
@@ -1,0 +1,56 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { test } from "bun:test";
+import { createHostShell } from "../../../dist/feishu/host-shell.mjs";
+import { inboxAuditRegistryFile, readInboxAuditTargets } from "../../../dist/agent/missed-outbound-scan.mjs";
+
+const CHAT = "oc_7961b9d7be893b46520a926b90cf46eb";
+const testManagedCli = () => ({ command: { command: "/test/official-lark-cli", argsPrefix: [], version: "1.0.80" }, env: {} });
+
+test("Host ingest records only originally wake=true group traffic into the audit registry", async () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "larkin-inbox-audit-host-"));
+  const agentId = "cli_inboxAuditHostA1";
+  const agent = {
+    agentId, name: agentId, runtime: "codex", model: "gpt", feishuAppId: agentId,
+    feishuAppSecret: "fixture-secret", feishuProfile: agentId, feishuDomain: "https://open.feishu.cn",
+    workspaceDir: path.join(root, "agents", agentId), stateDir: path.join(root, "state", "agents", agentId),
+    larkConfigDir: path.join(root, "state", "agents", agentId, "lark-cli-config"),
+  };
+  const env = {
+    LARKIN_HOME: root, LARKIN_CONFIG_DIR: root, LARKIN_SERVER_ID: "server-inbox-audit-host",
+    LARKIN_AGENTS_CONFIG: JSON.stringify([agent]),
+  };
+  const runtimeHost = {
+    subscribe() { return () => {}; },
+    async start() {},
+    async deliver() { return { status: "accepted" }; },
+    async stop() {},
+    async shutdown() {},
+  };
+  const host = createHostShell({
+    env, runtimeHost, eventSourceStartDelayMs: 60_000,
+    managedCliForAgent: testManagedCli,
+    execFileImpl(_command, _args, _options, callback) {
+      callback(null, JSON.stringify({ ok: true, data: { items: [{ member_id: "ou_human", name: "Human" }] } }), "");
+      return {};
+    },
+  });
+  const event = {
+    chat_id: CHAT, chat_type: "group", sender_id: "ou_human", message_id: "om_unmentioned",
+    event_id: "ev_unmentioned", content: "hello", thread_id: null,
+    _mentioned_bot: false, _mention_all: false, _sender_is_bot: false, _scan_authority: true,
+  };
+  try {
+    await host.ingest(agentId, event, { wake: false });
+    assert.equal(readInboxAuditTargets(inboxAuditRegistryFile(root), agentId).targets.length, 0);
+    await host.ingest(agentId, { ...event, message_id: "om_mentioned", event_id: "ev_mentioned" }, { wake: true });
+    const audit = readInboxAuditTargets(inboxAuditRegistryFile(root), agentId);
+    assert.deepEqual(audit.targets.map((row) => row.anchor), ["om_mentioned"]);
+    assert.equal(audit.targets[0].target, `chat:${CHAT}`);
+  } finally {
+    await host.shutdown("cleanup");
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});

--- a/test/unit/feishu/lark-passthrough.test.mjs
+++ b/test/unit/feishu/lark-passthrough.test.mjs
@@ -48,7 +48,7 @@ test("public CLI exposes package version and complete nested config help without
     for (const args of [["config", "--help"], ["config", "-h"], ["help", "config"]]) {
       const result = run(...args);
       assert.equal(result.status, 0, result.stderr);
-      for (const token of ["config runtime", "config model", "config effort", "config mention global", "config mention agent", "config mention chat", "config apply", "--agent", "--chat", "--json", "inherit", "default", "clear"]) {
+      for (const token of ["config runtime", "config model", "config effort", "config mention global", "config mention agent", "config mention chat", "config inbox-audit global", "config inbox-audit agent", "config apply", "--agent", "--chat", "--interval", "--json", "inherit", "default", "clear"]) {
         assert.match(result.stdout, new RegExp(token.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")), `${args.join(" ")} missing ${token}`);
       }
       for (const operation of AGENT_CLI_CAPABILITIES.commands.config) assert.match(result.stdout, new RegExp(`config ${operation}`));

--- a/test/unit/platform/inbox-audit-config.test.mjs
+++ b/test/unit/platform/inbox-audit-config.test.mjs
@@ -1,0 +1,104 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { spawnSync } from "node:child_process";
+import { test } from "bun:test";
+import { createRequire } from "node:module";
+import { fileURLToPath } from "node:url";
+
+const require = createRequire(import.meta.url);
+const configApi = require("../../../dist/platform/config.cjs");
+const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../../..");
+const CONFIG_ENTRY = path.join(ROOT, "dist", "app", "agent-config.mjs");
+const CLI_ENTRY = path.join(ROOT, "dist", "app", "cli.mjs");
+const APP = "cli_inboxAuditA1";
+const OTHER = "cli_inboxAuditB2";
+
+function fixture() {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "larkin-inbox-audit-config-"));
+  fs.writeFileSync(path.join(root, "config.json"), `${JSON.stringify({
+    version: 4,
+    serverId: "server-inbox-audit",
+    mentionPolicy: "require",
+    activeAgent: APP,
+    agents: {
+      [APP]: { runtime: "codex", model: "gpt-5.6-sol" },
+      [OTHER]: { runtime: "claude", model: "sonnet" },
+    },
+  }, null, 2)}\n`, { mode: 0o600 });
+  return { root, env: { LARKIN_CONFIG_DIR: root } };
+}
+
+test("inbox audit defaults off and inherits global cadence until an Agent override", () => {
+  const { root, env } = fixture();
+  try {
+    const { config } = configApi.loadConfig(env);
+    assert.equal(config.inboxAudit, undefined);
+    assert.deepEqual(configApi.resolveInboxAuditSchedule(config, APP), {
+      enabled: false,
+      intervalMs: configApi.DEFAULT_INBOX_AUDIT_INTERVAL_MS,
+      enabledSource: "default",
+      intervalSource: "default",
+    });
+    const view = configApi.safeConfigView(config, APP);
+    assert.equal(view.inboxAudit.enabled, false);
+    assert.equal(view.inboxAudit.intervalMs, configApi.DEFAULT_INBOX_AUDIT_INTERVAL_MS);
+    assert.equal(view.agents[0].inboxAudit.override.enabled, "inherit");
+    assert.equal(view.agents[0].inboxAudit.effective.enabled, false);
+
+    configApi.mutateConfig(env, configApi.inboxAuditMutationFromCli({
+      scope: "global", enabled: "on", interval: "30m", agentId: APP,
+    }), { kind: "user" });
+    let stored = JSON.parse(fs.readFileSync(path.join(root, "config.json"), "utf8"));
+    assert.deepEqual(stored.inboxAudit, { enabled: true, intervalMs: 30 * 60_000 });
+    assert.equal("inboxAudit" in stored.agents[APP], false);
+
+    configApi.mutateConfig(env, configApi.inboxAuditMutationFromCli({
+      scope: "agent", enabled: "off", interval: "1h", agentId: APP,
+    }), { kind: "user" });
+    const after = configApi.loadConfig(env).config;
+    assert.deepEqual(configApi.resolveInboxAuditSchedule(after, APP), {
+      enabled: false, intervalMs: 60 * 60_000, enabledSource: "agent", intervalSource: "agent",
+    });
+    assert.deepEqual(configApi.resolveInboxAuditSchedule(after, OTHER), {
+      enabled: true, intervalMs: 30 * 60_000, enabledSource: "global", intervalSource: "global",
+    });
+
+    configApi.mutateConfig(env, configApi.inboxAuditMutationFromCli({
+      scope: "agent", enabled: "inherit", interval: "inherit", agentId: APP,
+    }), { kind: "user" });
+    stored = JSON.parse(fs.readFileSync(path.join(root, "config.json"), "utf8"));
+    assert.equal("inboxAudit" in stored.agents[APP], false);
+    assert.equal(configApi.parseInboxAuditInterval("15m"), configApi.DEFAULT_INBOX_AUDIT_INTERVAL_MS);
+    assert.throws(() => configApi.parseInboxAuditInterval("1s"), /15m\/1h|毫秒/);
+    assert.throws(() => configApi.inboxAuditMutationFromCli({
+      scope: "global", enabled: "on", interval: "inherit", agentId: APP,
+    }), /不支持 interval=inherit/);
+  } finally { fs.rmSync(root, { recursive: true, force: true }); }
+});
+
+test("larkin config inbox-audit CLI persists per-Agent cadence without editing config.json by hand", () => {
+  const { root, env } = fixture();
+  try {
+    const help = spawnSync(process.execPath, [CLI_ENTRY, "help", "config"], { encoding: "utf8" });
+    assert.equal(help.status, 0, help.stderr);
+    assert.match(help.stdout, /config inbox-audit global/);
+    assert.match(help.stdout, /config inbox-audit agent/);
+    assert.match(help.stdout, /--interval/);
+    const run = (...args) => {
+      const spawnEnv = { ...process.env, ...env };
+      delete spawnEnv.LARKIN_AGENT_ID;
+      return spawnSync(process.execPath, [CONFIG_ENTRY, "config", ...args], { encoding: "utf8", env: spawnEnv });
+    };
+    const enabled = run("inbox-audit", "global", "on", "--interval", "15m");
+    assert.equal(enabled.status, 0, enabled.stderr);
+    const stored = JSON.parse(fs.readFileSync(path.join(root, "config.json"), "utf8"));
+    assert.deepEqual(stored.inboxAudit, { enabled: true, intervalMs: 15 * 60_000 });
+    const agentOff = run("inbox-audit", "agent", "off", "--agent", APP, "--interval", "1h");
+    assert.equal(agentOff.status, 0, agentOff.stderr);
+    const after = JSON.parse(fs.readFileSync(path.join(root, "config.json"), "utf8"));
+    assert.deepEqual(after.agents[APP].inboxAudit, { enabled: false, intervalMs: 60 * 60_000 });
+    assert.equal("inboxAudit" in after.agents[OTHER], false);
+  } finally { fs.rmSync(root, { recursive: true, force: true }); }
+});


### PR DESCRIPTION
## Summary

https://github.com/eddiearc/larkin/issues/186

`require` was only applied to the immediate wake path. Inbox Audit still recorded unmentioned human group/topic traffic and the Host timer woke every Agent every 15 minutes, so audit could turn `wake=false` context into a proactive reply and burn tokens on unchanged targets.

This PR makes Inbox Audit a safe, optional, per-Agent compensation loop:

1. Configurable only through `larkin config inbox-audit` (never raw `config.json` edits).
2. Default **off**.
3. One Host timer per Agent/Bot, not one scan for all Agents.
4. Cadence is configurable (`--interval 15m|1h` or 60000–86400000 ms). Default interval remains 15m when enabled.
5. `require` is a hard rule: audit observes only originally `wake=true` human group/topic sources. Unmentioned require-policy traffic is stored as ordinary Inbox context and is not audited into a proactive reply.
6. No model wake when audit is disabled or there is no pending originally-wake=true work. `larkin inbox audit` reports the current pending page once, then marks those targets completed so they are not scanned again. A new originally-wake=true `om_` anchor may reopen the same target.

Does not duplicate #185.

## Behavior

- Global default: `enabled=false`, `intervalMs=15m`.
- Per-Agent override: `inherit|on|off` and optional interval, inherited independently.
- Effective config is re-read on each tick, so later `larkin config inbox-audit` changes apply without a Runtime session restart.
- `observeInboxAuditTarget` now requires `wake === true` in addition to scan authority / human / group.
- Registry v2 stores `pending|completed`. v1 rows cannot prove originally-wake=true and are discarded rather than re-scanned.
- Heartbeat injects the same targetless `runtime:reminder` envelope as before; no delivery target or default DM.

```text
larkin config inbox-audit global <on|off> [--interval <15m|1h>]
larkin config inbox-audit agent <inherit|on|off> [--agent <App ID>] [--interval <15m|inherit>]
```

## Non-goals

- No merge or release.
- No standing-prompt / eval dataset change (no E3 claim).
- No Host semantic classifier and no Host direct Feishu send.
- No restoration of the overbuilt #169 scheduler/cursor/eval surface.
- No live Feishu client proof that a human will or will not see a reply.

## Tests (E2)

- unmentioned `wake=false` group/topic traffic is not observed
- DMs, bots, and non-`om_` anchors still cannot enter audit
- v1 registry rows are discarded
- completed/reported targets are omitted and not re-observed for the same anchor
- a new originally-wake=true anchor may reopen the same target
- one Host timer per Agent; disabled / empty pending work produces zero model wakes
- configured intervals are used instead of a hardcoded 15m callback
- `larkin config inbox-audit` defaults off, inherits globally, and persists Agent overrides
- `larkin inbox audit` returns pending targets once
- Host ingest with `wake=false` does not write the audit registry; `wake=true` does

Locally run:

- `bun run typecheck`
- focused `bun test` on the unit files above

## Claim boundaries

- **E2 only.** Deterministic unit/host/CLI tests prove the wake gate, default-off config, per-Agent cadence, and no-wake-when-empty contract.
- **Not E3.** No prompt or Agent-decision eval was added or re-run. No through-rate claim.
- **Not E4.** Fake Host ingest and CLI persistence do not prove real Feishu client rendering or a production missed-delivery recovery.
- Default-off is proven for missing config and for `larkin config show`; it is not a live multi-Agent production soak.
- Completing targets on `inbox audit` means a crash after a successful audit CLI call will not automatically re-present the same pending page. New originally-wake=true evidence can still reopen.

## Version

Package version remains `0.4.24`. No release.