### PR TITLE
Probe external Pi readiness with owned catalog dir

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "larkin",
-  "version": "0.4.26",
+  "version": "0.4.27",
   "private": false,
   "larkinPackageRole": "npm-published",
   "files": [

--- a/src/runtime/runtime-readiness.ts
+++ b/src/runtime/runtime-readiness.ts
@@ -1,6 +1,8 @@
 import fs from "node:fs";
+import os from "node:os";
 import path from "node:path";
 import { spawnSync } from "node:child_process";
+import { resolveConfigDir as resolveRootConfigDir } from "../platform/root-layout.js";
 import { applyPiPackageDirForChild, piChildDistributionFromOverrides } from "./builtin-pi-assets.js";
 import { assertBuiltinPiAgentDirectory, BUNDLED_PI_VERSION, ownedPiCatalogAgentDir, piAgentDirectory } from "./pi-provider-config.js";
 import { traceProcessBoundary } from "../platform/process-boundary-trace.js";
@@ -132,14 +134,13 @@ export async function probeNativeRuntimeReadiness(options: ProbeNativeRuntimeRea
       ? "Install Pi and ensure `pi` is on PATH, or set LARKIN_PI_COMMAND."
       : `Install ${options.runtime} and ensure it is on PATH.`,
   };
-  const piConfigDir = env.LARKIN_CONFIG_DIR;
   const piAgentId = options.agentId;
-  if (options.runtime === "pi" && (!piAgentId || !piConfigDir)) {
+  if (options.runtime === "pi" && !piAgentId) {
     return {
       runtime: "pi",
       state: "unavailable",
       executable,
-      reason: "Pi catalog readiness requires Agent ID and LARKIN_CONFIG_DIR",
+      reason: "Pi catalog readiness requires Agent ID",
       nextAction: "Retry setup or start so Larkin can probe the Agent-owned Pi provider directory.",
     };
   }
@@ -152,7 +153,7 @@ export async function probeNativeRuntimeReadiness(options: ProbeNativeRuntimeRea
         command: executable,
         commandArgs: options.commandArgs,
         env,
-        agentDir: ownedPiCatalogAgentDir(piConfigDir as string, piAgentId as string),
+        agentDir: ownedPiCatalogAgentDir(resolveRootConfigDir(env, os.homedir()), piAgentId as string),
       });
     } else if (options.runtime === "codex") {
       const { discoverCodexModelCatalog } = await import("./codex-model-catalog.js");

--- a/src/runtime/runtime-readiness.ts
+++ b/src/runtime/runtime-readiness.ts
@@ -2,7 +2,7 @@ import fs from "node:fs";
 import path from "node:path";
 import { spawnSync } from "node:child_process";
 import { applyPiPackageDirForChild, piChildDistributionFromOverrides } from "./builtin-pi-assets.js";
-import { assertBuiltinPiAgentDirectory, BUNDLED_PI_VERSION, piAgentDirectory } from "./pi-provider-config.js";
+import { assertBuiltinPiAgentDirectory, BUNDLED_PI_VERSION, ownedPiCatalogAgentDir, piAgentDirectory } from "./pi-provider-config.js";
 import { traceProcessBoundary } from "../platform/process-boundary-trace.js";
 
 export type RuntimeReadinessState = "missing" | "unauthenticated" | "unavailable" | "incompatible" | "ready";
@@ -132,11 +132,28 @@ export async function probeNativeRuntimeReadiness(options: ProbeNativeRuntimeRea
       ? "Install Pi and ensure `pi` is on PATH, or set LARKIN_PI_COMMAND."
       : `Install ${options.runtime} and ensure it is on PATH.`,
   };
+  const piConfigDir = env.LARKIN_CONFIG_DIR;
+  const piAgentId = options.agentId;
+  if (options.runtime === "pi" && (!piAgentId || !piConfigDir)) {
+    return {
+      runtime: "pi",
+      state: "unavailable",
+      executable,
+      reason: "Pi catalog readiness requires Agent ID and LARKIN_CONFIG_DIR",
+      nextAction: "Retry setup or start so Larkin can probe the Agent-owned Pi provider directory.",
+    };
+  }
   const version = executableVersion(executable, env, options.commandArgs);
   try {
     if (options.runtime === "pi") {
       const { discoverPiModelCatalog } = await import("./pi-model-catalog.js");
-      await discoverPiModelCatalog({ cwd: options.cwd, command: executable, commandArgs: options.commandArgs, env });
+      await discoverPiModelCatalog({
+        cwd: options.cwd,
+        command: executable,
+        commandArgs: options.commandArgs,
+        env,
+        agentDir: ownedPiCatalogAgentDir(piConfigDir as string, piAgentId as string),
+      });
     } else if (options.runtime === "codex") {
       const { discoverCodexModelCatalog } = await import("./codex-model-catalog.js");
       await discoverCodexModelCatalog({ cwd: options.cwd, command: executable, env });

--- a/src/setup/bot-register.ts
+++ b/src/setup/bot-register.ts
@@ -687,7 +687,8 @@ if (!flag("--runtime") && (!testFixture || injectedAgentChoice || process.env.LA
     const choice = injectedAgentChoice
       ? requested
       : await recoverUnavailableExternalPi(requested, questioner, () => probeNativeRuntimeReadiness({
-        runtime: "pi", agentId: id, cwd: path.join(CFG_DIR, "agents", id), env: process.env,
+        runtime: "pi", agentId: id, cwd: path.join(CFG_DIR, "agents", id),
+        env: { ...process.env, LARKIN_CONFIG_DIR: CFG_DIR, LARKIN_PI_DISTRIBUTION: "external" },
       }), (message) => say(`! ${message}`), authServices);
     if (choice) {
       let serializedChoice: SetupAgentChoice & { authCompleted?: true; readinessCompleted?: true } = choice;

--- a/test/unit/runtime/runtime-readiness.test.mjs
+++ b/test/unit/runtime/runtime-readiness.test.mjs
@@ -40,7 +40,7 @@ import path from "node:path";
 import readline from "node:readline";
 const marker = ${JSON.stringify(marker)};
 const args = process.argv.slice(2);
-fs.appendFileSync(marker, JSON.stringify({ args, packageDir: process.env.PI_PACKAGE_DIR || null }) + "\\n");
+fs.appendFileSync(marker, JSON.stringify({ args, packageDir: process.env.PI_PACKAGE_DIR || null, agentDir: process.env.PI_CODING_AGENT_DIR || null }) + "\\n");
 if (args.includes("--version")) {
   if (${failIfDirty ? "true" : "false"} && process.env.PI_PACKAGE_DIR) {
     const theme = path.join(process.env.PI_PACKAGE_DIR, "dist/modes/interactive/theme/dark.json");
@@ -69,6 +69,7 @@ function writeThemeRoot(root, name) {
 
 test("external Pi readiness keeps a real package root and strips minimal or broken roots", async () => {
   const root = fs.mkdtempSync(path.join(os.tmpdir(), "larkin-readiness-pkg-"));
+  const agentId = "cli_readinessPkgA1";
   const { script, marker } = writeReadinessPi(root);
   const real = writeThemeRoot(root, "nix-store-pi");
   const minimal = path.join(root, ".larkin-official-pi-package");
@@ -76,20 +77,25 @@ test("external Pi readiness keeps a real package root and strips minimal or brok
   fs.writeFileSync(path.join(minimal, "theme", "dark.json"), "{}\n");
   const broken = path.join(root, "broken-link");
   fs.symlinkSync(path.join(root, "missing-target"), broken);
+  const ownedDir = path.join(root, "providers", "pi", agentId);
+  const envFor = (packageDir) => ({
+    PI_PACKAGE_DIR: packageDir, LARKIN_PI_DISTRIBUTION: "external",
+    LARKIN_CONFIG_DIR: root, PI_CODING_AGENT_DIR: path.join(root, "decoy-pi"),
+  });
   try {
     const ready = await probeNativeRuntimeReadiness({
-      runtime: "pi", cwd: root, command: process.execPath, commandArgs: [script],
-      env: { PI_PACKAGE_DIR: real, LARKIN_PI_DISTRIBUTION: "external" },
+      runtime: "pi", agentId, cwd: root, command: process.execPath, commandArgs: [script],
+      env: envFor(real),
     });
     assert.equal(ready.state, "ready", JSON.stringify(ready));
     const strippedMinimal = await probeNativeRuntimeReadiness({
-      runtime: "pi", cwd: root, command: process.execPath, commandArgs: [script],
-      env: { PI_PACKAGE_DIR: minimal, LARKIN_PI_DISTRIBUTION: "external" },
+      runtime: "pi", agentId, cwd: root, command: process.execPath, commandArgs: [script],
+      env: envFor(minimal),
     });
     assert.equal(strippedMinimal.state, "ready", JSON.stringify(strippedMinimal));
     const strippedBroken = await probeNativeRuntimeReadiness({
-      runtime: "pi", cwd: root, command: process.execPath, commandArgs: [script],
-      env: { PI_PACKAGE_DIR: broken, LARKIN_PI_DISTRIBUTION: "external" },
+      runtime: "pi", agentId, cwd: root, command: process.execPath, commandArgs: [script],
+      env: envFor(broken),
     });
     assert.equal(strippedBroken.state, "ready", JSON.stringify(strippedBroken));
     const rows = fs.readFileSync(marker, "utf8").trim().split("\n").filter(Boolean).map(JSON.parse);
@@ -99,6 +105,25 @@ test("external Pi readiness keeps a real package root and strips minimal or brok
     assert.ok(realRows.some((row) => row.args.includes("--mode") && row.args.includes("rpc")), JSON.stringify(rows));
     assert.ok(realRows.length >= 2, JSON.stringify(rows));
     assert.equal(dirtyRows.length, 0, JSON.stringify(rows));
+    const rpcRows = rows.filter((row) => row.args.includes("--mode") && row.args.includes("rpc"));
+    assert.ok(rpcRows.length > 0 && rpcRows.every((row) => row.agentDir === ownedDir), JSON.stringify(rows));
+    assert.equal(rpcRows.some((row) => String(row.agentDir).includes("decoy-pi")), false);
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("external Pi readiness without Agent identity does not fall through to host Pi", async () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "larkin-readiness-noid-"));
+  const { script, marker } = writeReadinessPi(root);
+  try {
+    const readiness = await probeNativeRuntimeReadiness({
+      runtime: "pi", cwd: root, command: process.execPath, commandArgs: [script],
+      env: { LARKIN_PI_DISTRIBUTION: "external", PI_CODING_AGENT_DIR: path.join(root, "decoy-pi") },
+    });
+    assert.equal(readiness.state, "unavailable", JSON.stringify(readiness));
+    assert.match(readiness.reason || "", /Agent ID and LARKIN_CONFIG_DIR/);
+    assert.equal(fs.readFileSync(marker, "utf8").trim(), "");
   } finally {
     fs.rmSync(root, { recursive: true, force: true });
   }

--- a/test/unit/runtime/runtime-readiness.test.mjs
+++ b/test/unit/runtime/runtime-readiness.test.mjs
@@ -122,7 +122,7 @@ test("external Pi readiness without Agent identity does not fall through to host
       env: { LARKIN_PI_DISTRIBUTION: "external", PI_CODING_AGENT_DIR: path.join(root, "decoy-pi") },
     });
     assert.equal(readiness.state, "unavailable", JSON.stringify(readiness));
-    assert.match(readiness.reason || "", /Agent ID and LARKIN_CONFIG_DIR/);
+    assert.match(readiness.reason || "", /requires Agent ID/);
     assert.equal(fs.readFileSync(marker, "utf8").trim(), "");
   } finally {
     fs.rmSync(root, { recursive: true, force: true });


### PR DESCRIPTION
## Summary
Independent review of #188 found interactive external-Pi setup still called `discoverPiModelCatalog` without an owned `agentDir`, so a decoy/`~/.pi` catalog leaked in.

## Changes
- `probeNativeRuntimeReadiness` requires Agent ID + `LARKIN_CONFIG_DIR` before spawning Pi, then passes `ownedPiCatalogAgentDir`.
- `bot-register` forwards `LARKIN_CONFIG_DIR` into that probe.
- Tests assert decoy `PI_CODING_AGENT_DIR` is ignored and identity-less probes do not spawn host Pi.
- Patch version 0.4.26 → 0.4.27.

## Test
`bun test test/unit/runtime/runtime-readiness.test.mjs` (10 pass)