### PR TITLE
fix(runtime): treat explicit Pi missing-key rejections as terminal auth

### DIFF
--- a/src/feishu/host-shell.ts
+++ b/src/feishu/host-shell.ts
@@ -26,7 +26,14 @@ import { HostInteractionOrchestrator } from "./interaction-orchestrator.js";
 import { targetFor, type FeishuInboundEvent } from "./message-policy.js";
 import type { PreviousSessionRef } from "../agent/context-prompt.js";
 import type { RuntimeHost, RuntimeHostEvent, RuntimeSessionRecoveryResult } from "../runtime/runtime-host.js";
-import { providerAuthenticationFailureReadiness, RuntimePrerequisiteError } from "../runtime/runtime-readiness.js";
+import {
+  authFailureAppliesTo,
+  parsePersistedAuthFailure,
+  providerAuthenticationFailureReadiness,
+  readinessForPersistedAuthFailure,
+  RuntimePrerequisiteError,
+  type PersistedAuthFailure,
+} from "../runtime/runtime-readiness.js";
 import { readDocumentCommentSubscription, verifyCallbackProbe, type EffectiveDocumentCommentSubscription } from "../platform/callback-capability.js";
 import { loadConfig, resolveMentionPolicy } from "../platform/config.js";
 import { processCommandToken } from "../app/internal-command.js";
@@ -67,6 +74,8 @@ interface AgentState {
   agentId?: string;
   sessions: Record<string, string>;
   previousSessions?: Record<string, PreviousSessionRef>;
+  authFailureProvider?: string;
+  authFailure?: PersistedAuthFailure;
 }
 interface PendingDocumentComment {
   messageId: string;
@@ -299,6 +308,30 @@ export function createHostShell({
       runtimeReadiness: { runtime: agent.runtime, state: "unavailable", reason, nextAction: "Wait for the current daemon epoch to publish Runtime readiness.", observedAt: new Date().toISOString() },
     });
   };
+  const unresolvedCurrentAuth = (agent: ConfiguredAgent): PersistedAuthFailure | null => {
+    try {
+      const persisted = parsePersistedAuthFailure(stateStore(agent).readJson<Partial<AgentState>>("agentState", {}));
+      if (!persisted) return null;
+      // 只使用当前 agentState 作用域标记，不扫描历史 delivery 的 authProvider。
+      return authFailureAppliesTo({
+        runtime: agent.runtime,
+        model: agent.model,
+        piDistribution: agent.piDistribution,
+      }, persisted) ? persisted : null;
+    } catch {
+      return null;
+    }
+  };
+  const projectReadyUnlessUnresolvedAuth = (agent: ConfiguredAgent, observedAt: string): void => {
+    const failure = unresolvedCurrentAuth(agent);
+    if (failure) {
+      hostState.updateStatus(agent, {
+        runtimeReadiness: { ...readinessForPersistedAuthFailure(failure), observedAt },
+      });
+      return;
+    }
+    hostState.updateStatus(agent, { runtimeReadiness: { runtime: agent.runtime, state: "ready", observedAt } });
+  };
   const recordInboundDeliveryFailure = (
     agent: ConfiguredAgent,
     code: "non_retryable_receipt" | "runtime_delivery_exception" | "runtime_delivery_event",
@@ -306,22 +339,40 @@ export function createHostShell({
     const at = new Date().toISOString();
     const reason = "Inbound Runtime delivery failed non-retryably; durable Inbox/ledger state is retained for recovery.";
     const nextAction = "Inspect the delivery/status error, correct the Runtime or canonical Inbox state, then restart to replay safely.";
+    const currentReadiness = hostState.readStatus(agent).runtimeReadiness as { state?: string } | undefined;
     hostState.updateStatus(agent, {
       inboundDeliveryHealth: { state: "error", code, at, reason, nextAction },
-      runtimeReadiness: { runtime: agent.runtime, state: "incompatible", reason, nextAction },
+      ...(currentReadiness?.state === "unauthenticated" ? {} : {
+        runtimeReadiness: { runtime: agent.runtime, state: "incompatible" as const, reason, nextAction },
+      }),
     });
     hostState.recordStatusError(agent, `${reason} ${nextAction} code=${code}`);
   };
   const agentStates = new Map<string, AgentStateRecord>();
+  const mergePersistedAgentState = (record: AgentStateRecord): void => {
+    const latest = record.store.readJson<Partial<AgentState>>("agentState", {});
+    if (isRecord(latest.previousSessions)) {
+      record.state.previousSessions = {
+        ...latest.previousSessions,
+        ...(record.state.previousSessions ?? {}),
+      };
+    }
+    const persisted = parsePersistedAuthFailure(latest);
+    if (persisted) {
+      record.state.authFailure = persisted;
+      if (persisted.kind === "missing-provider" && persisted.provider) {
+        record.state.authFailureProvider = persisted.provider;
+      } else {
+        delete record.state.authFailureProvider;
+      }
+    } else {
+      delete record.state.authFailure;
+      delete record.state.authFailureProvider;
+    }
+  };
   const saveAgentState = (record: AgentStateRecord): void => {
     try {
-      const latest = record.store.readJson<Partial<AgentState>>("agentState", {});
-      if (isRecord(latest.previousSessions)) {
-        record.state.previousSessions = {
-          ...latest.previousSessions,
-          ...(record.state.previousSessions ?? {}),
-        };
-      }
+      mergePersistedAgentState(record);
       record.store.writeJson("agentState", record.state);
     }
     catch (error) { log(`agent-state 写失败: ${errorMessage(error)}`); }
@@ -1264,10 +1315,14 @@ export function createHostShell({
           observedAt,
         },
       });
-      else if (message.readiness) hostState.updateStatus(agent, { runtimeReadiness: { ...message.readiness, observedAt } });
-      else if (message.status === "active") hostState.updateStatus(agent, { runtimeReadiness: {
-        runtime: agent.runtime, state: "ready", observedAt,
-      } });
+      else if (message.readiness) {
+        if (message.readiness.state === "ready" && unresolvedCurrentAuth(agent)) {
+          projectReadyUnlessUnresolvedAuth(agent, observedAt);
+        } else {
+          hostState.updateStatus(agent, { runtimeReadiness: { ...message.readiness, observedAt } });
+        }
+      }
+      else if (message.status === "active") projectReadyUnlessUnresolvedAuth(agent, observedAt);
       if (message.status === "active") {
         const redeliveryTimer = setTimeout(() => {
           void reminder.redeliverUnread(agent).catch((error) => log("启动补投失败", errorMessage(error)));
@@ -1425,6 +1480,7 @@ export function createHostShell({
         if (record) {
           if (reset.sessionId) record.state.sessions[agent.runtime] = reset.sessionId;
           else delete record.state.sessions[agent.runtime];
+          mergePersistedAgentState(record);
           record.store.writeJson("agentState", record.state);
         }
         if (!reset.sessionId) {
@@ -1432,10 +1488,10 @@ export function createHostShell({
           hostState.updateStatus(agent, {
             session: { runtime: agent.runtime, id: null, launchId: null, startedAt: observedAt,
               lastSeenAt: null, lastTurnAt: null, turns: 0 },
-            runtimeReadiness: { runtime: agent.runtime, state: "ready", observedAt },
           });
+          projectReadyUnlessUnresolvedAuth(agent, observedAt);
         } else if (reset.runtimeReady) {
-          hostState.updateStatus(agent, { runtimeReadiness: { runtime: agent.runtime, state: "ready", observedAt: new Date().toISOString() } });
+          projectReadyUnlessUnresolvedAuth(agent, new Date().toISOString());
         }
       } catch (error) {
         const projection = readinessProjection();
@@ -1503,13 +1559,14 @@ export function createHostShell({
         throw Object.assign(error instanceof Error ? error : new Error(String(error)), readinessProjection());
       }
       if (recovery.runtimeReady) {
-        hostState.updateStatus(agent, { runtimeReadiness: { runtime: agent.runtime, state: "ready", observedAt: new Date().toISOString() } });
+        projectReadyUnlessUnresolvedAuth(agent, new Date().toISOString());
       }
       const record = agentStates.get(agentId);
       try {
         if (record) {
           if (recovery.sessionId) record.state.sessions[agent.runtime] = recovery.sessionId;
           else delete record.state.sessions[agent.runtime];
+          mergePersistedAgentState(record);
           record.store.writeJson("agentState", record.state);
         }
       } catch (error) {

--- a/src/runtime/pi-official-auth.ts
+++ b/src/runtime/pi-official-auth.ts
@@ -172,6 +172,47 @@ function readCredentialData(authPath: string): Record<string, Credential> {
   return parsed as Record<string, Credential>;
 }
 
+/** 只读校验 Agent 凭证路径：每级必须是当前用户拥有的非 symlink 目录，不创建、不改权限。 */
+function officialPiOwnedAuthPath(configDir: string, agentId: string): string | null {
+  if (!/^cli_[A-Za-z0-9]+$/.test(agentId)) return null;
+  const root = path.resolve(configDir);
+  const expected = path.join(root, "providers", "pi", agentId, "auth.json");
+  const segments = ["providers", "pi", agentId] as const;
+  let current = root;
+  try {
+    const rootStat = fs.lstatSync(current);
+    if (!rootStat.isDirectory() || rootStat.isSymbolicLink()) return null;
+    if (typeof process.getuid === "function" && rootStat.uid !== process.getuid()) return null;
+  } catch {
+    return null;
+  }
+  for (let index = 0; index < segments.length; index += 1) {
+    current = path.join(current, segments[index]!);
+    let stat: fs.Stats;
+    try { stat = fs.lstatSync(current); }
+    catch { return null; }
+    if (!stat.isDirectory() || stat.isSymbolicLink()) return null;
+    if (typeof process.getuid === "function" && stat.uid !== process.getuid()) return null;
+    if (index === segments.length - 1 && !isWindows && (stat.mode & 0o777) !== 0o700) return null;
+  }
+  const authPath = path.join(current, "auth.json");
+  return authPath === expected ? authPath : null;
+}
+
+/** Presence-only check against the Agent-owned official store. Never returns credential bytes. */
+export function officialPiHasStoredProvider(configDir: string, agentId: string, providerId: string): boolean {
+  const provider = typeof providerId === "string" ? providerId.trim() : "";
+  if (!/^[A-Za-z0-9][A-Za-z0-9._-]{0,79}$/.test(provider)) return false;
+  try {
+    const authPath = officialPiOwnedAuthPath(configDir, agentId);
+    if (!authPath) return false;
+    const credential = readCredentialData(authPath)[provider];
+    return credential?.type === "api_key" || credential?.type === "oauth";
+  } catch {
+    return false;
+  }
+}
+
 function writeCredentialData(authPath: string, data: Record<string, Credential>): void {
   ensurePrivateDirectory(path.dirname(authPath));
   const temporary = `${authPath}.${process.pid}.${crypto.randomUUID()}.tmp`;

--- a/src/runtime/runtime-adapters.ts
+++ b/src/runtime/runtime-adapters.ts
@@ -31,7 +31,10 @@ import { resolvePiSubagentRecordWatchdogExtensionArg } from "./pi-subagent-recor
 import { effectivePiStateDir, extractBackgroundPiSubagentDispatch } from "./pi-subagent-ledger.js";
 import { resolvePiBashTimeoutExtensionArg } from "./pi-bash-timeout-injection.js";
 import {
+  classifyPiMissingCredentialRejection,
   classifyRuntimePrerequisite,
+  isBuiltinPiDistribution,
+  missingProviderCredentialReadiness,
   probeNativeRuntimeReadiness,
   providerAuthenticationFailureReadiness,
   RuntimePrerequisiteError,
@@ -604,7 +607,23 @@ class PiSession extends EventSession {
       this.awaitingAcknowledgement.delete(input.inputId);
       this.ownedInputIds.delete(input.inputId);
       this.inputEpochs.delete(input.inputId);
-      return { status: "rejected", inputId: input.inputId, retryable: true, reason: (error as Error).message };
+      const rawReason = error instanceof Error ? error.message : String(error);
+      const missing = isBuiltinPiDistribution(this.distribution)
+        ? classifyPiMissingCredentialRejection(rawReason)
+        : null;
+      if (missing) {
+        const classified = classifyPiProviderError(
+          { provider: missing.provider, message: missing.diagnostic },
+          { distribution: this.distribution },
+        );
+        this.emit({
+          type: "input-error", inputId: input.inputId, retryable: false, willRetry: false,
+          message: classified.reason, errorCategory: classified.category, nextAction: classified.nextAction,
+          upstream: { provider: missing.provider, message: missing.diagnostic },
+        });
+        return { status: "rejected", inputId: input.inputId, retryable: false, reason: classified.reason };
+      }
+      return { status: "rejected", inputId: input.inputId, retryable: true, reason: rawReason };
     }
   }
 
@@ -723,7 +742,7 @@ class PiSession extends EventSession {
       this.emitObservation("settled");
       const owned = [...this.ownedInputIds].filter((inputId) => this.inputEpochs.get(inputId) === epoch);
       if (error) {
-        const classified = classifyPiProviderError(error);
+        const classified = classifyPiProviderError(error, { distribution: this.distribution });
         const retryable = classified.category === "rate_limit" || isRetryablePiProviderError(error.upstream.message);
         for (const inputId of owned) this.emit({
           type: "input-error", inputId, retryable, willRetry: false, message: classified.reason,
@@ -858,7 +877,10 @@ function piAssistantProviderError(message: Record<string, any>): PiProviderError
   };
 }
 
-export function classifyPiProviderError(error: PiProviderErrorDetails | UpstreamProviderError): {
+export function classifyPiProviderError(
+  error: PiProviderErrorDetails | UpstreamProviderError,
+  scope?: { distribution?: "builtin" | "external" },
+): {
   category: "billing" | "quota" | "rate_limit" | "auth" | "context_window" | "provider"; reason: string; nextAction: string;
 } {
   const upstream = "upstream" in error ? error.upstream : error;
@@ -880,6 +902,13 @@ export function classifyPiProviderError(error: PiProviderErrorDetails | Upstream
   if (upstream.status === 429 || [...signal].some((value) => ["rate_limit", "rate_limit_exceeded", "too_many_requests"].includes(value))) return {
     category: "rate_limit", reason, nextAction: "Wait for the provider rate-limit window, then retry.",
   };
+  const missing = isBuiltinPiDistribution(scope?.distribution)
+    ? classifyPiMissingCredentialRejection(reason)
+    : null;
+  if (missing) {
+    const readiness = missingProviderCredentialReadiness("pi", missing.provider);
+    return { category: "auth", reason: readiness.reason!, nextAction: readiness.nextAction! };
+  }
   if (upstream.status === 401
       || [...signal].some((value) => ["authentication_error", "invalid_api_key", "invalid_token", "token_expired", "unauthorized", "provider_auth_error"].includes(value))
       || /\bAPI key auth failed\b|\bFailed to resolve API key\b/i.test(reason)) {

--- a/src/runtime/runtime-host.ts
+++ b/src/runtime/runtime-host.ts
@@ -12,11 +12,22 @@ import type {
 } from "./runtime-contracts.js";
 import { buildStrictProviderErrorInput, classifyStrictProviderError } from "./provider-error-classifier.js";
 import {
+  authFailureAppliesTo,
+  classifyPiMissingCredentialRejection,
   classifyRuntimePrerequisite,
+  configuredProviderId,
+  isBuiltinPiDistribution,
+  missingProviderCredentialReadiness,
+  parsePersistedAuthFailure,
   providerAuthenticationFailureReadiness,
+  readinessForPersistedAuthFailure,
+  safeProviderId,
   RuntimePrerequisiteError,
+  type AuthFailureScope,
+  type PersistedAuthFailure,
   type RuntimeReadiness,
 } from "./runtime-readiness.js";
+import { officialPiHasStoredProvider } from "./pi-official-auth.js";
 import { resolveOfficialLarkCli } from "../app/official-lark-cli.js";
 import { assertAgentWorkspaceBound, managedLarkCliEnv } from "../app/agent-lark-cli-workspace.js";
 import type { TelemetryRuntime } from "../platform/telemetry-tracing.js";
@@ -63,6 +74,8 @@ export interface DeliveryRecord {
   target?: string;
   wakeReason?: string;
   reason?: string; retryable?: boolean; errorCategory?: string;
+  /** Bounded missing-provider identity for builtin-Pi terminal auth; never a secret. */
+  authProvider?: string;
 }
 interface DeliveryFile { version: 1; records: DeliveryRecord[] }
 interface DeliveryStateStore {
@@ -118,6 +131,8 @@ interface ManagedAgent {
   previousSession: PreviousSessionRef | null;
   readiness: RuntimeReadiness | null;
   turnInProgress: boolean; turnHadFailure: boolean; turnHadAuthenticatedOutput: boolean; authFailureActive: boolean;
+  authFailureKind: PersistedAuthFailure["kind"] | null;
+  authFailureProvider: string | null;
   /** Delivery ids already promoted from accepted inbox_update to a wake while idle. */
   promotedInboxUpdateIds: Set<string>;
   backgroundCompletionQueue: string[]; backgroundCompletionKeys: Set<string>;
@@ -241,6 +256,116 @@ function persistPreviousSession(agent: ManagedAgent, previous: PreviousSessionRe
   } catch {
     // In-memory ref still holds for this process; restart will miss it only if this write failed.
   }
+}
+
+function isBuiltinPiAgent(agent: Pick<ManagedAgent, "adapter" | "config">): boolean {
+  return agent.adapter.id === "pi"
+    && (isBuiltinPiDistribution(agent.config.piDistribution) || agent.config.runtime === "builtin-pi");
+}
+
+function authFailureScopeOf(agent: Pick<ManagedAgent, "adapter" | "config">): AuthFailureScope {
+  return {
+    runtime: agent.config.runtime,
+    model: agent.config.model,
+    piDistribution: agent.config.piDistribution,
+    adapterId: agent.adapter.id,
+  };
+}
+
+function currentAuthFailure(agent: ManagedAgent): PersistedAuthFailure | null {
+  if (!agent.authFailureActive) return null;
+  const kind = agent.authFailureKind
+    ?? (agent.authFailureProvider ? "missing-provider" : "generic");
+  if (kind === "missing-provider") {
+    if (!agent.authFailureProvider) return null;
+    return { kind: "missing-provider", runtime: "pi", piDistribution: "builtin", provider: agent.authFailureProvider };
+  }
+  const runtime = agent.adapter.id === "codex" || agent.adapter.id === "claude" || agent.adapter.id === "pi"
+    ? agent.adapter.id : null;
+  if (!runtime) return null;
+  return {
+    kind: "generic",
+    runtime,
+    ...(runtime === "pi" && (agent.config.piDistribution === "builtin" || agent.config.piDistribution === "external")
+      ? { piDistribution: agent.config.piDistribution } : {}),
+    provider: agent.authFailureProvider,
+  };
+}
+
+function genericAuthProvider(agent: Pick<ManagedAgent, "config">, upstream?: { provider?: unknown }): string | null {
+  return safeProviderId(upstream?.provider) ?? configuredProviderId(agent.config.model);
+}
+
+function persistAuthFailure(agent: ManagedAgent): void {
+  const store = agent.stateStore;
+  if (!store) return;
+  try {
+    const write = (): void => {
+      const current = store.readJson<Record<string, unknown>>("agentState", { sessions: {} });
+      if (Array.isArray((current as { records?: unknown }).records) && !("sessions" in current)) return;
+      const { authFailureProvider: _legacy, authFailure: _scoped, ...rest } = current;
+      const failure = currentAuthFailure(agent);
+      if (!failure) {
+        if (!("authFailureProvider" in current) && !("authFailure" in current)) return;
+        store.writeJson("agentState", rest);
+        return;
+      }
+      store.writeJson("agentState", {
+        ...rest,
+        authFailure: failure,
+        ...(failure.kind === "missing-provider" && failure.provider
+          ? { authFailureProvider: failure.provider } : {}),
+      });
+    };
+    if (store.withInboxTransaction) store.withInboxTransaction(write);
+    else write();
+  } catch {
+    // In-memory flags and the delivery ledger still hold for this process.
+  }
+}
+
+function loadPersistedAuthFailure(store?: DeliveryStateStore): PersistedAuthFailure | null {
+  if (!store) return null;
+  try {
+    return parsePersistedAuthFailure(store.readJson<Record<string, unknown>>("agentState", {}));
+  } catch {
+    return null;
+  }
+}
+
+function applyAuthFailure(agent: ManagedAgent, failure: PersistedAuthFailure): void {
+  agent.authFailureActive = true;
+  agent.authFailureKind = failure.kind;
+  agent.authFailureProvider = failure.provider ?? null;
+  agent.readiness = readinessForPersistedAuthFailure(failure);
+}
+
+function clearAuthFailure(agent: ManagedAgent, persist = true): void {
+  agent.authFailureActive = false;
+  agent.authFailureKind = null;
+  agent.authFailureProvider = null;
+  if (persist) persistAuthFailure(agent);
+}
+
+function restoreAuthFailure(agent: ManagedAgent): void {
+  const persisted = loadPersistedAuthFailure(agent.stateStore);
+  if (!persisted) return;
+  // 只恢复仍绑定当前 candidate 的当前作用域 auth；不从历史 delivery 回灌。
+  if (!authFailureAppliesTo(authFailureScopeOf(agent), persisted)) {
+    clearAuthFailure(agent);
+    return;
+  }
+  applyAuthFailure(agent, persisted);
+}
+
+function clearLedgerAuthProviders(agent: ManagedAgent): void {
+  let changed = false;
+  for (const record of agent.records.values()) {
+    if (!record.authProvider) continue;
+    delete record.authProvider;
+    changed = true;
+  }
+  if (changed) persist(agent);
 }
 type ReplayFailureCode = "canonical_inbox_row_missing" | "canonical_inbox_malformed" | "duplicate_message_id"
   | "inbox_state_conflict" | "delivery_target_conflict" | "structured_target_invalid"
@@ -618,6 +743,38 @@ export function createRuntimeHost(options: {
     }
   };
 
+  const ownedConfigDir = (): string | null => {
+    const value = process.env.LARKIN_CONFIG_DIR?.trim();
+    return value || null;
+  };
+
+  const projectAuthFailure = (
+    agent: ManagedAgent,
+    readiness: RuntimeReadiness,
+    failure: { kind: PersistedAuthFailure["kind"]; provider: string | null },
+  ): void => {
+    agent.authFailureActive = true;
+    agent.authFailureKind = failure.kind;
+    agent.authFailureProvider = failure.provider;
+    agent.readiness = {
+      ...readiness,
+      ...(agent.readiness?.executable ? { executable: agent.readiness.executable } : {}),
+      ...(agent.readiness?.version ? { version: agent.readiness.version } : {}),
+    };
+    persistAuthFailure(agent);
+    emit({ type: "agent-status", agentId: agent.config.agentId, status: "error",
+      error: `${agent.readiness.reason} ${agent.readiness.nextAction}`, readiness: agent.readiness });
+  };
+
+  const namedAuthProviderPresent = (agent: ManagedAgent): boolean => {
+    if (agent.authFailureKind !== "missing-provider" || !agent.authFailureProvider) return true;
+    const failure = currentAuthFailure(agent);
+    if (!failure || !authFailureAppliesTo(authFailureScopeOf(agent), failure)) return false;
+    const configDir = ownedConfigDir();
+    if (!configDir) return false;
+    return officialPiHasStoredProvider(configDir, agent.config.agentId, agent.authFailureProvider);
+  };
+
   const resultFor = (agent: ManagedAgent, record: DeliveryRecord, result: RuntimeInputResult): DeliveryReceipt => {
     if (result.status === "accepted") {
       if (record.errorCategory !== "context_window") {
@@ -629,6 +786,27 @@ export function createRuntimeHost(options: {
       if (finalRecord.status !== "consumed") emit({ type: "delivery", agentId: agent.config.agentId,
         deliveryId: record.deliveryId, messageId: record.messageId, status: "accepted" });
       return { status: "accepted", deliveryId: record.deliveryId };
+    }
+    const missing = result.status === "rejected" && isBuiltinPiAgent(agent)
+      ? classifyPiMissingCredentialRejection(result.reason)
+      : null;
+    if (missing) {
+      const readiness = missingProviderCredentialReadiness(agent.adapter.id, missing.provider);
+      const reason = readiness.reason ?? `Provider ${missing.provider} is missing from this Agent's official credential store.`;
+      if (record.status !== "error") {
+        record.reason = reason;
+        record.retryable = false;
+        record.errorCategory = "auth";
+        record.authProvider = missing.provider;
+        const finalRecord = setRecord(agent, record, "error");
+        if (finalRecord.status !== "consumed") emit({ type: "delivery", agentId: agent.config.agentId,
+          deliveryId: record.deliveryId, messageId: record.messageId, status: "error", reason });
+        projectAuthFailure(agent, readiness, { kind: "missing-provider", provider: missing.provider });
+      }
+      return { status: "error", deliveryId: record.deliveryId, reason: record.reason ?? reason, retryable: false };
+    }
+    if (record.status === "error") {
+      return { status: "error", deliveryId: record.deliveryId, reason: record.reason ?? result.reason, retryable: false };
     }
     if (record.errorCategory !== "context_window") delete record.errorCategory;
     const retryable = result.status === "deferred" || result.retryable;
@@ -1387,7 +1565,7 @@ export function createRuntimeHost(options: {
         if (["closed", "fallback_committed"].includes(machine.state)) agent.compactionMachines.delete(inputId);
       }
       const recoveredAuthentication = agent.authFailureActive && agent.turnInProgress
-        && agent.turnHadAuthenticatedOutput && !agent.turnHadFailure;
+        && agent.turnHadAuthenticatedOutput && !agent.turnHadFailure && namedAuthProviderPresent(agent);
       agent.turnInProgress = false;
       agent.busy = false;
       emit({ type: "activity", agentId: agent.config.agentId, activity: "idle", activityKind: "idle", detailKind: "turn_ended" });
@@ -1407,7 +1585,8 @@ export function createRuntimeHost(options: {
       reconcileSubagentLedger(agent);
       telemetry?.runtimeEvent(agent.config.agentId, event);
       if (recoveredAuthentication) {
-        agent.authFailureActive = false;
+        clearAuthFailure(agent);
+        clearLedgerAuthProviders(agent);
         const prior = agent.readiness;
         agent.readiness = {
           runtime: agent.adapter.id,
@@ -1490,20 +1669,22 @@ export function createRuntimeHost(options: {
       }));
       if (classifiedCategory) record.errorCategory = classifiedCategory;
       else delete record.errorCategory;
+      const missing = event.errorCategory === "auth" && !event.retryable && isBuiltinPiAgent(agent)
+        ? classifyPiMissingCredentialRejection(event.upstream?.message)
+          ?? classifyPiMissingCredentialRejection(event.message)
+        : null;
+      if (missing) record.authProvider = missing.provider;
       const finalRecord = setRecord(agent, record, event.retryable ? "pending" : "error");
       if (finalRecord.status !== "consumed") emit({ type: "delivery", agentId: agent.config.agentId,
         deliveryId: record.deliveryId, messageId: record.messageId,
         status: event.retryable ? "deferred" : "error", reason: event.message });
       if (event.errorCategory === "auth" && !event.retryable) {
-        const readiness = providerAuthenticationFailureReadiness(agent.adapter.id, event.upstream?.provider);
-        agent.authFailureActive = true;
-        agent.readiness = {
-          ...readiness,
-          ...(agent.readiness?.executable ? { executable: agent.readiness.executable } : {}),
-          ...(agent.readiness?.version ? { version: agent.readiness.version } : {}),
-        };
-        emit({ type: "agent-status", agentId: agent.config.agentId, status: "error",
-          error: `${agent.readiness.reason} ${agent.readiness.nextAction}`, readiness: agent.readiness });
+        const readiness = missing
+          ? missingProviderCredentialReadiness(agent.adapter.id, missing.provider)
+          : providerAuthenticationFailureReadiness(agent.adapter.id, event.upstream?.provider);
+        projectAuthFailure(agent, readiness, missing
+          ? { kind: "missing-provider", provider: missing.provider }
+          : { kind: "generic", provider: genericAuthProvider(agent, event.upstream) });
       }
       if (event.retryable && !agent.busy && !agent.turnInProgress) void retryPending(agent);
     } else if (event.type === "configuration-error") {
@@ -1737,14 +1918,26 @@ export function createRuntimeHost(options: {
           if (previous.stabilityTimer) clearTimeout(previous.stabilityTimer);
           if (previous.backgroundCompletionRetryTimer) clearTimeout(previous.backgroundCompletionRetryTimer);
           if (previous.subagentReconcileTimer) clearInterval(previous.subagentReconcileTimer);
+          const previousFailure = currentAuthFailure(previous);
+          const scoped = Boolean(previousFailure
+            && authFailureAppliesTo({
+              runtime: config.runtime,
+              model: config.model,
+              piDistribution: config.piDistribution,
+              adapterId: adapter.id,
+            }, previousFailure));
           const candidate: ManagedAgent = {
             ...previous, config, adapter, session, launchId: crypto.randomUUID(), busy: false, submitting: false,
             starting: null, retryAfterSubmit: false, generation: 0, poller: null, retryTimer: null,
             recreateAttempts: 0, stabilityTimer: null, recreateReason: null, stopped: false,
             backgroundCompletionRetryTimer: null, subagentReconcileTimer: null,
             disabledReason: null, configurationRecovery: null,
-            readiness: previous.authFailureActive ? previous.readiness : readiness,
+            authFailureActive: scoped && previous.authFailureActive,
+            authFailureKind: scoped ? previous.authFailureKind : null,
+            authFailureProvider: scoped ? previous.authFailureProvider : null,
+            readiness: scoped && previous.authFailureActive ? previous.readiness : readiness,
           };
+          if (previous.authFailureActive && !candidate.authFailureActive) clearAuthFailure(candidate);
           managed.set(config.agentId, candidate);
           session.subscribe((event) => observe(candidate, session, event));
           if (session.sessionId) {
@@ -1829,7 +2022,7 @@ export function createRuntimeHost(options: {
         agent.config.sessionId = null;
         agent.session = fresh;
         persistPreviousSession(agent, previousRef);
-        agent.readiness = readiness;
+        if (!agent.authFailureActive) agent.readiness = readiness;
         agent.disabledReason = null;
       };
       try {
@@ -1847,7 +2040,13 @@ export function createRuntimeHost(options: {
           ...(fresh.effectiveReasoningEffort ? { reasoningEffort: fresh.effectiveReasoningEffort } : {}),
           ...(agent.previousSession ? { previousSession: agent.previousSession } : {}) });
       }
-      emit({ type: "agent-status", agentId, status: "active", readiness });
+      emit({
+        type: "agent-status",
+        agentId,
+        status: agent.authFailureActive ? "error" : "active",
+        ...(agent.authFailureActive ? { error: `${agent.readiness?.reason} ${agent.readiness?.nextAction}` } : {}),
+        readiness: agent.authFailureActive ? agent.readiness ?? readiness : readiness,
+      });
       agent.piSessionOwner = probeEnv[PI_SUBAGENT_SESSION_OWNER_ENV];
       await oldSession.close("fresh session reset committed")
         .catch((error) => log("previous runtime close after fresh reset failed", String(error)));
@@ -1967,7 +2166,7 @@ export function createRuntimeHost(options: {
           agent.config.sessionId = null;
           agent.session = fresh;
           persistPreviousSession(agent, previousRef);
-          agent.readiness = readiness;
+          if (!agent.authFailureActive) agent.readiness = readiness;
           agent.disabledReason = null;
           for (const record of agent.records.values()) {
             if (!messageIds.includes(record.messageId)) continue;
@@ -1984,7 +2183,13 @@ export function createRuntimeHost(options: {
             ...(fresh.effectiveReasoningEffort ? { reasoningEffort: fresh.effectiveReasoningEffort } : {}),
             ...(agent.previousSession ? { previousSession: agent.previousSession } : {}) });
         }
-        emit({ type: "agent-status", agentId, status: "active", readiness });
+        emit({
+          type: "agent-status",
+          agentId,
+          status: agent.authFailureActive ? "error" : "active",
+          ...(agent.authFailureActive ? { error: `${agent.readiness?.reason} ${agent.readiness?.nextAction}` } : {}),
+          readiness: agent.authFailureActive ? agent.readiness ?? readiness : readiness,
+        });
         durableRollback = null;
         agent.piSessionOwner = probeEnv[PI_SUBAGENT_SESSION_OWNER_ENV];
         await oldSession.close("context-window recovery committed")
@@ -2058,11 +2263,13 @@ export function createRuntimeHost(options: {
           piProactiveCompactionFailedGeneration: null,
           previousSession: loadPersistedPreviousSession(config, stateStore), readiness: null,
           turnInProgress: false, turnHadFailure: false, turnHadAuthenticatedOutput: false, authFailureActive: false,
+          authFailureKind: null, authFailureProvider: null,
           promotedInboxUpdateIds: new Set(),
           backgroundCompletionQueue: [], backgroundCompletionKeys: new Set(),
           backgroundCompletionInFlight: null, backgroundCompletionWakeInputId: null,
           backgroundCompletionRejectStreak: 0, backgroundCompletionRetryTimer: null,
           subagentLedger: loadSubagentLedger(config), subagentReconcileTimer: null };
+        restoreAuthFailure(agent);
         const startupConsumed: DeliveryRecord[] = [];
         const startupQuarantined: Array<{ record: DeliveryRecord; code: ReplayFailureCode }> = [];
         for (const record of agent.records.values()) {

--- a/src/runtime/runtime-readiness.ts
+++ b/src/runtime/runtime-readiness.ts
@@ -20,9 +20,124 @@ export interface RuntimeReadiness {
   observedAt?: string;
 }
 
-function safeProviderLabel(value: unknown): string | null {
+export function safeProviderId(value: unknown): string | null {
   const provider = typeof value === "string" ? value.trim() : "";
   return /^[A-Za-z0-9][A-Za-z0-9._-]{0,79}$/.test(provider) ? provider : null;
+}
+
+function safeProviderLabel(value: unknown): string | null {
+  return safeProviderId(value);
+}
+
+export function isBuiltinPiDistribution(value: unknown): boolean {
+  return value === "builtin";
+}
+
+export type PersistedAuthFailureKind = "missing-provider" | "generic";
+
+/** Current scoped auth-failure marker. Never stores secrets or ledger history. */
+export interface PersistedAuthFailure {
+  kind: PersistedAuthFailureKind;
+  runtime: RuntimeReadiness["runtime"];
+  piDistribution?: "builtin" | "external";
+  provider?: string | null;
+}
+
+export interface AuthFailureScope {
+  runtime: string;
+  model?: string;
+  piDistribution?: unknown;
+  adapterId?: string;
+}
+
+/** Model ids are `provider/model`; only the provider prefix is used for scope. */
+export function configuredProviderId(model: unknown): string | null {
+  const value = typeof model === "string" ? model.trim() : "";
+  const slash = value.indexOf("/");
+  return slash > 0 ? safeProviderId(value.slice(0, slash)) : null;
+}
+
+function persistedRuntime(value: unknown): RuntimeReadiness["runtime"] | null {
+  return value === "pi" || value === "codex" || value === "claude" ? value : null;
+}
+
+export function parsePersistedAuthFailure(state: unknown): PersistedAuthFailure | null {
+  if (!state || typeof state !== "object" || Array.isArray(state)) return null;
+  const record = state as Record<string, unknown>;
+  if (record.authFailure && typeof record.authFailure === "object" && !Array.isArray(record.authFailure)) {
+    const failure = record.authFailure as Record<string, unknown>;
+    const kind = failure.kind === "missing-provider" || failure.kind === "generic" ? failure.kind : null;
+    const runtime = persistedRuntime(failure.runtime);
+    if (!kind || !runtime) return null;
+    const provider = safeProviderId(failure.provider);
+    if (kind === "missing-provider" && !provider) return null;
+    const piDistribution = failure.piDistribution === "builtin" || failure.piDistribution === "external"
+      ? failure.piDistribution : undefined;
+    return {
+      kind,
+      runtime,
+      ...(piDistribution ? { piDistribution } : {}),
+      provider,
+    };
+  }
+  const legacy = safeProviderId(record.authFailureProvider);
+  return legacy
+    ? { kind: "missing-provider", runtime: "pi", piDistribution: "builtin", provider: legacy }
+    : null;
+}
+
+function currentAdapterId(current: AuthFailureScope): string {
+  return current.adapterId ?? (current.runtime === "builtin-pi" ? "pi" : current.runtime);
+}
+
+function currentIsBuiltinPi(current: AuthFailureScope): boolean {
+  return currentAdapterId(current) === "pi"
+    && (isBuiltinPiDistribution(current.piDistribution) || current.runtime === "builtin-pi");
+}
+
+/**
+ * Missing-provider and known-provider generic markers apply only to that provider.
+ * Generic without a provider is conservative fallback: it still binds runtime /
+ * builtin distribution, but cannot reject an A→B model switch because the
+ * upstream provider was genuinely unavailable.
+ */
+export function authFailureAppliesTo(current: AuthFailureScope, failure: PersistedAuthFailure): boolean {
+  if (failure.kind === "missing-provider") {
+    return currentIsBuiltinPi(current)
+      && failure.runtime === "pi"
+      && failure.piDistribution === "builtin"
+      && Boolean(failure.provider)
+      && configuredProviderId(current.model) === failure.provider;
+  }
+  if (failure.runtime !== currentAdapterId(current)) return false;
+  if (failure.runtime === "pi") {
+    const persistedBuiltin = failure.piDistribution === "builtin";
+    if (currentIsBuiltinPi(current) !== persistedBuiltin) return false;
+  }
+  if (!failure.provider) return true;
+  const currentProvider = configuredProviderId(current.model);
+  if (currentIsBuiltinPi(current)) return currentProvider === failure.provider;
+  return currentProvider ? currentProvider === failure.provider : true;
+}
+
+export function readinessForPersistedAuthFailure(failure: PersistedAuthFailure): RuntimeReadiness {
+  if (failure.kind === "missing-provider") {
+    return missingProviderCredentialReadiness(failure.runtime, failure.provider);
+  }
+  return providerAuthenticationFailureReadiness(failure.runtime, failure.provider);
+}
+
+const MISSING_CREDENTIAL_REJECTION =
+  /^(?:Pi RPC (?:prompt|steer) failed: )?(No API key found for|No login found for) ([A-Za-z0-9][A-Za-z0-9._-]{0,79})$/;
+
+/** Narrow match for an explicit Pi absent-key / absent-login diagnostic. */
+export function classifyPiMissingCredentialRejection(message: unknown): { provider: string; diagnostic: string } | null {
+  const text = typeof message === "string"
+    ? message.replace(/[\r\n\t]+/g, " ").replace(/\s+/g, " ").trim()
+    : "";
+  const match = MISSING_CREDENTIAL_REJECTION.exec(text);
+  const provider = match ? safeProviderLabel(match[2]) : null;
+  return provider && match ? { provider, diagnostic: `${match[1]} ${provider}` } : null;
 }
 
 export function providerAuthenticationFailureReadiness(
@@ -37,6 +152,23 @@ export function providerAuthenticationFailureReadiness(
       ? `Provider ${label} API-key authentication failed during a Runtime turn.`
       : "Configured provider API-key authentication failed during a Runtime turn.",
     nextAction: "Check the provider login or API-key resolver command, then retry the Agent turn.",
+  };
+}
+
+export function missingProviderCredentialReadiness(
+  runtime: RuntimeReadiness["runtime"],
+  provider?: unknown,
+): RuntimeReadiness {
+  const label = safeProviderLabel(provider);
+  return {
+    runtime,
+    state: "unauthenticated",
+    reason: label
+      ? `Provider ${label} is missing from this Agent's official credential store.`
+      : "The configured provider is missing from this Agent's official credential store.",
+    nextAction: label
+      ? `Add the missing ${label} credential to this Agent's official store, then retry the Agent turn.`
+      : "Add the missing provider credential to this Agent's official store, then retry the Agent turn.",
   };
 }
 

--- a/test/e2e/pi-prompt-preflight-recovery-mock-e2e.test.mjs
+++ b/test/e2e/pi-prompt-preflight-recovery-mock-e2e.test.mjs
@@ -334,3 +334,85 @@ test("external Pi production-order preflight timeout stays bounded, pending, obs
     fs.rmSync(root, { recursive: true, force: true });
   }
 });
+
+test("real Pi adapter missing-key RPC rejection terminals the ledger and projects unauthenticated", async () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "larkin-pi-missing-key-e2e-"));
+  const agentId = "cli_piMissingKeyA1";
+  const messageId = "om_missing_key_rpc";
+  const stateDir = path.join(root, "state", "agents", agentId);
+  const workspaceDir = path.join(root, "workspace");
+  const store = createAgentStateStore(root, agentId);
+  const previousConfigDir = process.env.LARKIN_CONFIG_DIR;
+  const previousHome = process.env.HOME;
+  const configDir = path.join(root, "config");
+  const writeOwned = (providers) => {
+    const directory = path.join(configDir, "providers", "pi", agentId);
+    fs.mkdirSync(directory, { recursive: true, mode: 0o700 });
+    fs.chmodSync(directory, 0o700);
+    fs.writeFileSync(path.join(directory, "auth.json"), `${JSON.stringify(Object.fromEntries(
+      providers.map((id) => [id, { type: "api_key", key: `fixture-${id}` }]),
+    ))}\n`, { mode: 0o600 });
+  };
+  let rejectMissing = true;
+  let sdkListener;
+  const sdk = {
+    sessionId: "pi-missing-key-session",
+    prompt() {
+      if (rejectMissing) throw new Error("Pi RPC prompt failed: No API key found for zai-coding-cn");
+    },
+    steer() {},
+    abort() {},
+    subscribe(next) { sdkListener = next; return () => { sdkListener = undefined; }; },
+  };
+  process.env.LARKIN_CONFIG_DIR = configDir;
+  process.env.HOME = path.join(root, "decoy-home");
+  writeOwned(["openai-codex"]);
+  const native = createNativeRuntimeAdapter("pi", {
+    env: { LARKIN_PI_DISTRIBUTION: "builtin", LARKIN_CONFIG_DIR: configDir },
+    createPiSession: async () => sdk,
+  });
+  const adapter = { id: native.id, capabilities: native.capabilities,
+    probe: async () => ({ runtime: "pi", state: "ready" }), createSession: (input) => native.createSession(input) };
+  const events = [];
+  const host = createRuntimeHost({ adapterFor: () => adapter, promptBuilder: new ContextPromptBuilder(),
+    stateStoreFor: () => store, assertOfficialCliReady: () => {},
+    retryPolicy: { baseDelayMs: 60_000, maxDelayMs: 60_000, maxAttempts: 0 } });
+  host.subscribe((event) => events.push(event));
+  const target = "chat:oc_missing_key_rpc";
+  try {
+    fs.mkdirSync(workspaceDir, { recursive: true });
+    await host.start([{ agentId, name: agentId, runtime: "pi", model: "zai-coding-cn/glm-5.2", piDistribution: "builtin",
+      workspaceDir, stateDir, env: { LARKIN_PI_DISTRIBUTION: "builtin", LARKIN_CONFIG_DIR: configDir } }]);
+    store.prepareInboxDelivery({ message_id: messageId, target, content: "missing key", wake: true });
+    const receipt = await host.deliver(agentId, { message_id: messageId, target, content: "missing key", wake: true });
+    assert.equal(receipt.status, "error");
+    assert.equal(receipt.retryable, false);
+    assert.match(receipt.reason, /zai-coding-cn.*missing/i);
+    const record = store.readJson("runtimeDeliveries", { records: [] }).records[0];
+    assert.equal(record.status, "error");
+    assert.equal(record.retryable, false);
+    assert.equal(record.errorCategory, "auth");
+    const status = events.filter((event) => event.type === "agent-status").at(-1);
+    assert.equal(status.readiness.state, "unauthenticated");
+    assert.match(status.readiness.nextAction, /Add the missing zai-coding-cn credential to this Agent's official store/);
+    assert.equal(events.filter((event) => event.type === "delivery" && event.status === "deferred").length, 0);
+
+    rejectMissing = false;
+    writeOwned(["openai-codex", "zai-coding-cn"]);
+    const retry = await host.deliver(agentId, { message_id: messageId, target, content: "missing key", wake: true });
+    assert.equal(retry.status, "accepted");
+    sdkListener({ type: "turn_start", turnIndex: 0 });
+    sdkListener({ type: "message_update", assistantMessageEvent: { type: "text_delta", delta: "authenticated fixture output" } });
+    sdkListener({ type: "agent_end", willRetry: false, messages: [{ role: "assistant", provider: "zai-coding-cn", stopReason: "stop" }] });
+    sdkListener({ type: "agent_settled" });
+    await new Promise((resolve) => setImmediate(resolve));
+    assert.equal(events.filter((event) => event.type === "agent-status").at(-1).readiness.state, "ready");
+  } finally {
+    await host.shutdown("missing-key adapter e2e complete").catch(() => {});
+    if (previousConfigDir === undefined) delete process.env.LARKIN_CONFIG_DIR;
+    else process.env.LARKIN_CONFIG_DIR = previousConfigDir;
+    if (previousHome === undefined) delete process.env.HOME;
+    else process.env.HOME = previousHome;
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});

--- a/test/e2e/runtime-production-mock-e2e.test.mjs
+++ b/test/e2e/runtime-production-mock-e2e.test.mjs
@@ -825,3 +825,103 @@ else process.stdout.write(JSON.stringify({ok:true,data:{users:[],bots:[],message
     }
   });
 }
+
+test("missing-key prompt rejection terminals the HostShell ledger and projects unauthenticated", async () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "larkin-production-missing-key-"));
+  const agentId = "cli_mockMissingKeyA1";
+  const otherId = "cli_mockMissingKeyB2";
+  const previousConfigDir = process.env.LARKIN_CONFIG_DIR;
+  const previousHome = process.env.HOME;
+  const writeOwned = (id, providers) => {
+    const directory = path.join(root, "providers", "pi", id);
+    fs.mkdirSync(directory, { recursive: true, mode: 0o700 });
+    fs.chmodSync(directory, 0o700);
+    fs.writeFileSync(path.join(directory, "auth.json"), `${JSON.stringify(Object.fromEntries(
+      providers.map((provider) => [provider, { type: "api_key", key: `fixture-${provider}` }]),
+    ))}\n`, { mode: 0o600 });
+  };
+  const session = new FakeNativeSession("pi");
+  let rejectMissing = true;
+  session.prompt = async function(input) {
+    this.prompts.push(input);
+    if (rejectMissing) {
+      return { status: "rejected", inputId: input.inputId, retryable: true, reason: "No API key found for zai-coding-cn" };
+    }
+    return { status: "accepted", inputId: input.inputId };
+  };
+  const otherSession = new FakeNativeSession("pi");
+  const store = createAgentStateStore(root, agentId);
+  const otherStore = createAgentStateStore(root, otherId);
+  const runtimeHost = createRuntimeHost({
+    adapterFor: (runtime) => ({
+      id: runtime, capabilities: {},
+      async createSession(input) { return input.agentId === otherId ? otherSession : session; },
+    }),
+    promptBuilder: new ContextPromptBuilder(),
+    stateStoreFor: (id) => id === otherId ? otherStore : store,
+    assertOfficialCliReady: () => {},
+    retryPolicy: { baseDelayMs: 60_000, maxDelayMs: 60_000, maxAttempts: 0 },
+  });
+  const agents = [agentId, otherId].map((id) => ({
+    agentId: id, name: id, runtime: "pi", piDistribution: "builtin", model: "zai-coding-cn/glm-5.2", feishuAppId: id, feishuProfile: id,
+    feishuAppSecret: "fixture-secret", feishuDomain: "https://open.feishu.cn",
+    larkConfigDir: path.join(root, "lark-cli-config"), workspaceDir: path.join(root, "agents", id),
+    stateDir: path.join(root, "state", "agents", id),
+  }));
+  fs.mkdirSync(root, { recursive: true });
+  writeOwned(agentId, ["openai-codex"]);
+  writeOwned(otherId, ["openai-codex"]);
+  fs.writeFileSync(path.join(root, "config.json"), `${JSON.stringify({
+    version: 3, serverId: "server-missing-key", activeAgent: agentId,
+    agents: Object.fromEntries([agentId, otherId].map((id) => [id, { runtime: "pi", piDistribution: "builtin", model: "zai-coding-cn/glm-5.2" }])),
+  })}\n`, { mode: 0o600 });
+  process.env.LARKIN_CONFIG_DIR = root;
+  process.env.HOME = path.join(root, "decoy-home");
+  const hostShell = createHostShell({
+    env: { LARKIN_HOME: root, LARKIN_CONFIG_DIR: root, LARKIN_SERVER_ID: "server-missing-key",
+      LARKIN_AGENTS_CONFIG: JSON.stringify(agents), LARKIN_FEISHU_DRYRUN: "1", LARKIN_INBOUND_DROUGHT_SEC: "0" },
+    runtimeHost,
+    stateStoreForImpl: (_root, id) => id === otherId ? otherStore : store,
+    managedCliForAgent: testManagedCli,
+    eventSourceStartDelayMs: 60_000,
+    channelPackage: { createLarkChannel() { throw new Error("event source must not start in missing-key fixture"); } },
+  });
+  try {
+    await hostShell.start();
+    await hostShell.ingest(agentId, { chat_id: "oc_missing_key", chat_type: "p2p", sender_id: "ou_sender",
+      message_id: "om_missing_key", event_id: "evt_missing_key", content: "auth retry",
+      create_time: "1784160002000", thread_id: null, _mentioned_bot: false, _mention_all: false, _sender_is_bot: true });
+    await new Promise((resolve) => setImmediate(resolve));
+    const failed = store.readJson("runtimeDeliveries", { records: [] }).records[0];
+    assert.equal(failed.status, "error");
+    assert.equal(failed.retryable, false);
+    assert.equal(failed.errorCategory, "auth");
+    assert.equal(session.prompts.length, 1);
+    const failedStatus = store.readJson("status", {});
+    assert.equal(failedStatus.runtimeReadiness.state, "unauthenticated");
+    assert.match(failedStatus.runtimeReadiness.reason, /zai-coding-cn.*missing/i);
+    assert.match(failedStatus.runtimeReadiness.nextAction, /Add the missing zai-coding-cn credential to this Agent's official store/);
+    assert.doesNotMatch(JSON.stringify(failedStatus.runtimeReadiness), /fixture-openai-codex|larkin setup|profile import/);
+    await hostShell.ingest(otherId, { chat_id: "oc_missing_other", chat_type: "p2p", sender_id: "ou_sender",
+      message_id: "om_missing_other", event_id: "evt_missing_other", content: "other",
+      create_time: "1784160003000", thread_id: null, _mentioned_bot: false, _mention_all: false, _sender_is_bot: true });
+    assert.equal((otherStore.readJson("runtimeDeliveries", { records: [] }).records[0] || {}).status, "accepted");
+
+    rejectMissing = false;
+    writeOwned(agentId, ["openai-codex", "zai-coding-cn"]);
+    const retry = await runtimeHost.deliver(agentId, { message_id: "om_missing_key", chat_id: "oc_missing_key" });
+    assert.equal(retry.status, "accepted");
+    session.emit({ type: "turn-start", turnId: "pi-missing-recovered" });
+    session.emit({ type: "activity", activity: "text" });
+    session.emit({ type: "turn-end", turnId: "pi-missing-recovered" });
+    await new Promise((resolve) => setImmediate(resolve));
+    assert.equal(store.readJson("status", {}).runtimeReadiness.state, "ready");
+  } finally {
+    await hostShell.shutdown("missing-key mock e2e complete");
+    if (previousConfigDir === undefined) delete process.env.LARKIN_CONFIG_DIR;
+    else process.env.LARKIN_CONFIG_DIR = previousConfigDir;
+    if (previousHome === undefined) delete process.env.HOME;
+    else process.env.HOME = previousHome;
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});

--- a/test/fixtures/runtime/pi-missing-credential.json
+++ b/test/fixtures/runtime/pi-missing-credential.json
@@ -1,0 +1,5 @@
+{
+  "absentKey": "No API key found for zai-coding-cn",
+  "absentLogin": "No login found for zai-coding-cn",
+  "rpcWrappedAbsentKey": "Pi RPC prompt failed: No API key found for zai-coding-cn"
+}

--- a/test/unit/feishu/host-runtime-lifecycle.test.mjs
+++ b/test/unit/feishu/host-runtime-lifecycle.test.mjs
@@ -215,6 +215,234 @@ test("HostShell reset publishes a current readiness observation and rejects stal
   }
 });
 
+test("HostShell keeps durable missing-key auth across ready status and reset", async () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "larkin-host-missing-key-persist-"));
+  const agentId = "cli_hostMissingKeyA1";
+  const stateDir = path.join(root, "state", "agents", agentId);
+  const store = createAgentStateStore(root, agentId);
+  store.writeJson("agentState", { sessions: {}, authFailureProvider: "zai-coding-cn" });
+  store.writeJson("runtimeDeliveries", { version: 1, records: [{
+    deliveryId: "d-missing-key", messageId: "om_host_missing_key", status: "error", retryable: false,
+    errorCategory: "auth", authProvider: "zai-coding-cn",
+    reason: "Provider zai-coding-cn is missing from this Agent's official credential store.",
+    input: { inputId: "i-missing-key", deliveryId: "d-missing-key", kind: "wake", text: "redacted", attempt: 0 },
+    updatedAt: "2026-09-04T00:00:00.000Z",
+  }] });
+  let listener = () => {};
+  let channelCreated = false;
+  const runtimeHost = {
+    subscribe(next) { listener = next; return () => {}; },
+    async start() {
+      listener({ type: "agent-status", agentId, status: "active", readiness: { runtime: "pi", state: "ready" } });
+    },
+    async resetSession() {
+      return { generationChanged: true, sessionChanged: true, turns: 0, runtimeReady: true, pendingCount: 0, sessionId: "fresh-session" };
+    },
+    async deliver() { throw new Error("not used"); },
+    async stop() {},
+    async shutdown() {},
+  };
+  const agent = { agentId, name: agentId, runtime: "pi", piDistribution: "builtin", model: "zai-coding-cn/glm-5.2",
+    feishuAppId: agentId, feishuAppSecret: "fixture", feishuProfile: agentId, feishuDomain: "https://open.feishu.cn",
+    workspaceDir: path.join(root, "agents", agentId), stateDir };
+  const env = { LARKIN_HOME: root, LARKIN_CONFIG_DIR: root, LARKIN_SERVER_ID: "server-missing-key-persist",
+    LARKIN_AGENTS_CONFIG: JSON.stringify([agent]), LARKIN_INBOUND_DROUGHT_SEC: "0" };
+  const channelPackage = { createLarkChannel() { channelCreated = true; return {
+    botIdentity: { openId: "ou_missing_key", name: "Missing Key" }, rawClient: null, dispatcher: { register() {} }, on() {},
+    async connect() {}, async disconnect() {},
+  }; } };
+  const host = createHostShell({ env, runtimeHost, channelPackage, eventSourceStartDelayMs: 0, stateStoreForImpl: () => store });
+  try {
+    await host.start();
+    const statusFile = path.join(stateDir, "status.json");
+    const deadline = Date.now() + 1_000;
+    while ((!channelCreated || !fs.existsSync(statusFile) || JSON.parse(fs.readFileSync(statusFile, "utf8")).connectedVia !== "channel")
+      && Date.now() < deadline) {
+      await new Promise((resolve) => setTimeout(resolve, 5));
+    }
+    assert.equal(store.readJson("status", {}).runtimeReadiness.state, "unauthenticated");
+    assert.match(store.readJson("status", {}).runtimeReadiness.nextAction, /official store/);
+    const reset = await host.resetSession(agentId, 0);
+    assert.equal(reset.resetCommitted, true);
+    assert.equal(store.readJson("status", {}).runtimeReadiness.state, "unauthenticated");
+    assert.doesNotMatch(JSON.stringify(store.readJson("status", {}).runtimeReadiness), /pi-auth login|larkin setup|profile import/);
+  } finally {
+    await host.shutdown("missing-key persist test complete");
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("HostShell does not rehydrate missing-key auth from historical delivery rows", async () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "larkin-host-ledger-auth-stale-"));
+  const agentId = "cli_hostLedgerAuthA1";
+  const stateDir = path.join(root, "state", "agents", agentId);
+  const store = createAgentStateStore(root, agentId);
+  store.writeJson("agentState", { sessions: {} });
+  store.writeJson("runtimeDeliveries", { version: 1, records: [{
+    deliveryId: "d-stale-missing", messageId: "om_host_stale_missing", status: "error", retryable: false,
+    errorCategory: "auth", authProvider: "zai-coding-cn",
+    reason: "Provider zai-coding-cn is missing from this Agent's official credential store.",
+    input: { inputId: "i-stale-missing", deliveryId: "d-stale-missing", kind: "wake", text: "redacted", attempt: 0 },
+    updatedAt: "2026-09-04T00:00:00.000Z",
+  }] });
+  let listener = () => {};
+  const runtimeHost = {
+    subscribe(next) { listener = next; return () => {}; },
+    async start() {
+      listener({ type: "agent-status", agentId, status: "active", readiness: { runtime: "pi", state: "ready" } });
+    },
+    async resetSession() {
+      return { generationChanged: true, sessionChanged: true, turns: 0, runtimeReady: true, pendingCount: 0, sessionId: "fresh-session" };
+    },
+    async deliver() { throw new Error("not used"); },
+    async stop() {},
+    async shutdown() {},
+  };
+  const agent = { agentId, name: agentId, runtime: "pi", piDistribution: "builtin", model: "zai-coding-cn/glm-5.2",
+    feishuAppId: agentId, feishuAppSecret: "fixture", feishuProfile: agentId, feishuDomain: "https://open.feishu.cn",
+    workspaceDir: path.join(root, "agents", agentId), stateDir };
+  const env = { LARKIN_HOME: root, LARKIN_CONFIG_DIR: root, LARKIN_SERVER_ID: "server-ledger-auth-stale",
+    LARKIN_AGENTS_CONFIG: JSON.stringify([agent]), LARKIN_INBOUND_DROUGHT_SEC: "0" };
+  const channelPackage = { createLarkChannel() { return {
+    botIdentity: { openId: "ou_ledger_stale", name: "Ledger Stale" }, rawClient: null, dispatcher: { register() {} }, on() {},
+    async connect() {}, async disconnect() {},
+  }; } };
+  const host = createHostShell({ env, runtimeHost, channelPackage, eventSourceStartDelayMs: 0, stateStoreForImpl: () => store });
+  try {
+    await host.start();
+    const statusFile = path.join(stateDir, "status.json");
+    const deadline = Date.now() + 1_000;
+    while ((!fs.existsSync(statusFile) || JSON.parse(fs.readFileSync(statusFile, "utf8")).connectedVia !== "channel")
+      && Date.now() < deadline) {
+      await new Promise((resolve) => setTimeout(resolve, 5));
+    }
+    assert.equal(store.readJson("status", {}).runtimeReadiness.state, "ready");
+    await host.resetSession(agentId, 0);
+    assert.equal(store.readJson("status", {}).runtimeReadiness.state, "ready");
+  } finally {
+    await host.shutdown("ledger auth stale test complete");
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("HostShell keeps a newer generic auth over historical missing-key rows across ready and reset", async () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "larkin-host-generic-supersede-"));
+  const agentId = "cli_hostGenericAuthA1";
+  const stateDir = path.join(root, "state", "agents", agentId);
+  const store = createAgentStateStore(root, agentId);
+  store.writeJson("agentState", {
+    sessions: {},
+    authFailure: { kind: "generic", runtime: "pi", piDistribution: "builtin", provider: "zai-coding-cn" },
+  });
+  store.writeJson("runtimeDeliveries", { version: 1, records: [{
+    deliveryId: "d-old-missing", messageId: "om_host_old_missing", status: "error", retryable: false,
+    errorCategory: "auth", authProvider: "zai-coding-cn",
+    reason: "Provider zai-coding-cn is missing from this Agent's official credential store.",
+    input: { inputId: "i-old-missing", deliveryId: "d-old-missing", kind: "wake", text: "redacted", attempt: 0 },
+    updatedAt: "2026-09-04T00:00:00.000Z",
+  }] });
+  let listener = () => {};
+  const runtimeHost = {
+    subscribe(next) { listener = next; return () => {}; },
+    async start() {
+      listener({ type: "agent-status", agentId, status: "active", readiness: { runtime: "pi", state: "ready" } });
+    },
+    async resetSession() {
+      return { generationChanged: true, sessionChanged: true, turns: 0, runtimeReady: true, pendingCount: 0, sessionId: "fresh-session" };
+    },
+    async deliver() { throw new Error("not used"); },
+    async stop() {},
+    async shutdown() {},
+  };
+  const agent = { agentId, name: agentId, runtime: "pi", piDistribution: "builtin", model: "zai-coding-cn/glm-5.2",
+    feishuAppId: agentId, feishuAppSecret: "fixture", feishuProfile: agentId, feishuDomain: "https://open.feishu.cn",
+    workspaceDir: path.join(root, "agents", agentId), stateDir };
+  const env = { LARKIN_HOME: root, LARKIN_CONFIG_DIR: root, LARKIN_SERVER_ID: "server-generic-supersede",
+    LARKIN_AGENTS_CONFIG: JSON.stringify([agent]), LARKIN_INBOUND_DROUGHT_SEC: "0" };
+  const channelPackage = { createLarkChannel() { return {
+    botIdentity: { openId: "ou_generic_auth", name: "Generic Auth" }, rawClient: null, dispatcher: { register() {} }, on() {},
+    async connect() {}, async disconnect() {},
+  }; } };
+  const host = createHostShell({ env, runtimeHost, channelPackage, eventSourceStartDelayMs: 0, stateStoreForImpl: () => store });
+  try {
+    await host.start();
+    const statusFile = path.join(stateDir, "status.json");
+    const deadline = Date.now() + 1_000;
+    while ((!fs.existsSync(statusFile) || JSON.parse(fs.readFileSync(statusFile, "utf8")).connectedVia !== "channel")
+      && Date.now() < deadline) {
+      await new Promise((resolve) => setTimeout(resolve, 5));
+    }
+    const started = store.readJson("status", {}).runtimeReadiness;
+    assert.equal(started.state, "unauthenticated");
+    assert.match(started.nextAction, /login|API-key resolver/);
+    assert.doesNotMatch(JSON.stringify(started), /official store/);
+    await host.resetSession(agentId, 0);
+    const reset = store.readJson("status", {}).runtimeReadiness;
+    assert.equal(reset.state, "unauthenticated");
+    assert.match(reset.nextAction, /login|API-key resolver/);
+    assert.doesNotMatch(JSON.stringify(reset), /official store/);
+  } finally {
+    await host.shutdown("generic supersede test complete");
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("HostShell does not keep generic provider A auth after a builtin model switch to B", async () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "larkin-host-generic-provider-switch-"));
+  const agentId = "cli_hostGenericSwitchA1";
+  const stateDir = path.join(root, "state", "agents", agentId);
+  const store = createAgentStateStore(root, agentId);
+  store.writeJson("agentState", {
+    sessions: {},
+    authFailure: { kind: "generic", runtime: "pi", piDistribution: "builtin", provider: "zai-coding-cn" },
+  });
+  store.writeJson("runtimeDeliveries", { version: 1, records: [{
+    deliveryId: "d-generic-a", messageId: "om_host_generic_a", status: "error", retryable: false,
+    errorCategory: "auth",
+    reason: "Provider zai-coding-cn API-key authentication failed during a Runtime turn.",
+    input: { inputId: "i-generic-a", deliveryId: "d-generic-a", kind: "wake", text: "redacted", attempt: 0 },
+    updatedAt: "2026-09-04T00:00:00.000Z",
+  }] });
+  let listener = () => {};
+  const runtimeHost = {
+    subscribe(next) { listener = next; return () => {}; },
+    async start() {
+      listener({ type: "agent-status", agentId, status: "active", readiness: { runtime: "pi", state: "ready" } });
+    },
+    async resetSession() {
+      return { generationChanged: true, sessionChanged: true, turns: 0, runtimeReady: true, pendingCount: 0, sessionId: "fresh-session" };
+    },
+    async deliver() { throw new Error("not used"); },
+    async stop() {},
+    async shutdown() {},
+  };
+  const agent = { agentId, name: agentId, runtime: "pi", piDistribution: "builtin", model: "openai-codex/gpt-5",
+    feishuAppId: agentId, feishuAppSecret: "fixture", feishuProfile: agentId, feishuDomain: "https://open.feishu.cn",
+    workspaceDir: path.join(root, "agents", agentId), stateDir };
+  const env = { LARKIN_HOME: root, LARKIN_CONFIG_DIR: root, LARKIN_SERVER_ID: "server-generic-provider-switch",
+    LARKIN_AGENTS_CONFIG: JSON.stringify([agent]), LARKIN_INBOUND_DROUGHT_SEC: "0" };
+  const channelPackage = { createLarkChannel() { return {
+    botIdentity: { openId: "ou_generic_switch", name: "Generic Switch" }, rawClient: null, dispatcher: { register() {} }, on() {},
+    async connect() {}, async disconnect() {},
+  }; } };
+  const host = createHostShell({ env, runtimeHost, channelPackage, eventSourceStartDelayMs: 0, stateStoreForImpl: () => store });
+  try {
+    await host.start();
+    const statusFile = path.join(stateDir, "status.json");
+    const deadline = Date.now() + 1_000;
+    while ((!fs.existsSync(statusFile) || JSON.parse(fs.readFileSync(statusFile, "utf8")).connectedVia !== "channel")
+      && Date.now() < deadline) {
+      await new Promise((resolve) => setTimeout(resolve, 5));
+    }
+    assert.equal(store.readJson("status", {}).runtimeReadiness.state, "ready");
+    await host.resetSession(agentId, 0);
+    assert.equal(store.readJson("status", {}).runtimeReadiness.state, "ready");
+  } finally {
+    await host.shutdown("generic provider switch test complete");
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});
+
 test("assembled HostShell recovery compensates persisted session/status after a later Runtime listener throws", async () => {
   const root = fs.mkdtempSync(path.join(os.tmpdir(), "larkin-host-context-listener-failure-"));
   const agentId = "cli_hostListenerA1";

--- a/test/unit/runtime/pi-official-auth.test.mjs
+++ b/test/unit/runtime/pi-official-auth.test.mjs
@@ -17,6 +17,7 @@ import {
   listOfficialPiAuthProviders,
   logoutOfficialPiProvider,
   officialPiAuthStatus,
+  officialPiHasStoredProvider,
   runOfficialPiLogin,
 } from "../../../dist/runtime/pi-official-auth.mjs";
 
@@ -31,6 +32,65 @@ function provider(id, name, options = {}) {
     getModels: () => options.models || [], stream() {}, streamSimple() {},
   };
 }
+
+test("official provider presence reads only the Agent-owned store", () => {
+  const temp = fs.mkdtempSync(path.join(os.tmpdir(), "larkin-pi-stored-provider-"));
+  const previousHome = process.env.HOME;
+  const agentId = "cli_storedProviderA1";
+  try {
+    fs.chmodSync(temp, 0o700);
+    process.env.HOME = path.join(temp, "decoy-home");
+    fs.mkdirSync(path.join(temp, "decoy-home", ".pi"), { recursive: true, mode: 0o700 });
+    fs.writeFileSync(path.join(temp, "decoy-home", ".pi", "auth.json"),
+      `${JSON.stringify({ "zai-coding-cn": { type: "api_key", key: "fixture-global" } })}\n`, { mode: 0o600 });
+    const directory = path.join(temp, "providers", "pi", agentId);
+    fs.mkdirSync(directory, { recursive: true, mode: 0o700 });
+    fs.writeFileSync(path.join(directory, "auth.json"), `${JSON.stringify({
+      "openai-codex": { type: "api_key", key: "fixture-unrelated" },
+    })}\n`, { mode: 0o600 });
+    assert.equal(officialPiHasStoredProvider(temp, agentId, "openai-codex"), true);
+    assert.equal(officialPiHasStoredProvider(temp, agentId, "zai-coding-cn"), false);
+    assert.equal(officialPiHasStoredProvider(temp, "cli_absentStoredA1", "openai-codex"), false);
+    assert.equal(officialPiHasStoredProvider(temp, agentId, "../secret"), false);
+  } finally {
+    if (previousHome === undefined) delete process.env.HOME;
+    else process.env.HOME = previousHome;
+    fs.rmSync(temp, { recursive: true, force: true });
+  }
+});
+
+test("official provider presence refuses a symlinked Agent credential path", () => {
+  const temp = fs.mkdtempSync(path.join(os.tmpdir(), "larkin-pi-symlink-provider-"));
+  const previousHome = process.env.HOME;
+  const agentId = "cli_symlinkProviderA1";
+  try {
+    fs.chmodSync(temp, 0o700);
+    process.env.HOME = path.join(temp, "decoy-home");
+    const hostPi = path.join(temp, "host-pi");
+    fs.mkdirSync(hostPi, { recursive: true, mode: 0o700 });
+    fs.chmodSync(hostPi, 0o700);
+    fs.writeFileSync(path.join(hostPi, "auth.json"), `${JSON.stringify({
+      "zai-coding-cn": { type: "api_key", key: "fixture-host" },
+    })}\n`, { mode: 0o600 });
+    const configDir = path.join(temp, "config");
+    const piRoot = path.join(configDir, "providers", "pi");
+    fs.mkdirSync(piRoot, { recursive: true, mode: 0o700 });
+    fs.chmodSync(configDir, 0o700);
+    fs.chmodSync(path.join(configDir, "providers"), 0o700);
+    fs.chmodSync(piRoot, 0o700);
+    fs.symlinkSync(hostPi, path.join(piRoot, agentId));
+    const before = fs.readdirSync(piRoot, { withFileTypes: true }).map((entry) => `${entry.name}:${entry.isSymbolicLink()}`);
+    assert.equal(fs.existsSync(path.join(piRoot, agentId, "auth.json")), true);
+    assert.equal(officialPiHasStoredProvider(configDir, agentId, "zai-coding-cn"), false);
+    const after = fs.readdirSync(piRoot, { withFileTypes: true }).map((entry) => `${entry.name}:${entry.isSymbolicLink()}`);
+    assert.deepEqual(after, before);
+    assert.equal(fs.lstatSync(path.join(piRoot, agentId)).isSymbolicLink(), true);
+  } finally {
+    if (previousHome === undefined) delete process.env.HOME;
+    else process.env.HOME = previousHome;
+    fs.rmSync(temp, { recursive: true, force: true });
+  }
+});
 
 test("official Pi auth registry projection is dynamic and preserves every login-capable method", async () => {
   const fake = { getProviders: () => [

--- a/test/unit/runtime/runtime-adapters.test.mjs
+++ b/test/unit/runtime/runtime-adapters.test.mjs
@@ -16,6 +16,7 @@ import {
   requirePiResumeSessionFile,
   resolvePiProcessExtensionArgs,
 } from "../../../dist/runtime/runtime-adapters.mjs";
+import { classifyPiMissingCredentialRejection } from "../../../dist/runtime/runtime-readiness.mjs";
 import {
   buildCanonicalPiSubagentAssistantMessage,
   buildCanonicalPiSubagentNotificationContent,
@@ -1381,16 +1382,18 @@ test("strict classifier accepts only the exact categorized Pi context projection
 });
 
 test("Pi provider failures preserve safe actionable categories", () => {
-  for (const [upstream, category] of [
+  for (const [upstream, category, scope] of [
     [{ provider: "openai-codex", message: "Codex error: Your input exceeds the context window of this model. Please adjust your input and try again." }, "context_window"],
     [{ status: 402, message: "payment required" }, "billing"],
     [{ status: 429, code: "insufficient_quota", message: "monthly allowance exhausted" }, "quota"],
     [{ status: 429, message: "too many requests" }, "rate_limit"],
     [{ status: 401, message: "credentials rejected Bearer fixture-secret" }, "auth"],
     [{ provider: "bigmodel-anthropic", code: "key_command_failed", message: "API key auth failed: resolver command exited nonzero at /Users/example/cc-switch-token" }, "auth"],
+    [{ provider: "zai-coding-cn", message: "No API key found for zai-coding-cn" }, "auth", { distribution: "builtin" }],
+    [{ message: "Pi RPC prompt failed: No login found for zai-coding-cn" }, "auth", { distribution: "builtin" }],
     [{ status: 403, message: "billing policy review" }, "provider"],
   ]) {
-    const result = classifyPiProviderError(upstream);
+    const result = classifyPiProviderError(upstream, scope);
     assert.equal(result.category, category);
     assert.ok(result.nextAction.length > 10);
     assert.doesNotMatch(result.reason, /fixture-secret/);
@@ -1399,9 +1402,18 @@ test("Pi provider failures preserve safe actionable categories", () => {
     { provider: "policy-gateway", message: "Authorization metadata documents the API key policy for this workspace" },
     { provider: "openai-codex", message: "The context policy token limit may apply" },
     { provider: "policy-gateway", code: "policy_error", message: "API key authorization requirements are controlled by tenant policy" },
+    { provider: "zai-coding-cn", message: "provider overloaded; retry later" },
+    { message: "No API key found for ../etc/passwd" },
+    { message: "No API key found for zai-coding-cn and extra diagnostic" },
   ]) {
     assert.equal(classifyPiProviderError(upstream).category, "provider");
   }
+  const missing = classifyPiProviderError({ message: "No API key found for zai-coding-cn" }, { distribution: "builtin" });
+  assert.match(missing.reason, /zai-coding-cn.*missing/i);
+  assert.match(missing.nextAction, /Add the missing zai-coding-cn credential to this Agent's official store/);
+  assert.doesNotMatch(missing.reason + missing.nextAction, /larkin setup|profile import|pi-auth login|Dashboard|fixture-secret/i);
+  assert.equal(classifyPiProviderError({ message: "No API key found for zai-coding-cn" }).category, "provider");
+  assert.equal(classifyPiProviderError({ message: "No API key found for zai-coding-cn" }, { distribution: "external" }).category, "provider");
   const unknown = classifyPiProviderError({ provider: "gateway", code: "server_error", status: 502,
     message: "unusual failure Authorization: Bearer auth-secret Cookie=session-secret request body: {\"description\":\"useful detail\",\"api_key\":\"private\"}" });
   assert.equal(unknown.category, "provider");
@@ -1436,6 +1448,52 @@ test("Pi carries the structured 0.82 provider fixture without flattening fields 
       assert.doesNotMatch(failure.message + failure.nextAction, /Users\/example|cc-switch-token|fixture-secret/);
     }
   }
+});
+
+test("Pi prompt rejection of an explicit missing credential is terminal auth", async () => {
+  const fixture = JSON.parse(fs.readFileSync(path.join(import.meta.dirname, "../../fixtures/runtime/pi-missing-credential.json"), "utf8"));
+  for (const message of [fixture.absentKey, fixture.rpcWrappedAbsentKey, fixture.absentLogin]) {
+    const sdk = { sessionId: "pi-missing-key", prompt() { throw new Error(message); }, steer() {}, abort() {},
+      subscribe() { return () => {}; } };
+    const session = await createNativeRuntimeAdapter("pi", {
+      createPiSession: async () => sdk, env: { LARKIN_PI_DISTRIBUTION: "builtin" },
+    }).createSession(create({ env: { LARKIN_PI_DISTRIBUTION: "builtin" } }));
+    const events = [];
+    session.subscribe((event) => events.push(event));
+    const result = await session.prompt({ inputId: "pi-missing-a", kind: "user", text: "work", attempt: 0 });
+    assert.deepEqual(result, {
+      status: "rejected", inputId: "pi-missing-a", retryable: false,
+      reason: "Provider zai-coding-cn is missing from this Agent's official credential store.",
+    });
+    const failure = events.find((event) => event.type === "input-error");
+    assert.equal(failure.errorCategory, "auth");
+    assert.equal(failure.retryable, false);
+    assert.equal(failure.willRetry, false);
+    assert.equal(failure.upstream.provider, "zai-coding-cn");
+    assert.match(failure.nextAction, /Add the missing zai-coding-cn credential to this Agent's official store/);
+    assert.doesNotMatch(JSON.stringify(failure), /fixture-secret|larkin setup|profile import|pi-auth login/i);
+    assert.equal(classifyPiMissingCredentialRejection(message)?.provider, "zai-coding-cn");
+  }
+  const transientSdk = { sessionId: "pi-transient", prompt() { throw new Error("fetch failed: provider overloaded"); },
+    steer() {}, abort() {}, subscribe() { return () => {}; } };
+  const transient = await createNativeRuntimeAdapter("pi", { createPiSession: async () => transientSdk }).createSession(create());
+  assert.deepEqual(await transient.prompt({ inputId: "pi-transient-a", kind: "user", text: "work", attempt: 0 }), {
+    status: "rejected", inputId: "pi-transient-a", retryable: true, reason: "fetch failed: provider overloaded",
+  });
+});
+
+test("external Pi keeps a matching missing-key prompt rejection retryable", async () => {
+  const sdk = { sessionId: "pi-external-missing-key", prompt() { throw new Error("No API key found for zai-coding-cn"); },
+    steer() {}, abort() {}, subscribe() { return () => {}; } };
+  const session = await createNativeRuntimeAdapter("pi", {
+    createPiSession: async () => sdk, env: { LARKIN_PI_DISTRIBUTION: "external" },
+  }).createSession(create({ env: { LARKIN_PI_DISTRIBUTION: "external" } }));
+  const events = [];
+  session.subscribe((event) => events.push(event));
+  assert.deepEqual(await session.prompt({ inputId: "pi-external-a", kind: "user", text: "work", attempt: 0 }), {
+    status: "rejected", inputId: "pi-external-a", retryable: true, reason: "No API key found for zai-coding-cn",
+  });
+  assert.equal(events.some((event) => event.type === "input-error"), false);
 });
 
 test("Pi exposes terminal provider errors without resubmitting them", async () => {

--- a/test/unit/runtime/runtime-host.test.mjs
+++ b/test/unit/runtime/runtime-host.test.mjs
@@ -1663,6 +1663,559 @@ test("terminal provider auth failure downgrades only its Agent and a later succe
   await host.shutdown("provider auth readiness test complete");
 });
 
+test("missing-key prompt rejection terminals once as auth and stays unauthenticated until that provider is stored", async () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "larkin-runtime-missing-key-"));
+  const failedId = "cli_missingKeyA1";
+  const healthyId = "cli_missingKeyB2";
+  const previousConfigDir = process.env.LARKIN_CONFIG_DIR;
+  const previousHome = process.env.HOME;
+  const writeOwned = (agentId, providers) => {
+    const directory = path.join(root, "providers", "pi", agentId);
+    fs.mkdirSync(directory, { recursive: true, mode: 0o700 });
+    fs.chmodSync(directory, 0o700);
+    fs.writeFileSync(path.join(directory, "auth.json"), `${JSON.stringify(Object.fromEntries(
+      providers.map((id) => [id, { type: "api_key", key: `fixture-${id}` }]),
+    ))}\n`, { mode: 0o600 });
+  };
+  const failedSession = new FakeSession();
+  failedSession.prompt = async function(input) {
+    this.prompts.push(input);
+    return { status: "rejected", inputId: input.inputId, retryable: true, reason: "No API key found for zai-coding-cn" };
+  };
+  const recoveredSession = new FakeSession();
+  const healthySession = new FakeSession();
+  const events = [];
+  process.env.LARKIN_CONFIG_DIR = root;
+  process.env.HOME = path.join(root, "decoy-home");
+  writeOwned(failedId, ["openai-codex"]);
+  writeOwned(healthyId, ["openai-codex"]);
+  fs.mkdirSync(path.join(root, "decoy-home", ".pi"), { recursive: true, mode: 0o700 });
+  fs.writeFileSync(path.join(root, "decoy-home", ".pi", "auth.json"),
+    `${JSON.stringify({ "zai-coding-cn": { type: "api_key", key: "fixture-global" } })}\n`, { mode: 0o600 });
+  const host = createRuntimeHost({
+    adapterFor: () => ({
+      id: "pi", capabilities: {},
+      async createSession(input) {
+        if (input.agentId === healthyId) return healthySession;
+        return input.model === "zai-coding-cn/glm-5.2-recovered" ? recoveredSession : failedSession;
+      },
+    }),
+    promptBuilder: new ContextPromptBuilder(),
+  });
+  host.subscribe((event) => events.push(event));
+  try {
+    await host.start([
+      { agentId: failedId, name: "failed", runtime: "pi", piDistribution: "builtin", model: "zai-coding-cn/glm-5.2", workspaceDir: "/tmp" },
+      { agentId: healthyId, name: "healthy", runtime: "pi", piDistribution: "builtin", model: "fixture/healthy", workspaceDir: "/tmp" },
+    ]);
+    const first = await host.deliver(failedId, { message_id: "om_missing_key" });
+    assert.deepEqual(first, { status: "error", deliveryId: first.deliveryId, reason: first.reason, retryable: false });
+    assert.match(first.reason, /zai-coding-cn.*missing/i);
+    assert.equal(failedSession.prompts.length, 1, "missing-key must not retry the same rejection");
+    const downgraded = events.filter((event) => event.type === "agent-status" && event.agentId === failedId).at(-1);
+    assert.equal(downgraded.status, "error");
+    assert.equal(downgraded.readiness.state, "unauthenticated");
+    assert.match(downgraded.readiness.nextAction, /Add the missing zai-coding-cn credential to this Agent's official store/);
+    assert.doesNotMatch(JSON.stringify(downgraded), /fixture-openai-codex|fixture-global|larkin setup|profile import/);
+    assert.equal(events.filter((event) => event.type === "delivery" && event.messageId === "om_missing_key"
+      && event.status === "deferred").length, 0);
+    assert.equal(events.filter((event) => event.type === "agent-status" && event.agentId === healthyId).at(-1).status, "active");
+    assert.equal((await host.deliver(healthyId, { message_id: "om_healthy_missing_key" })).status, "accepted");
+
+    const staged = await host.stage({ agentId: failedId, name: "failed", runtime: "pi", piDistribution: "builtin",
+      model: "zai-coding-cn/glm-5.2-recovered", workspaceDir: "/tmp" });
+    assert.equal(staged.readiness.state, "ready");
+    await staged.commit();
+    assert.equal(events.filter((event) => event.type === "agent-status" && event.agentId === failedId).at(-1).readiness.state,
+      "unauthenticated", "unrelated stored credentials must not clear a missing zai-coding-cn failure");
+
+    recoveredSession.prompt = async function(input) {
+      this.prompts.push(input);
+      return { status: "accepted", inputId: input.inputId };
+    };
+    const retry = await host.deliver(failedId, { message_id: "om_missing_key" });
+    assert.equal(retry.status, "accepted");
+    recoveredSession.emit({ type: "turn-start", turnId: "turn-missing-empty" });
+    recoveredSession.emit({ type: "activity", activity: "text" });
+    recoveredSession.emit({ type: "turn-end", turnId: "turn-missing-empty" });
+    await new Promise((resolve) => setImmediate(resolve));
+    assert.equal(events.filter((event) => event.type === "agent-status" && event.agentId === failedId).at(-1).readiness.state,
+      "unauthenticated", "a successful turn without the named provider still stays unauthenticated");
+
+    writeOwned(failedId, ["openai-codex", "zai-coding-cn"]);
+    recoveredSession.emit({ type: "turn-start", turnId: "turn-missing-recovered" });
+    recoveredSession.emit({ type: "activity", activity: "text" });
+    recoveredSession.emit({ type: "turn-end", turnId: "turn-missing-recovered" });
+    await new Promise((resolve) => setImmediate(resolve));
+    const recovered = events.filter((event) => event.type === "agent-status" && event.agentId === failedId).at(-1);
+    assert.equal(recovered.status, "active");
+    assert.equal(recovered.readiness.state, "ready");
+  } finally {
+    await host.shutdown("missing-key readiness test complete");
+    if (previousConfigDir === undefined) delete process.env.LARKIN_CONFIG_DIR;
+    else process.env.LARKIN_CONFIG_DIR = previousConfigDir;
+    if (previousHome === undefined) delete process.env.HOME;
+    else process.env.HOME = previousHome;
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("builtin missing-key auth survives restart and reset until that provider is stored", async () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "larkin-runtime-missing-key-restart-"));
+  const agentId = "cli_missingKeyRestartA1";
+  const store = createAgentStateStore(root, agentId);
+  const previousConfigDir = process.env.LARKIN_CONFIG_DIR;
+  const previousHome = process.env.HOME;
+  const writeOwned = (providers) => {
+    const directory = path.join(root, "providers", "pi", agentId);
+    fs.mkdirSync(directory, { recursive: true, mode: 0o700 });
+    fs.chmodSync(directory, 0o700);
+    fs.writeFileSync(path.join(directory, "auth.json"), `${JSON.stringify(Object.fromEntries(
+      providers.map((id) => [id, { type: "api_key", key: `fixture-${id}` }]),
+    ))}\n`, { mode: 0o600 });
+  };
+  const rejectSession = new FakeSession();
+  rejectSession.prompt = async function(input) {
+    this.prompts.push(input);
+    return { status: "rejected", inputId: input.inputId, retryable: true, reason: "No API key found for zai-coding-cn" };
+  };
+  process.env.LARKIN_CONFIG_DIR = root;
+  process.env.HOME = path.join(root, "decoy-home");
+  writeOwned(["openai-codex"]);
+  const config = { agentId, name: "failed", runtime: "pi", piDistribution: "builtin",
+    model: "zai-coding-cn/glm-5.2", workspaceDir: "/tmp", stateDir: store.paths.root };
+  const firstEvents = [];
+  const first = createRuntimeHost({
+    adapterFor: () => ({ id: "pi", capabilities: {}, async createSession() { return rejectSession; } }),
+    promptBuilder: new ContextPromptBuilder(), stateStoreFor: () => store,
+  });
+  first.subscribe((event) => firstEvents.push(event));
+  try {
+    await first.start([config]);
+    store.prepareInboxDelivery({ message_id: "om_missing_restart", target: "chat:oc_missing_restart", content: "missing key", wake: true });
+    const receipt = await first.deliver(agentId, { message_id: "om_missing_restart", target: "chat:oc_missing_restart", content: "missing key", wake: true });
+    assert.equal(receipt.status, "error");
+    assert.equal(receipt.retryable, false);
+    assert.match(receipt.reason, /zai-coding-cn.*missing/i);
+    assert.equal(firstEvents.filter((event) => event.type === "delivery" && event.messageId === "om_missing_restart"
+      && event.status === "error").length, 1);
+    assert.equal(store.readJson("runtimeDeliveries", { records: [] }).records[0].errorCategory, "auth");
+    assert.equal(store.readJson("runtimeDeliveries", { records: [] }).records[0].authProvider, "zai-coding-cn");
+    assert.equal(store.readJson("agentState", {}).authFailureProvider, "zai-coding-cn");
+    assert.deepEqual(store.readJson("agentState", {}).authFailure, {
+      kind: "missing-provider", runtime: "pi", piDistribution: "builtin", provider: "zai-coding-cn",
+    });
+    store.pollInbox();
+    await first.shutdown("restart boundary");
+
+    const restartedSession = new FakeSession();
+    const restartEvents = [];
+    const restarted = createRuntimeHost({
+      adapterFor: () => ({ id: "pi", capabilities: {}, async createSession() { return restartedSession; } }),
+      promptBuilder: new ContextPromptBuilder(), stateStoreFor: () => store,
+    });
+    restarted.subscribe((event) => restartEvents.push(event));
+    await restarted.start([config]);
+    const restartStatus = restartEvents.filter((event) => event.type === "agent-status" && event.agentId === agentId);
+    assert.equal(restartStatus.at(-1).readiness.state, "unauthenticated");
+    assert.equal(restartEvents.filter((event) => event.type === "delivery" && event.messageId === "om_missing_restart").length, 0,
+      "restart must not re-emit the already-terminal delivery");
+    const reset = await restarted.resetSession(agentId);
+    assert.equal(reset.runtimeReady, true);
+    assert.equal(restartEvents.filter((event) => event.type === "agent-status" && event.agentId === agentId).at(-1).readiness.state,
+      "unauthenticated", "reset must not publish ready over unresolved missing-key auth");
+    await restarted.shutdown("reset boundary");
+  } finally {
+    if (previousConfigDir === undefined) delete process.env.LARKIN_CONFIG_DIR;
+    else process.env.LARKIN_CONFIG_DIR = previousConfigDir;
+    if (previousHome === undefined) delete process.env.HOME;
+    else process.env.HOME = previousHome;
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("runtime or provider switch clears stale missing-provider unauthenticated state", async () => {
+  const switches = [
+    { runtime: "pi", piDistribution: "external", model: "zai-coding-cn/glm-5.2", adapterId: "pi" },
+    { runtime: "codex", model: "codex", adapterId: "codex" },
+    { runtime: "claude", model: "claude", adapterId: "claude" },
+    { runtime: "pi", piDistribution: "builtin", model: "openai-codex/gpt-5", adapterId: "pi" },
+  ];
+  for (const next of switches) {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), "larkin-runtime-auth-switch-"));
+    const agentId = `cli_authSwitch${next.adapterId}${next.piDistribution === "external" ? "Ext" : next.model.includes("openai") ? "Prov" : "A"}1`;
+    const store = createAgentStateStore(root, agentId);
+    const previousConfigDir = process.env.LARKIN_CONFIG_DIR;
+    const previousHome = process.env.HOME;
+    const rejectSession = new FakeSession();
+    rejectSession.prompt = async function(input) {
+      this.prompts.push(input);
+      return { status: "rejected", inputId: input.inputId, retryable: true, reason: "No API key found for zai-coding-cn" };
+    };
+    const switchedSession = new FakeSession();
+    process.env.LARKIN_CONFIG_DIR = root;
+    process.env.HOME = path.join(root, "decoy-home");
+    const directory = path.join(root, "providers", "pi", agentId);
+    fs.mkdirSync(directory, { recursive: true, mode: 0o700 });
+    fs.chmodSync(directory, 0o700);
+    fs.writeFileSync(path.join(directory, "auth.json"), `${JSON.stringify({
+      "openai-codex": { type: "api_key", key: "fixture-openai-codex" },
+      "zai-coding-cn": { type: "api_key", key: "fixture-zai-coding-cn" },
+    })}\n`, { mode: 0o600 });
+    const events = [];
+    let created = 0;
+    const host = createRuntimeHost({
+      adapterFor: (runtime) => ({
+        id: runtime,
+        capabilities: {},
+        async createSession() {
+          created += 1;
+          return created === 1 ? rejectSession : switchedSession;
+        },
+      }),
+      promptBuilder: new ContextPromptBuilder(),
+      stateStoreFor: () => store,
+    });
+    host.subscribe((event) => events.push(event));
+    const builtin = { agentId, name: "switch", runtime: "pi", piDistribution: "builtin",
+      model: "zai-coding-cn/glm-5.2", workspaceDir: "/tmp", stateDir: store.paths.root };
+    try {
+      await host.start([builtin]);
+      store.prepareInboxDelivery({ message_id: "om_switch_missing", target: "chat:oc_switch_missing", content: "missing", wake: true });
+      const receipt = await host.deliver(agentId, { message_id: "om_switch_missing", target: "chat:oc_switch_missing", content: "missing", wake: true });
+      assert.equal(receipt.status, "error", next.runtime);
+      store.pollInbox();
+      const staged = await host.stage({
+        agentId, name: "switch", runtime: next.runtime, model: next.model, workspaceDir: "/tmp",
+        stateDir: store.paths.root, ...(next.piDistribution ? { piDistribution: next.piDistribution } : {}),
+      });
+      assert.equal(staged.readiness.state, "ready", next.runtime);
+      await staged.commit();
+      assert.equal(events.filter((event) => event.type === "agent-status" && event.agentId === agentId).at(-1).readiness.state,
+        "ready", `${next.runtime} ${next.model}`);
+      const persisted = store.readJson("agentState", {});
+      assert.equal(persisted.authFailure, undefined, next.runtime);
+      assert.equal(persisted.authFailureProvider, undefined, next.runtime);
+      store.prepareInboxDelivery({ message_id: "om_switch_success", target: "chat:oc_switch_success", content: "ok", wake: true });
+      const accepted = await host.deliver(agentId, { message_id: "om_switch_success", target: "chat:oc_switch_success", content: "ok", wake: true });
+      assert.equal(accepted.status, "accepted", next.runtime);
+      switchedSession.emit({ type: "turn-start", turnId: "turn-switch-success" });
+      switchedSession.emit({ type: "activity", activity: "text" });
+      switchedSession.emit({ type: "turn-end", turnId: "turn-switch-success" });
+      await new Promise((resolve) => setImmediate(resolve));
+      assert.equal(events.filter((event) => event.type === "agent-status" && event.agentId === agentId).at(-1).readiness.state,
+        "ready", `${next.runtime} success`);
+      assert.equal(store.readJson("agentState", {}).authFailure, undefined, next.runtime);
+      store.pollInbox();
+    } finally {
+      await host.shutdown("auth switch test complete");
+      if (previousConfigDir === undefined) delete process.env.LARKIN_CONFIG_DIR;
+      else process.env.LARKIN_CONFIG_DIR = previousConfigDir;
+      if (previousHome === undefined) delete process.env.HOME;
+      else process.env.HOME = previousHome;
+      fs.rmSync(root, { recursive: true, force: true });
+    }
+  }
+});
+
+test("restart after a runtime switch does not restore missing-provider auth from ledger history", async () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "larkin-runtime-auth-switch-restart-"));
+  const agentId = "cli_authSwitchRestartA1";
+  const store = createAgentStateStore(root, agentId);
+  const previousConfigDir = process.env.LARKIN_CONFIG_DIR;
+  const previousHome = process.env.HOME;
+  const rejectSession = new FakeSession();
+  rejectSession.prompt = async function(input) {
+    this.prompts.push(input);
+    return { status: "rejected", inputId: input.inputId, retryable: true, reason: "No API key found for zai-coding-cn" };
+  };
+  process.env.LARKIN_CONFIG_DIR = root;
+  process.env.HOME = path.join(root, "decoy-home");
+  const directory = path.join(root, "providers", "pi", agentId);
+  fs.mkdirSync(directory, { recursive: true, mode: 0o700 });
+  fs.chmodSync(directory, 0o700);
+  fs.writeFileSync(path.join(directory, "auth.json"), `${JSON.stringify({
+    "zai-coding-cn": { type: "api_key", key: "fixture-zai-coding-cn" },
+  })}\n`, { mode: 0o600 });
+  const builtin = { agentId, name: "switch", runtime: "pi", piDistribution: "builtin",
+    model: "zai-coding-cn/glm-5.2", workspaceDir: "/tmp", stateDir: store.paths.root };
+  const first = createRuntimeHost({
+    adapterFor: () => ({ id: "pi", capabilities: {}, async createSession() { return rejectSession; } }),
+    promptBuilder: new ContextPromptBuilder(), stateStoreFor: () => store,
+  });
+  try {
+    await first.start([builtin]);
+    store.prepareInboxDelivery({ message_id: "om_switch_restart", target: "chat:oc_switch_restart", content: "missing", wake: true });
+    assert.equal((await first.deliver(agentId, {
+      message_id: "om_switch_restart", target: "chat:oc_switch_restart", content: "missing", wake: true,
+    })).status, "error");
+    assert.equal(store.readJson("agentState", {}).authFailure.kind, "missing-provider");
+    store.pollInbox();
+    await first.shutdown("switch restart boundary");
+
+    const codexSession = new FakeSession();
+    const events = [];
+    const restarted = createRuntimeHost({
+      adapterFor: () => ({ id: "codex", capabilities: {}, async createSession() { return codexSession; } }),
+      promptBuilder: new ContextPromptBuilder(), stateStoreFor: () => store,
+    });
+    restarted.subscribe((event) => events.push(event));
+    await restarted.start([{ agentId, name: "switch", runtime: "codex", model: "codex",
+      workspaceDir: "/tmp", stateDir: store.paths.root }]);
+    assert.equal(events.filter((event) => event.type === "agent-status" && event.agentId === agentId).at(-1).readiness.state,
+      "ready");
+    assert.equal(store.readJson("agentState", {}).authFailure, undefined);
+    assert.equal(store.readJson("runtimeDeliveries", { records: [] }).records[0].authProvider, "zai-coding-cn");
+    await restarted.resetSession(agentId);
+    assert.equal(events.filter((event) => event.type === "agent-status" && event.agentId === agentId).at(-1).readiness.state,
+      "ready");
+    store.prepareInboxDelivery({ message_id: "om_switch_restart_ok", target: "chat:oc_switch_restart_ok", content: "ok", wake: true });
+    assert.equal((await restarted.deliver(agentId, {
+      message_id: "om_switch_restart_ok", target: "chat:oc_switch_restart_ok", content: "ok", wake: true,
+    })).status, "accepted");
+    codexSession.emit({ type: "turn-start", turnId: "turn-codex-ok" });
+    codexSession.emit({ type: "activity", activity: "text" });
+    codexSession.emit({ type: "turn-end", turnId: "turn-codex-ok" });
+    await new Promise((resolve) => setImmediate(resolve));
+    assert.equal(events.filter((event) => event.type === "agent-status" && event.agentId === agentId).at(-1).readiness.state,
+      "ready");
+    assert.equal(store.readJson("agentState", {}).authFailure, undefined);
+    store.pollInbox();
+    await restarted.shutdown("switch restart complete");
+  } finally {
+    if (previousConfigDir === undefined) delete process.env.LARKIN_CONFIG_DIR;
+    else process.env.LARKIN_CONFIG_DIR = previousConfigDir;
+    if (previousHome === undefined) delete process.env.HOME;
+    else process.env.HOME = previousHome;
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("missing-key then generic auth survives restart and reset without rehydrating the old provider", async () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "larkin-runtime-missing-then-generic-"));
+  const agentId = "cli_missingThenGenericA1";
+  const store = createAgentStateStore(root, agentId);
+  const previousConfigDir = process.env.LARKIN_CONFIG_DIR;
+  const previousHome = process.env.HOME;
+  const session = new FakeSession();
+  session.prompt = async function(input) {
+    this.prompts.push(input);
+    return this.prompts.length === 1
+      ? { status: "rejected", inputId: input.inputId, retryable: true, reason: "No API key found for zai-coding-cn" }
+      : { status: "accepted", inputId: input.inputId };
+  };
+  process.env.LARKIN_CONFIG_DIR = root;
+  process.env.HOME = path.join(root, "decoy-home");
+  const directory = path.join(root, "providers", "pi", agentId);
+  fs.mkdirSync(directory, { recursive: true, mode: 0o700 });
+  fs.chmodSync(directory, 0o700);
+  fs.writeFileSync(path.join(directory, "auth.json"), `${JSON.stringify({
+    "openai-codex": { type: "api_key", key: "fixture-openai-codex" },
+  })}\n`, { mode: 0o600 });
+  const config = { agentId, name: "failed", runtime: "pi", piDistribution: "builtin",
+    model: "zai-coding-cn/glm-5.2", workspaceDir: "/tmp", stateDir: store.paths.root };
+  const firstEvents = [];
+  const first = createRuntimeHost({
+    adapterFor: () => ({ id: "pi", capabilities: {}, async createSession() { return session; } }),
+    promptBuilder: new ContextPromptBuilder(), stateStoreFor: () => store,
+  });
+  first.subscribe((event) => firstEvents.push(event));
+  try {
+    await first.start([config]);
+    store.prepareInboxDelivery({ message_id: "om_missing_then_generic_a", target: "chat:oc_missing_then_generic", content: "missing", wake: true });
+    const missing = await first.deliver(agentId, {
+      message_id: "om_missing_then_generic_a", target: "chat:oc_missing_then_generic", content: "missing", wake: true,
+    });
+    assert.equal(missing.status, "error");
+    store.pollInbox();
+    store.prepareInboxDelivery({ message_id: "om_missing_then_generic_b", target: "chat:oc_missing_then_generic_b", content: "generic", wake: true });
+    const genericReceipt = await first.deliver(agentId, {
+      message_id: "om_missing_then_generic_b", target: "chat:oc_missing_then_generic_b", content: "generic", wake: true,
+    });
+    assert.equal(genericReceipt.status, "accepted");
+    session.emit({ type: "turn-start", turnId: "turn-generic-auth" });
+    session.emit({
+      type: "input-error", inputId: genericReceipt.deliveryId, retryable: false, willRetry: false,
+      message: "API key auth failed", errorCategory: "auth",
+      upstream: { provider: "zai-coding-cn", message: "invalid key" },
+    });
+    session.emit({ type: "turn-end", turnId: "turn-generic-auth" });
+    await new Promise((resolve) => setImmediate(resolve));
+    const afterGeneric = firstEvents.filter((event) => event.type === "agent-status" && event.agentId === agentId).at(-1);
+    assert.equal(afterGeneric.readiness.state, "unauthenticated");
+    assert.match(afterGeneric.readiness.nextAction, /login|API-key resolver/);
+    assert.doesNotMatch(JSON.stringify(afterGeneric.readiness), /official store/);
+    const persisted = store.readJson("agentState", {});
+    assert.equal(persisted.authFailure.kind, "generic");
+    assert.equal(persisted.authFailure.provider, "zai-coding-cn");
+    assert.equal(persisted.authFailureProvider, undefined);
+    assert.equal(store.readJson("runtimeDeliveries", { records: [] }).records[0].authProvider, "zai-coding-cn");
+    store.pollInbox();
+    await first.shutdown("generic supersede boundary");
+
+    const restartedSession = new FakeSession();
+    const restartEvents = [];
+    const restarted = createRuntimeHost({
+      adapterFor: () => ({ id: "pi", capabilities: {}, async createSession() { return restartedSession; } }),
+      promptBuilder: new ContextPromptBuilder(), stateStoreFor: () => store,
+    });
+    restarted.subscribe((event) => restartEvents.push(event));
+    await restarted.start([config]);
+    const restartStatus = restartEvents.filter((event) => event.type === "agent-status" && event.agentId === agentId).at(-1);
+    assert.equal(restartStatus.readiness.state, "unauthenticated");
+    assert.match(restartStatus.readiness.nextAction, /login|API-key resolver/);
+    assert.doesNotMatch(JSON.stringify(restartStatus.readiness), /official store|missing from this Agent/);
+    const reset = await restarted.resetSession(agentId);
+    assert.equal(reset.runtimeReady, true);
+    const resetStatus = restartEvents.filter((event) => event.type === "agent-status" && event.agentId === agentId).at(-1);
+    assert.equal(resetStatus.readiness.state, "unauthenticated");
+    assert.match(resetStatus.readiness.nextAction, /login|API-key resolver/);
+    await restarted.shutdown("generic reset boundary");
+  } finally {
+    if (previousConfigDir === undefined) delete process.env.LARKIN_CONFIG_DIR;
+    else process.env.LARKIN_CONFIG_DIR = previousConfigDir;
+    if (previousHome === undefined) delete process.env.HOME;
+    else process.env.HOME = previousHome;
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("generic builtin-Pi auth with a known provider clears on A-to-B stage, restart, and reset", async () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "larkin-runtime-generic-provider-switch-"));
+  const agentId = "cli_genericProviderSwitchA1";
+  const store = createAgentStateStore(root, agentId);
+  const previousConfigDir = process.env.LARKIN_CONFIG_DIR;
+  const previousHome = process.env.HOME;
+  const failedSession = new FakeSession();
+  const switchedSession = new FakeSession();
+  process.env.LARKIN_CONFIG_DIR = root;
+  process.env.HOME = path.join(root, "decoy-home");
+  const directory = path.join(root, "providers", "pi", agentId);
+  fs.mkdirSync(directory, { recursive: true, mode: 0o700 });
+  fs.chmodSync(directory, 0o700);
+  fs.writeFileSync(path.join(directory, "auth.json"), `${JSON.stringify({
+    "zai-coding-cn": { type: "api_key", key: "fixture-zai-coding-cn" },
+    "openai-codex": { type: "api_key", key: "fixture-openai-codex" },
+  })}\n`, { mode: 0o600 });
+  let created = 0;
+  const events = [];
+  const host = createRuntimeHost({
+    adapterFor: () => ({
+      id: "pi",
+      capabilities: {},
+      async createSession() {
+        created += 1;
+        return created === 1 ? failedSession : switchedSession;
+      },
+    }),
+    promptBuilder: new ContextPromptBuilder(),
+    stateStoreFor: () => store,
+  });
+  host.subscribe((event) => events.push(event));
+  const builtinA = { agentId, name: "switch", runtime: "pi", piDistribution: "builtin",
+    model: "zai-coding-cn/glm-5.2", workspaceDir: "/tmp", stateDir: store.paths.root };
+  const builtinB = { ...builtinA, model: "openai-codex/gpt-5" };
+  try {
+    await host.start([builtinA]);
+    store.prepareInboxDelivery({ message_id: "om_generic_a", target: "chat:oc_generic_a", content: "generic", wake: true });
+    const receipt = await host.deliver(agentId, {
+      message_id: "om_generic_a", target: "chat:oc_generic_a", content: "generic", wake: true,
+    });
+    failedSession.emit({ type: "turn-start", turnId: "turn-generic-a" });
+    failedSession.emit({
+      type: "input-error", inputId: receipt.deliveryId, retryable: false, willRetry: false,
+      message: "API key auth failed", errorCategory: "auth",
+      upstream: { provider: "zai-coding-cn", message: "invalid key" },
+    });
+    failedSession.emit({ type: "turn-end", turnId: "turn-generic-a" });
+    await new Promise((resolve) => setImmediate(resolve));
+    assert.equal(events.filter((event) => event.type === "agent-status" && event.agentId === agentId).at(-1).readiness.state,
+      "unauthenticated");
+    assert.deepEqual(store.readJson("agentState", {}).authFailure, {
+      kind: "generic", runtime: "pi", piDistribution: "builtin", provider: "zai-coding-cn",
+    });
+    store.pollInbox();
+    const staged = await host.stage(builtinB);
+    assert.equal(staged.readiness.state, "ready");
+    await staged.commit();
+    assert.equal(events.filter((event) => event.type === "agent-status" && event.agentId === agentId).at(-1).readiness.state,
+      "ready");
+    assert.equal(store.readJson("agentState", {}).authFailure, undefined);
+    await host.shutdown("generic A-to-B stage boundary");
+
+    const restartedSession = new FakeSession();
+    const restartEvents = [];
+    store.writeJson("agentState", {
+      ...store.readJson("agentState", {}),
+      authFailure: { kind: "generic", runtime: "pi", piDistribution: "builtin", provider: "zai-coding-cn" },
+    });
+    const restarted = createRuntimeHost({
+      adapterFor: () => ({ id: "pi", capabilities: {}, async createSession() { return restartedSession; } }),
+      promptBuilder: new ContextPromptBuilder(), stateStoreFor: () => store,
+    });
+    restarted.subscribe((event) => restartEvents.push(event));
+    await restarted.start([builtinB]);
+    assert.equal(restartEvents.filter((event) => event.type === "agent-status" && event.agentId === agentId).at(-1).readiness.state,
+      "ready");
+    assert.equal(store.readJson("agentState", {}).authFailure, undefined);
+    await restarted.resetSession(agentId);
+    assert.equal(restartEvents.filter((event) => event.type === "agent-status" && event.agentId === agentId).at(-1).readiness.state,
+      "ready");
+    await restarted.shutdown("generic A-to-B restart boundary");
+  } finally {
+    if (previousConfigDir === undefined) delete process.env.LARKIN_CONFIG_DIR;
+    else process.env.LARKIN_CONFIG_DIR = previousConfigDir;
+    if (previousHome === undefined) delete process.env.HOME;
+    else process.env.HOME = previousHome;
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("matching missing-key rejections stay retryable for external Pi, Codex, and Claude", async () => {
+  for (const [runtime, piDistribution] of [["pi", "external"], ["codex", undefined], ["claude", undefined]]) {
+    const session = new FakeSession();
+    session.prompt = async function(input) {
+      this.prompts.push(input);
+      return { status: "rejected", inputId: input.inputId, retryable: true, reason: "No API key found for zai-coding-cn" };
+    };
+    const events = [];
+    const host = createRuntimeHost({ adapterFor: () => ({ id: runtime, capabilities: {}, async createSession() { return session; } }),
+      promptBuilder: new ContextPromptBuilder(), retryPolicy: { baseDelayMs: 60_000, maxDelayMs: 60_000, maxAttempts: 0 } });
+    host.subscribe((event) => events.push(event));
+    const agentId = `cli_missingKeyIsolate${runtime === "pi" ? "External" : runtime[0].toUpperCase() + runtime.slice(1)}A1`;
+    try {
+      await host.start([{ agentId, name: runtime, runtime, ...(piDistribution ? { piDistribution } : {}),
+        model: "fixture/model", workspaceDir: "/tmp" }]);
+      const receipt = await host.deliver(agentId, { message_id: `om_missing_${runtime}` });
+      assert.equal(receipt.status, "deferred", runtime);
+      assert.match(receipt.reason, /No API key found for zai-coding-cn/);
+      assert.equal(events.some((event) => event.type === "agent-status" && event.readiness?.state === "unauthenticated"),
+        false, runtime);
+    } finally {
+      await host.shutdown(`${runtime} isolation test complete`);
+    }
+  }
+});
+
+test("transient provider rejection remains retryable after the missing-key classifier", async () => {
+  const session = new FakeSession();
+  session.prompt = async function(input) {
+    this.prompts.push(input);
+    return { status: "rejected", inputId: input.inputId, retryable: true, reason: "fetch failed: provider overloaded" };
+  };
+  const host = createRuntimeHost({ adapterFor: () => ({ id: "pi", capabilities: {}, async createSession() { return session; } }),
+    promptBuilder: new ContextPromptBuilder(), retryPolicy: { baseDelayMs: 60_000, maxDelayMs: 60_000, maxAttempts: 0 } });
+  try {
+    await host.start([{ agentId: "cli_transientProviderA1", name: "transient", runtime: "pi", model: "fixture/model", workspaceDir: "/tmp" }]);
+    const receipt = await host.deliver("cli_transientProviderA1", { message_id: "om_transient_provider" });
+    assert.equal(receipt.status, "deferred");
+    assert.match(receipt.reason, /fetch failed|overloaded/);
+    assert.equal(session.prompts.length, 1);
+  } finally {
+    await host.shutdown("transient provider test complete");
+  }
+});
+
 test("synchronous terminal rejection returns an explicit error receipt and a later explicit delivery retries the same ownership", async () => {
   const session = new FakeSession();
   let reject = true;

--- a/test/unit/runtime/runtime-readiness.test.mjs
+++ b/test/unit/runtime/runtime-readiness.test.mjs
@@ -3,7 +3,15 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { test } from "bun:test";
-import { classifyRuntimePrerequisite, probeNativeRuntimeReadiness } from "../../../dist/runtime/runtime-readiness.mjs";
+import {
+  authFailureAppliesTo,
+  classifyPiMissingCredentialRejection,
+  classifyRuntimePrerequisite,
+  missingProviderCredentialReadiness,
+  parsePersistedAuthFailure,
+  probeNativeRuntimeReadiness,
+  readinessForPersistedAuthFailure,
+} from "../../../dist/runtime/runtime-readiness.mjs";
 
 for (const runtime of ["codex", "claude", "pi"]) {
   test(`${runtime} readiness classifies an unresolved configured command as missing`, async () => {
@@ -28,6 +36,68 @@ for (const message of ["get_state timeout after 5000ms", "unexpected EOF", "TLS 
 test("readiness keeps unknown failures unavailable and reserves incompatible for proven protocol failures", () => {
   assert.equal(classifyRuntimePrerequisite("pi", new Error("opaque probe failure")).state, "unavailable");
   assert.equal(classifyRuntimePrerequisite("pi", new Error("RPC protocol version mismatch")).state, "incompatible");
+});
+
+test("missing-credential classifier matches only the explicit absent-key or absent-login shape", () => {
+  for (const message of [
+    "No API key found for zai-coding-cn",
+    "No login found for zai-coding-cn",
+    "Pi RPC prompt failed: No API key found for zai-coding-cn",
+    "Pi RPC steer failed: No login found for zai-coding-cn",
+  ]) {
+    assert.deepEqual(classifyPiMissingCredentialRejection(message), {
+      provider: "zai-coding-cn",
+      diagnostic: message.includes("login") ? "No login found for zai-coding-cn" : "No API key found for zai-coding-cn",
+    });
+  }
+  for (const message of [
+    "No API key found for zai-coding-cn and extra text",
+    "provider reported no API key found for zai-coding-cn",
+    "No API key found for ../secret",
+    "fetch failed: provider overloaded",
+    "API key auth failed for zai-coding-cn",
+  ]) {
+    assert.equal(classifyPiMissingCredentialRejection(message), null);
+  }
+  const readiness = missingProviderCredentialReadiness("pi", "zai-coding-cn");
+  assert.equal(readiness.state, "unauthenticated");
+  assert.match(readiness.reason, /zai-coding-cn/);
+  assert.match(readiness.nextAction, /Add the missing zai-coding-cn credential to this Agent's official store/);
+  assert.doesNotMatch(readiness.nextAction, /larkin setup|profile import|pi-auth login|Dashboard/);
+});
+
+test("scoped auth persistence prefers current generic over a legacy missing-provider string", () => {
+  const missing = parsePersistedAuthFailure({
+    authFailure: { kind: "missing-provider", runtime: "pi", piDistribution: "builtin", provider: "zai-coding-cn" },
+  });
+  const generic = parsePersistedAuthFailure({
+    authFailure: { kind: "generic", runtime: "pi", piDistribution: "builtin" },
+    authFailureProvider: "zai-coding-cn",
+  });
+  const legacy = parsePersistedAuthFailure({ authFailureProvider: "zai-coding-cn" });
+  assert.deepEqual(missing, {
+    kind: "missing-provider", runtime: "pi", piDistribution: "builtin", provider: "zai-coding-cn",
+  });
+  assert.equal(generic?.kind, "generic");
+  assert.equal(legacy?.kind, "missing-provider");
+  const builtinZai = { runtime: "pi", piDistribution: "builtin", model: "zai-coding-cn/glm-5.2", adapterId: "pi" };
+  assert.equal(authFailureAppliesTo(builtinZai, missing), true);
+  assert.equal(authFailureAppliesTo({ ...builtinZai, piDistribution: "external" }, missing), false);
+  assert.equal(authFailureAppliesTo({ ...builtinZai, runtime: "codex", adapterId: "codex", model: "codex" }, missing), false);
+  assert.equal(authFailureAppliesTo({ ...builtinZai, model: "openai-codex/gpt-5" }, missing), false);
+  assert.equal(authFailureAppliesTo(builtinZai, generic), true);
+  const genericZai = parsePersistedAuthFailure({
+    authFailure: { kind: "generic", runtime: "pi", piDistribution: "builtin", provider: "zai-coding-cn" },
+  });
+  assert.deepEqual(genericZai, {
+    kind: "generic", runtime: "pi", piDistribution: "builtin", provider: "zai-coding-cn",
+  });
+  assert.equal(authFailureAppliesTo(builtinZai, genericZai), true);
+  assert.equal(authFailureAppliesTo({ ...builtinZai, model: "openai-codex/gpt-5" }, genericZai), false);
+  assert.equal(authFailureAppliesTo({ ...builtinZai, model: "openai-codex/gpt-5" }, generic), true,
+    "unbound generic is conservative fallback only when the upstream provider was unavailable");
+  assert.match(readinessForPersistedAuthFailure(generic).nextAction, /login|API-key resolver/);
+  assert.doesNotMatch(readinessForPersistedAuthFailure(generic).nextAction, /official store/);
 });
 
 function writeReadinessPi(root, { failIfDirty = false } = {}) {


### PR DESCRIPTION
## Summary
- Classify the exact Pi prompt rejection `No API key found for <provider>` (and the matching `No login found for <provider>` / RPC-wrapped forms) as non-retryable `auth`.
- Persist the owned delivery as `error`, project the Agent as `unauthenticated` with a per-Agent `pi-auth login` / Dashboard action, and keep other Agents plus transient provider failures retryable.
- Clear that missing-key projection only after the named provider is present in the same Agent's official credential store and a later successful turn proves readiness.

## Test plan
- [x] `bun test --max-concurrency 1 test/unit/runtime/runtime-adapters.test.mjs test/unit/runtime/runtime-host.test.mjs test/unit/runtime/runtime-readiness.test.mjs test/unit/runtime/pi-official-auth.test.mjs`
- [x] `bun test --max-concurrency 1 test/e2e/runtime-production-mock-e2e.test.mjs test/e2e/pi-prompt-preflight-recovery-mock-e2e.test.mjs test/unit/feishu/host-runtime-delivery-health.test.mjs`
- [x] `bun run typecheck && bun run build && bun run test && git diff --check`


Made with [Cursor](https://cursor.com)