### PR TITLE
feat(runtime): expose pi and builtin-pi as sibling runtimes

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "larkin",
-  "version": "0.4.27",
+  "version": "0.4.28",
   "private": false,
   "larkinPackageRole": "npm-published",
   "files": [

--- a/src/app/agent-cli.ts
+++ b/src/app/agent-cli.ts
@@ -189,7 +189,7 @@ function agentConfigRequest(
   const targetId = options.values.get("--agent") || agent.agentId;
   const target = config.agents[targetId];
   if (!target) throw new Error(`Agent 不存在：${targetId}；运行 larkin config show --json 查看可用 Agent`);
-  const currentDirectory = (runtime = target.runtime): RuntimeDirectoryModel[] => (dependencies.modelDirectory ?? ((input) => discoverRuntimeModelDirectorySync(input, env)))({
+  const currentDirectory = (runtime = larkinConfig.toUserRuntime(target.runtime, target.piDistribution)): RuntimeDirectoryModel[] => (dependencies.modelDirectory ?? ((input) => discoverRuntimeModelDirectorySync(input, env)))({
     agentId: target.agentId, cwd: target.workspaceDir, runtime,
   });
   if (operation === "show") {
@@ -569,7 +569,9 @@ export function runAgentCli(
         kind: "agent", id: agent.agentId, isSelf: true, name, displayName: name,
         openId: identity?.open_id ?? identity?.openId ?? null,
         avatarUrl: identity?.avatar_url ?? identity?.avatarUrl ?? null,
-        runtime: agent.runtime, model: agent.model, reasoningEffort: agent.effort ?? null,
+        runtime: agent.runtime,
+        runtimeOption: larkinConfig.toUserRuntime(agent.runtime, agent.piDistribution),
+        model: agent.model, reasoningEffort: agent.effort ?? null,
         createdAt: agent.createdAt ?? "1970-01-01T00:00:00.000Z",
       });
       return 0;

--- a/src/app/agent-config.ts
+++ b/src/app/agent-config.ts
@@ -20,7 +20,8 @@ import { isChannelReconnecting, projectAgentReadiness, type AgentReadinessStatus
 import { requestAgentUpsert } from "./local-control.js";
 import * as larkinConfig from "../platform/config.js";
 import { managedOfficialLarkCli } from "./agent-lark-cli-workspace.js";
-import { assertBuiltinPiAgentDirectory, ownedPiCatalogAgentDir, piAgentDirectory, piCatalogCommandSpec, piDistributionLabel } from "../runtime/pi-provider-config.js";
+import { assertBuiltinPiAgentDirectory, ownedPiCatalogAgentDir, piAgentDirectory, piCatalogCommandSpec } from "../runtime/pi-provider-config.js";
+import { RUNTIME_OPTIONS, fromUserRuntime, isUserRuntime, piCatalogDistributionForUserRuntime, toUserRuntime } from "../runtime/user-runtime.js";
 import { traceProcessBoundary } from "../platform/process-boundary-trace.js";
 
 interface RuntimeModel {
@@ -273,6 +274,7 @@ if (kind === "agents") {
         agent_id: agent.agentId,
         name: agent.name,
         runtime: agent.runtime,
+        runtimeOption: toUserRuntime(agent.runtime, agent.piDistribution),
         model: effectiveModel,
         document_comment: {
           event: "drive.notice.comment_add_v1",
@@ -335,7 +337,7 @@ if (kind === "agents") {
     say(`  ${agent.name}${agent.name === config.activeAgent ? " [active]" : ""}`);
     const effectiveModel = status?.session?.runtime === agent.runtime && status.session.model ? status.session.model : agent.model;
     const effectiveEffort = status?.session?.runtime === agent.runtime && status.session.reasoningEffort ? status.session.reasoningEffort : agent.effort;
-    say(`    runtime=${agent.runtime}  model=${effectiveModel}${effectiveModel !== agent.model ? `  stored=${agent.model}` : ""}${effectiveEffort ? `  effort=${effectiveEffort}` : ""}`);
+    say(`    runtime=${toUserRuntime(agent.runtime, agent.piDistribution)}  model=${effectiveModel}${effectiveModel !== agent.model ? `  stored=${agent.model}` : ""}${effectiveEffort ? `  effort=${effectiveEffort}` : ""}`);
     if (status?.runtimeReadiness) {
       const current = projectedReadiness.readiness.runtime_ready;
       const state = status.runtimeReadiness.state === "ready" && !current ? "unavailable" : status.runtimeReadiness.state || "incompatible";
@@ -445,7 +447,7 @@ if (!key) {
     say(`共 ${keys.length} 个 agent（用 --agent <appId> 查看/修改指定一个）:`);
     for (const candidate of keys) {
       const item = config.agents[candidate];
-      say(`  ${candidate}${candidate === config.activeAgent ? " [active]" : ""}  runtime=${item.runtime}  model=${item.model}`);
+      say(`  ${candidate}${candidate === config.activeAgent ? " [active]" : ""}  runtime=${toUserRuntime(item.runtime, item.piDistribution)}  model=${item.model}`);
     }
     process.exit(0);
   }
@@ -458,7 +460,12 @@ if (kind === "pi-distribution") {
   const requested = value || "show";
   if (importExternalProfile && requested !== "builtin") die("--import-external-profile 只允许与 builtin 一起使用");
   if (requested === "show") {
-    say(JSON.stringify({ agentId: selectedKey, runtime: agent.runtime, piDistribution: agent.piDistribution ?? "external" }));
+    say(JSON.stringify({
+      agentId: selectedKey,
+      runtime: agent.runtime,
+      runtimeOption: toUserRuntime(agent.runtime, agent.piDistribution),
+      piDistribution: agent.piDistribution ?? "external",
+    }));
     process.exit(0);
   }
   if (requested !== "builtin" && requested !== "external") die("Pi distribution 只允许 show/builtin/external");
@@ -501,10 +508,18 @@ if ((["model", "effort"].includes(kind || "") && agent.runtime === "claude") || 
   }
 }
 let piCatalog: PiModelCatalog | null = null;
-if (agent.runtime === "pi" || (kind === "runtime" && value === "pi")) {
-  if (kind === "model" && !value) say(`发行版: ${piDistributionLabel(agent.piDistribution)}`);
+const userRuntime = toUserRuntime(agent.runtime, agent.piDistribution);
+const catalogUserRuntime = kind === "runtime" && (value === "pi" || value === "builtin-pi")
+  ? value
+  : userRuntime;
+if ((kind === "model" || kind === "effort" || kind === "runtime") && !value) {
+  say(`agent=${selectedKey}  runtime=${userRuntime}  model=${agent.model}`);
+}
+const needsLivePiCatalog = (["model", "effort"].includes(kind) && agent.runtime === "pi")
+  || (kind === "runtime" && (value === "pi" || value === "builtin-pi") && Boolean(flagModel));
+if (needsLivePiCatalog) {
   try {
-    const catalogCommand = piCatalogCommandSpec(agent.piDistribution, process.env);
+    const catalogCommand = piCatalogCommandSpec(piCatalogDistributionForUserRuntime(catalogUserRuntime), process.env);
     piCatalog = await discoverPiModelCatalog({
       cwd: String(agent.workspaceDir),
       agentDir: ownedPiCatalogAgentDir(configDir, selectedKey),
@@ -518,11 +533,16 @@ if (agent.runtime === "pi" || (kind === "runtime" && value === "pi")) {
   if (!piCatalog) die("Pi 模型目录加载失败");
   const loadedPiCatalog = piCatalog as PiModelCatalog;
   for (const diagnostic of loadedPiCatalog.diagnostics) console.error(`Pi diagnostic: ${diagnostic}`);
-  catalog.pi = [{ id: "default", label: `default: ${loadedPiCatalog.effectiveModel}` }, ...loadedPiCatalog.models];
+  const piModels = [{ id: "default", label: `default: ${loadedPiCatalog.effectiveModel}` }, ...loadedPiCatalog.models];
+  catalog.pi = piModels;
+}
+
+function catalogRuntimeKey(runtime: string): string {
+  return isUserRuntime(runtime) ? fromUserRuntime(runtime).runtime : runtime;
 }
 
 function listModels(runtime: string, current: string): void {
-  const items = catalog[runtime];
+  const items = catalog[catalogRuntimeKey(runtime)];
   if (!items) {
     say(`  （无 ${runtime} 的目录数据）`);
     return;
@@ -543,7 +563,7 @@ function writeAndHint(mutation: ConfigMutation): void {
 }
 
 function effortChoicesFor(runtime: string, model: string): { list: string[]; note: string; def: string | null } | null {
-  const entry = catalog[runtime]?.find((candidate) => candidate.id === model);
+  const entry = catalog[catalogRuntimeKey(runtime)]?.find((candidate) => candidate.id === model);
   if (!entry?.supportedReasoningEfforts?.length) return null;
   return { list: entry.supportedReasoningEfforts, note: "模型声明", def: entry.defaultReasoningEffort || null };
 }
@@ -560,15 +580,14 @@ function dropEffortIfInvalid(next: AgentConfig): AgentConfig {
 }
 
 if (kind === "model") {
-  const runtime = agent.runtime;
+  const runtime = userRuntime;
   if (!value) {
-    say(`agent=${selectedKey}  runtime=${runtime}  model=${agent.model}`);
     say(`\n${runtime} 可选模型:`);
     listModels(runtime, agent.model);
     say("\n切换: larkin model <id>");
     process.exit(0);
   }
-  const items = catalog[runtime];
+  const items = catalog[catalogRuntimeKey(runtime)];
   if (items && !items.some((model) => model.id === value)) {
     console.error(`✗ "${value}" 不是 ${runtime} 的合法模型。合法值:`);
     for (const model of items) console.error(`    ${model.id}`);
@@ -592,13 +611,11 @@ if (kind === "model") {
   }
   const choices = effortChoicesFor(agent.runtime, agent.model);
   if (!choices) {
-    say(`agent=${selectedKey}  runtime=${agent.runtime}  model=${agent.model}`);
-    say(`模型 ${agent.runtime}/${agent.model} 未显式声明 supportedReasoningEfforts，不能设置 effort。`);
+    say(`模型 ${userRuntime}/${agent.model} 未显式声明 supportedReasoningEfforts，不能设置 effort。`);
     process.exit(value ? 1 : 0);
   }
   const { list, note, def } = choices;
   if (!value) {
-    say(`agent=${selectedKey}  runtime=${agent.runtime}  model=${agent.model}`);
     say(`effort=${agent.effort || `（未设置，runtime 默认${def ? `，该模型默认 ${def}` : ""}）`}`);
     say(`\n${agent.model} 可选档位（${note}）:`);
     for (const level of list) say(`  ${level.padEnd(10)}${level === agent.effort ? "  [← 当前]" : ""}${level === def ? "  [模型默认]" : ""}`);
@@ -606,7 +623,7 @@ if (kind === "model") {
     process.exit(0);
   }
   if (!list.includes(value)) {
-    console.error(`✗ "${value}" 不是 ${agent.runtime}/${agent.model} 的合法档位。合法值: ${list.join(", ")}`);
+    console.error(`✗ "${value}" 不是 ${userRuntime}/${agent.model} 的合法档位。合法值: ${list.join(", ")}`);
     process.exit(1);
   }
   if (value === agent.effort) {
@@ -662,31 +679,30 @@ if (kind === "model") {
   writeAndHint({ kind: "set-chat-mention", agentId: selectedKey, chatId: chatArg, value: action === "free" ? "free" : "require" });
 } else {
   if (!value) {
-    say(`agent=${selectedKey}  runtime=${agent.runtime}  model=${agent.model}`);
     say("\n可选 runtime:");
-    for (const runtime of Object.keys(catalog)) {
-      say(`  ${runtime.padEnd(12)}${runtime === agent.runtime ? "  [← 当前]" : ""}  默认模型=${larkinConfig.defaultModelFor(runtime)}`);
+    for (const runtime of RUNTIME_OPTIONS) {
+      say(`  ${runtime.padEnd(12)}${runtime === userRuntime ? "  [← 当前]" : ""}  默认模型=${larkinConfig.defaultModelFor(runtime)}`);
     }
     say("\n切换: larkin runtime <id> [--model <id>]");
     process.exit(0);
   }
-  if (!catalog[value]) {
-    console.error(`✗ "${value}" 不是合法 runtime。合法值: ${Object.keys(catalog).join(", ")}`);
+  if (!isUserRuntime(value)) {
+    console.error(`✗ "${value}" 不是合法 runtime。合法值: ${RUNTIME_OPTIONS.join(", ")}`);
     process.exit(1);
   }
   let model = flagModel;
   if (model) {
-    const items = catalog[value];
-    if (!items.some((candidate) => candidate.id === model)) {
+    const items = catalog[catalogRuntimeKey(value)];
+    if (!items || !items.some((candidate) => candidate.id === model)) {
       console.error(`✗ "${model}" 不是 ${value} 的合法模型。合法值:`);
-      for (const item of items) console.error(`    ${item.id}`);
+      for (const item of items || []) console.error(`    ${item.id}`);
       process.exit(1);
     }
   } else {
     model = larkinConfig.defaultModelFor(value);
-    if (value !== agent.runtime) say(`model 随 runtime 重置为默认: ${agent.model} → ${model}（可用 --model 显式指定）`);
+    if (value !== userRuntime) say(`model 随 runtime 重置为默认: ${agent.model} → ${model}（可用 --model 显式指定）`);
   }
-  if (value === agent.runtime && model === agent.model) {
+  if (value === userRuntime && model === agent.model) {
     say(`runtime 已经是 ${value}，无需修改`);
     process.exit(0);
   }

--- a/src/app/cli.ts
+++ b/src/app/cli.ts
@@ -54,8 +54,8 @@ if (runtimeAgentAuthority && command === "comment") routes.comment = ["lark-cli"
 const commandHelp: Record<string, string> = {
   start: `Usage: larkin start [--agent <App ID> | --agents <App ID,...>]
 Start one foreground supervisor for the daemon and local dashboard, or reuse it.`,
-  setup: `Usage: larkin setup [--tenant feishu|lark] [--runtime <builtin-pi|external-pi|codex|claude>] [--provider <id> --api-key <key>]
-Run setup to create or connect a bot, configure its Agent, and attach it. Choose Feishu or Lark before the authorization QR (--tenant; default feishu). Interactive terminals keep the guided flow; Agent-driven (non-TTY) runs default to builtin-pi and need --provider/--api-key (or --runtime external-pi).`,
+  setup: `Usage: larkin setup [--tenant feishu|lark] [--runtime <builtin-pi|pi|codex|claude>] [--provider <id> --api-key <key>]
+Run setup to create or connect a bot, configure its Agent, and attach it. Choose Feishu or Lark before the authorization QR (--tenant; default feishu). Interactive terminals keep the guided flow; Agent-driven (non-TTY) runs default to builtin-pi and need --provider/--api-key (or --runtime pi).`,
   status: `Usage: larkin status [--json]
 Show Agent configuration, bot identity, credentials, and connection status. Use --json for readiness automation.`,
   agents: `Usage: larkin agents [--json]
@@ -63,7 +63,7 @@ List every configured Agent and its current local status. Use --json for daemon/
   model: `Usage: larkin model [<model>] [--agent <App ID>]
 Show or change an Agent model.`,
   runtime: `Usage: larkin runtime [<runtime>] [--agent <App ID>] [--model <model>]
-Show or change an Agent runtime.`,
+Show or change an Agent runtime. User-facing ids: pi | builtin-pi | codex | claude.`,
   "pi-distribution": `Usage: larkin pi-distribution [show|builtin|external] [--agent <App ID>] [--snapshot <private-file>] [--import-external-profile]
        larkin pi-distribution rollback --snapshot <private-file>
 Show or change one Pi Agent distribution. builtin requires configured provider state, or explicitly imports the external Pi 0.84.2 profile with --import-external-profile; all changes support config-lock CAS rollback.`,

--- a/src/app/runtime-model-directory.ts
+++ b/src/app/runtime-model-directory.ts
@@ -8,6 +8,7 @@ import { discoverClaudeModelCatalog } from "../runtime/claude-model-catalog.js";
 import { discoverPiModelCatalog } from "../runtime/pi-model-catalog.js";
 import { discoverCodexModelCatalog } from "../runtime/codex-model-catalog.js";
 import { ownedPiCatalogAgentDir, piCatalogCommandSpec } from "../runtime/pi-provider-config.js";
+import { piCatalogDistributionForUserRuntime } from "../runtime/user-runtime.js";
 
 type Env = Record<string, string | undefined>;
 
@@ -52,7 +53,7 @@ export async function discoverRuntimeModelDirectory(input: RuntimeModelDirectory
       ...catalog.models.map(({ id, label, supportedReasoningEfforts }) => ({ id, label, supportedReasoningEfforts })),
     ];
   }
-  if (input.runtime === "pi") {
+  if (input.runtime === "pi" || input.runtime === "builtin-pi") {
     const env = input.env ?? process.env;
     const agentId = input.agentId || "";
     if (!agentId) throw new Error("runtime model directory requires agentId for Pi");
@@ -60,7 +61,7 @@ export async function discoverRuntimeModelDirectory(input: RuntimeModelDirectory
     const { config } = loadConfig(env);
     const agent = config.agents[agentId];
     if (!agent) throw new Error(`unknown agent: ${agentId}`);
-    const catalogCommand = piCatalogCommandSpec(agent.piDistribution, env);
+    const catalogCommand = piCatalogCommandSpec(piCatalogDistributionForUserRuntime(input.runtime), env);
     const catalog = await discoverPiModelCatalog({
       cwd: input.cwd,
       agentDir: ownedPiCatalogAgentDir(configDir, agentId),

--- a/src/app/setup.ts
+++ b/src/app/setup.ts
@@ -8,6 +8,7 @@ import readline from "node:readline/promises";
 import { fileURLToPath } from "node:url";
 import * as larkinConfig from "../platform/config.js";
 import { PI_PROVIDER_PRESETS } from "../runtime/pi-provider-config.js";
+import { fromUserRuntime, isUserRuntime } from "../runtime/user-runtime.js";
 const PI_PROVIDER_IDS = PI_PROVIDER_PRESETS.map((p) => p.id).join(" | ") + " | custom";
 import { acquireProcessLock, readProcessState } from "../platform/process-state.js";
 import { requestAgentUpsert } from "./local-control.js";
@@ -41,17 +42,18 @@ if (has("--comment-subscription")) {
 const commentSubscription = "application";
 const OPT = { runtime: flag("--runtime") || null, commentSubscription, start: true, help: has("--help") || has("-h"), nonInteractive: !Boolean(process.stdin.isTTY) };
 
-// runtime 枚举归一：builtin-pi（默认）/ external-pi / codex / claude → 内部 (runtime, distribution)
-const RUNTIME_ENUM = ["builtin-pi", "external-pi", "codex", "claude"] as const;
-type RuntimeEnum = (typeof RUNTIME_ENUM)[number];
+// runtime 枚举归一：builtin-pi（默认）/ pi / codex / claude → 内部 (runtime, distribution)
+const RUNTIME_ENUM = ["builtin-pi", "pi", "codex", "claude"] as const;
 function normalizeRuntime(value: string | null): { runtime: "pi" | "codex" | "claude"; distribution?: "builtin" | "external" } {
-  const chosen: RuntimeEnum = (value || "builtin-pi") as RuntimeEnum;
-  if (!RUNTIME_ENUM.includes(chosen)) {
+  const raw = value || "builtin-pi";
+  if (raw === "external-pi") {
+    console.error("external-pi 已改名为 pi");
+    return fromUserRuntime("pi");
+  }
+  if (!isUserRuntime(raw) || !RUNTIME_ENUM.includes(raw)) {
     die(`未知 runtime \`${value}\`；可选：${RUNTIME_ENUM.join(" | ")}`);
   }
-  if (chosen === "builtin-pi") return { runtime: "pi", distribution: "builtin" };
-  if (chosen === "external-pi") return { runtime: "pi", distribution: "external" };
-  return { runtime: chosen };
+  return fromUserRuntime(raw);
 }
 const normalizedRuntime = normalizeRuntime(OPT.runtime);
 // 参数化路径：显式 --runtime、无 TTY（Agent 驱动）、或任何 provider 参数。
@@ -63,11 +65,11 @@ if (!OPT.help && parameterized && normalizedRuntime.distribution === "builtin") 
   const p = flag("--provider");
   const b = flag("--base-url");
   const k = flag("--api-key");
-  if (!p && !b) die(`builtin-pi 需要 --provider <id>（${PI_PROVIDER_IDS}）或 --base-url；或 --runtime external-pi 用已有 pi`);
-  if (!k) die("builtin-pi 需要 --api-key；或 --runtime external-pi 用已有登录");
+  if (!p && !b) die(`builtin-pi 需要 --provider <id>（${PI_PROVIDER_IDS}）或 --base-url；或 --runtime pi 用已有 pi`);
+  if (!k) die("builtin-pi 需要 --api-key；或 --runtime pi 用已有登录");
 }
 if (!OPT.help && normalizedRuntime.distribution === "external" && (flag("--provider") || flag("--api-key") || flag("--base-url"))) {
-  die("external-pi 使用已有 pi 环境，不接受 --provider/--api-key/--base-url");
+  die("pi 使用已有 pi 环境，不接受 --provider/--api-key/--base-url");
 }
 if (OPT.help) {
   say(`larkin setup — Create or connect a Feishu (Lark) bot, then configure and attach its Agent
@@ -77,7 +79,7 @@ Usage:
   larkin setup --provider <id> --api-key <key>   指定内置 Pi provider（无需交互）
 
 Options:
-  --runtime <runtime>                   Agent runtime 枚举：builtin-pi（默认，内置 Pi）| external-pi | codex | claude
+  --runtime <runtime>                   Agent runtime 枚举：builtin-pi（默认，内置 Pi）| pi | codex | claude
   --provider <id>                       内置 Pi provider：deepseek | kimi | minimax | zhipu | openai |
                                           anthropic | gemini | groq | cerebras | xai | fireworks |
                                           together | mistral | openrouter | kimi-coding | qwen-cn | custom
@@ -99,7 +101,7 @@ daemon + dashboard supervisor used by larkin start.
 
 Interactive terminals without flags keep the guided flow (browser bot selection + runtime choice).
 Non-interactive (Agent-driven) runs default to builtin-pi and require --provider/--api-key (or
---runtime external-pi to reuse an existing pi login).`);
+--runtime pi to reuse an existing pi login).`);
   process.exit(0);
 }
 

--- a/src/dashboard/dashboard-config-controller.ts
+++ b/src/dashboard/dashboard-config-controller.ts
@@ -9,6 +9,7 @@ import { discoverCodexModelCatalog, type DiscoverCodexCatalogOptions } from "../
 import { discoverPiModelCatalog, type DiscoverPiCatalogOptions } from "../runtime/pi-model-catalog.js";
 import { managedOfficialLarkCli } from "../app/agent-lark-cli-workspace.js";
 import { ownedPiCatalogAgentDir, piCatalogCommandSpec } from "../runtime/pi-provider-config.js";
+import { RUNTIME_OPTIONS, piCatalogDistributionForUserRuntime, toUserRuntime } from "../runtime/user-runtime.js";
 
 type Env = Record<string, string | undefined>;
 type LarkJsonCall = { command: string; args: string[]; env: Env; maxBuffer: number; timeout: number };
@@ -405,11 +406,11 @@ export function createDashboardConfigController({
   codexModelDirectoryResolver?: CodexModelDirectoryResolver;
   piModelDirectoryResolver?: PiModelDirectoryResolver;
 }) {
-  const resolvePiModelDirectory = async (agentId: string) => {
+  const resolvePiModelDirectory = async (agentId: string, userRuntime: "pi" | "builtin-pi") => {
     const { config, configDir } = loadConfig(env);
     const agent = config.agents[agentId];
     if (!agent) throw new Error("unknown agent");
-    const catalogCommand = piCatalogCommandSpec(agent.piDistribution, env);
+    const catalogCommand = piCatalogCommandSpec(piCatalogDistributionForUserRuntime(userRuntime), env);
     return await piModelDirectoryResolver.resolve({
       agentId,
       cwd: agent.workspaceDir,
@@ -422,7 +423,7 @@ export function createDashboardConfigController({
     const { config } = loadConfig(env);
     const agent = config.agents[agentId];
     if (!agent) throw new Error("unknown agent");
-    if (runtime === "pi") return await resolvePiModelDirectory(agentId);
+    if (runtime === "pi" || runtime === "builtin-pi") return await resolvePiModelDirectory(agentId, runtime);
     if (runtime === "codex") return await codexModelDirectoryResolver.resolve({ agentId, cwd: agent.workspaceDir, env });
     if (runtime === "claude") return await claudeModelDirectoryResolver.resolve({ agentId, cwd: agent.workspaceDir, env });
     const authored = loadRuntimeModels()[runtime];
@@ -434,7 +435,9 @@ export function createDashboardConfigController({
     const { config } = loadConfig(env);
     const agent = config.agents[mutation.agentId];
     if (!agent) throw new Error("unknown agent");
-    const runtime = mutation.kind === "set-agent-runtime" ? mutation.runtime : agent.runtime;
+    const runtime = mutation.kind === "set-agent-runtime"
+      ? mutation.runtime
+      : toUserRuntime(agent.runtime, agent.piDistribution);
     const model = mutation.kind === "set-agent-runtime" ? mutation.model || "default"
       : mutation.kind === "set-agent-model" ? mutation.model : agent.model;
     if (mutation.kind === "set-agent-effort" && mutation.effort === null) return;
@@ -451,17 +454,21 @@ export function createDashboardConfigController({
       if (requestUrl.pathname === "/api/config" && req.method === "GET") {
         try {
           assertPrivateReadRequest(req, csrfCapability);
-          json(res, 200, { ...await sanitizedView(env, chatDirectoryResolver, requestUrl.searchParams.get("agent") || undefined, requestUrl.searchParams.get("chat") || undefined), runtimeModels: loadRuntimeModels() });
+          json(res, 200, {
+            ...await sanitizedView(env, chatDirectoryResolver, requestUrl.searchParams.get("agent") || undefined, requestUrl.searchParams.get("chat") || undefined),
+            runtimeModels: loadRuntimeModels(),
+            runtimeOptions: [...RUNTIME_OPTIONS],
+          });
         } catch (error) {
           json(res, error instanceof Error && /host|capability/.test(error.message) ? 403 : 500, { error: "configuration unavailable" });
         }
         return true;
       }
-      if (requestUrl.pathname === "/api/models/pi" && req.method === "GET") {
+      if ((requestUrl.pathname === "/api/models/pi" || requestUrl.pathname === "/api/models/builtin-pi") && req.method === "GET") {
         try {
           assertPrivateReadRequest(req, csrfCapability);
           const agentId = requestUrl.searchParams.get("agent") || "";
-          const models = await resolvePiModelDirectory(agentId);
+          const models = await resolvePiModelDirectory(agentId, requestUrl.pathname === "/api/models/builtin-pi" ? "builtin-pi" : "pi");
           json(res, 200, { models });
         } catch (error) {
           json(res, error instanceof Error && /host|capability/.test(error.message) ? 403 : 500, { error: "Pi model directory unavailable" });

--- a/src/dashboard/dashboard-view-model.ts
+++ b/src/dashboard/dashboard-view-model.ts
@@ -14,6 +14,7 @@ import { collectWorkspaceEntry as collectTypedWorkspaceEntry } from "./dashboard
 import { buildFingerprint, packageVersion } from "../platform/build-info.js";
 import * as larkinConfig from "../platform/config.js";
 import { ownedPiCatalogAgentDir, piCatalogCommandSpec } from "../runtime/pi-provider-config.js";
+import { toUserRuntime } from "../runtime/user-runtime.js";
 
 export interface JsonRecord {
   [key: string]: unknown;
@@ -564,7 +565,7 @@ async function collectAgentStatus(a: DashboardAgent, configDir: string, daemonSt
     agentId: a.agentId,
     name: a.name,
     displayName: (botIdentity && botIdentity.name) || a.name,
-    runtime: a.runtime,
+    runtime: toUserRuntime(a.runtime, a.piDistribution),
     model: status.session?.runtime === a.runtime && status.session?.model ? String(status.session.model) : a.model,
     effort: status.session?.runtime === a.runtime && status.session?.reasoningEffort ? String(status.session.reasoningEffort) : a.effort || null,
     runtimeReadiness,
@@ -588,7 +589,7 @@ async function collectAgentStatus(a: DashboardAgent, configDir: string, daemonSt
     sessions: agentState.sessions || {},
     session: sessionId ? {
       id: sessionId,
-      runtime: a.runtime,
+      runtime: toUserRuntime(a.runtime, a.piDistribution),
       startedAt: usage.startedAt || (status.session?.id === sessionId ? status.session.startedAt : null) || null,
       ageSec: ageSec(usage.startedAt || (status.session?.id === sessionId ? status.session.startedAt : null)),
       lastTurnAt: status.session?.lastTurnAt || null,

--- a/src/dashboard/web/app.tsx
+++ b/src/dashboard/web/app.tsx
@@ -6,7 +6,7 @@ import {
 import { AGENT_TABS, createLatestResponseGate, filterAgents, parseRoute, reconcileAgentId, routeSearch, sameDraft, type AgentTab } from "./dashboard-state";
 import type { ConfigAgent, ConfigResponse, DashboardAgent, RuntimeModel, RuntimeReadinessView, StatusResponse, WorkspaceProjection } from "./types";
 import { Badge, Button, EmptyState, Sheet, cn } from "./components/ui";
-import { piDistributionLabel } from "../../runtime/pi-distribution-label";
+import { RUNTIME_OPTIONS } from "../../runtime/user-runtime.js";
 
 const TAB_LABELS: Record<AgentTab, string> = {
   overview: "概览", conversation: "对话", configuration: "配置", reminders: "提醒", workspace: "工作区", logs: "日志",
@@ -287,7 +287,7 @@ function AgentConfiguration({ agentId, onDirtyChange, refreshKey }: { agentId: s
       if (!gate.current.accepts(token)) return;
       const agent = next.agents[0];
       if (!agent) throw new Error("配置投影中没有当前 Agent");
-      const values = { runtime: agent.runtime, model: agent.model, effort: agent.effort || "default", mention: agent.mention.override };
+      const values = { runtime: agent.runtimeOption || agent.runtime, model: agent.model, effort: agent.effort || "default", mention: agent.mention.override };
       setResponse(next);
       setServerDraft(values);
       if (!preserveDraft || !dirty) setDraft(values);
@@ -303,7 +303,7 @@ function AgentConfiguration({ agentId, onDirtyChange, refreshKey }: { agentId: s
   const model = String(draft.model || config?.model || "default");
   useEffect(() => {
     setModelDirectory({ runtime, status: "loading", models: [] });
-    if (!new Set(["pi", "codex", "claude"]).has(runtime)) {
+    if (!new Set(["pi", "builtin-pi", "codex", "claude"]).has(runtime)) {
       setModelDirectory({ runtime, status: "error", models: [] });
       return;
     }
@@ -386,8 +386,7 @@ function AgentConfiguration({ agentId, onDirtyChange, refreshKey }: { agentId: s
     <section className="config-section"><div className="section-heading"><div><h3>Agent 配置</h3><p>只作用于 {agentId}；运行配置会在安全时机自动应用，Agent 正忙时会保留待处理。</p></div><Badge className={config.apply.applyState === "pending" ? "warning" : "success"}>{applyStateLabel}</Badge></div>
       <p className="cli-guidance">这里只提供常用微调。更多配置可以直接告诉当前 Agent，让它运行 <code>larkin config --help</code> 后完成。</p>
       <div className="config-grid">
-        <label><span>Runtime</span><select value={runtime} disabled={loading} onChange={(event) => { update("runtime", event.target.value); update("model", "default"); update("effort", "default"); }}>{Object.keys(response?.runtimeModels || {}).map((value) => <option value={value} key={value}>{value}</option>)}</select></label>
-        {runtime === "pi" ? <label><span>Pi 发行版</span><input readOnly disabled aria-label="Pi 发行版" value={piDistributionLabel(config.piDistribution)} /></label> : null}
+        <label><span>Runtime</span><select value={runtime} disabled={loading} onChange={(event) => { update("runtime", event.target.value); update("model", "default"); update("effort", "default"); }}>{(response?.runtimeOptions || RUNTIME_OPTIONS).map((value) => <option value={value} key={value}>{value}</option>)}</select></label>
         <label><span>Model</span><select value={model} disabled={loading || !directoryReady} onChange={(event) => { update("model", event.target.value); if (event.target.value === "default") update("effort", "default"); }}>{visibleModels.map((item) => <option value={item.id} key={item.id}>{item.label || item.id}</option>)}</select></label>
         <label><span>Effort</span><select value={String(draft.effort || "default")} disabled={loading || !directoryReady || model === "default" || !efforts.length} onChange={(event) => update("effort", event.target.value)}><option value="default">default · 不指定</option>{efforts.map((value) => <option value={value} key={value}>{value}</option>)}</select></label>
         <label><span>群消息策略</span><select value={String(draft.mention || "inherit")} disabled={loading} onChange={(event) => update("mention", event.target.value)}><option value="inherit">跟随全局设置</option><option value="require">需要 @</option><option value="free">无需 @</option></select></label>

--- a/src/dashboard/web/types.ts
+++ b/src/dashboard/web/types.ts
@@ -103,6 +103,7 @@ export interface KnownChat {
 export interface ConfigAgent {
   agentId: string;
   runtime: string;
+  runtimeOption: "codex" | "claude" | "pi" | "builtin-pi";
   model: string;
   effort: string | null;
   piDistribution: "builtin" | "external" | null;
@@ -124,6 +125,7 @@ export interface ConfigResponse {
   persistedRevision: string;
   agents: ConfigAgent[];
   runtimeModels: Record<string, RuntimeModel[]>;
+  runtimeOptions: Array<"codex" | "claude" | "pi" | "builtin-pi">;
 }
 
 export type WorkspaceProjection = {

--- a/src/platform/config.ts
+++ b/src/platform/config.ts
@@ -5,6 +5,8 @@ import * as path from "node:path";
 import { TargetRootLayout, resolveConfigDir as resolveRootConfigDir } from "./root-layout.js";
 import { exactMode, fsyncDirectoryOf } from "./secure-metadata.js";
 import { CURRENT_RUNTIME_MODELS, type RuntimeModels } from "../runtime/runtime-model-catalog.js";
+import { assertBuiltinPiAgentDirectory, piAgentDirectory } from "../runtime/pi-provider-config.js";
+import { fromUserRuntime, isAdapterRuntime, isUserRuntime, toUserRuntime } from "../runtime/user-runtime.js";
 import processInspect from "./process-inspect.cjs";
 import {
   applyPiProfileMigration,
@@ -20,6 +22,9 @@ import {
 type Env = Record<string, string | undefined>;
 type Obj = Record<string, unknown>;
 export type { RuntimeModels } from "../runtime/runtime-model-catalog.js";
+export {
+  RUNTIME_OPTIONS, fromUserRuntime, isAdapterRuntime, isUserRuntime, runtimeOptionOf, runtimeOptionTarget, toUserRuntime,
+} from "../runtime/user-runtime.js";
 export type MentionPolicy = "require" | "free";
 export type MentionPolicyOverride = MentionPolicy | "inherit";
 
@@ -123,7 +128,8 @@ export function loadRuntimeModels(): RuntimeModels {
 }
 
 export function defaultModelFor(runtime: string): string {
-  const models = loadRuntimeModels()[runtime];
+  const adapter = isUserRuntime(runtime) ? fromUserRuntime(runtime).runtime : runtime;
+  const models = loadRuntimeModels()[adapter];
   if (!models) throw new Error(`runtime 模型目录不存在 runtime: ${runtime}`);
   return models[0].id;
 }
@@ -169,7 +175,7 @@ function validateStoredAgent(key: string, agent: unknown, version: 3 | 4): asser
   if (!isPlainObject(agent)) throw new Error(`Agent ${key} 必须是普通 object`);
   assertAllowedFields(agent, version === 3 ? AGENT_FIELDS_V3 : AGENT_FIELDS_V4, `Agent ${key}`);
   if (typeof agent.runtime !== "string" || !agent.runtime) throw new Error(`Agent ${key}.runtime 必须是非空字符串`);
-  if (!loadRuntimeModels()[agent.runtime]) throw new Error(`Agent ${key}.runtime 未知：${agent.runtime}`);
+  if (!isAdapterRuntime(agent.runtime)) throw new Error(`Agent ${key}.runtime 未知：${agent.runtime}`);
   if (typeof agent.model !== "string" || !agent.model) throw new Error(`Agent ${key}.model 必须是非空字符串`);
   assertModel(agent.runtime, agent.model);
   if (Object.hasOwn(agent, "piDistribution")) {
@@ -579,11 +585,20 @@ function applyMutation(config: HydratedConfig, mutation: ConfigMutation): { scop
     if (mutation.distribution !== "builtin" && mutation.distribution !== "external") throw new Error("Pi distribution 只允许 builtin/external");
     agent.piDistribution = mutation.distribution;
   } else if (mutation.kind === "set-agent-runtime") {
-    if (!loadRuntimeModels()[mutation.runtime]) throw new Error(`未知 runtime：${mutation.runtime}`);
-    assertModel(mutation.runtime, mutation.model || "default");
-    agent.runtime = mutation.runtime;
+    if (!isUserRuntime(mutation.runtime)) throw new Error(`未知 runtime：${mutation.runtime}`);
+    const stored = fromUserRuntime(mutation.runtime);
+    if (stored.piDistribution === "builtin") {
+      try {
+        assertBuiltinPiAgentDirectory(piAgentDirectory(config.configDir, mutation.agentId));
+      } catch (error) {
+        throw new Error(`无法切换到 builtin-pi：${error instanceof Error ? error.message : String(error)}。请先运行 larkin setup 并为该 Agent 选择 builtin-pi 完成 provider 配置`);
+      }
+    }
+    assertModel(stored.runtime, mutation.model || "default");
+    agent.runtime = stored.runtime;
     agent.model = mutation.model || "default";
-    if (mutation.runtime !== "pi") delete agent.piDistribution;
+    if (stored.piDistribution) agent.piDistribution = stored.piDistribution;
+    else delete agent.piDistribution;
     delete agent.effort;
   } else if (mutation.kind === "set-agent-model") {
     if (!mutation.model.trim()) throw new Error("model 不能为空");
@@ -958,7 +973,7 @@ export function commitSetupConfig(env: Env, expectedRevision: string, nextStored
 export function safeConfigView(config: HydratedConfig, onlyAgentId?: string, chatId?: string, applyState?: Record<string, unknown>): Record<string, unknown> {
   const entries = onlyAgentId ? [[onlyAgentId, config.agents[onlyAgentId]]] as const : Object.entries(config.agents);
   const agents = entries.filter((entry): entry is readonly [string, HydratedAgent] => Boolean(entry[1])).map(([agentId, agent]) => ({
-    agentId, runtime: agent.runtime, model: agent.model, piDistribution: agent.piDistribution ?? (agent.runtime === "pi" ? "external" : null), effort: agent.effort ?? null,
+    agentId, runtime: agent.runtime, runtimeOption: toUserRuntime(agent.runtime, agent.piDistribution), model: agent.model, piDistribution: agent.piDistribution ?? (agent.runtime === "pi" ? "external" : null), effort: agent.effort ?? null,
     mention: {
       override: agent.mentionPolicy ?? "inherit",
       effective: agent.mentionPolicy ?? config.mentionPolicy,

--- a/src/runtime/runtime-model-catalog.ts
+++ b/src/runtime/runtime-model-catalog.ts
@@ -8,10 +8,12 @@ export interface RuntimeModelDefinition {
 
 export type RuntimeModels = Record<string, RuntimeModelDefinition[]>;
 
-// Larkin supports exactly these three native Runtime adapters. Pi, Codex and Claude replace
-// these placeholders/fallbacks at runtime with their machine-readable catalogs.
+// Authored catalog keys are adapter ids only. builtin-pi is a user-facing sibling, not a stored runtime.
+// Pi, Codex and Claude replace these placeholders/fallbacks at runtime with their machine-readable catalogs.
 // Claude's supported stdin control-channel list is the live authority; its entries below
 // remain explicit compatibility candidates for config loading and discovery failures.
+const PI_AUTHORED_MODELS: RuntimeModelDefinition[] = [{ id: "default", label: "default", verified: "dynamic" }];
+
 export const CURRENT_RUNTIME_MODELS: RuntimeModels = {
   codex: [
     { id: "default", label: "default", verified: "dynamic" },
@@ -46,5 +48,5 @@ export const CURRENT_RUNTIME_MODELS: RuntimeModels = {
     { id: "claude-sonnet-4-6", label: "Claude Sonnet 4.6 · 静态候选", verified: "authored-candidate" },
     { id: "claude-haiku-4-5", label: "Claude Haiku 4.5 · 静态候选", verified: "authored-candidate" },
   ],
-  pi: [{ id: "default", label: "default", verified: "dynamic" }],
+  pi: [...PI_AUTHORED_MODELS],
 };

--- a/src/runtime/user-runtime.ts
+++ b/src/runtime/user-runtime.ts
@@ -1,0 +1,46 @@
+export const RUNTIME_OPTIONS = ["codex", "claude", "pi", "builtin-pi"] as const;
+export type RuntimeOption = (typeof RUNTIME_OPTIONS)[number];
+
+export const USER_RUNTIMES = RUNTIME_OPTIONS;
+export type UserRuntime = RuntimeOption;
+
+export const ADAPTER_RUNTIMES = ["pi", "codex", "claude"] as const;
+export type AdapterRuntime = (typeof ADAPTER_RUNTIMES)[number];
+
+export function isUserRuntime(value: string): value is RuntimeOption {
+  return value === "pi" || value === "builtin-pi" || value === "codex" || value === "claude";
+}
+
+export function isAdapterRuntime(value: string): value is AdapterRuntime {
+  return value === "pi" || value === "codex" || value === "claude";
+}
+
+/** Project stored adapter + distribution to the user-facing sibling id. Legacy `runtime=pi` without distribution is `pi`, never builtin. */
+export function runtimeOptionOf(input: { runtime: string; piDistribution?: "builtin" | "external" | null }): RuntimeOption | string {
+  const { runtime, piDistribution } = input;
+  if (runtime === "codex" || runtime === "claude" || runtime === "builtin-pi") return runtime;
+  if (runtime === "pi") return piDistribution === "builtin" ? "builtin-pi" : "pi";
+  return runtime;
+}
+
+export function toUserRuntime(runtime: string, piDistribution?: "builtin" | "external" | null): string {
+  return runtimeOptionOf({ runtime, piDistribution });
+}
+
+/** Persist a user-facing sibling as adapter id + distribution. Adapter id stays `pi` for both Pi siblings. */
+export function runtimeOptionTarget(option: string): { runtime: AdapterRuntime; piDistribution?: "builtin" | "external" } {
+  if (!isUserRuntime(option)) throw new Error(`未知 runtime：${option}`);
+  if (option === "builtin-pi") return { runtime: "pi", piDistribution: "builtin" };
+  if (option === "pi") return { runtime: "pi", piDistribution: "external" };
+  return { runtime: option };
+}
+
+export function fromUserRuntime(userRuntime: string): { runtime: AdapterRuntime; piDistribution?: "builtin" | "external" } {
+  return runtimeOptionTarget(userRuntime);
+}
+
+export function piCatalogDistributionForUserRuntime(userRuntime: string): "builtin" | "external" {
+  if (userRuntime === "builtin-pi") return "builtin";
+  if (userRuntime === "pi") return "external";
+  throw new Error(`非 Pi sibling runtime：${userRuntime}`);
+}

--- a/src/setup/bot-register.ts
+++ b/src/setup/bot-register.ts
@@ -736,9 +736,9 @@ const setupBaseUrl = flag("--base-url");
 const setupModel = flag("--model");
 if (piDistributionFlag === "builtin") {
   if (!setupProvider && !setupBaseUrl) {
-    throw new Error(`builtin-pi 需要 --provider <id>（${PI_PROVIDER_PRESETS.map((p) => p.id).join("|")}|custom）或 --base-url；或改用 --runtime external-pi 使用已有 pi 环境`);
+    throw new Error(`builtin-pi 需要 --provider <id>（${PI_PROVIDER_PRESETS.map((p) => p.id).join("|")}|custom）或 --base-url；或改用 --runtime pi 使用已有 pi 环境`);
   }
-  if (!setupApiKey) throw new Error("builtin-pi 需要 --api-key；或改用 --runtime external-pi 使用已有 pi 登录");
+  if (!setupApiKey) throw new Error("builtin-pi 需要 --api-key；或改用 --runtime pi 使用已有 pi 登录");
   // 自定义网关（--base-url）走 custom 预设：pi 会把 baseUrl 作为 provider 端点写入配置，
   // 而不是用预设厂商目录（否则会打到预设默认地址，如 api.openai.com）。
   const presetId = setupBaseUrl ? "custom" : (setupProvider ?? "custom");
@@ -776,7 +776,7 @@ if (piDistributionFlag === "builtin") {
     `${JSON.stringify({ ...raw, runtime: "pi", model: validated.model, authCompleted: true, readinessCompleted: true })}\n`, { mode: 0o600, flag: "wx" });
   say(`[setup 2/5] ✓ 内置 Pi provider 已配置（${presetId}${setupBaseUrl ? " / custom" : ""}）`);
 } else if (piDistributionFlag === "external" && (setupProvider || setupApiKey || setupBaseUrl)) {
-  throw new Error("external-pi 使用已有 pi 环境与登录，不接受 --provider/--api-key/--base-url");
+  throw new Error("pi 使用已有 pi 环境与登录，不接受 --provider/--api-key/--base-url");
 }
 
 const stagedBotFile = path.join(botsDir, `.${id}.${process.pid}.tmp`);

--- a/src/setup/setup-agent-choice.ts
+++ b/src/setup/setup-agent-choice.ts
@@ -1,11 +1,11 @@
 import { createInterface } from "node:readline/promises";
 import { stdin, stdout } from "node:process";
 import type { StoredAgent } from "./setup-binding.js";
+import { toUserRuntime } from "../runtime/user-runtime.js";
 import {
   PI_PROVIDER_PRESETS,
   resolveBuiltinPiProviderSetupSelection,
   type BuiltinPiProviderSetupSelection,
-  type PiDistribution,
 } from "../runtime/pi-provider-config.js";
 import type { OfficialPiAuthProvider, OfficialPiAuthStatus } from "../runtime/pi-official-auth.js";
 
@@ -90,16 +90,15 @@ export async function collectBuiltinPiChoice(questioner: SetupQuestioner,
 export async function collectSetupAgentChoice(questioner: SetupQuestioner, prior?: StoredAgent,
   services?: BuiltinPiChoiceServices): Promise<SetupAgentChoice | null> {
   if (prior) {
-    const keep = (await questioner.ask(`已有 Agent：${prior.runtime}/${prior.model}。直接回车保留；输入 c 才修改：`)).trim().toLowerCase();
+    const keep = (await questioner.ask(`已有 Agent：${toUserRuntime(prior.runtime, prior.piDistribution)}/${prior.model}。直接回车保留；输入 c 才修改：`)).trim().toLowerCase();
     if (!keep) return null;
     if (keep !== "c") throw new Error("请输入 c 修改，或直接回车保留现有配置");
   }
-  const runtimeChoice = number(await questioner.ask("选择 Agent：\n  1. Pi（推荐）\n  2. Codex\n  3. Claude Code\n> "), 1, 3);
-  if (runtimeChoice === 2) return { runtime: "codex" };
-  if (runtimeChoice === 3) return { runtime: "claude" };
-  const sourceChoice = number(await questioner.ask("选择 Pi：\n  1. 外置 Pi（使用本机官方 pi）\n  2. 内置 Pi（无需安装 Agent CLI，推荐）\n> "), 2, 2);
-  const distribution: PiDistribution = sourceChoice === 1 ? "external" : "builtin";
-  return distribution === "external" ? { runtime: "pi", distribution } : collectBuiltinPiChoice(questioner, services);
+  const runtimeChoice = number(await questioner.ask("选择 Agent：\n  1. builtin-pi（Larkin 捆绑，推荐）\n  2. pi（本机官方 pi CLI）\n  3. Codex\n  4. Claude Code\n> "), 1, 4);
+  if (runtimeChoice === 3) return { runtime: "codex" };
+  if (runtimeChoice === 4) return { runtime: "claude" };
+  if (runtimeChoice === 2) return { runtime: "pi", distribution: "external" };
+  return collectBuiltinPiChoice(questioner, services);
 }
 
 export async function recoverUnavailableExternalPi(
@@ -114,8 +113,8 @@ export async function recoverUnavailableExternalPi(
     if (choice?.runtime !== "pi" || choice.distribution !== "external") return choice;
     const readiness = await probe();
     if (readiness.state === "ready") return choice;
-    report(`外置 Pi ${readiness.state}：${readiness.reason || "prerequisite unavailable"}；${readiness.nextAction || "可切换到内置 Pi"}`);
-    const action = number(await questioner.ask("外置 Pi 当前不可用：\n  1. 切换到内置 Pi（推荐）\n  2. 重新选择 Agent\n  3. 取消 setup（保留原配置）\n> "), 1, 3);
+    report(`外置 Pi ${readiness.state}：${readiness.reason || "prerequisite unavailable"}；${readiness.nextAction || "可切换到 builtin-pi"}`);
+    const action = number(await questioner.ask("外置 Pi 当前不可用：\n  1. 切换到 builtin-pi（推荐）\n  2. 重新选择 Agent\n  3. 取消 setup（保留原配置）\n> "), 1, 3);
     if (action === 1) return collectBuiltinPiChoice(questioner, services);
     if (action === 3) throw new Error("setup 已取消；未修改 Agent/config");
     choice = await collectSetupAgentChoice(questioner, undefined, services);

--- a/src/setup/setup-bind.ts
+++ b/src/setup/setup-bind.ts
@@ -278,10 +278,10 @@ function formatExternalPiSetupFailure(error: unknown, options: { agentExisted: b
   const alternatives = catalogModelsFromError(error);
   const parts: string[] = [];
   if (/external Pi (?:auth\.json|models\.json|settings\.json) is required|external Pi profile|external Pi auth\.json has an unsafe mode|external Pi models\.json has an unsafe mode|external Pi settings\.json has an unsafe mode/.test(original)) {
-    parts.push("external-pi requires the official file-backed Pi profile containing auth.json (0600), models.json, and settings.json, normally after `pi` login and default-model selection. Environment-variable-only credentials are unsupported.");
+    parts.push("pi requires the official file-backed Pi profile containing auth.json (0600), models.json, and settings.json, normally after `pi` login and default-model selection. Environment-variable-only credentials are unsupported.");
   }
   if (original) parts.push(original);
-  parts.push("Fix the official `pi` login and default model, then rerun `larkin setup --runtime external-pi`.");
+  parts.push("Fix the official `pi` login and default model, then rerun `larkin setup --runtime pi`.");
   if (options.agentExisted) {
     parts.push("This Agent already exists; after a successful setup you can switch models with `larkin model <provider>/<model>`.");
   }

--- a/test/frontend/dashboard-workbench.test.tsx
+++ b/test/frontend/dashboard-workbench.test.tsx
@@ -41,11 +41,13 @@ const status = {
 const config = (agentId?: string) => ({
   version: 4, mentionPolicy: "free", persistedRevision: "sha256:revision",
   runtimeModels: {
+    pi: [{ id: "default" }],
     codex: [{ id: "default" }, { id: "gpt-5.6-sol", supportedReasoningEfforts: ["low", "high"] }],
-    claude: [{ id: "default" }], pi: [{ id: "default" }],
+    claude: [{ id: "default" }],
   },
+  runtimeOptions: ["codex", "claude", "pi", "builtin-pi"] as const,
   agents: (agentId ? agents.filter((agent) => agent.agentId === agentId) : agents).map((agent) => ({
-    agentId: agent.agentId, runtime: agent.runtime, model: agent.model, effort: agent.effort,
+    agentId: agent.agentId, runtime: agent.runtime, runtimeOption: agent.runtime, model: agent.model, effort: agent.effort,
     piDistribution: null,
     mention: { override: agent.agentId === "cli_AgentB2" ? "require" : "inherit", effective: agent.agentId === "cli_AgentB2" ? "require" : "free", source: agent.agentId === "cli_AgentB2" ? "agent" : "global" },
     knownChats: agent.agentId === "cli_AgentB2" ? [
@@ -325,33 +327,37 @@ describe("Agent-centric dashboard workbench", () => {
       String(input) === "/api/models/pi?agent=cli_AgentA1")).toBe(true));
     expect(screen.getByRole("option", { name: "default: openai/gpt-5.2" })).toBeVisible();
     expect(screen.getByRole("option", { name: "Claude Sonnet 4.5 · anthropic" })).toBeVisible();
-    expect(screen.getByDisplayValue("用户安装的 Pi")).toBeVisible();
+    expect(screen.queryByLabelText("Pi 发行版")).not.toBeInTheDocument();
+    expect(["pi", "builtin-pi", "codex", "claude"].every((value) =>
+      screen.getByRole("option", { name: value }))).toBe(true);
   });
 
-  it.each([
-    { distribution: "builtin" as const, label: "内置 Pi", absent: "用户安装的 Pi" },
-    { distribution: "external" as const, label: "用户安装的 Pi", absent: "内置 Pi" },
-    { distribution: null, label: "用户安装的 Pi", absent: "内置 Pi" },
-  ])("renders $label for Pi runtime when piDistribution is $distribution", async ({ distribution, label, absent }) => {
+  it("loads builtin-pi catalog when Runtime is the sibling builtin-pi", async () => {
     window.history.replaceState(null, "", "/?agent=cli_AgentA1&tab=configuration");
     vi.stubGlobal("fetch", vi.fn((input: RequestInfo | URL) => {
       const url = new URL(String(input), "http://localhost");
       if (url.pathname === "/api/status") return ok(status);
       if (url.pathname === "/api/config") {
         const value = config("cli_AgentA1");
-        value.agents[0].piDistribution = distribution;
+        value.agents[0].runtime = "pi";
+        value.agents[0].runtimeOption = "builtin-pi";
+        value.agents[0].piDistribution = "builtin";
         return ok(value);
       }
-      if (url.pathname === "/api/models/pi") return ok({ models: [{ id: "default", label: "default: fixture/model" }] });
+      if (url.pathname === "/api/models/builtin-pi") return ok({ models: [
+        { id: "default", label: "default: deepseek/deepseek-v4-pro" },
+      ] });
       throw new Error(`unexpected request ${url}`);
     }));
     render(<App />);
-    expect(await screen.findByLabelText("Runtime")).toHaveValue("pi");
-    expect(await screen.findByDisplayValue(label)).toBeVisible();
-    expect(screen.queryByDisplayValue(absent)).not.toBeInTheDocument();
+    expect(await screen.findByLabelText("Runtime")).toHaveValue("builtin-pi");
+    await waitFor(() => expect(vi.mocked(fetch).mock.calls.some(([input]) =>
+      String(input) === "/api/models/builtin-pi?agent=cli_AgentA1")).toBe(true));
+    expect(screen.getByRole("option", { name: "default: deepseek/deepseek-v4-pro" })).toBeVisible();
+    expect(screen.queryByLabelText("Pi 发行版")).not.toBeInTheDocument();
   });
 
-  it("does not render a Pi distribution label for non-Pi runtimes", async () => {
+  it("does not render a Pi distribution control for any runtime", async () => {
     render(<App />);
     expect(await screen.findByLabelText("Runtime")).toHaveValue("codex");
     expect(screen.queryByText("内置 Pi")).not.toBeInTheDocument();

--- a/test/integration/platform/strict-config-contract.test.mjs
+++ b/test/integration/platform/strict-config-contract.test.mjs
@@ -224,5 +224,6 @@ test("authored runtime model catalog contains exactly the native adapters", () =
   assert.ok(catalog.codex.slice(1).every((item) => item.verified === "authored-compatibility"), "Codex authored entries are explicitly a compatibility fallback, not the live catalog");
   assert.ok(catalog.claude.slice(1).every((item) => item.verified === "authored-candidate"), "Claude entries are explicitly authored candidates because Claude exposes no list command");
   assert.deepEqual(catalog.pi, [{ id: "default", label: "default", verified: "dynamic" }]);
+  assert.equal(Object.hasOwn(catalog, "builtin-pi"), false);
   assert.throws(() => defaultModelFor("unknown-runtime"), /unknown-runtime|runtime|模型|目录|不存在/i);
 });

--- a/test/integration/setup/external-pi-setup-hot-attach.test.mjs
+++ b/test/integration/setup/external-pi-setup-hot-attach.test.mjs
@@ -160,7 +160,7 @@ test("external-pi setup failure keeps the bot credential, leaves config untouche
     assert.equal(fs.existsSync(path.join(root, "providers", "pi", APP)), false);
     assert.deepEqual(resultFiles(root), []);
     assert.equal(fs.existsSync(path.join(root, "control")), false);
-    assert.match(`${result.stdout}\n${result.stderr}`, /larkin setup --runtime external-pi/);
+    assert.match(`${result.stdout}\n${result.stderr}`, /larkin setup --runtime pi/);
     assert.doesNotMatch(`${result.stdout}\n${result.stderr}`, /larkin model/);
   } finally {
     fs.rmSync(root, { recursive: true, force: true });
@@ -277,7 +277,7 @@ test("builtin host + minimal PI_PACKAGE_DIR rolls back imported artifacts after 
     const output = `${result.stdout}\n${result.stderr}`;
     assert.notEqual(result.status, 0, output);
     assert.match(output, /Pi effective model is missing a context window/);
-    assert.match(output, /larkin setup --runtime external-pi/);
+    assert.match(output, /larkin setup --runtime pi/);
     assert.equal(fs.readFileSync(configFile, "utf8"), before);
     assert.deepEqual(fs.readFileSync(botFile), botBefore);
     assert.deepEqual(fs.readFileSync(path.join(profile.dir, "auth.json")), profile.auth);

--- a/test/integration/setup/setup-cli.test.mjs
+++ b/test/integration/setup/setup-cli.test.mjs
@@ -231,6 +231,8 @@ denied("rmdirSync", () => fs.rmdirSync(createThenDelete));
 
 const setupHelp = run("dist/app/setup.mjs", "--help");
 assert.equal(setupHelp.status, 0);
+assert.match(setupHelp.stdout, /builtin-pi（默认，内置 Pi）\| pi \| codex \| claude/);
+assert.doesNotMatch(setupHelp.stdout, /external-pi \|/);
 assert.match(setupHelp.stdout, /Each Agent is identified by its bot App ID/);
 assert.match(setupHelp.stdout, /selecting\s+the same bot reuses\s+its existing Agent, memory, and state/);
 assert.doesNotMatch(setupHelp.stdout, /--no-dashboard/);
@@ -240,8 +242,20 @@ assert.doesNotMatch(setupHelp.stdout, /--app-id/);
 
 const publicSetupHelp = run("dist/app/cli.mjs", "setup", "--help");
 assert.equal(publicSetupHelp.status, 0);
+assert.match(publicSetupHelp.stdout, /builtin-pi\|pi\|codex\|claude/);
+assert.doesNotMatch(publicSetupHelp.stdout, /external-pi/);
 assert.doesNotMatch(publicSetupHelp.stdout, /--app-id/);
 assert.doesNotMatch(publicSetupHelp.stdout, /--comment-subscription/);
+
+const aliasHelp = run("dist/app/setup.mjs", "--runtime", "external-pi", "--help");
+assert.equal(aliasHelp.status, 0, aliasHelp.stderr);
+assert.match(aliasHelp.stderr, /external-pi 已改名为 pi/);
+
+const unknownRuntime = run("dist/app/setup.mjs", "--runtime", "unknown");
+assert.equal(unknownRuntime.status, 1);
+assert.match(unknownRuntime.stderr, /未知 runtime/);
+assert.match(unknownRuntime.stderr, /builtin-pi \| pi \| codex \| claude/);
+assert.doesNotMatch(unknownRuntime.stderr, /external-pi/);
 
 for (const args of [["--comment-subscription"], ["--comment-subscription", "broad"], ["--comment-subscription", "user"]]) {
   const invalidSubscription = run("dist/app/setup.mjs", ...args);

--- a/test/unit/app/agent-cli.test.mjs
+++ b/test/unit/app/agent-cli.test.mjs
@@ -625,7 +625,7 @@ test("profile show is local and the removed internal IM surface points to larkin
     assert.equal(profile.code, 0, profile.stderr);
     assert.deepEqual(JSON.parse(profile.stdout), {
       kind: "agent", id: f.agentId, isSelf: true, name: "Larkin Bot", displayName: "Larkin Bot", openId: "ou_bot",
-      avatarUrl: "https://example.test/avatar.png", runtime: "codex", model: "gpt-5.6-sol", reasoningEffort: "high",
+      avatarUrl: "https://example.test/avatar.png", runtime: "codex", runtimeOption: "codex", model: "gpt-5.6-sol", reasoningEffort: "high",
       createdAt: "2026-07-19T00:00:00.000Z",
     });
 

--- a/test/unit/app/agent-config-typescript.test.mjs
+++ b/test/unit/app/agent-config-typescript.test.mjs
@@ -300,6 +300,7 @@ test("TypeScript agent-config bridge preserves listing, fail-closed selection, a
           agent_id: first,
           name: first,
           runtime: "codex",
+          runtimeOption: "codex",
           model: "gpt-5.3-codex",
           document_comment: { event: "drive.notice.comment_add_v1", category: "not_requested", reason: "setup_required", requested_at: null,
             reply_scope: "docs:document.comment:create", reply_requested_at: null, event_verified_at: null, accepted_at: null, last_error: null, last_error_at: null,
@@ -317,6 +318,7 @@ test("TypeScript agent-config bridge preserves listing, fail-closed selection, a
           agent_id: second,
           name: second,
           runtime: "claude",
+          runtimeOption: "claude",
           model: "claude-sonnet-4-5",
           document_comment: { event: "drive.notice.comment_add_v1", category: "not_requested", reason: "setup_required", requested_at: null,
             reply_scope: "docs:document.comment:create", reply_requested_at: null, event_verified_at: null, accepted_at: null, last_error: null, last_error_at: null,
@@ -647,7 +649,8 @@ test("larkin model isolates owned Pi catalog from host decoy and does not spawn 
     const decoyPattern = new RegExp(decoy.replace(/[.*+?^${}()|[\]\\]/g, "\\$&"));
 
     const listedExternal = run("model", "--agent", external);
-    assert.match(`${listedExternal.stdout}\n${listedExternal.stderr}`, /用户安装的 Pi/);
+    assert.match(listedExternal.stdout, /runtime=pi\b/);
+    assert.doesNotMatch(listedExternal.stdout, /runtime=builtin-pi|发行版|用户安装的 Pi|内置 Pi/);
     assert.doesNotMatch(`${listedExternal.stdout}\n${listedExternal.stderr}`, decoyPattern);
     const recorded = fs.readFileSync(logFile, "utf8").trim().split("\n").filter(Boolean).map((line) => JSON.parse(line));
     assert.ok(recorded.length >= 1, "external catalog must spawn host pi");
@@ -657,8 +660,55 @@ test("larkin model isolates owned Pi catalog from host decoy and does not spawn 
 
     fs.writeFileSync(logFile, "");
     const listedBuiltin = run("model", "--agent", builtin);
-    assert.match(`${listedBuiltin.stdout}\n${listedBuiltin.stderr}`, /内置 Pi/);
+    assert.match(listedBuiltin.stdout, /runtime=builtin-pi\b/);
+    assert.doesNotMatch(listedBuiltin.stdout, /发行版|用户安装的 Pi|内置 Pi/);
     assert.doesNotMatch(`${listedBuiltin.stdout}\n${listedBuiltin.stderr}`, decoyPattern);
     assert.equal(fs.readFileSync(logFile, "utf8").trim(), "", "builtin catalog must not spawn host pi");
+  } finally { fs.rmSync(temp, { recursive: true, force: true }); }
+});
+
+test("larkin runtime accepts sibling builtin-pi and persists storage projection", () => {
+  const temp = fs.mkdtempSync(path.join(os.tmpdir(), "larkin-runtime-sibling-cli-"));
+  const app = "cli_runtimeSiblingA1";
+  try {
+    fs.writeFileSync(path.join(temp, "config.json"), `${JSON.stringify({
+      version: 4, serverId: "server-runtime-sibling", mentionPolicy: "require", activeAgent: app,
+      agents: { [app]: { runtime: "pi", model: "default", piDistribution: "external" } },
+    })}\n`, { mode: 0o600 });
+    const run = (...args) => spawnSync(process.execPath, [ENTRY, ...args], {
+      cwd: ROOT, encoding: "utf8", env: { ...process.env, LARKIN_CONFIG_DIR: temp },
+    });
+    const listed = run("runtime", "--agent", app);
+    assert.equal(listed.status, 0, listed.stderr);
+    assert.match(listed.stdout, /runtime=pi\b/);
+    assert.match(listed.stdout, /builtin-pi/);
+    assert.doesNotMatch(listed.stdout, /发行版/);
+
+    const refused = run("runtime", "builtin-pi", "--agent", app);
+    assert.notEqual(refused.status, 0);
+    assert.match(`${refused.stdout}\n${refused.stderr}`, /无法切换到 builtin-pi|larkin setup/);
+    assert.equal(JSON.parse(fs.readFileSync(path.join(temp, "config.json"), "utf8")).agents[app].piDistribution, "external");
+
+    const providerDir = path.join(temp, "providers", "pi", app);
+    fs.mkdirSync(providerDir, { recursive: true, mode: 0o700 });
+    fs.chmodSync(providerDir, 0o700);
+    fs.writeFileSync(path.join(providerDir, "auth.json"), JSON.stringify({ fixture: { type: "api_key", key: "fixture-only" } }) + "\n", { mode: 0o600 });
+    const changed = run("runtime", "builtin-pi", "--agent", app);
+    assert.equal(changed.status, 0, changed.stderr);
+    const stored = JSON.parse(fs.readFileSync(path.join(temp, "config.json"), "utf8"));
+    assert.equal(stored.agents[app].runtime, "pi");
+    assert.equal(stored.agents[app].piDistribution, "builtin");
+    const shown = run("config", "show", "--agent", app, "--json");
+    const view = JSON.parse(shown.stdout).agents[0];
+    assert.equal(view.runtime, "pi");
+    assert.equal(view.runtimeOption, "builtin-pi");
+    const agentsJson = JSON.parse(run("agents", "--json").stdout).agents[0];
+    assert.equal(agentsJson.runtime, "pi");
+    assert.equal(agentsJson.runtimeOption, "builtin-pi");
+    assert.match(run("agents").stdout, /runtime=builtin-pi\b/);
+
+    const back = run("runtime", "pi", "--agent", app);
+    assert.equal(back.status, 0, back.stderr);
+    assert.equal(JSON.parse(fs.readFileSync(path.join(temp, "config.json"), "utf8")).agents[app].piDistribution, "external");
   } finally { fs.rmSync(temp, { recursive: true, force: true }); }
 });

--- a/test/unit/dashboard/dashboard-config-directories.test.mjs
+++ b/test/unit/dashboard/dashboard-config-directories.test.mjs
@@ -386,7 +386,7 @@ function writePiAgents(root, agents) {
   })}\n`, { mode: 0o600 });
 }
 
-test("GET /api/models/pi and directory mutation ignore decoy or unset PI_CODING_AGENT_DIR and use owned dir plus engine", async () => {
+test("GET /api/models/pi and /api/models/builtin-pi select engines by sibling and keep owned dirs", async () => {
   const { createDashboardConfigController } = await import(`${CONTROLLER}?pi-owned=${Date.now()}`);
   const f = fixture();
   onTestFinished(() => fs.rmSync(f.root, { recursive: true, force: true }));
@@ -409,18 +409,36 @@ test("GET /api/models/pi and directory mutation ignore decoy or unset PI_CODING_
     if (decoyDir) env.PI_CODING_AGENT_DIR = decoyDir;
     else delete env.PI_CODING_AGENT_DIR;
     const controller = createDashboardConfigController({ csrfCapability: "test", env, piModelDirectoryResolver });
+    const projected = await get(controller, `/api/config?agent=${builtin}`);
+    assert.equal(projected.status, 200);
+    assert.equal(projected.body.agents[0].runtime, "pi");
+    assert.equal(projected.body.agents[0].runtimeOption, "builtin-pi");
+    assert.deepEqual(projected.body.runtimeOptions, ["codex", "claude", "pi", "builtin-pi"]);
+    assert.equal(Object.hasOwn(projected.body.runtimeModels, "builtin-pi"), false);
+    assert.ok(Object.hasOwn(projected.body.runtimeModels, "pi"));
     calls.length = 0;
     const listed = await get(controller, `/api/models/pi?agent=${builtin}`);
     assert.equal(listed.status, 200, JSON.stringify(listed.body));
     assert.equal(calls[0].agentDir, path.join(f.root, "providers", "pi", builtin));
     assert.notEqual(calls[0].agentDir, decoy);
-    assert.equal(calls[0].commandArgs.includes("pi-rpc"), true, "builtin catalog must use internal pi-rpc");
+    assert.equal(calls[0].commandArgs.includes("pi-rpc"), false, "user-facing pi sibling must use host pi");
+
+    calls.length = 0;
+    const builtinListed = await get(controller, `/api/models/builtin-pi?agent=${builtin}`);
+    assert.equal(builtinListed.status, 200);
+    assert.equal(calls[0].agentDir, path.join(f.root, "providers", "pi", builtin));
+    assert.equal(calls[0].commandArgs.includes("pi-rpc"), true, "builtin-pi sibling must use internal pi-rpc");
 
     calls.length = 0;
     const externalListed = await get(controller, `/api/models/pi?agent=${external}`);
     assert.equal(externalListed.status, 200);
     assert.equal(calls[0].agentDir, path.join(f.root, "providers", "pi", external));
     assert.equal(calls[0].commandArgs.includes("pi-rpc"), false, "external catalog must use host pi");
+
+    calls.length = 0;
+    const externalBuiltin = await get(controller, `/api/models/builtin-pi?agent=${external}`);
+    assert.equal(externalBuiltin.status, 200);
+    assert.equal(calls[0].commandArgs.includes("pi-rpc"), true, "builtin-pi path must not follow stored external distribution");
 
     calls.length = 0;
     const saved = await patch(controller, { operation: "set-agent-model", agentId: external, model: "owned/model" });

--- a/test/unit/dashboard/dashboard-workbench-source.test.mjs
+++ b/test/unit/dashboard/dashboard-workbench-source.test.mjs
@@ -87,6 +87,7 @@ test("dashboard Pi model directory is wired to the official catalog authority", 
     "Dashboard Pi discovery must reuse discoverPiModelCatalog instead of creating another catalog implementation");
   assert.match(controller, /createPiModelDirectoryResolver/);
   assert.match(controller, /\/api\/models\/pi/);
+  assert.match(controller, /\/api\/models\/builtin-pi/);
 });
 
 test("Pi catalog isolation deletes host-dir fallbacks and labels builtin versus user Pi", () => {
@@ -105,9 +106,15 @@ test("Pi catalog isolation deletes host-dir fallbacks and labels builtin versus 
     assert.doesNotMatch(source, /PI_CODING_AGENT_DIR\s*\?\s*\{\s*agentDir/, `${name} must not omit agentDir when PI_CODING_AGENT_DIR is unset`);
   }
   assert.match(types, /piDistribution:\s*"builtin"\s*\|\s*"external"\s*\|\s*null/);
-  assert.match(app, /piDistributionLabel/);
-  assert.match(app, /内置 Pi|用户安装的 Pi|piDistributionLabel/);
-  assert.match(agentConfig, /piDistributionLabel/);
+  assert.match(app, /RUNTIME_OPTIONS/);
+  assert.match(app, /builtin-pi/);
+  assert.doesNotMatch(app, /Pi 发行版/);
+  assert.match(agentConfig, /toUserRuntime/);
+  assert.match(agentConfig, /RUNTIME_OPTIONS/);
+  assert.match(agentConfig, /builtin-pi/);
+  assert.match(read("src/runtime/runtime-model-catalog.ts"), /pi: \[\.\.\.PI_AUTHORED_MODELS\]/);
+  assert.doesNotMatch(read("src/runtime/runtime-model-catalog.ts"), /"builtin-pi":/);
   assert.match(runtimeDirectory, /ownedPiCatalogAgentDir/);
   assert.match(runtimeDirectory, /piCatalogCommandSpec/);
+  assert.match(runtimeDirectory, /builtin-pi/);
 });

--- a/test/unit/platform/config-management.test.mjs
+++ b/test/unit/platform/config-management.test.mjs
@@ -211,6 +211,66 @@ test("rollback journal recovery completes apply-state restoration after config r
   } finally { fs.rmSync(root, { recursive: true, force: true }); }
 });
 
+test("stored config rejects builtin-pi as an adapter id", () => {
+  const { root, file } = fixture();
+  try {
+    const stored = JSON.parse(fs.readFileSync(file, "utf8"));
+    stored.version = 4;
+    stored.mentionPolicy = "require";
+    stored.agents[APP] = { runtime: "builtin-pi", model: "default" };
+    fs.writeFileSync(file, `${JSON.stringify(stored, null, 2)}\n`, { mode: 0o600 });
+    assert.throws(() => configApi.loadConfig({ LARKIN_CONFIG_DIR: root }), /runtime 未知：builtin-pi/);
+  } finally { fs.rmSync(root, { recursive: true, force: true }); }
+});
+
+function seedBuiltinPiAuth(configDir, agentId) {
+  const directory = path.join(configDir, "providers", "pi", agentId);
+  fs.mkdirSync(directory, { recursive: true, mode: 0o700 });
+  fs.chmodSync(directory, 0o700);
+  fs.writeFileSync(path.join(directory, "auth.json"), JSON.stringify({ fixture: { type: "api_key", key: "fixture-only" } }) + "\n", { mode: 0o600 });
+}
+
+test("user-facing runtime siblings project to stored pi + piDistribution", () => {
+  const { root, file } = fixture();
+  try {
+    const stored = JSON.parse(fs.readFileSync(file, "utf8"));
+    stored.version = 4;
+    stored.mentionPolicy = "require";
+    stored.agents[APP] = { runtime: "pi", model: "default" };
+    fs.writeFileSync(file, `${JSON.stringify(stored, null, 2)}\n`, { mode: 0o600 });
+    const env = { LARKIN_CONFIG_DIR: root };
+    const beforeBytes = fs.readFileSync(file);
+    assert.throws(
+      () => configApi.mutateConfig(env, { kind: "set-agent-runtime", agentId: APP, runtime: "builtin-pi", model: "default" }, { kind: "user" }),
+      /无法切换到 builtin-pi|larkin setup/,
+    );
+    assert.deepEqual(fs.readFileSync(file), beforeBytes);
+
+    seedBuiltinPiAuth(root, APP);
+    configApi.mutateConfig(env, { kind: "set-agent-runtime", agentId: APP, runtime: "builtin-pi", model: "default" }, { kind: "user" });
+    let after = JSON.parse(fs.readFileSync(file, "utf8"));
+    assert.equal(after.agents[APP].runtime, "pi");
+    assert.equal(after.agents[APP].piDistribution, "builtin");
+    const builtinView = configApi.safeConfigView(configApi.loadConfig(env).config, APP).agents[0];
+    assert.equal(builtinView.runtime, "pi");
+    assert.equal(builtinView.runtimeOption, "builtin-pi");
+
+    configApi.mutateConfig(env, { kind: "set-agent-runtime", agentId: APP, runtime: "pi", model: "default" }, { kind: "user" });
+    after = JSON.parse(fs.readFileSync(file, "utf8"));
+    assert.equal(after.agents[APP].runtime, "pi");
+    assert.equal(after.agents[APP].piDistribution, "external");
+    const hostView = configApi.safeConfigView(configApi.loadConfig(env).config, APP).agents[0];
+    assert.equal(hostView.runtime, "pi");
+    assert.equal(hostView.runtimeOption, "pi");
+
+    stored.agents[APP] = { runtime: "pi", model: "default" };
+    fs.writeFileSync(file, `${JSON.stringify(stored, null, 2)}\n`, { mode: 0o600 });
+    const legacyView = configApi.safeConfigView(configApi.loadConfig(env).config, APP).agents[0];
+    assert.equal(legacyView.runtime, "pi");
+    assert.equal(legacyView.runtimeOption, "pi");
+  } finally { fs.rmSync(root, { recursive: true, force: true }); }
+});
+
 test("switching a Pi Agent to a non-Pi runtime removes piDistribution before persistence", () => {
   const { root, file } = fixture();
   try {

--- a/test/unit/runtime/user-runtime.test.mjs
+++ b/test/unit/runtime/user-runtime.test.mjs
@@ -1,0 +1,28 @@
+import assert from "node:assert/strict";
+import { test } from "bun:test";
+import path from "node:path";
+import { fileURLToPath, pathToFileURL } from "node:url";
+
+const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../../..");
+const {
+  RUNTIME_OPTIONS, fromUserRuntime, isAdapterRuntime, isUserRuntime, piCatalogDistributionForUserRuntime,
+  runtimeOptionOf, runtimeOptionTarget, toUserRuntime,
+} = await import(pathToFileURL(path.join(ROOT, "dist/runtime/user-runtime.mjs")).href);
+
+test("user-facing siblings project to stored adapter id plus distribution", () => {
+  assert.deepEqual([...RUNTIME_OPTIONS], ["codex", "claude", "pi", "builtin-pi"]);
+  assert.deepEqual(fromUserRuntime("builtin-pi"), { runtime: "pi", piDistribution: "builtin" });
+  assert.deepEqual(runtimeOptionTarget("pi"), { runtime: "pi", piDistribution: "external" });
+  assert.deepEqual(fromUserRuntime("codex"), { runtime: "codex" });
+  assert.deepEqual(fromUserRuntime("claude"), { runtime: "claude" });
+  assert.equal(toUserRuntime("pi", "builtin"), "builtin-pi");
+  assert.equal(runtimeOptionOf({ runtime: "pi", piDistribution: "external" }), "pi");
+  assert.equal(toUserRuntime("pi"), "pi");
+  assert.equal(toUserRuntime("pi", null), "pi");
+  assert.equal(toUserRuntime("codex"), "codex");
+  assert.equal(piCatalogDistributionForUserRuntime("builtin-pi"), "builtin");
+  assert.equal(piCatalogDistributionForUserRuntime("pi"), "external");
+  assert.equal(isUserRuntime("builtin-pi"), true);
+  assert.equal(isAdapterRuntime("builtin-pi"), false);
+  assert.equal(isAdapterRuntime("pi"), true);
+});

--- a/test/unit/setup/setup-agent-choice.test.mjs
+++ b/test/unit/setup/setup-agent-choice.test.mjs
@@ -18,18 +18,23 @@ function questioner(answers, secret = "test-secret") {
   };
 }
 
-test("new setup visibly offers Pi first, then external/built-in, before Codex and Claude", async () => {
-  const q = questioner(["1", "2", "1", ""]);
-  const choice = await collectSetupAgentChoice(q);
-  assert.deepEqual(choice, { runtime: "pi", distribution: "builtin", preset: "deepseek", model: "deepseek/deepseek-v4-pro" });
-  assert.match(q.prompts[0], /1\. Pi（推荐）[\s\S]*2\. Codex[\s\S]*3\. Claude Code/);
-  assert.match(q.prompts[1], /1\. 外置 Pi[\s\S]*2\. 内置 Pi/);
-  assert.match(q.prompts[2], /DeepSeek（推荐）[\s\S]*Kimi[\s\S]*MiniMax[\s\S]*智谱[\s\S]*Custom[\s\S]*官方 Pi provider 登录/);
+test("new setup offers four sibling runtimes without a nested Pi distribution submenu", async () => {
+  const builtin = questioner(["1", "1", ""]);
+  const builtinChoice = await collectSetupAgentChoice(builtin);
+  assert.deepEqual(builtinChoice, { runtime: "pi", distribution: "builtin", preset: "deepseek", model: "deepseek/deepseek-v4-pro" });
+  assert.match(builtin.prompts[0], /1\. builtin-pi（Larkin 捆绑，推荐）[\s\S]*2\. pi（本机官方 pi CLI）[\s\S]*3\. Codex[\s\S]*4\. Claude Code/);
+  assert.equal(builtin.prompts.some((prompt) => /选择 Pi：/.test(prompt)), false);
+  assert.match(builtin.prompts[1], /DeepSeek（推荐）[\s\S]*Kimi[\s\S]*MiniMax[\s\S]*智谱[\s\S]*Custom[\s\S]*官方 Pi provider 登录/);
+
+  const host = questioner(["2"]);
+  assert.deepEqual(await collectSetupAgentChoice(host), { runtime: "pi", distribution: "external" });
+  assert.equal(host.prompts.length, 1);
 });
 
 test("existing Agent setup preserves runtime/model unless the user explicitly chooses change", async () => {
   const q = questioner([""]);
   assert.equal(await collectSetupAgentChoice(q, { runtime: "pi", model: "deepseek/deepseek-v4-pro", piDistribution: "builtin" }), null);
+  assert.match(q.prompts[0], /已有 Agent：builtin-pi\/deepseek\/deepseek-v4-pro/);
   assert.match(q.prompts[0], /直接回车保留/);
 });
 
@@ -51,7 +56,7 @@ test("missing external Pi offers a bounded recovery and can switch to built-in P
 });
 
 test("built-in Pi dynamically offers every official provider auth method", async () => {
-  const q = questioner(["1", "2", "6", "2", ""]);
+  const q = questioner(["1", "6", "2", ""]);
   const services = {
     providers: async () => [{ id: "alpha", name: "Alpha", methods: [
       { type: "api_key", name: "Alpha key" }, { type: "oauth", name: "Alpha subscription" },
@@ -61,13 +66,13 @@ test("built-in Pi dynamically offers every official provider auth method", async
   assert.deepEqual(await collectSetupAgentChoice(q, undefined, services), {
     runtime: "pi", distribution: "builtin", preset: "official", providerId: "alpha", authType: "oauth", model: "alpha/a-1",
   });
-  assert.match(q.prompts[3], /Alpha key \[api_key\][\s\S]*Alpha subscription \[oauth\]/);
+  assert.match(q.prompts[2], /Alpha key \[api_key\][\s\S]*Alpha subscription \[oauth\]/);
 });
 
 test("built-in Pi status/logout returns to selection without exposing credential values", async () => {
   const reports = [];
   const loggedOut = [];
-  const q = questioner(["1", "2", "7", "1", "1", ""]);
+  const q = questioner(["1", "7", "1", "1", ""]);
   const services = {
     providers: async () => [],
     status: async () => [{ providerId: "alpha", providerName: "Alpha", credentialType: "oauth", source: "OAuth", stored: true }],
@@ -87,7 +92,7 @@ test("external Pi recovery cancellation preserves config and the retry loop is b
 
   // Three re-selections of the same unavailable external Pi are allowed; a
   // fourth probe is never attempted and no configuration is published.
-  const repeated = questioner(["2", "1", "1", "2", "1", "1", "2", "1", "1"]);
+  const repeated = questioner(["2", "2", "2", "2", "2", "2"]);
   let probes = 0;
   await assert.rejects(() => recoverUnavailableExternalPi(
     { runtime: "pi", distribution: "external" }, repeated,

--- a/test/unit/setup/setup-bind-typescript.test.mjs
+++ b/test/unit/setup/setup-bind-typescript.test.mjs
@@ -359,7 +359,7 @@ test("external-pi setup rolls back when the effective model lacks a context wind
     assert.equal(fs.existsSync(path.join(root, "providers", "pi", APP)), false);
     assert.equal(fs.existsSync(path.join(root, "bots", `${APP}.json`)), true);
     const output = `${result.stdout}\n${result.stderr}`;
-    assert.match(output, /larkin setup --runtime external-pi/);
+    assert.match(output, /larkin setup --runtime pi/);
     assert.match(output, /fixture\/pi-windowed/);
     assert.doesNotMatch(output, /larkin model/);
   } finally {
@@ -383,7 +383,7 @@ test("external-pi setup fails closed without an official auth.json", () => {
     assert.match(output, /official file-backed Pi profile/);
     assert.match(output, /auth\.json/);
     assert.match(output, /settings\.json/);
-    assert.match(output, /larkin setup --runtime external-pi/);
+    assert.match(output, /larkin setup --runtime pi/);
     assert.doesNotMatch(output, /larkin model/);
   } finally {
     fs.rmSync(root, { recursive: true, force: true });
@@ -406,7 +406,7 @@ test("external-pi setup fails closed without settings.json or models.json", () =
       const output = `${result.stdout}\n${result.stderr}`;
       assert.match(output, /official file-backed Pi profile/);
       assert.match(output, new RegExp(missing.replace(".", "\\.")));
-      assert.match(output, /larkin setup --runtime external-pi/);
+      assert.match(output, /larkin setup --runtime pi/);
     } finally {
       fs.rmSync(root, { recursive: true, force: true });
     }


### PR DESCRIPTION
## Summary

- Setup, Dashboard Runtime, and `larkin runtime` now offer four peer options: `codex`, `claude`, `pi`, and `builtin-pi`. The nested “Pi 发行版” control is no longer the engine switch.
- Disk storage stays `runtime=pi` plus `piDistribution`. JSON/status keep the kernel `runtime` and add `runtimeOption`. Writing `builtin-pi` requires an owned provider dir and does not persist on failure.
- Catalog isolation is unchanged: `builtin-pi` uses bundled `pi-rpc` + owned dir; `pi` uses host `pi` + owned dir. `external-pi` remains a setup alias for `pi`.

## Related issue

Small-change exemption: this is the aligned Owner delivery for `larkin.runtime-pi-builtin-siblings`. No separate GitHub issue is required; the contract lives in the coding-context plan.

## Scope

- In scope: user-facing sibling ids, storage projection, Setup/Dashboard/CLI entry points, catalog routing, patch `0.4.28`.
- Out of scope: copying `~/.pi`, deleting `larkin pi-distribution`, Inbox/Codex/Claude protocol changes, config v4 migration.
- Compatibility or migration impact: old `runtime=pi` without distribution still projects as `pi`. `larkin setup --runtime external-pi` maps to `pi` and prints a one-time rename notice.

## Validation

- [x] Relevant focused tests pass (`bun test --max-concurrency 1` on setup/agent-config/agent-cli/dashboard/config/user-runtime suites).
- [x] `bun run build` passes.
- [x] `bun run test` passes (typecheck + build + frontend + unit + integration + e2e).
- [x] `bun run licenses:check` passes.
- [x] `bun run publication:check:tree` passes.
- [x] `git diff --check` passes.

## Safety and publication

- [x] This change contains no credentials, private messages, user data, private filesystem paths, generated `dist/`, or release artifacts.
- [x] Security-sensitive details, if any, were reported privately rather than included in this PR.
- [x] I did not create, move, or replace a release tag as part of this ordinary contribution.


Made with [Cursor](https://cursor.com)