### PR TITLE
Isolate builtin Pi catalog from host ~/.pi

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "larkin",
-  "version": "0.4.25",
+  "version": "0.4.26",
   "private": false,
   "larkinPackageRole": "npm-published",
   "files": [

--- a/src/app/agent-cli.ts
+++ b/src/app/agent-cli.ts
@@ -52,7 +52,7 @@ function discoverRuntimeModelDirectorySync(
   input: { agentId: string; cwd: string; runtime: string },
   env: Env,
 ): RuntimeDirectoryModel[] {
-  const childSpec = internalCommandSpec("runtime-model-directory", [input.runtime, input.cwd], env);
+  const childSpec = internalCommandSpec("runtime-model-directory", [input.runtime, input.cwd, input.agentId], env);
   const result = spawnSync(childSpec.command, childSpec.args, {
     encoding: "utf8", env: { ...process.env, ...env }, timeout: 20_000, maxBuffer: 1024 * 1024,
   });

--- a/src/app/agent-config.ts
+++ b/src/app/agent-config.ts
@@ -20,7 +20,7 @@ import { isChannelReconnecting, projectAgentReadiness, type AgentReadinessStatus
 import { requestAgentUpsert } from "./local-control.js";
 import * as larkinConfig from "../platform/config.js";
 import { managedOfficialLarkCli } from "./agent-lark-cli-workspace.js";
-import { assertBuiltinPiAgentDirectory, piAgentDirectory } from "../runtime/pi-provider-config.js";
+import { assertBuiltinPiAgentDirectory, ownedPiCatalogAgentDir, piAgentDirectory, piCatalogCommandSpec, piDistributionLabel } from "../runtime/pi-provider-config.js";
 import { traceProcessBoundary } from "../platform/process-boundary-trace.js";
 
 interface RuntimeModel {
@@ -35,6 +35,7 @@ interface AgentConfig {
   name: string;
   runtime: string;
   model: string;
+  piDistribution?: "external" | "builtin";
   effort?: string;
   stateDir: string;
   feishuProfile: string;
@@ -501,13 +502,18 @@ if ((["model", "effort"].includes(kind || "") && agent.runtime === "claude") || 
 }
 let piCatalog: PiModelCatalog | null = null;
 if (agent.runtime === "pi" || (kind === "runtime" && value === "pi")) {
+  if (kind === "model" && !value) say(`发行版: ${piDistributionLabel(agent.piDistribution)}`);
   try {
+    const catalogCommand = piCatalogCommandSpec(agent.piDistribution, process.env);
     piCatalog = await discoverPiModelCatalog({
       cwd: String(agent.workspaceDir),
-      ...(process.env.PI_CODING_AGENT_DIR ? { agentDir: process.env.PI_CODING_AGENT_DIR } : {}),
+      agentDir: ownedPiCatalogAgentDir(configDir, selectedKey),
+      command: catalogCommand.command,
+      commandArgs: catalogCommand.commandArgs,
+      env: process.env,
     });
   } catch (error) {
-    die(`Pi 模型目录加载失败：${error instanceof Error ? error.message : String(error)}。请先用官方 pi 登录或检查 PI_CODING_AGENT_DIR。`);
+    die(`Pi 模型目录加载失败：${error instanceof Error ? error.message : String(error)}。请先用官方 pi 登录或检查该 Agent 的隔离 provider 目录。`);
   }
   if (!piCatalog) die("Pi 模型目录加载失败");
   const loadedPiCatalog = piCatalog as PiModelCatalog;

--- a/src/app/runtime-model-directory.ts
+++ b/src/app/runtime-model-directory.ts
@@ -3,9 +3,11 @@
 import fs from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
+import { loadConfig, resolveConfigDir } from "../platform/config.js";
 import { discoverClaudeModelCatalog } from "../runtime/claude-model-catalog.js";
-import { discoverCodexModelCatalog } from "../runtime/codex-model-catalog.js";
 import { discoverPiModelCatalog } from "../runtime/pi-model-catalog.js";
+import { discoverCodexModelCatalog } from "../runtime/codex-model-catalog.js";
+import { ownedPiCatalogAgentDir, piCatalogCommandSpec } from "../runtime/pi-provider-config.js";
 
 type Env = Record<string, string | undefined>;
 
@@ -20,7 +22,7 @@ export interface RuntimeModelDirectoryInput {
   runtime: string;
   cwd: string;
   env?: Env;
-  agentDir?: string;
+  agentId?: string;
 }
 
 function readTestModelDirectory(env: Env | undefined): RuntimeDirectoryModel[] | undefined {
@@ -51,7 +53,21 @@ export async function discoverRuntimeModelDirectory(input: RuntimeModelDirectory
     ];
   }
   if (input.runtime === "pi") {
-    const catalog = await discoverPiModelCatalog({ cwd: input.cwd, ...(input.agentDir ? { agentDir: input.agentDir } : {}) });
+    const env = input.env ?? process.env;
+    const agentId = input.agentId || "";
+    if (!agentId) throw new Error("runtime model directory requires agentId for Pi");
+    const configDir = resolveConfigDir(env);
+    const { config } = loadConfig(env);
+    const agent = config.agents[agentId];
+    if (!agent) throw new Error(`unknown agent: ${agentId}`);
+    const catalogCommand = piCatalogCommandSpec(agent.piDistribution, env);
+    const catalog = await discoverPiModelCatalog({
+      cwd: input.cwd,
+      agentDir: ownedPiCatalogAgentDir(configDir, agentId),
+      command: catalogCommand.command,
+      commandArgs: catalogCommand.commandArgs,
+      env,
+    });
     if (!catalog.effectiveModel) throw new Error("Pi 模型目录未解析出默认模型");
     return [
       { id: "default", label: `default: ${catalog.effectiveModel}` },
@@ -72,12 +88,13 @@ function isMainEntry(argvPath = process.argv[1]): boolean {
 export async function main(): Promise<void> {
   const runtime = process.argv[2] || "";
   const cwd = process.argv[3] || "";
+  const agentId = process.argv[4] || "";
   if (!runtime || !cwd) throw new Error("runtime model directory requires runtime and cwd");
   const models = await discoverRuntimeModelDirectory({
     runtime,
     cwd,
     env: process.env,
-    ...(process.env.PI_CODING_AGENT_DIR ? { agentDir: process.env.PI_CODING_AGENT_DIR } : {}),
+    ...(agentId ? { agentId } : {}),
   });
   process.stdout.write(`${JSON.stringify({ models })}\n`);
 }

--- a/src/dashboard/dashboard-config-controller.ts
+++ b/src/dashboard/dashboard-config-controller.ts
@@ -8,13 +8,20 @@ import { discoverClaudeModelCatalog, type DiscoverClaudeCatalogOptions } from ".
 import { discoverCodexModelCatalog, type DiscoverCodexCatalogOptions } from "../runtime/codex-model-catalog.js";
 import { discoverPiModelCatalog, type DiscoverPiCatalogOptions } from "../runtime/pi-model-catalog.js";
 import { managedOfficialLarkCli } from "../app/agent-lark-cli-workspace.js";
+import { ownedPiCatalogAgentDir, piCatalogCommandSpec } from "../runtime/pi-provider-config.js";
 
 type Env = Record<string, string | undefined>;
 type LarkJsonCall = { command: string; args: string[]; env: Env; maxBuffer: number; timeout: number };
 type ChatDirectoryInput = { agentId: string; chatIds: string[]; configDir: string; profile: string };
 type ClaudeModelDirectoryInput = { agentId: string; cwd: string; env: Env };
 type CodexModelDirectoryInput = { agentId: string; cwd: string; env: Env };
-type PiModelDirectoryInput = { agentDir?: string; agentId: string; cwd: string };
+type PiModelDirectoryInput = {
+  agentDir: string;
+  agentId: string;
+  cwd: string;
+  command?: string;
+  commandArgs?: readonly string[];
+};
 
 export type ChatDirectoryResolver = { resolve(input: ChatDirectoryInput): Promise<Record<string, string>> };
 export type ClaudeModelDirectoryResolver = { resolve(input: ClaudeModelDirectoryInput): Promise<Array<Record<string, unknown> & { id: string; label: string }>> };
@@ -177,7 +184,7 @@ export function createPiModelDirectoryResolver(options: {
   const inFlight = new Map<string, Promise<Array<Record<string, unknown> & { id: string; label: string }>>>();
   return {
     async resolve(input) {
-      const key = [input.agentId, input.cwd, input.agentDir ?? ""].join("\u0000");
+      const key = [input.agentId, input.cwd, input.agentDir, input.command ?? "", ...(input.commandArgs ?? [])].join("\u0000");
       pruneCache(cache, (entry) => now() >= entry.expiresAt, 64);
       pruneCache(failures, (entry) => now() >= entry.expiresAt, 64);
       const cached = cache.get(key);
@@ -187,7 +194,12 @@ export function createPiModelDirectoryResolver(options: {
       if (!pending) {
         pending = (async () => {
           try {
-            const catalog = await discover({ cwd: input.cwd, ...(input.agentDir ? { agentDir: input.agentDir } : {}) });
+            const catalog = await discover({
+              cwd: input.cwd,
+              agentDir: input.agentDir,
+              ...(input.command ? { command: input.command } : {}),
+              ...(input.commandArgs ? { commandArgs: input.commandArgs } : {}),
+            });
             const models = [
               { id: "default", label: `default: ${catalog.effectiveModel}` },
               ...catalog.models.map(({ id, label, contextWindow, supportedReasoningEfforts, defaultReasoningEffort }) => ({
@@ -393,13 +405,24 @@ export function createDashboardConfigController({
   codexModelDirectoryResolver?: CodexModelDirectoryResolver;
   piModelDirectoryResolver?: PiModelDirectoryResolver;
 }) {
+  const resolvePiModelDirectory = async (agentId: string) => {
+    const { config, configDir } = loadConfig(env);
+    const agent = config.agents[agentId];
+    if (!agent) throw new Error("unknown agent");
+    const catalogCommand = piCatalogCommandSpec(agent.piDistribution, env);
+    return await piModelDirectoryResolver.resolve({
+      agentId,
+      cwd: agent.workspaceDir,
+      agentDir: ownedPiCatalogAgentDir(configDir, agentId),
+      command: catalogCommand.command,
+      commandArgs: catalogCommand.commandArgs,
+    });
+  };
   const resolveModelDirectory = async (runtime: string, agentId: string) => {
     const { config } = loadConfig(env);
     const agent = config.agents[agentId];
     if (!agent) throw new Error("unknown agent");
-    if (runtime === "pi") return await piModelDirectoryResolver.resolve({
-      agentId, cwd: agent.workspaceDir, ...(env.PI_CODING_AGENT_DIR ? { agentDir: env.PI_CODING_AGENT_DIR } : {}),
-    });
+    if (runtime === "pi") return await resolvePiModelDirectory(agentId);
     if (runtime === "codex") return await codexModelDirectoryResolver.resolve({ agentId, cwd: agent.workspaceDir, env });
     if (runtime === "claude") return await claudeModelDirectoryResolver.resolve({ agentId, cwd: agent.workspaceDir, env });
     const authored = loadRuntimeModels()[runtime];
@@ -438,14 +461,7 @@ export function createDashboardConfigController({
         try {
           assertPrivateReadRequest(req, csrfCapability);
           const agentId = requestUrl.searchParams.get("agent") || "";
-          const { config } = loadConfig(env);
-          const agent = config.agents[agentId];
-          if (!agent) throw new Error("unknown agent");
-          const models = await piModelDirectoryResolver.resolve({
-            agentId,
-            cwd: agent.workspaceDir,
-            ...(env.PI_CODING_AGENT_DIR ? { agentDir: env.PI_CODING_AGENT_DIR } : {}),
-          });
+          const models = await resolvePiModelDirectory(agentId);
           json(res, 200, { models });
         } catch (error) {
           json(res, error instanceof Error && /host|capability/.test(error.message) ? 403 : 500, { error: "Pi model directory unavailable" });

--- a/src/dashboard/dashboard-view-model.ts
+++ b/src/dashboard/dashboard-view-model.ts
@@ -13,6 +13,7 @@ import { isAllowedDashboardAvatarUrl } from "./dashboard-avatar.js";
 import { collectWorkspaceEntry as collectTypedWorkspaceEntry } from "./dashboard-workspace.js";
 import { buildFingerprint, packageVersion } from "../platform/build-info.js";
 import * as larkinConfig from "../platform/config.js";
+import { ownedPiCatalogAgentDir, piCatalogCommandSpec } from "../runtime/pi-provider-config.js";
 
 export interface JsonRecord {
   [key: string]: unknown;
@@ -89,6 +90,7 @@ export interface DashboardAgent {
   workspaceDir: string;
   feishuProfile: string;
   effort?: string;
+  piDistribution?: "external" | "builtin";
   noMentionChats?: string[];
 }
 export interface DashboardConfig {
@@ -483,7 +485,13 @@ export function projectStatusTimeline(status: JsonRecord) {
 }
 
 export type PiStatusModelResolver = {
-  resolve(input: { agentDir?: string; agentId: string; cwd: string }): Promise<PiContextCatalogModel[]>;
+  resolve(input: {
+    agentDir: string;
+    agentId: string;
+    cwd: string;
+    command?: string;
+    commandArgs?: readonly string[];
+  }): Promise<PiContextCatalogModel[]>;
 };
 
 async function collectAgentStatus(a: DashboardAgent, configDir: string, daemonStartedAt: unknown, piModelResolver?: PiStatusModelResolver) {
@@ -498,10 +506,13 @@ async function collectAgentStatus(a: DashboardAgent, configDir: string, daemonSt
   let piCatalog: readonly PiContextCatalogModel[] = [];
   if (a.runtime === "pi" && piModelResolver) {
     try {
+      const catalogCommand = piCatalogCommandSpec(a.piDistribution, process.env);
       piCatalog = await piModelResolver.resolve({
         agentId: a.agentId,
         cwd: a.workspaceDir,
-        ...(process.env.PI_CODING_AGENT_DIR ? { agentDir: process.env.PI_CODING_AGENT_DIR } : {}),
+        agentDir: ownedPiCatalogAgentDir(configDir, a.agentId),
+        command: catalogCommand.command,
+        commandArgs: catalogCommand.commandArgs,
       });
     } catch { /* unknown or unavailable catalog keeps the explicit turns fallback */ }
   }

--- a/src/dashboard/web/app.tsx
+++ b/src/dashboard/web/app.tsx
@@ -6,6 +6,7 @@ import {
 import { AGENT_TABS, createLatestResponseGate, filterAgents, parseRoute, reconcileAgentId, routeSearch, sameDraft, type AgentTab } from "./dashboard-state";
 import type { ConfigAgent, ConfigResponse, DashboardAgent, RuntimeModel, RuntimeReadinessView, StatusResponse, WorkspaceProjection } from "./types";
 import { Badge, Button, EmptyState, Sheet, cn } from "./components/ui";
+import { piDistributionLabel } from "../../runtime/pi-distribution-label";
 
 const TAB_LABELS: Record<AgentTab, string> = {
   overview: "概览", conversation: "对话", configuration: "配置", reminders: "提醒", workspace: "工作区", logs: "日志",
@@ -386,6 +387,7 @@ function AgentConfiguration({ agentId, onDirtyChange, refreshKey }: { agentId: s
       <p className="cli-guidance">这里只提供常用微调。更多配置可以直接告诉当前 Agent，让它运行 <code>larkin config --help</code> 后完成。</p>
       <div className="config-grid">
         <label><span>Runtime</span><select value={runtime} disabled={loading} onChange={(event) => { update("runtime", event.target.value); update("model", "default"); update("effort", "default"); }}>{Object.keys(response?.runtimeModels || {}).map((value) => <option value={value} key={value}>{value}</option>)}</select></label>
+        {runtime === "pi" ? <label><span>Pi 发行版</span><input readOnly disabled aria-label="Pi 发行版" value={piDistributionLabel(config.piDistribution)} /></label> : null}
         <label><span>Model</span><select value={model} disabled={loading || !directoryReady} onChange={(event) => { update("model", event.target.value); if (event.target.value === "default") update("effort", "default"); }}>{visibleModels.map((item) => <option value={item.id} key={item.id}>{item.label || item.id}</option>)}</select></label>
         <label><span>Effort</span><select value={String(draft.effort || "default")} disabled={loading || !directoryReady || model === "default" || !efforts.length} onChange={(event) => update("effort", event.target.value)}><option value="default">default · 不指定</option>{efforts.map((value) => <option value={value} key={value}>{value}</option>)}</select></label>
         <label><span>群消息策略</span><select value={String(draft.mention || "inherit")} disabled={loading} onChange={(event) => update("mention", event.target.value)}><option value="inherit">跟随全局设置</option><option value="require">需要 @</option><option value="free">无需 @</option></select></label>

--- a/src/dashboard/web/styles.css
+++ b/src/dashboard/web/styles.css
@@ -168,7 +168,8 @@ button:disabled, select:disabled, input:disabled { cursor: not-allowed; opacity:
 .cli-guidance code { color: var(--ink); font: 600 10.5px ui-monospace, monospace; overflow-wrap: anywhere; }
 .config-grid { display: grid; grid-template-columns: repeat(4, minmax(120px, 1fr)); gap: 12px; }
 .config-grid label, .settings-form label, .chat-add label { min-width: 0; display: grid; gap: 5px; color: var(--subtle); font-size: 11px; font-weight: 600; }
-.config-grid select, .settings-form select, .chat-add select, .chat-add input, .policy-table select { min-width: 0; width: 100%; min-height: 37px; border: 1px solid var(--line); border-radius: 8px; padding: 7px 9px; background: var(--paper); color: var(--ink); font-size: 12px; }
+.config-grid select, .config-grid input, .settings-form select, .chat-add select, .chat-add input, .policy-table select { min-width: 0; width: 100%; min-height: 37px; border: 1px solid var(--line); border-radius: 8px; padding: 7px 9px; background: var(--paper); color: var(--ink); font-size: 12px; }
+.config-grid input:disabled { color: var(--subtle); }
 .form-actions { display: flex; flex-wrap: wrap; justify-content: flex-end; gap: 8px; margin-top: 16px; }
 .feedback { margin: 10px 0 0; color: var(--subtle); font-size: 11px; }
 .table-search { min-width: min(300px, 42vw); padding: 7px 9px; }

--- a/src/dashboard/web/types.ts
+++ b/src/dashboard/web/types.ts
@@ -105,6 +105,7 @@ export interface ConfigAgent {
   runtime: string;
   model: string;
   effort: string | null;
+  piDistribution: "builtin" | "external" | null;
   mention: { override: "inherit" | "require" | "free"; effective: "require" | "free"; source: "global" | "agent" };
   knownChats: KnownChat[];
   apply: { applyState?: "unknown" | "pending" | "applied" };

--- a/src/dashboard/web/vite.config.mjs
+++ b/src/dashboard/web/vite.config.mjs
@@ -11,6 +11,9 @@ export default defineConfig({
   root,
   base: "/dashboard-assets/",
   plugins: [react(), tailwindcss()],
+  server: {
+    fs: { allow: [path.resolve(root, "../..")] },
+  },
   build: {
     outDir,
     emptyOutDir: true,

--- a/src/runtime/pi-distribution-label.ts
+++ b/src/runtime/pi-distribution-label.ts
@@ -1,0 +1,3 @@
+export function piDistributionLabel(distribution: "builtin" | "external" | null | undefined): string {
+  return distribution === "builtin" ? "内置 Pi" : "用户安装的 Pi";
+}

--- a/src/runtime/pi-provider-config.ts
+++ b/src/runtime/pi-provider-config.ts
@@ -1,7 +1,10 @@
 import crypto from "node:crypto";
 import fs from "node:fs";
 import path from "node:path";
+import { internalCommandSpec } from "../app/internal-command.js";
 import { isWindows, secureWindowsDirectoryAcl } from "../platform/secure-metadata.js";
+
+export { piDistributionLabel } from "./pi-distribution-label.js";
 
 export type PiDistribution = "external" | "builtin";
 export const BUNDLED_PI_VERSION = "0.84.2";
@@ -158,6 +161,25 @@ export function validateBuiltinPiProviderSelection(input: BuiltinPiProviderSelec
 export function piAgentDirectory(configDir: string, agentId: string): string {
   if (!APP_ID.test(agentId)) throw new Error("Pi Agent ID 格式无效");
   return path.join(path.resolve(configDir), "providers", "pi", agentId);
+}
+
+/** Catalog/CLI/dashboard must use the Agent-owned provider dir, never host ~/.pi. */
+export function ownedPiCatalogAgentDir(configDir: string, agentId: string): string {
+  return piAgentDirectory(configDir, agentId);
+}
+
+export function piCatalogCommandSpec(
+  distribution: "builtin" | "external" | null | undefined,
+  env: NodeJS.ProcessEnv = process.env,
+): { command: string; commandArgs: readonly string[] } {
+  if (distribution === "builtin") {
+    const spec = internalCommandSpec("pi-rpc", [], env);
+    return { command: spec.command, commandArgs: spec.args };
+  }
+  return {
+    command: env.LARKIN_PI_COMMAND ?? process.env.LARKIN_PI_COMMAND ?? "pi",
+    commandArgs: [],
+  };
 }
 
 function assertPrivateDirectory(directory: string): void {

--- a/test/frontend/dashboard-workbench.test.tsx
+++ b/test/frontend/dashboard-workbench.test.tsx
@@ -46,6 +46,7 @@ const config = (agentId?: string) => ({
   },
   agents: (agentId ? agents.filter((agent) => agent.agentId === agentId) : agents).map((agent) => ({
     agentId: agent.agentId, runtime: agent.runtime, model: agent.model, effort: agent.effort,
+    piDistribution: null,
     mention: { override: agent.agentId === "cli_AgentB2" ? "require" : "inherit", effective: agent.agentId === "cli_AgentB2" ? "require" : "free", source: agent.agentId === "cli_AgentB2" ? "agent" : "global" },
     knownChats: agent.agentId === "cli_AgentB2" ? [
       { chatId: "oc_BuildRoom", displayName: "构建群", kind: "group", override: "free", effective: "free", source: "chat" },
@@ -324,6 +325,38 @@ describe("Agent-centric dashboard workbench", () => {
       String(input) === "/api/models/pi?agent=cli_AgentA1")).toBe(true));
     expect(screen.getByRole("option", { name: "default: openai/gpt-5.2" })).toBeVisible();
     expect(screen.getByRole("option", { name: "Claude Sonnet 4.5 · anthropic" })).toBeVisible();
+    expect(screen.getByDisplayValue("用户安装的 Pi")).toBeVisible();
+  });
+
+  it.each([
+    { distribution: "builtin" as const, label: "内置 Pi", absent: "用户安装的 Pi" },
+    { distribution: "external" as const, label: "用户安装的 Pi", absent: "内置 Pi" },
+    { distribution: null, label: "用户安装的 Pi", absent: "内置 Pi" },
+  ])("renders $label for Pi runtime when piDistribution is $distribution", async ({ distribution, label, absent }) => {
+    window.history.replaceState(null, "", "/?agent=cli_AgentA1&tab=configuration");
+    vi.stubGlobal("fetch", vi.fn((input: RequestInfo | URL) => {
+      const url = new URL(String(input), "http://localhost");
+      if (url.pathname === "/api/status") return ok(status);
+      if (url.pathname === "/api/config") {
+        const value = config("cli_AgentA1");
+        value.agents[0].piDistribution = distribution;
+        return ok(value);
+      }
+      if (url.pathname === "/api/models/pi") return ok({ models: [{ id: "default", label: "default: fixture/model" }] });
+      throw new Error(`unexpected request ${url}`);
+    }));
+    render(<App />);
+    expect(await screen.findByLabelText("Runtime")).toHaveValue("pi");
+    expect(await screen.findByDisplayValue(label)).toBeVisible();
+    expect(screen.queryByDisplayValue(absent)).not.toBeInTheDocument();
+  });
+
+  it("does not render a Pi distribution label for non-Pi runtimes", async () => {
+    render(<App />);
+    expect(await screen.findByLabelText("Runtime")).toHaveValue("codex");
+    expect(screen.queryByText("内置 Pi")).not.toBeInTheDocument();
+    expect(screen.queryByText("用户安装的 Pi")).not.toBeInTheDocument();
+    expect(screen.queryByLabelText("Pi 发行版")).not.toBeInTheDocument();
   });
 
   it("loads the current Codex CLI catalog instead of presenting only the authored compatibility list", async () => {

--- a/test/unit/app/agent-cli.test.mjs
+++ b/test/unit/app/agent-cli.test.mjs
@@ -258,7 +258,7 @@ let input="";process.stdin.on("data",c=>{input+=c;for(;;){const i=input.indexOf(
         LARKIN_TEST_RUNTIME_MODEL_DIRECTORY_FILE: modelDirectoryFixture,
       };
       const run = (...args) => spawnSync(process.execPath, [entry, ...args], { cwd: ROOT, encoding: "utf8", env, timeout: 30_000 });
-      const directory = spawnSync(process.execPath, [path.join(ROOT, "dist/app/runtime-model-directory.mjs"), runtimeCase.runtime, path.join(root, "agents", agentId)], {
+      const directory = spawnSync(process.execPath, [path.join(ROOT, "dist/app/runtime-model-directory.mjs"), runtimeCase.runtime, path.join(root, "agents", agentId), agentId], {
         cwd: ROOT, encoding: "utf8", env, timeout: 30_000,
       });
       assert.equal(directory.status, 0, `${runtimeCase.runtime}: ${directory.stderr}`);
@@ -280,6 +280,54 @@ let input="";process.stdin.on("data",c=>{input+=c;for(;;){const i=input.indexOf(
         { model: JSON.parse(shown.stdout).agents[0].model, effort: JSON.parse(shown.stdout).agents[0].effort },
         { model: runtimeCase.model, effort: "high" },
       );
+    }
+  } finally { fs.rmSync(temp, { recursive: true, force: true }); }
+});
+
+test("Runtime session querying another Pi Agent uses the target owned dir and ignores host decoy", () => {
+  const temp = fs.mkdtempSync(path.join(os.tmpdir(), "larkin-agent-cli-pi-isolation-"));
+  const session = "cli_piCatalogSessionA1";
+  const target = "cli_piCatalogTargetB2";
+  const decoy = path.join(temp, "decoy-host-pi");
+  const logFile = path.join(temp, "fake-pi.log");
+  const bin = path.join(temp, "bin");
+  const entry = path.join(ROOT, "dist", "app", "agent-cli.mjs");
+  try {
+    fs.mkdirSync(bin, { recursive: true, mode: 0o700 });
+    fs.writeFileSync(path.join(bin, "pi"), `#!${process.execPath}
+import fs from "node:fs";
+fs.appendFileSync(${JSON.stringify(logFile)}, JSON.stringify({
+  agentDir: process.env.PI_CODING_AGENT_DIR || null,
+}) + "\\n");
+process.exit(1);
+`, { mode: 0o755 });
+    fs.writeFileSync(logFile, "");
+    fs.mkdirSync(path.join(temp, "agents", session), { recursive: true });
+    fs.mkdirSync(path.join(temp, "agents", target), { recursive: true });
+    fs.writeFileSync(path.join(temp, "config.json"), `${JSON.stringify({
+      version: 4, serverId: "server-agent-cli-pi-isolation", mentionPolicy: "require", activeAgent: session,
+      agents: {
+        [session]: { runtime: "pi", model: "default", piDistribution: "builtin" },
+        [target]: { runtime: "pi", model: "default", piDistribution: "external" },
+      },
+    })}\n`, { mode: 0o600 });
+    const env = {
+      ...process.env,
+      HOME: temp,
+      PATH: `${bin}:/usr/bin:/bin`,
+      LARKIN_CONFIG_DIR: temp,
+      LARKIN_AGENT_ID: session,
+      PI_CODING_AGENT_DIR: decoy,
+    };
+    const result = spawnSync(process.execPath, [entry, "config", "model", "owned/model", "--agent", target], {
+      cwd: ROOT, encoding: "utf8", env, timeout: 30_000,
+    });
+    assert.notEqual(result.status, 0);
+    assert.doesNotMatch(`${result.stdout}\n${result.stderr}`, new RegExp(decoy.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")));
+    const recorded = fs.readFileSync(logFile, "utf8").trim().split("\n").filter(Boolean).map((line) => JSON.parse(line));
+    assert.ok(recorded.length >= 1, "cross-agent catalog must spawn host pi for the external target");
+    for (const row of recorded) {
+      assert.equal(row.agentDir, path.join(temp, "providers", "pi", target));
     }
   } finally { fs.rmSync(temp, { recursive: true, force: true }); }
 });

--- a/test/unit/app/agent-config-typescript.test.mjs
+++ b/test/unit/app/agent-config-typescript.test.mjs
@@ -602,3 +602,63 @@ let input="";process.stdin.on("data",c=>{input+=c;for(;;){const i=input.indexOf(
     assert.equal(stillPending.agents[0].apply.applyState, "pending");
   } finally { fs.rmSync(temp, { recursive: true, force: true }); }
 });
+
+function writeFakePiRecorder(bin, logFile) {
+  fs.mkdirSync(bin, { recursive: true, mode: 0o700 });
+  fs.writeFileSync(path.join(bin, "pi"), `#!${process.execPath}
+import fs from "node:fs";
+fs.appendFileSync(${JSON.stringify(logFile)}, JSON.stringify({
+  agentDir: process.env.PI_CODING_AGENT_DIR || null,
+  argv: process.argv.slice(2),
+}) + "\\n");
+process.exit(1);
+`, { mode: 0o755 });
+}
+
+test("larkin model isolates owned Pi catalog from host decoy and does not spawn host pi for builtin", () => {
+  const temp = fs.mkdtempSync(path.join(os.tmpdir(), "larkin-pi-catalog-isolation-cli-"));
+  const builtin = "cli_piCatalogBuiltinA1";
+  const external = "cli_piCatalogExternalB2";
+  const decoy = path.join(temp, "decoy-host-pi");
+  const logFile = path.join(temp, "fake-pi.log");
+  const bin = path.join(temp, "bin");
+  try {
+    writeFakePiRecorder(bin, logFile);
+    fs.writeFileSync(logFile, "");
+    fs.mkdirSync(path.join(temp, "agents", builtin), { recursive: true });
+    fs.mkdirSync(path.join(temp, "agents", external), { recursive: true });
+    fs.writeFileSync(path.join(temp, "config.json"), `${JSON.stringify({
+      version: 4, serverId: "server-pi-catalog-isolation", mentionPolicy: "require", activeAgent: external,
+      agents: {
+        [builtin]: { runtime: "pi", model: "default", piDistribution: "builtin" },
+        [external]: { runtime: "pi", model: "default", piDistribution: "external" },
+      },
+    })}\n`, { mode: 0o600 });
+    const env = {
+      ...process.env,
+      HOME: temp,
+      PATH: `${bin}:/usr/bin:/bin`,
+      LARKIN_CONFIG_DIR: temp,
+      PI_CODING_AGENT_DIR: decoy,
+    };
+    const run = (...args) => spawnSync(process.execPath, [ENTRY, ...args], {
+      cwd: ROOT, encoding: "utf8", env, timeout: 30_000,
+    });
+    const decoyPattern = new RegExp(decoy.replace(/[.*+?^${}()|[\]\\]/g, "\\$&"));
+
+    const listedExternal = run("model", "--agent", external);
+    assert.match(`${listedExternal.stdout}\n${listedExternal.stderr}`, /用户安装的 Pi/);
+    assert.doesNotMatch(`${listedExternal.stdout}\n${listedExternal.stderr}`, decoyPattern);
+    const recorded = fs.readFileSync(logFile, "utf8").trim().split("\n").filter(Boolean).map((line) => JSON.parse(line));
+    assert.ok(recorded.length >= 1, "external catalog must spawn host pi");
+    for (const row of recorded) {
+      assert.equal(row.agentDir, path.join(temp, "providers", "pi", external));
+    }
+
+    fs.writeFileSync(logFile, "");
+    const listedBuiltin = run("model", "--agent", builtin);
+    assert.match(`${listedBuiltin.stdout}\n${listedBuiltin.stderr}`, /内置 Pi/);
+    assert.doesNotMatch(`${listedBuiltin.stdout}\n${listedBuiltin.stderr}`, decoyPattern);
+    assert.equal(fs.readFileSync(logFile, "utf8").trim(), "", "builtin catalog must not spawn host pi");
+  } finally { fs.rmSync(temp, { recursive: true, force: true }); }
+});

--- a/test/unit/dashboard/dashboard-config-directories.test.mjs
+++ b/test/unit/dashboard/dashboard-config-directories.test.mjs
@@ -372,6 +372,87 @@ test("GET /api/models/pi returns default plus authenticated models through the i
   assert.deepEqual(response.body.models, models);
   assert.equal(calls.length, 1);
   assert.equal(calls[0].agentId, APP);
+  assert.equal(calls[0].agentDir, path.join(f.root, "providers", "pi", APP));
+  assert.equal(calls[0].commandArgs?.includes("pi-rpc") ?? false, false);
+});
+
+function writePiAgents(root, agents) {
+  fs.writeFileSync(path.join(root, "config.json"), `${JSON.stringify({
+    version: 4,
+    serverId: "server-dashboard-directory",
+    mentionPolicy: "require",
+    activeAgent: Object.keys(agents)[0],
+    agents,
+  })}\n`, { mode: 0o600 });
+}
+
+test("GET /api/models/pi and directory mutation ignore decoy or unset PI_CODING_AGENT_DIR and use owned dir plus engine", async () => {
+  const { createDashboardConfigController } = await import(`${CONTROLLER}?pi-owned=${Date.now()}`);
+  const f = fixture();
+  onTestFinished(() => fs.rmSync(f.root, { recursive: true, force: true }));
+  const builtin = "cli_dashboardBuiltinA1";
+  const external = "cli_dashboardExternalB2";
+  writePiAgents(f.root, {
+    [builtin]: { runtime: "pi", model: "default", piDistribution: "builtin", createdAt: "2026-07-24T00:00:00.000Z" },
+    [external]: { runtime: "pi", model: "default", piDistribution: "external", createdAt: "2026-07-24T00:00:00.000Z" },
+  });
+  const decoy = path.join(f.root, "decoy-host-pi");
+  const calls = [];
+  const models = [
+    { id: "default", label: "default: owned/model" },
+    { id: "owned/model", label: "Owned", supportedReasoningEfforts: ["off"] },
+  ];
+  const piModelDirectoryResolver = { async resolve(input) { calls.push(input); return models; } };
+
+  for (const decoyDir of [decoy, undefined]) {
+    const env = { ...f.env };
+    if (decoyDir) env.PI_CODING_AGENT_DIR = decoyDir;
+    else delete env.PI_CODING_AGENT_DIR;
+    const controller = createDashboardConfigController({ csrfCapability: "test", env, piModelDirectoryResolver });
+    calls.length = 0;
+    const listed = await get(controller, `/api/models/pi?agent=${builtin}`);
+    assert.equal(listed.status, 200, JSON.stringify(listed.body));
+    assert.equal(calls[0].agentDir, path.join(f.root, "providers", "pi", builtin));
+    assert.notEqual(calls[0].agentDir, decoy);
+    assert.equal(calls[0].commandArgs.includes("pi-rpc"), true, "builtin catalog must use internal pi-rpc");
+
+    calls.length = 0;
+    const externalListed = await get(controller, `/api/models/pi?agent=${external}`);
+    assert.equal(externalListed.status, 200);
+    assert.equal(calls[0].agentDir, path.join(f.root, "providers", "pi", external));
+    assert.equal(calls[0].commandArgs.includes("pi-rpc"), false, "external catalog must use host pi");
+
+    calls.length = 0;
+    const saved = await patch(controller, { operation: "set-agent-model", agentId: external, model: "owned/model" });
+    assert.equal(saved.status, 200, JSON.stringify(saved.body));
+    assert.equal(calls[0].agentDir, path.join(f.root, "providers", "pi", external));
+
+    const rejected = await patch(controller, { operation: "set-agent-model", agentId: external, model: "host-only/decoy" });
+    assert.equal(rejected.status, 400);
+  }
+});
+
+test("Pi model directory cache key isolates builtin and external engines", async () => {
+  const module = await import(`${CONTROLLER}?pi-engine-cache=${Date.now()}`);
+  const calls = [];
+  const resolver = module.createPiModelDirectoryResolver({
+    async discoverPiModelCatalog(options) {
+      calls.push(options);
+      return {
+        models: [{ id: "owned/model", label: "Owned", supportedReasoningEfforts: ["off"], verified: "launchable" }],
+        effectiveModel: "owned/model",
+        effectiveThinkingLevel: "off",
+        defaultSource: "settings",
+        diagnostics: [],
+      };
+    },
+  });
+  const shared = { agentId: APP, cwd: "/tmp/pi-workspace", agentDir: "/tmp/owned-pi" };
+  await resolver.resolve({ ...shared, command: "/bin/bun", commandArgs: ["entry", "__internal", "pi-rpc"] });
+  await resolver.resolve({ ...shared, command: "pi", commandArgs: [] });
+  assert.equal(calls.length, 2, "builtin and external engines must not share a cache entry");
+  assert.deepEqual(calls[0].commandArgs, ["entry", "__internal", "pi-rpc"]);
+  assert.deepEqual(calls[1].commandArgs, []);
 });
 
 test("Codex model directory reuses app-server model/list with five-minute caching and dedupe", async () => {

--- a/test/unit/dashboard/dashboard-pi-context.test.mjs
+++ b/test/unit/dashboard/dashboard-pi-context.test.mjs
@@ -83,7 +83,9 @@ test("collectStatus projects a known Pi catalog window using the latest assistan
     { type: "message", timestamp: "2026-07-25T00:00:03.000Z", message: { role: "assistant", provider: "mock", model: "known", usage: { totalTokens: 10_000 } } },
   ].map((row) => JSON.stringify(row)).join("\n")}\n`);
   const previousConfigDir = process.env.LARKIN_CONFIG_DIR;
+  const previousAgentDir = process.env.PI_CODING_AGENT_DIR;
   process.env.LARKIN_CONFIG_DIR = root;
+  process.env.PI_CODING_AGENT_DIR = path.join(root, "decoy-host-pi");
   try {
     const calls = [];
     const projected = await collectStatus({ piModelResolver: { async resolve(input) {
@@ -92,6 +94,10 @@ test("collectStatus projects a known Pi catalog window using the latest assistan
     } } });
     const usage = projected.agents[0].session.usage;
     assert.equal(calls.length, 1);
+    assert.equal(calls[0].agentId, agentId);
+    assert.equal(calls[0].agentDir, path.join(root, "providers", "pi", agentId));
+    assert.notEqual(calls[0].agentDir, process.env.PI_CODING_AGENT_DIR);
+    assert.equal(calls[0].commandArgs?.includes("pi-rpc") ?? false, false);
     assert.equal(usage.cumulativeTokens, 90_000);
     assert.equal(usage.latestTokens, 10_000);
     assert.equal(usage.contextWindow, 200_000);
@@ -106,6 +112,43 @@ test("collectStatus projects a known Pi catalog window using the latest assistan
   } finally {
     if (previousConfigDir === undefined) delete process.env.LARKIN_CONFIG_DIR;
     else process.env.LARKIN_CONFIG_DIR = previousConfigDir;
+    if (previousAgentDir === undefined) delete process.env.PI_CODING_AGENT_DIR;
+    else process.env.PI_CODING_AGENT_DIR = previousAgentDir;
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("collectStatus builtin Pi catalog uses owned dir and pi-rpc even when host PI_CODING_AGENT_DIR is a decoy", async () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "larkin-pi-status-builtin-"));
+  fs.chmodSync(root, 0o700);
+  const agentId = "cli_PiContextBuiltinA1";
+  const stateDir = path.join(root, "state", "agents", agentId);
+  fs.mkdirSync(stateDir, { recursive: true });
+  fs.writeFileSync(path.join(root, "config.json"), `${JSON.stringify({
+    version: 4,
+    serverId: "server-pi-context-builtin",
+    mentionPolicy: "require",
+    activeAgent: agentId,
+    agents: { [agentId]: { runtime: "pi", model: "default", piDistribution: "builtin", createdAt: "2026-07-25T00:00:00.000Z" } },
+  })}\n`, { mode: 0o600 });
+  const previousConfigDir = process.env.LARKIN_CONFIG_DIR;
+  const previousAgentDir = process.env.PI_CODING_AGENT_DIR;
+  process.env.LARKIN_CONFIG_DIR = root;
+  process.env.PI_CODING_AGENT_DIR = path.join(root, "decoy-host-pi");
+  try {
+    const calls = [];
+    await collectStatus({ piModelResolver: { async resolve(input) {
+      calls.push(input);
+      return [];
+    } } });
+    assert.equal(calls.length, 1);
+    assert.equal(calls[0].agentDir, path.join(root, "providers", "pi", agentId));
+    assert.equal(calls[0].commandArgs.includes("pi-rpc"), true);
+  } finally {
+    if (previousConfigDir === undefined) delete process.env.LARKIN_CONFIG_DIR;
+    else process.env.LARKIN_CONFIG_DIR = previousConfigDir;
+    if (previousAgentDir === undefined) delete process.env.PI_CODING_AGENT_DIR;
+    else process.env.PI_CODING_AGENT_DIR = previousAgentDir;
     fs.rmSync(root, { recursive: true, force: true });
   }
 });

--- a/test/unit/dashboard/dashboard-workbench-source.test.mjs
+++ b/test/unit/dashboard/dashboard-workbench-source.test.mjs
@@ -88,3 +88,26 @@ test("dashboard Pi model directory is wired to the official catalog authority", 
   assert.match(controller, /createPiModelDirectoryResolver/);
   assert.match(controller, /\/api\/models\/pi/);
 });
+
+test("Pi catalog isolation deletes host-dir fallbacks and labels builtin versus user Pi", () => {
+  const controller = read("src/dashboard/dashboard-config-controller.ts");
+  const viewModel = read("src/dashboard/dashboard-view-model.ts");
+  const agentConfig = read("src/app/agent-config.ts");
+  const runtimeDirectory = read("src/app/runtime-model-directory.ts");
+  const types = read("src/dashboard/web/types.ts");
+  const app = read("src/dashboard/web/app.tsx");
+  for (const [name, source] of [
+    ["controller", controller],
+    ["view-model", viewModel],
+    ["agent-config", agentConfig],
+    ["runtime-model-directory", runtimeDirectory],
+  ]) {
+    assert.doesNotMatch(source, /PI_CODING_AGENT_DIR\s*\?\s*\{\s*agentDir/, `${name} must not omit agentDir when PI_CODING_AGENT_DIR is unset`);
+  }
+  assert.match(types, /piDistribution:\s*"builtin"\s*\|\s*"external"\s*\|\s*null/);
+  assert.match(app, /piDistributionLabel/);
+  assert.match(app, /内置 Pi|用户安装的 Pi|piDistributionLabel/);
+  assert.match(agentConfig, /piDistributionLabel/);
+  assert.match(runtimeDirectory, /ownedPiCatalogAgentDir/);
+  assert.match(runtimeDirectory, /piCatalogCommandSpec/);
+});

--- a/test/unit/runtime/runtime-host.test.mjs
+++ b/test/unit/runtime/runtime-host.test.mjs
@@ -1904,9 +1904,7 @@ test("short-lived successful creations share one crash epoch and reach bounded e
     retryPolicy: { baseDelayMs: 2, maxDelayMs: 4, maxAttempts: 2, stableWindowMs: 20 } });
   host.subscribe((event) => { if (event.type === "agent-status" && event.status === "error") errors.push(event.error); });
   await host.start([{ agentId: "cli_crashEpochA1", name: "cli_crashEpochA1", runtime: "pi", model: "p", workspaceDir: "/tmp" }]);
-  await new Promise((resolve) => setTimeout(resolve, 35));
-  assert.equal(creates, 3, "initial session plus two recreation attempts remain bounded");
-  assert.ok(errors.some((message) => /recreation exhausted after 2 attempts/.test(message)), errors.join("\n"));
+  await waitForCondition(() => creates === 3 && errors.some((message) => /recreation exhausted after 2 attempts/.test(message)));
   await host.shutdown("test complete");
 });
 


### PR DESCRIPTION
## Summary
- Pi catalog discovery now always uses `piAgentDirectory(configDir, agentId)` so Dashboard, status usage, `larkin model`, and Runtime `larkin config model --agent` cannot fall back to host `~/.pi` or a decoy `PI_CODING_AGENT_DIR`.
- Builtin Agents discover through bundled `pi-rpc`; external Agents keep host `pi`. Resolver cache keys include the engine so the two distributions do not share results.
- Dashboard and `larkin model` show a read-only 内置 Pi / 用户安装的 Pi label via shared `piDistributionLabel`. No `builtin-pi` provider and no Dashboard write path for `piDistribution`.

## Test plan
- [x] `bun test --max-concurrency 1 test/unit/dashboard/dashboard-config-directories.test.mjs test/unit/app/agent-config-typescript.test.mjs test/unit/app/agent-cli.test.mjs test/unit/app/internal-dispatch-build.test.mjs test/unit/dashboard/dashboard-workbench-source.test.mjs test/unit/dashboard/dashboard-pi-context.test.mjs`
- [x] `bun run test:frontend`
- [x] `bun run test` (typecheck + build + frontend + unit + integration + Mock E2E)
- [x] `git diff --check`

Key assertions:
- decoy / unset `PI_CODING_AGENT_DIR` is ignored; owned dir is always passed
- builtin catalog uses `pi-rpc` and does not spawn host `pi` (fake-pi log empty)
- external catalog records the Agent owned dir
- Agent A session querying Agent B uses B's owned dir
- frontend renders 内置 Pi / 用户安装的 Pi / no label for non-Pi


Made with [Cursor](https://cursor.com)