### PR TITLE
feat(runtime): configure existing builtin Pi providers

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "larkin",
-  "version": "0.4.28",
+  "version": "0.4.29",
   "private": false,
   "larkinPackageRole": "npm-published",
   "files": [

--- a/src/app/agent-config.ts
+++ b/src/app/agent-config.ts
@@ -475,7 +475,9 @@ if (kind === "pi-distribution") {
     try {
       assertBuiltinPiAgentDirectory(piAgentDirectory(configDir, selectedKey));
     } catch {
-      die("内置 Pi provider 尚未为该 Agent 配置；请先运行 larkin setup 完成内置 Pi provider 配置，或使用 --import-external-profile");
+      die(agent.piDistribution === "builtin"
+        ? "内置 Pi provider 尚未为该 Agent 配置。请使用 Dashboard Provider Credentials 或 larkin pi-auth login。"
+        : "内置 Pi provider 尚未为该 Agent 配置。");
     }
   }
   try {

--- a/src/app/cli.ts
+++ b/src/app/cli.ts
@@ -89,8 +89,10 @@ Credentials, internal paths, serverId, activeAgent, and raw config are never exp
        larkin session recover --agent <App ID> --reason context-overflow --json [--wait-ready <seconds>]
 Reset replaces one idle, zero-backlog Runtime session. Recover is an explicit operator-only context-window recovery that preserves and replays canonical Inbox deliveries.`,
   "pi-auth": `Usage: larkin pi-auth status [--agent <App ID>] [--json]
+       larkin pi-auth providers [--json]
+       larkin pi-auth login <preset|custom> --agent <App ID> [--model <model>] [--base-url <url>] [--api-key-stdin] [--json]
        larkin pi-auth logout <provider> [--agent <App ID>]
-Show non-sensitive official Pi credential metadata or remove one target provider credential.`,
+Show a redacted builtin Pi provider catalog, configure one existing Agent with a known preset or custom OpenAI-compatible endpoint, or remove one target provider credential. API keys are accepted only from a TTY prompt or --api-key-stdin.`,
   comment: `Usage: larkin comment reply --message-id <doc_comment_message_id> --text '<reply>' --json
 Reply as the Runtime-bound Bot to the exact cloud-document comment locator supplied by canonical Inbox. Retrying the same body is idempotent; a different body appends a follow-up reply to the same comment.`,
   telemetry: `Usage: larkin telemetry <status|export|import|flush>
@@ -141,7 +143,7 @@ Usage: larkin <command>
   config           Inspect effective config/source, edit mention inheritance, or explicitly apply runtime changes
   session reset    Replace one idle, zero-backlog Agent Runtime session for a fresh scenario
   session recover  Explicitly recover a context-overflowed session and replay retained Inbox deliveries
-  pi-auth          Show non-sensitive built-in Pi auth status or logout one provider
+  pi-auth          Show, configure, or logout one built-in Pi Agent provider credential
   comment reply    Reply to the exact cloud-document comment bound by a polled Inbox message
   telemetry        Inspect, export, import, or flush the durable OpenTelemetry trace queue
   <lark-cli 命令组>  im/docs/wiki/drive 等 lark-cli 命令原样转发，机器人身份已锁定（如 larkin im +chat-list）
@@ -156,7 +158,13 @@ Process persistence is managed externally. larkin start stays in the foreground 
 
 const [mode, ...presetArguments] = routes[command];
 const childSpec = internalCommandSpec(mode, [...presetArguments, ...rest]);
-const child = spawn(childSpec.command, childSpec.args, { stdio: "inherit" });
+// 管道 stdin 必须显式转发：Linux 上 inherit 会在父进程排空后再交给子进程，导致 --api-key-stdin 读到空。
+const pipeStdin = command === "pi-auth" && rest.includes("--api-key-stdin") && !process.stdin.isTTY;
+if (pipeStdin && typeof process.stdin.pause === "function") process.stdin.pause();
+const child = spawn(childSpec.command, childSpec.args, {
+  stdio: [pipeStdin ? "pipe" : "inherit", "inherit", "inherit"],
+});
+if (pipeStdin && child.stdin) process.stdin.pipe(child.stdin);
 
 // Package-manager bin shims add a wrapper process. Forward terminal signals so the actual command
 // does not become an orphan that keeps the machine lock or Feishu connection.

--- a/src/app/local-control.ts
+++ b/src/app/local-control.ts
@@ -9,8 +9,13 @@ import { currentProcessMetadata } from "../platform/process-inspect.cjs";
 import { processCommandToken } from "./internal-command.js";
 import { isWindows, notGroupOrWorldAccessible, secureWindowsDirectoryAcl } from "../platform/secure-metadata.js";
 
-export interface AgentUpsertRequest { operationId: string; agentId: string; authorization: string }
-export type AgentUpsertOperation = Pick<AgentUpsertRequest, "operationId" | "agentId">;
+export interface AgentUpsertRequest {
+  operationId: string;
+  agentId: string;
+  authorization: string;
+  expectedSignature?: string;
+}
+export type AgentUpsertOperation = Pick<AgentUpsertRequest, "operationId" | "agentId" | "expectedSignature">;
 export interface AgentUpsertResponse { ok: boolean; operationId: string; agentId: string; code?: string; error?: string; readiness?: RuntimeReadiness }
 export interface DashboardRecoveryResponse { ok: boolean; operationId: string; state?: string; error?: string }
 export interface SupervisorAgentUpsertResponse {
@@ -54,6 +59,7 @@ interface ControlAuthority {
 const AGENT_ID = /^cli_[A-Za-z0-9]+$/;
 const OPERATION_ID = /^[A-Za-z0-9_-]{8,128}$/;
 const AUTHORIZATION = /^[A-Za-z0-9_-]{43,128}$/;
+const CONFIG_SIGNATURE = /^sha256:[a-f0-9]{64}$/;
 const UNIX_SOCKET_PATH_MAX_BYTES = process.platform === "darwin" ? 103 : 107;
 
 function recoveryErrorText(code: string | undefined): string {
@@ -201,8 +207,12 @@ function parseRequest(line: string): AgentControlRequest {
   if (value.waitReadyMs !== undefined) {
     throw new Error("invalid session reset waitReadyMs");
   }
-  if (Object.keys(value).some((key) => !["operationId", "agentId", "authorization"].includes(key))) {
+  if (Object.keys(value).some((key) => !["operationId", "agentId", "authorization", "expectedSignature"].includes(key))) {
     throw new Error("agent control request 包含未知字段");
+  }
+  if (value.expectedSignature !== undefined
+      && (typeof value.expectedSignature !== "string" || !CONFIG_SIGNATURE.test(value.expectedSignature))) {
+    throw new Error("invalid agent upsert expectedSignature");
   }
   return value as unknown as AgentUpsertRequest;
 }
@@ -770,7 +780,11 @@ export function createAgentControlServer({
             }
             const execute = async (): Promise<AgentUpsertResponse> => {
               try {
-                await upsert({ operationId: upsertRequest.operationId, agentId: upsertRequest.agentId });
+                await upsert({
+                  operationId: upsertRequest.operationId,
+                  agentId: upsertRequest.agentId,
+                  ...(upsertRequest.expectedSignature ? { expectedSignature: upsertRequest.expectedSignature } : {}),
+                });
                 return { ok: true, operationId: upsertRequest.operationId, agentId: upsertRequest.agentId };
               } catch (error) {
                 return { ok: false, operationId: upsertRequest.operationId, agentId: upsertRequest.agentId,
@@ -958,10 +972,15 @@ export async function requestAgentUpsert(input: {
   larkinHome: string;
   agentId: string;
   operationId?: string;
+  expectedSignature?: string;
   timeoutMs?: number;
 }): Promise<AgentUpsertResponse> {
   return requestAgentControl<AgentUpsertResponse>({ larkinHome: input.larkinHome, timeoutMs: input.timeoutMs,
-    request: { operationId: input.operationId ?? crypto.randomUUID(), agentId: input.agentId } });
+    request: {
+      operationId: input.operationId ?? crypto.randomUUID(),
+      agentId: input.agentId,
+      ...(input.expectedSignature ? { expectedSignature: input.expectedSignature } : {}),
+    } });
 }
 
 export async function requestSessionReset({

--- a/src/app/pi-auth-cli.ts
+++ b/src/app/pi-auth-cli.ts
@@ -1,22 +1,235 @@
+import fs from "node:fs";
 import * as larkinConfig from "../platform/config.js";
 import {
-  beginBuiltinPiCredentialTransaction,
   createOfficialPiCredentialRuntime,
-  createOfficialPiLogoutRuntime,
-  logoutOfficialPiProvider,
   officialPiAuthStatus,
 } from "../runtime/pi-official-auth.js";
+import {
+  configureBuiltinPiProvider,
+  listBuiltinPiProviderCatalog,
+  logoutBuiltinPiProvider,
+} from "../runtime/pi-provider-login.js";
+import { MAX_BUILTIN_PI_API_KEY_LENGTH } from "../runtime/pi-provider-config.js";
 
 const APP_ID = /^cli_[A-Za-z0-9]+$/;
+const USAGE = "Usage: larkin pi-auth status [--agent <App ID>] [--json] | larkin pi-auth providers [--json] | larkin pi-auth login <preset|custom> --agent <App ID> [--model <model>] [--base-url <url>] [--api-key-stdin] [--json] | larkin pi-auth logout <provider> [--agent <App ID>]";
+const API_KEY_ARGV_MESSAGE = "existing-Agent login does not accept --api-key. Use --api-key-stdin or an interactive TTY prompt.";
+const API_KEY_BUDGET_MESSAGE = "API Key 不能为空或包含控制字符";
+const STDIN_CHUNK_BYTES = 1024;
+const STDIN_BOM_BYTES = 3;
+const STDIN_TRAILING_NEWLINE_SLACK = 32;
+const MAX_STDIN_API_KEY_BYTES = MAX_BUILTIN_PI_API_KEY_LENGTH + STDIN_BOM_BYTES + STDIN_TRAILING_NEWLINE_SLACK;
 
 function flag(args: readonly string[], name: string): string | undefined {
   const index = args.indexOf(name);
   return index >= 0 ? args[index + 1] : undefined;
 }
 
-export async function main(args: readonly string[] = process.argv.slice(2), env: NodeJS.ProcessEnv = process.env): Promise<void> {
+function hasApiKeyArgv(args: readonly string[]): boolean {
+  return args.some((argument) => argument === "--api-key" || argument.startsWith("--api-key="));
+}
+
+function consumeFlags(args: readonly string[], allowed: ReadonlySet<string>, unary: ReadonlySet<string>): boolean {
+  let index = 0;
+  while (index < args.length) {
+    const argument = args[index];
+    if (!argument.startsWith("--")) return false;
+    if (unary.has(argument)) { index += 1; continue; }
+    if (allowed.has(argument) && args[index + 1] && !args[index + 1]!.startsWith("--")) { index += 2; continue; }
+    return false;
+  }
+  return true;
+}
+
+/** 去掉 BOM 与全部尾部换行；保留内部控制字符给后续校验拒绝。 */
+export function normalizeStdinApiKey(raw: string): string {
+  return raw.replace(/^\uFEFF/, "").replace(/[\r\n]+$/g, "");
+}
+
+function assertStdinApiKeyBudget(size: number): void {
+  if (size > MAX_STDIN_API_KEY_BYTES) throw new Error(API_KEY_BUDGET_MESSAGE);
+}
+
+function finishStdinApiKey(chunks: readonly Buffer[]): string {
+  const normalized = normalizeStdinApiKey(Buffer.concat(chunks).toString("utf8"));
+  if (normalized.length > MAX_BUILTIN_PI_API_KEY_LENGTH) throw new Error(API_KEY_BUDGET_MESSAGE);
+  return normalized;
+}
+
+function readFdChunk(fd: number, buffer: Buffer): Promise<number> {
+  return new Promise((resolve, reject) => {
+    fs.read(fd, buffer, 0, buffer.length, null, (error, bytesRead) => {
+      if (error) reject(error);
+      else resolve(bytesRead);
+    });
+  });
+}
+
+/** 按块读取 fd，超过 key 上限立即停止，不等待管道 EOF。 */
+async function readBoundedFdSecret(fd: number): Promise<string> {
+  const chunks: Buffer[] = [];
+  let size = 0;
+  const buffer = Buffer.alloc(STDIN_CHUNK_BYTES);
+  while (true) {
+    const bytesRead = await readFdChunk(fd, buffer);
+    if (bytesRead === 0) break;
+    size += bytesRead;
+    assertStdinApiKeyBudget(size);
+    chunks.push(Buffer.from(buffer.subarray(0, bytesRead)));
+  }
+  return finishStdinApiKey(chunks);
+}
+
+async function readBoundedStreamSecret(stdin: NodeJS.ReadableStream): Promise<string> {
+  const chunks: Buffer[] = [];
+  let size = 0;
+  for await (const chunk of stdin) {
+    const bytes = Buffer.from(chunk);
+    size += bytes.length;
+    assertStdinApiKeyBudget(size);
+    chunks.push(bytes);
+  }
+  return finishStdinApiKey(chunks);
+}
+
+export async function readStdinSecret(stdin: NodeJS.ReadableStream): Promise<string> {
+  const stream = stdin as NodeJS.ReadableStream & { fd?: number; isTTY?: boolean; pause?: () => void };
+  if (typeof stream.fd === "number" && stream.fd >= 0 && !stream.isTTY) {
+    if (typeof stream.pause === "function") stream.pause();
+    try {
+      return await readBoundedFdSecret(stream.fd);
+    } catch (error) {
+      if (error instanceof Error && error.message === API_KEY_BUDGET_MESSAGE) throw error;
+      // 回退到异步收集，例如测试传入的假 stream。
+    }
+  }
+  return readBoundedStreamSecret(stdin);
+}
+
+function createNoEchoQuestioner(stdin: NodeJS.ReadStream, stdout: NodeJS.WritableStream): {
+  secret(prompt: string): Promise<string>;
+  close(): void;
+} {
+  return {
+    close() {},
+    secret(prompt: string): Promise<string> {
+      if (!stdin.isTTY || typeof stdin.setRawMode !== "function") {
+        throw new Error("non-interactive API-key login requires --api-key-stdin");
+      }
+      stdout.write(prompt);
+      const wasRaw = stdin.isRaw;
+      stdin.setRawMode(true);
+      stdin.resume();
+      return new Promise<string>((resolve, reject) => {
+        let value = "";
+        const finish = (error?: Error): void => {
+          stdin.off("data", onData);
+          stdin.setRawMode(Boolean(wasRaw));
+          stdin.pause();
+          stdout.write("\n");
+          if (error) reject(error); else resolve(value);
+        };
+        const onData = (chunk: Buffer | string): void => {
+          const bytes = Buffer.from(chunk);
+          for (const byte of bytes) {
+            if (byte === 3) return finish(new Error("pi-auth login cancelled"));
+            if (byte === 10 || byte === 13) return finish();
+            if (byte === 8 || byte === 127) { value = value.slice(0, -1); continue; }
+            if (byte >= 32 && byte <= 126) value += String.fromCharCode(byte);
+          }
+        };
+        stdin.on("data", onData);
+      });
+    },
+  };
+}
+
+function resolveAgentId(args: readonly string[], env: NodeJS.ProcessEnv): string {
+  const loaded = larkinConfig.loadConfig(env);
+  const agentId = flag(args, "--agent") || loaded.config.activeAgent || undefined;
+  if (!agentId || !APP_ID.test(agentId)) throw new Error("请用 --agent <App ID> 选择 Agent");
+  const agent = loaded.config.agents[agentId];
+  if (!agent) throw new Error(`Agent ${agentId} 不存在`);
+  if (agent.runtime !== "pi" || agent.piDistribution !== "builtin") throw new Error(`Agent ${agentId} 不是内置 Pi`);
+  return agentId;
+}
+
+export interface PiAuthCliIo {
+  stdin: NodeJS.ReadableStream;
+  stdout: NodeJS.WritableStream;
+  isTTY: boolean;
+}
+
+export async function main(
+  args: readonly string[] = process.argv.slice(2),
+  env: NodeJS.ProcessEnv = process.env,
+  io: PiAuthCliIo = { stdin: process.stdin, stdout: process.stdout, isTTY: Boolean(process.stdin.isTTY) },
+): Promise<void> {
   const action = args[0] || "status";
   const json = args.includes("--json");
+  if (hasApiKeyArgv(args)) throw new Error(API_KEY_ARGV_MESSAGE);
+
+  if (action === "providers") {
+    if (!consumeFlags(args.slice(1), new Set(), new Set(["--json"]))) throw new Error(USAGE);
+    const providers = listBuiltinPiProviderCatalog();
+    if (json) {
+      console.log(JSON.stringify({ providers }));
+      return;
+    }
+    console.log("Builtin Pi providers:");
+    for (const entry of providers) {
+      const model = entry.defaultModel ? ` default=${entry.defaultModel}` : " (requires --base-url and --model)";
+      console.log(`  ${entry.id}  ${entry.name}${model}`);
+    }
+    return;
+  }
+
+  if (action === "login") {
+    const preset = args[1];
+    const rest = args.slice(2);
+    if (!preset || preset.startsWith("--")
+        || !consumeFlags(rest, new Set(["--agent", "--model", "--base-url"]), new Set(["--json", "--api-key-stdin"]))) {
+      throw new Error(USAGE);
+    }
+    const agentId = resolveAgentId(rest, env);
+    const stdinKey = rest.includes("--api-key-stdin");
+    let apiKey = "";
+    if (stdinKey) apiKey = await readStdinSecret(io.stdin);
+    else if (io.isTTY) {
+      const questioner = createNoEchoQuestioner(io.stdin as NodeJS.ReadStream, io.stdout);
+      try { apiKey = await questioner.secret("API Key:\n> "); }
+      finally { questioner.close(); }
+    } else {
+      throw new Error("non-interactive API-key login requires --api-key-stdin");
+    }
+    const result = await configureBuiltinPiProvider({
+      agentId,
+      preset,
+      apiKey,
+      model: flag(rest, "--model"),
+      baseUrl: flag(rest, "--base-url"),
+      env,
+    });
+    const payload = {
+      agentId: result.agentId,
+      provider: result.provider,
+      model: result.model,
+      credentialType: result.credentialType,
+      applyState: result.applyState,
+      ...(result.applyError ? { applyError: result.applyError } : {}),
+    };
+    if (json) console.log(JSON.stringify(payload));
+    else {
+      const pending = result.applyState === "applied"
+        ? "applied"
+        : result.applyState === "pending"
+          ? `pending${result.applyError ? ` (${result.applyError})` : ""}`
+          : "saved; will apply on larkin start";
+      console.log(`Agent ${result.agentId} provider=${result.provider} model=${result.model} credential=${result.credentialType} apply=${pending}`);
+    }
+    return;
+  }
+
   const requestedAgent = flag(args, "--agent");
   let index = action === "logout" ? 2 : 1;
   let valid = action === "status" || action === "logout";
@@ -26,9 +239,7 @@ export async function main(args: readonly string[] = process.argv.slice(2), env:
     if (argument === "--agent" && args[index + 1]) { index += 2; continue; }
     valid = false;
   }
-  if (!valid) {
-    throw new Error("Usage: larkin pi-auth status [--agent <App ID>] [--json] | larkin pi-auth logout <provider> [--agent <App ID>]");
-  }
+  if (!valid) throw new Error(USAGE);
   const loaded = larkinConfig.loadConfig(env);
   const agentId = requestedAgent || loaded.config.activeAgent || undefined;
   if (!agentId || !APP_ID.test(agentId)) throw new Error("请用 --agent <App ID> 选择 Agent");
@@ -47,14 +258,7 @@ export async function main(args: readonly string[] = process.argv.slice(2), env:
     return;
   }
   const providerId = args[1];
-  if (!providerId || providerId.startsWith("--") || !/^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$/.test(providerId)) {
-    throw new Error("logout 需要安全的 provider ID");
-  }
-  const transaction = beginBuiltinPiCredentialTransaction(loaded.configDir, agentId);
-  try {
-    const runtime = await createOfficialPiLogoutRuntime(loaded.configDir, agentId);
-    await logoutOfficialPiProvider(runtime, providerId);
-    transaction.commit();
-  } catch (error) { transaction.rollback(); throw error; }
+  if (!providerId || providerId.startsWith("--")) throw new Error("logout 需要安全的 provider ID");
+  await logoutBuiltinPiProvider({ agentId, providerId, env });
   console.log(`Agent ${agentId} 已退出 ${providerId}；其他 provider 未修改`);
 }

--- a/src/app/runtime-process.ts
+++ b/src/app/runtime-process.ts
@@ -16,10 +16,22 @@ import { packageVersion } from "../platform/build-info.js";
 
 type HostShellOptions = Parameters<typeof createHostShell>[0];
 
-export function loadAndSyncRuntimeAgent(env: NodeJS.ProcessEnv, agentId: string, dependencies: RuntimeAgentConfigDependencies = {}) {
+export function loadAndSyncRuntimeAgent(
+  env: NodeJS.ProcessEnv,
+  agentId: string,
+  dependencies: RuntimeAgentConfigDependencies = {},
+  options: { expectedSignature?: string } = {},
+) {
   const loaded = loadConfig(env);
   const stored = loaded.config.agents[agentId];
   if (!stored) throw new Error(`Agent ${agentId} 不存在于 canonical config`);
+  // 先对权威签名 CAS，再 hydrate/sync，避免热加载已切换 runtime 的 Agent。
+  if (options.expectedSignature) {
+    const current = runtimeConfigSignature(loaded.config, agentId);
+    if (current !== options.expectedSignature) {
+      throw new Error("配置在 apply 期间发生变化；未热加载已切换的 Agent");
+    }
+  }
   const agent = hydrateRuntimeAgent(loaded.configDir, stored);
   syncAgentProfile(agent, { ...env, LARKIN_CONFIG_DIR: loaded.configDir }, dependencies);
   return agent;
@@ -107,7 +119,9 @@ export async function main(env: NodeJS.ProcessEnv = process.env, overrides: {
     larkinHome: env.LARKIN_HOME,
     authorityToken: env.LARKIN_CONTROL_AUTHORIZATION,
     async upsert(request) {
-      const agent = loadAndSyncRuntimeAgent(env, request.agentId);
+      const agent = loadAndSyncRuntimeAgent(env, request.agentId, {}, {
+        ...(request.expectedSignature ? { expectedSignature: request.expectedSignature } : {}),
+      });
       // Only the selected profile is synchronized; active profiles and their directory
       // are never quarantined or rebuilt during hot attach.
       await hostShell.upsertAgent(agent);

--- a/src/app/runtime-process.ts
+++ b/src/app/runtime-process.ts
@@ -6,35 +6,95 @@ import { ContextPromptBuilder } from "../agent/context-prompt.js";
 import { createNativeRuntimeAdapter } from "../runtime/runtime-adapters.js";
 import { createRuntimeHost, type RuntimeHost } from "../runtime/runtime-host.js";
 import { createAgentStateStore } from "../agent/agent-state-store.js";
-import { loadConfig, markConfigApplied, runtimeConfigSignature } from "../platform/config.js";
+import {
+  loadConfig, markConfigApplied, runtimeConfigSignature,
+  withConfigMutationLock, withConfigMutationLockAsync,
+} from "../platform/config.js";
 import { traceProcessBoundary } from "../platform/process-boundary-trace.js";
 import { createAgentControlServer, requestSupervisorAgentUpsert } from "./local-control.js";
-import { hydrateRuntimeAgent, syncAgentProfile, type RuntimeAgentConfigDependencies } from "./runtime-agent-config.js";
+import {
+  hydrateRuntimeAgent, syncAgentProfile,
+  type RuntimeAgentConfig, type RuntimeAgentConfigDependencies,
+} from "./runtime-agent-config.js";
 import { loadTelemetryConfig } from "../platform/telemetry-config.js";
 import { telemetrySingleton, type TelemetryRuntime } from "../platform/telemetry-tracing.js";
 import { packageVersion } from "../platform/build-info.js";
 
 type HostShellOptions = Parameters<typeof createHostShell>[0];
+type LoadedRuntimeConfig = ReturnType<typeof loadConfig>;
+
+export interface RuntimeAgentApplyOptions {
+  expectedSignature?: string;
+  /** 测试缝：签名校验已通过、尚未 hydrate/profile/Host upsert。不是兼容回退。 */
+  afterCanonicalValidate?: () => void;
+}
+
+function readRuntimeAgent(
+  env: NodeJS.ProcessEnv,
+  agentId: string,
+  expectedSignature?: string,
+): { loaded: LoadedRuntimeConfig; stored: LoadedRuntimeConfig["config"]["agents"][string] } {
+  const loaded = loadConfig(env);
+  const stored = loaded.config.agents[agentId];
+  if (!stored) throw new Error(`Agent ${agentId} 不存在于 canonical config`);
+  if (expectedSignature) {
+    const current = runtimeConfigSignature(loaded.config, agentId);
+    if (current !== expectedSignature) {
+      throw new Error("配置在 apply 期间发生变化；未热加载已切换的 Agent");
+    }
+  }
+  return { loaded, stored };
+}
+
+function hydrateAndSyncRuntimeAgent(
+  env: NodeJS.ProcessEnv,
+  loaded: LoadedRuntimeConfig,
+  stored: LoadedRuntimeConfig["config"]["agents"][string],
+  dependencies: RuntimeAgentConfigDependencies,
+): RuntimeAgentConfig {
+  const agent = hydrateRuntimeAgent(loaded.configDir, stored);
+  syncAgentProfile(agent, { ...env, LARKIN_CONFIG_DIR: loaded.configDir }, dependencies);
+  return agent;
+}
 
 export function loadAndSyncRuntimeAgent(
   env: NodeJS.ProcessEnv,
   agentId: string,
   dependencies: RuntimeAgentConfigDependencies = {},
-  options: { expectedSignature?: string } = {},
+  options: RuntimeAgentApplyOptions = {},
 ) {
-  const loaded = loadConfig(env);
-  const stored = loaded.config.agents[agentId];
-  if (!stored) throw new Error(`Agent ${agentId} 不存在于 canonical config`);
-  // 先对权威签名 CAS，再 hydrate/sync，避免热加载已切换 runtime 的 Agent。
-  if (options.expectedSignature) {
-    const current = runtimeConfigSignature(loaded.config, agentId);
-    if (current !== options.expectedSignature) {
-      throw new Error("配置在 apply 期间发生变化；未热加载已切换的 Agent");
-    }
+  const snapshot = readRuntimeAgent(env, agentId, options.expectedSignature);
+  options.afterCanonicalValidate?.();
+  if (!options.expectedSignature) {
+    return hydrateAndSyncRuntimeAgent(env, snapshot.loaded, snapshot.stored, dependencies);
   }
-  const agent = hydrateRuntimeAgent(loaded.configDir, stored);
-  syncAgentProfile(agent, { ...env, LARKIN_CONFIG_DIR: loaded.configDir }, dependencies);
-  return agent;
+  return withConfigMutationLock(env, () => {
+    const locked = readRuntimeAgent(env, agentId, options.expectedSignature);
+    return hydrateAndSyncRuntimeAgent(env, locked.loaded, locked.stored, dependencies);
+  });
+}
+
+/** 签名校验贯穿实际 Host upsert；并发 config mutation 不能热挂载已失效的 snapshot。 */
+export async function applyRuntimeAgentUpsert(
+  env: NodeJS.ProcessEnv,
+  agentId: string,
+  dependencies: RuntimeAgentConfigDependencies = {},
+  options: RuntimeAgentApplyOptions = {},
+  upsert: (agent: RuntimeAgentConfig) => unknown = () => undefined,
+): Promise<RuntimeAgentConfig> {
+  const snapshot = readRuntimeAgent(env, agentId, options.expectedSignature);
+  options.afterCanonicalValidate?.();
+  if (!options.expectedSignature) {
+    const agent = hydrateAndSyncRuntimeAgent(env, snapshot.loaded, snapshot.stored, dependencies);
+    await upsert(agent);
+    return agent;
+  }
+  return withConfigMutationLockAsync(env, async () => {
+    const locked = readRuntimeAgent(env, agentId, options.expectedSignature);
+    const agent = hydrateAndSyncRuntimeAgent(env, locked.loaded, locked.stored, dependencies);
+    await upsert(agent);
+    return agent;
+  });
 }
 
 export async function markConfigAppliedAfterRuntimeReady(
@@ -119,12 +179,11 @@ export async function main(env: NodeJS.ProcessEnv = process.env, overrides: {
     larkinHome: env.LARKIN_HOME,
     authorityToken: env.LARKIN_CONTROL_AUTHORIZATION,
     async upsert(request) {
-      const agent = loadAndSyncRuntimeAgent(env, request.agentId, {}, {
+      const agent = await applyRuntimeAgentUpsert(env, request.agentId, {}, {
         ...(request.expectedSignature ? { expectedSignature: request.expectedSignature } : {}),
-      });
+      }, (candidate) => hostShell.upsertAgent(candidate));
       // Only the selected profile is synchronized; active profiles and their directory
       // are never quarantined or rebuilt during hot attach.
-      await hostShell.upsertAgent(agent);
       const tracked = await requestSupervisorAgentUpsert({
         larkinHome: env.LARKIN_HOME as string, agentId: agent.agentId, operationId: request.operationId,
       });

--- a/src/dashboard/dashboard-config-controller.ts
+++ b/src/dashboard/dashboard-config-controller.ts
@@ -10,6 +10,16 @@ import { discoverPiModelCatalog, type DiscoverPiCatalogOptions } from "../runtim
 import { managedOfficialLarkCli } from "../app/agent-lark-cli-workspace.js";
 import { ownedPiCatalogAgentDir, piCatalogCommandSpec } from "../runtime/pi-provider-config.js";
 import { RUNTIME_OPTIONS, piCatalogDistributionForUserRuntime, toUserRuntime } from "../runtime/user-runtime.js";
+import {
+  configureBuiltinPiProvider,
+  listBuiltinPiProviderCatalog,
+  logoutBuiltinPiProvider,
+  sanitizeProviderLoginError,
+} from "../runtime/pi-provider-login.js";
+import {
+  createOfficialPiCredentialRuntime,
+  officialPiAuthStatus,
+} from "../runtime/pi-official-auth.js";
 
 type Env = Record<string, string | undefined>;
 type LarkJsonCall = { command: string; args: string[]; env: Env; maxBuffer: number; timeout: number };
@@ -27,7 +37,10 @@ type PiModelDirectoryInput = {
 export type ChatDirectoryResolver = { resolve(input: ChatDirectoryInput): Promise<Record<string, string>> };
 export type ClaudeModelDirectoryResolver = { resolve(input: ClaudeModelDirectoryInput): Promise<Array<Record<string, unknown> & { id: string; label: string }>> };
 export type CodexModelDirectoryResolver = { resolve(input: CodexModelDirectoryInput): Promise<Array<Record<string, unknown> & { id: string; label: string }>> };
-export type PiModelDirectoryResolver = { resolve(input: PiModelDirectoryInput): Promise<Array<Record<string, unknown> & { id: string; label: string }>> };
+export type PiModelDirectoryResolver = {
+  resolve(input: PiModelDirectoryInput): Promise<Array<Record<string, unknown> & { id: string; label: string }>>;
+  invalidate?(agentId?: string): void;
+};
 
 type KnownChat = { chatId: string; displayName: string | null; kind: "group" | "direct" };
 
@@ -183,9 +196,32 @@ export function createPiModelDirectoryResolver(options: {
   const cache = new Map<string, { expiresAt: number; value: Array<Record<string, unknown> & { id: string; label: string }> }>();
   const failures = new Map<string, { expiresAt: number }>();
   const inFlight = new Map<string, Promise<Array<Record<string, unknown> & { id: string; label: string }>>>();
+  const generations = new Map<string, number>();
+  // 单调序号：targeted 后再 global 时，in-flight 的 started 不能与新 generation 相等。
+  let seq = 0;
+  let baseline = 0;
+  const generationOf = (agentId: string) => Math.max(baseline, generations.get(agentId) ?? 0);
+  const dropPrefixed = <T>(store: Map<string, T>, agentId?: string): void => {
+    if (!agentId) { store.clear(); return; }
+    const prefix = `${agentId}\u0000`;
+    for (const key of store.keys()) if (key.startsWith(prefix)) store.delete(key);
+  };
   return {
+    invalidate(agentId?: string) {
+      dropPrefixed(cache, agentId);
+      dropPrefixed(failures, agentId);
+      dropPrefixed(inFlight, agentId);
+      seq += 1;
+      if (!agentId) {
+        baseline = seq;
+        generations.clear();
+      } else {
+        generations.set(agentId, seq);
+      }
+    },
     async resolve(input) {
       const key = [input.agentId, input.cwd, input.agentDir, input.command ?? "", ...(input.commandArgs ?? [])].join("\u0000");
+      const started = generationOf(input.agentId);
       pruneCache(cache, (entry) => now() >= entry.expiresAt, 64);
       pruneCache(failures, (entry) => now() >= entry.expiresAt, 64);
       const cached = cache.get(key);
@@ -207,16 +243,20 @@ export function createPiModelDirectoryResolver(options: {
                 id, label, ...(contextWindow ? { contextWindow } : {}), supportedReasoningEfforts, ...(defaultReasoningEffort ? { defaultReasoningEffort } : {}),
               })),
             ];
-            failures.delete(key);
-            cache.set(key, { expiresAt: now() + ttlMs, value: models });
+            if (generationOf(input.agentId) === started) {
+              failures.delete(key);
+              cache.set(key, { expiresAt: now() + ttlMs, value: models });
+            }
             return models;
           } catch (error) {
-            failures.set(key, { expiresAt: now() + negativeTtlMs });
+            if (generationOf(input.agentId) === started) failures.set(key, { expiresAt: now() + negativeTtlMs });
             throw error;
           }
         })();
         inFlight.set(key, pending);
-        void pending.finally(() => inFlight.delete(key)).catch(() => undefined);
+        void pending.finally(() => {
+          if (inFlight.get(key) === pending) inFlight.delete(key);
+        }).catch(() => undefined);
       }
       return await pending;
     },
@@ -397,6 +437,10 @@ export function createDashboardConfigController({
   claudeModelDirectoryResolver = createClaudeModelDirectoryResolver(),
   codexModelDirectoryResolver = createCodexModelDirectoryResolver(),
   piModelDirectoryResolver = createPiModelDirectoryResolver(),
+  configureProvider = configureBuiltinPiProvider,
+  logoutProvider = logoutBuiltinPiProvider,
+  listProviderCatalog = listBuiltinPiProviderCatalog,
+  loadProviderStatus = async (configDir: string, agentId: string) => officialPiAuthStatus(await createOfficialPiCredentialRuntime(configDir, agentId)),
 }: {
   csrfCapability: string;
   env?: Env;
@@ -405,6 +449,10 @@ export function createDashboardConfigController({
   claudeModelDirectoryResolver?: ClaudeModelDirectoryResolver;
   codexModelDirectoryResolver?: CodexModelDirectoryResolver;
   piModelDirectoryResolver?: PiModelDirectoryResolver;
+  configureProvider?: typeof configureBuiltinPiProvider;
+  logoutProvider?: typeof logoutBuiltinPiProvider;
+  listProviderCatalog?: typeof listBuiltinPiProviderCatalog;
+  loadProviderStatus?: (configDir: string, agentId: string) => Promise<unknown>;
 }) {
   const resolvePiModelDirectory = async (agentId: string, userRuntime: "pi" | "builtin-pi") => {
     const { config, configDir } = loadConfig(env);
@@ -511,6 +559,84 @@ export function createDashboardConfigController({
           const result = mutateConfig(env, mutation, { kind: "user" });
           json(res, 200, { ok: true, revision: result.revision, persisted: true, applyState: result.applyState, changedScope: result.changedScope });
         } catch { json(res, 400, { error: "configuration update rejected" }); }
+        return true;
+      }
+      if (requestUrl.pathname === "/api/pi-auth/providers" && req.method === "GET") {
+        try {
+          assertPrivateReadRequest(req, csrfCapability);
+          json(res, 200, { providers: listProviderCatalog() });
+        } catch (error) {
+          json(res, error instanceof Error && /host|capability/.test(error.message) ? 403 : 500, { error: "provider catalog unavailable" });
+        }
+        return true;
+      }
+      if (requestUrl.pathname === "/api/pi-auth/status" && req.method === "GET") {
+        try {
+          assertPrivateReadRequest(req, csrfCapability);
+          const agentId = requestUrl.searchParams.get("agent") || "";
+          const { config, configDir } = loadConfig(env);
+          const agent = config.agents[agentId];
+          if (!agent || agent.runtime !== "pi" || agent.piDistribution !== "builtin") throw new Error("unknown agent");
+          const credentials = await loadProviderStatus(configDir, agentId);
+          json(res, 200, { agentId, model: agent.model, credentials });
+        } catch (error) {
+          json(res, error instanceof Error && /host|capability/.test(error.message) ? 403 : 500, { error: "provider status unavailable" });
+        }
+        return true;
+      }
+      if (requestUrl.pathname === "/api/pi-auth/login" && req.method === "POST") {
+        let secret = "";
+        try {
+          assertWriteRequest(req, csrfCapability);
+          const body = await boundedJson(req);
+          const allowed = ["agentId", "preset", "apiKey", "model", "baseUrl"];
+          if (Object.keys(body).some((key) => !allowed.includes(key))) throw new Error("unsupported field");
+          const agentId = String(body.agentId || "");
+          const preset = String(body.preset || "");
+          const apiKey = typeof body.apiKey === "string" ? body.apiKey : "";
+          secret = apiKey;
+          if (!/^cli_[A-Za-z0-9]+$/.test(agentId) || !preset) throw new Error("invalid login request");
+          const { config } = loadConfig(env);
+          const agent = config.agents[agentId];
+          if (!agent || agent.runtime !== "pi" || agent.piDistribution !== "builtin") throw new Error("Agent is not builtin Pi");
+          const result = await configureProvider({
+            agentId,
+            preset,
+            apiKey,
+            ...(typeof body.model === "string" ? { model: body.model } : {}),
+            ...(typeof body.baseUrl === "string" ? { baseUrl: body.baseUrl } : {}),
+            env,
+          });
+          piModelDirectoryResolver.invalidate?.(agentId);
+          json(res, 200, {
+            ok: true,
+            agentId: result.agentId,
+            provider: result.provider,
+            preset: result.preset,
+            model: result.model,
+            credentialType: result.credentialType,
+            applyState: result.applyState,
+            ...(result.applyError ? { applyError: sanitizeProviderLoginError(result.applyError, secret || undefined) } : {}),
+          });
+        } catch (error) {
+          json(res, 400, { error: sanitizeProviderLoginError(error, secret || undefined) });
+        }
+        return true;
+      }
+      if (requestUrl.pathname === "/api/pi-auth/logout" && req.method === "POST") {
+        try {
+          assertWriteRequest(req, csrfCapability);
+          const body = await boundedJson(req);
+          if (Object.keys(body).sort().join(",") !== "agentId,provider") throw new Error("invalid logout request");
+          const agentId = String(body.agentId || "");
+          const provider = String(body.provider || "");
+          if (!/^cli_[A-Za-z0-9]+$/.test(agentId)) throw new Error("invalid logout request");
+          const result = await logoutProvider({ agentId, providerId: provider, env });
+          piModelDirectoryResolver.invalidate?.(agentId);
+          json(res, 200, { ok: true, agentId: result.agentId, provider: result.provider });
+        } catch (error) {
+          json(res, 400, { error: sanitizeProviderLoginError(error) });
+        }
         return true;
       }
       if (requestUrl.pathname === "/api/config/apply" && req.method === "POST") {

--- a/src/dashboard/web/app.tsx
+++ b/src/dashboard/web/app.tsx
@@ -4,7 +4,7 @@ import {
   Gauge, Logs, Menu, MessageSquareText, RefreshCw, Search, Settings2, SlidersHorizontal, Users, XCircle,
 } from "lucide-react";
 import { AGENT_TABS, createLatestResponseGate, filterAgents, parseRoute, reconcileAgentId, routeSearch, sameDraft, type AgentTab } from "./dashboard-state";
-import type { ConfigAgent, ConfigResponse, DashboardAgent, RuntimeModel, RuntimeReadinessView, StatusResponse, WorkspaceProjection } from "./types";
+import type { ConfigAgent, ConfigResponse, DashboardAgent, PiProviderCatalogEntry, PiProviderCredentialStatus, PiProviderLoginResult, RuntimeModel, RuntimeReadinessView, StatusResponse, WorkspaceProjection } from "./types";
 import { Badge, Button, EmptyState, Sheet, cn } from "./components/ui";
 import { RUNTIME_OPTIONS } from "../../runtime/user-runtime.js";
 
@@ -258,6 +258,111 @@ function GroupPolicyTable({ config, onSave, disabled }: {
   </section>;
 }
 
+function isBuiltinPiAgent(config: ConfigAgent | undefined): boolean {
+  return Boolean(config && (config.runtimeOption === "builtin-pi" || (config.runtime === "pi" && config.piDistribution === "builtin")));
+}
+
+function ProviderCredentials({ agentId, onConfigured }: { agentId: string; onConfigured: () => void }) {
+  const [catalog, setCatalog] = useState<PiProviderCatalogEntry[]>([]);
+  const [credentials, setCredentials] = useState<PiProviderCredentialStatus[]>([]);
+  const [model, setModel] = useState<string>("");
+  const [preset, setPreset] = useState("deepseek");
+  const [baseUrl, setBaseUrl] = useState("");
+  const [customModel, setCustomModel] = useState("");
+  const [apiKey, setApiKey] = useState("");
+  const [logoutProvider, setLogoutProvider] = useState("");
+  const [busy, setBusy] = useState(false);
+  const [feedback, setFeedback] = useState<string | null>(null);
+  const selected = catalog.find((entry) => entry.id === preset) || catalog[0];
+  const custom = selected?.custom === true;
+
+  const refresh = useCallback(async () => {
+    const [providers, status] = await Promise.all([
+      privateGet<{ providers: PiProviderCatalogEntry[] }>("/api/pi-auth/providers"),
+      privateGet<{ agentId: string; model: string; credentials: PiProviderCredentialStatus[] }>(`/api/pi-auth/status?agent=${encodeURIComponent(agentId)}`),
+    ]);
+    setCatalog(providers.providers);
+    setCredentials(status.credentials);
+    setModel(status.model);
+    setLogoutProvider((current) => current || status.credentials[0]?.providerId || "");
+  }, [agentId]);
+
+  useEffect(() => { void refresh().catch((error) => setFeedback(error instanceof Error ? error.message : String(error))); }, [agentId]); // eslint-disable-line react-hooks/exhaustive-deps
+
+  const clearKey = () => setApiKey("");
+  const save = async () => {
+    setBusy(true);
+    try {
+      const result = await jsonFetch<PiProviderLoginResult>("/api/pi-auth/login", {
+        method: "POST",
+        headers: { "Content-Type": "application/json", "X-Larkin-CSRF": bootstrap.csrfCapability },
+        body: JSON.stringify({
+          agentId,
+          preset,
+          apiKey,
+          ...(custom ? { baseUrl, model: customModel } : {}),
+        }),
+      });
+      clearKey();
+      const apply = result.applyState === "applied"
+        ? "已应用"
+        : result.applyState === "pending"
+          ? `已保存但待应用${result.applyError ? `：${result.applyError}` : ""}`
+          : "已保存，将在 larkin start 后生效";
+      setFeedback(`${result.provider} · ${result.model} · ${apply}`);
+      await refresh();
+      onConfigured();
+    } catch (error) {
+      clearKey();
+      setFeedback(error instanceof Error ? error.message : String(error));
+    } finally {
+      setBusy(false);
+    }
+  };
+  const logout = async () => {
+    if (!logoutProvider) return;
+    setBusy(true);
+    try {
+      const result = await jsonFetch<{ ok: true; provider: string }>("/api/pi-auth/logout", {
+        method: "POST",
+        headers: { "Content-Type": "application/json", "X-Larkin-CSRF": bootstrap.csrfCapability },
+        body: JSON.stringify({ agentId, provider: logoutProvider }),
+      });
+      setFeedback(`已退出 ${result.provider}`);
+      await refresh();
+      onConfigured();
+    } catch (error) {
+      setFeedback(error instanceof Error ? error.message : String(error));
+    } finally { setBusy(false); }
+  };
+
+  return <section className="config-section">
+    <div className="section-heading"><div><h3>Provider Credentials</h3><p>只配置当前 builtin Pi Agent 的 Provider 与 API Key；自定义端点必须是 OpenAI-compatible。密钥只在本次保存请求中使用。</p></div></div>
+    <p className="provider-status">当前模型 {model || "未设置"}。{credentials.length
+      ? credentials.map((entry) => `${entry.providerName} (${entry.providerId}): ${entry.credentialType}`).join(" · ")
+      : "尚无已存储的 provider credential"}</p>
+    <div className="config-grid provider-grid">
+      <label><span>Provider</span><select value={preset} disabled={busy} onChange={(event) => setPreset(event.target.value)} aria-label="Provider">
+        {catalog.map((entry) => <option value={entry.id} key={entry.id}>{entry.name}</option>)}
+      </select></label>
+      {!custom ? <label><span>Default model</span><input value={selected?.defaultModel || ""} disabled readOnly /></label> : null}
+      {custom ? <label><span>Base URL</span><input value={baseUrl} disabled={busy} onChange={(event) => setBaseUrl(event.target.value)} placeholder="https://api.example.com/v1" aria-label="Base URL" /></label> : null}
+      {custom ? <label><span>Model</span><input value={customModel} disabled={busy} onChange={(event) => setCustomModel(event.target.value)} placeholder="model-id" aria-label="Custom model" /></label> : null}
+      <label><span>API Key</span><input type="password" autoComplete="off" name="larkin-pi-api-key" value={apiKey} disabled={busy} onChange={(event) => setApiKey(event.target.value)} aria-label="API Key" /></label>
+    </div>
+    <div className="form-actions">
+      <Button className="primary" disabled={busy || !apiKey} onClick={() => void save()}>{busy ? "处理中…" : "保存 Provider"}</Button>
+    </div>
+    {credentials.length ? <div className="config-grid provider-grid provider-logout">
+      <label><span>Logout provider</span><select value={logoutProvider} disabled={busy} onChange={(event) => setLogoutProvider(event.target.value)} aria-label="Logout provider">
+        {credentials.map((entry) => <option value={entry.providerId} key={entry.providerId}>{entry.providerName} ({entry.providerId})</option>)}
+      </select></label>
+      <div className="form-actions"><Button disabled={busy || !logoutProvider} onClick={() => void logout()}>退出所选 Provider</Button></div>
+    </div> : null}
+    {feedback ? <p role="status" className="feedback">{feedback}</p> : null}
+  </section>;
+}
+
 function AgentConfiguration({ agentId, onDirtyChange, refreshKey }: { agentId: string; onDirtyChange: (dirty: boolean) => void; refreshKey: number }) {
   const [response, setResponse] = useState<ConfigResponse | null>(null);
   const [serverDraft, setServerDraft] = useState<Record<string, unknown>>({});
@@ -269,6 +374,7 @@ function AgentConfiguration({ agentId, onDirtyChange, refreshKey }: { agentId: s
     status: "loading" | "ready" | "error";
     models: RuntimeModel[];
   } | null>(null);
+  const [providerTick, setProviderTick] = useState(0);
   const gate = useRef(createLatestResponseGate());
   const modelDirectoryGate = useRef(createLatestResponseGate());
   const dirty = !sameDraft(serverDraft, draft);
@@ -318,7 +424,7 @@ function AgentConfiguration({ agentId, onDirtyChange, refreshKey }: { agentId: s
         }
       });
     return () => controller.abort();
-  }, [agentId, runtime]);
+  }, [agentId, runtime, providerTick]);
   const directoryReady = modelDirectory?.runtime === runtime && modelDirectory.status === "ready";
   const directoryStatus = modelDirectory?.runtime === runtime ? modelDirectory.status : "loading";
   const models = directoryReady ? modelDirectory.models : [];
@@ -399,6 +505,7 @@ function AgentConfiguration({ agentId, onDirtyChange, refreshKey }: { agentId: s
       </div> : null}
       {feedback ? <p role="status" className="feedback">{feedback}</p> : null}
     </section>
+    {isBuiltinPiAgent(config) ? <ProviderCredentials agentId={agentId} onConfigured={() => { setProviderTick((value) => value + 1); void load(false); }} /> : null}
     <GroupPolicyTable config={config} onSave={saveChat} disabled={loading} />
   </div>;
 }

--- a/src/dashboard/web/styles.css
+++ b/src/dashboard/web/styles.css
@@ -167,6 +167,9 @@ button:disabled, select:disabled, input:disabled { cursor: not-allowed; opacity:
 .cli-guidance { margin: 0 0 14px; border-left: 2px solid var(--accent); padding: 6px 10px; color: var(--subtle); font-size: 11px; line-height: 1.55; }
 .cli-guidance code { color: var(--ink); font: 600 10.5px ui-monospace, monospace; overflow-wrap: anywhere; }
 .config-grid { display: grid; grid-template-columns: repeat(4, minmax(120px, 1fr)); gap: 12px; }
+.provider-grid { grid-template-columns: repeat(2, minmax(160px, 1fr)); }
+.provider-status { margin: 0 0 12px; color: var(--subtle); font-size: 11px; line-height: 1.5; }
+.provider-logout { margin-top: 12px; }
 .config-grid label, .settings-form label, .chat-add label { min-width: 0; display: grid; gap: 5px; color: var(--subtle); font-size: 11px; font-weight: 600; }
 .config-grid select, .config-grid input, .settings-form select, .chat-add select, .chat-add input, .policy-table select { min-width: 0; width: 100%; min-height: 37px; border: 1px solid var(--line); border-radius: 8px; padding: 7px 9px; background: var(--paper); color: var(--ink); font-size: 12px; }
 .config-grid input:disabled { color: var(--subtle); }

--- a/src/dashboard/web/types.ts
+++ b/src/dashboard/web/types.ts
@@ -119,6 +119,34 @@ export interface RuntimeModel {
   defaultReasoningEffort?: string;
 }
 
+export interface PiProviderCatalogEntry {
+  id: string;
+  name: string;
+  provider: string | null;
+  defaultModel: string | null;
+  custom: boolean;
+  openaiCompatible: boolean;
+}
+
+export interface PiProviderCredentialStatus {
+  providerId: string;
+  providerName: string;
+  credentialType: "api_key" | "oauth";
+  source: string;
+  stored: boolean;
+}
+
+export interface PiProviderLoginResult {
+  ok: true;
+  agentId: string;
+  provider: string;
+  preset: string;
+  model: string;
+  credentialType: "api_key";
+  applyState: "applied" | "saved_not_applied" | "pending";
+  applyError?: string;
+}
+
 export interface ConfigResponse {
   version: 4;
   mentionPolicy: "require" | "free";

--- a/src/platform/config.ts
+++ b/src/platform/config.ts
@@ -726,7 +726,7 @@ function assertConfigRoot(root: string): void {
   if (typeof process.getuid === "function" && stat.uid !== process.getuid()) throw new Error("config root owner is unsafe");
 }
 
-function withConfigLock<T>(layout: TargetRootLayout, action: () => T): T {
+function acquireConfigLock(layout: TargetRootLayout): { release: () => void } {
   assertNoSymlinkAncestors(layout.root);
   fs.mkdirSync(layout.root, { recursive: true, mode: 0o700 });
   const rootStat = fs.lstatSync(layout.root);
@@ -754,15 +754,40 @@ function withConfigLock<T>(layout: TargetRootLayout, action: () => T): T {
     }
   }
   if (!acquired) throw new Error("配置正被其他进程修改，请稍后重试");
+  return {
+    release() {
+      const current = readLockRecord(lock);
+      if (current?.record?.nonce === owner.nonce && current.record.pid === owner.pid) {
+        try { fs.unlinkSync(lock); fsyncDirectoryOf(lock); } catch { /* best effort */ }
+      }
+    },
+  };
+}
+
+function withConfigLock<T>(layout: TargetRootLayout, action: () => T): T {
+  const held = acquireConfigLock(layout);
   try {
     recoverMigrationJournal(layout.root);
     recoverRollbackJournal(layout.root);
     return action();
   } finally {
-    const current = readLockRecord(lock);
-    if (current?.record?.nonce === owner.nonce && current.record.pid === owner.pid) {
-      try { fs.unlinkSync(lock); fsyncDirectoryOf(lock); } catch { /* best effort */ }
-    }
+    held.release();
+  }
+}
+
+export function withConfigMutationLock<T>(env: Env, action: () => T): T {
+  return withConfigLock(TargetRootLayout.fromConfigDir(resolveConfigDir(env)), action);
+}
+
+export async function withConfigMutationLockAsync<T>(env: Env, action: () => Promise<T>): Promise<T> {
+  const layout = TargetRootLayout.fromConfigDir(resolveConfigDir(env));
+  const held = acquireConfigLock(layout);
+  try {
+    recoverMigrationJournal(layout.root);
+    recoverRollbackJournal(layout.root);
+    return await action();
+  } finally {
+    held.release();
   }
 }
 

--- a/src/platform/config.ts
+++ b/src/platform/config.ts
@@ -69,7 +69,7 @@ export type ConfigMutation =
   | { kind: "set-chat-mention"; agentId: string; chatId: string; value: MentionPolicyOverride }
   | { kind: "set-agent-runtime"; agentId: string; runtime: string; model?: string }
   | { kind: "set-agent-pi-distribution"; agentId: string; distribution: "builtin" | "external" }
-  | { kind: "set-agent-model"; agentId: string; model: string }
+  | { kind: "set-agent-model"; agentId: string; model: string; requireBuiltinPi?: boolean }
   | { kind: "set-agent-effort"; agentId: string; effort: string | null };
 
 export type ConfigAuthority = { kind: "user" } | { kind: "agent"; agentId: string };
@@ -591,7 +591,7 @@ function applyMutation(config: HydratedConfig, mutation: ConfigMutation): { scop
       try {
         assertBuiltinPiAgentDirectory(piAgentDirectory(config.configDir, mutation.agentId));
       } catch (error) {
-        throw new Error(`无法切换到 builtin-pi：${error instanceof Error ? error.message : String(error)}。请先运行 larkin setup 并为该 Agent 选择 builtin-pi 完成 provider 配置`);
+        throw new Error(`无法切换到 builtin-pi：${error instanceof Error ? error.message : String(error)}。请使用 Dashboard Provider Credentials 或 larkin pi-auth login。`);
       }
     }
     assertModel(stored.runtime, mutation.model || "default");
@@ -601,6 +601,9 @@ function applyMutation(config: HydratedConfig, mutation: ConfigMutation): { scop
     else delete agent.piDistribution;
     delete agent.effort;
   } else if (mutation.kind === "set-agent-model") {
+    if (mutation.requireBuiltinPi && (agent.runtime !== "pi" || agent.piDistribution !== "builtin")) {
+      throw new Error(`Agent ${mutation.agentId} 不是内置 Pi`);
+    }
     if (!mutation.model.trim()) throw new Error("model 不能为空");
     assertModel(agent.runtime, mutation.model);
     const changedModel = mutation.model !== agent.model;

--- a/src/runtime/pi-provider-config.ts
+++ b/src/runtime/pi-provider-config.ts
@@ -8,6 +8,8 @@ export { piDistributionLabel } from "./pi-distribution-label.js";
 
 export type PiDistribution = "external" | "builtin";
 export const BUNDLED_PI_VERSION = "0.84.2";
+/** API Key 字符上限；stdin 必须在读入任意多余输入前按同一上限截断。 */
+export const MAX_BUILTIN_PI_API_KEY_LENGTH = 16_384;
 export type PiProviderPresetId = "deepseek" | "kimi" | "minimax" | "zhipu" | "openai" | "anthropic"
   | "gemini" | "groq" | "cerebras" | "xai" | "fireworks" | "together" | "mistral"
   | "openrouter" | "kimi-coding" | "qwen-cn" | "opencode-go" | "ant-ling" | "nvidia"
@@ -85,6 +87,26 @@ export interface ResolvedBuiltinPiProviderSetupSelection extends BuiltinPiProvid
 const APP_ID = /^cli_[A-Za-z0-9]+$/;
 const MODEL_ID = /^[A-Za-z0-9][A-Za-z0-9._:@+\/-]{0,255}$/;
 
+/** Node 的 URL.hostname 对 IPv6 是 [::1]，不是 ::1。 */
+export function isPiLoopbackHostname(hostname: string): boolean {
+  const host = hostname.trim().replace(/^\[|\]$/g, "").toLowerCase();
+  return host === "localhost" || host === "127.0.0.1" || host === "::1";
+}
+
+/** 官方 provider ID（如 zai-coding-cn）映射到 CLI/Dashboard 接受的 preset ID（如 zhipu）。 */
+export function presetIdForOfficialProvider(providerId: string): string | null {
+  const id = providerId.trim();
+  if (id === "larkin-custom") return "custom";
+  return PI_PROVIDER_PRESETS.find((preset) => preset.provider === id)?.id ?? null;
+}
+
+/** Agent 范围的缺凭证恢复路径：只用 preset，不指向 setup / import / 全局 ~/.pi。 */
+export function builtinPiProviderRecoveryNextAction(options: { agentId?: string; providerId?: string } = {}): string {
+  const preset = options.providerId ? presetIdForOfficialProvider(options.providerId) ?? "<preset|custom>" : "<preset|custom>";
+  const agent = options.agentId && /^cli_[A-Za-z0-9]+$/.test(options.agentId) ? options.agentId : "<App ID>";
+  return `在 Dashboard 的 Provider Credentials 中为该 Agent 配置 Provider 与 API Key，或运行 larkin pi-auth login ${preset} --agent ${agent}。`;
+}
+
 export function validatePiBaseUrl(raw: string): string {
   const input = raw.trim();
   if (!input || /[\0\r\n\t]/.test(input)) throw new Error("Base URL 不能为空或包含控制字符");
@@ -93,7 +115,7 @@ export function validatePiBaseUrl(raw: string): string {
   catch { throw new Error("Base URL 不是合法 URL"); }
   if (url.username || url.password) throw new Error("Base URL 不允许包含用户名或凭证");
   if (url.search || url.hash) throw new Error("Base URL 不允许 query 或 fragment");
-  const local = ["localhost", "127.0.0.1", "::1"].includes(url.hostname);
+  const local = isPiLoopbackHostname(url.hostname);
   if (url.protocol !== "https:" && !(url.protocol === "http:" && local)) {
     throw new Error("Base URL 必须使用 https；仅 localhost/loopback 开发端点允许 http");
   }
@@ -154,7 +176,7 @@ export function resolveBuiltinPiProviderSetupSelection(input: BuiltinPiProviderS
 
 export function validateBuiltinPiProviderSelection(input: BuiltinPiProviderSelection): ValidatedBuiltinPiProviderSelection {
   const key = input.apiKey.trim();
-  if (!key || key.length > 16_384 || /[\0\r\n]/.test(key)) throw new Error("API Key 不能为空或包含控制字符");
+  if (!key || key.length > MAX_BUILTIN_PI_API_KEY_LENGTH || /[\0\r\n]/.test(key)) throw new Error("API Key 不能为空或包含控制字符");
   return { ...resolveBuiltinPiProviderSetupSelection(input), apiKey: key };
 }
 

--- a/src/runtime/pi-provider-login.ts
+++ b/src/runtime/pi-provider-login.ts
@@ -1,0 +1,337 @@
+import {
+  PI_PROVIDER_PRESETS,
+  configureBuiltinPiProviderModel,
+  validateBuiltinPiProviderSelection,
+  type PiProviderPresetId,
+  type ValidatedBuiltinPiProviderSelection,
+} from "./pi-provider-config.js";
+import {
+  beginBuiltinPiCredentialTransaction,
+  createOfficialPiAuthInteraction,
+  createOfficialPiLogoutRuntime,
+  createOfficialPiModelRuntime,
+  logoutOfficialPiProvider,
+  runOfficialPiLogin,
+  type OfficialPiAuthRuntime,
+  type PiAuthQuestioner,
+} from "./pi-official-auth.js";
+import {
+  loadConfig,
+  markConfigApplied,
+  mutateConfig,
+  runtimeConfigSignature,
+  type ConfigMutationResult,
+} from "../platform/config.js";
+import { requestAgentUpsert, type AgentUpsertResponse } from "../app/local-control.js";
+import { readProcessState } from "../platform/process-state.js";
+import type { AuthInteraction } from "@earendil-works/pi-ai";
+
+const APP_ID = /^cli_[A-Za-z0-9]+$/;
+const PROVIDER_ID = /^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$/;
+const PRESET_IDS = new Set<string>([...PI_PROVIDER_PRESETS.map((preset) => preset.id), "custom"]);
+
+export type BuiltinPiProviderApplyState = "applied" | "saved_not_applied" | "pending";
+
+export interface BuiltinPiProviderCatalogEntry {
+  id: string;
+  name: string;
+  provider: string | null;
+  defaultModel: string | null;
+  custom: boolean;
+  openaiCompatible: boolean;
+}
+
+export interface BuiltinPiProviderLoginInput {
+  agentId: string;
+  preset: string;
+  apiKey: string;
+  model?: string;
+  baseUrl?: string;
+  env?: NodeJS.ProcessEnv;
+}
+
+export interface BuiltinPiProviderLoginResult {
+  agentId: string;
+  provider: string;
+  preset: string;
+  model: string;
+  credentialType: "api_key";
+  applyState: BuiltinPiProviderApplyState;
+  applyError?: string;
+}
+
+export interface ConfigureBuiltinPiProviderDeps {
+  loadConfig?: typeof loadConfig;
+  beginTransaction?: typeof beginBuiltinPiCredentialTransaction;
+  configureModel?: typeof configureBuiltinPiProviderModel;
+  createRuntime?: typeof createOfficialPiModelRuntime;
+  runLogin?: typeof runOfficialPiLogin;
+  createInteraction?: typeof createApiKeyOnlyInteraction;
+  mutateConfig?: typeof mutateConfig;
+  readProcessState?: typeof readProcessState;
+  requestUpsert?: typeof requestAgentUpsert;
+  markApplied?: typeof markConfigApplied;
+}
+
+export interface LogoutBuiltinPiProviderDeps {
+  loadConfig?: typeof loadConfig;
+  beginTransaction?: typeof beginBuiltinPiCredentialTransaction;
+  createLogoutRuntime?: typeof createOfficialPiLogoutRuntime;
+  logout?: typeof logoutOfficialPiProvider;
+}
+
+/** 用户可见 catalog：已知 preset + 自定义 OpenAI 兼容端点，不含 Base URL / secret。 */
+export function listBuiltinPiProviderCatalog(): BuiltinPiProviderCatalogEntry[] {
+  return [
+    ...PI_PROVIDER_PRESETS.map((preset) => ({
+      id: preset.id,
+      name: preset.name,
+      provider: preset.provider,
+      defaultModel: `${preset.provider}/${preset.defaultModel}`,
+      custom: false,
+      openaiCompatible: preset.api === "openai-completions",
+    })),
+    {
+      id: "custom",
+      name: "Custom OpenAI-compatible",
+      provider: "larkin-custom",
+      defaultModel: null,
+      custom: true,
+      openaiCompatible: true,
+    },
+  ];
+}
+
+export function sanitizeProviderLoginError(error: unknown, secret?: string): string {
+  let text = error instanceof Error ? error.message : String(error);
+  if (secret) {
+    let from = 0;
+    while (from < text.length) {
+      const at = text.indexOf(secret, from);
+      if (at < 0) break;
+      text = `${text.slice(0, at)}[redacted]${text.slice(at + secret.length)}`;
+      from = at + 10;
+    }
+  }
+  return text
+    .replace(/\b(?:authorization|proxy-authorization|api[_ -]?key|access[_ -]?token|refresh[_ -]?token|secret|password)\s*[:=]\s*\S+/gi,
+      (match) => `${match.split(/[:=]/, 1)[0]}=[redacted]`)
+    .replace(/Bearer\s+\S+/gi, "Bearer [redacted]")
+    .replace(/\bsk-[A-Za-z0-9_-]{8,}\b/g, "[redacted]")
+    .replace(/https?:\/\/[^\s]+/gi, (url) => {
+      try {
+        const parsed = new URL(url);
+        parsed.username = "";
+        parsed.password = "";
+        parsed.search = "";
+        parsed.hash = "";
+        return parsed.toString();
+      } catch {
+        return "(url)";
+      }
+    })
+    .replace(/[\0\r\n\t]+/g, " ")
+    .replace(/\s+/g, " ")
+    .trim()
+    .slice(0, 240) || "builtin Pi provider configuration failed";
+}
+
+export function resolveBuiltinPiLoginSelection(input: {
+  preset: string;
+  apiKey: string;
+  model?: string;
+  baseUrl?: string;
+}): ValidatedBuiltinPiProviderSelection {
+  if (!PRESET_IDS.has(input.preset)) throw new Error(`未知 Pi provider preset: ${input.preset}`);
+  const preset = input.preset as PiProviderPresetId;
+  if (preset === "custom") {
+    if (!input.baseUrl?.trim()) throw new Error("custom OpenAI-compatible endpoint 需要 Base URL");
+    if (!input.model?.trim()) throw new Error("custom OpenAI-compatible endpoint 需要 model");
+    return validateBuiltinPiProviderSelection({
+      distribution: "builtin",
+      preset,
+      apiKey: input.apiKey,
+      model: input.model,
+      baseUrl: input.baseUrl,
+    });
+  }
+  if (input.baseUrl?.trim()) throw new Error("已知 provider 不接受 --base-url；自定义端点请使用 custom");
+  const known = PI_PROVIDER_PRESETS.find((candidate) => candidate.id === preset);
+  if (!known) throw new Error(`未知 Pi provider preset: ${input.preset}`);
+  return validateBuiltinPiProviderSelection({
+    distribution: "builtin",
+    preset,
+    apiKey: input.apiKey,
+    model: input.model?.trim() || known.defaultModel,
+  });
+}
+
+export function createApiKeyOnlyInteraction(
+  apiKey: string,
+  options: { report?: (message: string) => void; signal?: AbortSignal } = {},
+): AuthInteraction {
+  const questioner: PiAuthQuestioner = {
+    ask: async () => {
+      throw new Error("API-key login does not accept interactive text prompts");
+    },
+    secret: async () => apiKey,
+  };
+  return createOfficialPiAuthInteraction({
+    questioner,
+    report: options.report ?? (() => {}),
+    signal: options.signal,
+  });
+}
+
+function assertTargetBuiltinPi(
+  env: NodeJS.ProcessEnv,
+  agentId: string,
+  load: typeof loadConfig,
+): { configDir: string } {
+  if (!APP_ID.test(agentId)) throw new Error("请用 --agent <App ID> 选择 Agent");
+  const loaded = load(env);
+  const agent = loaded.config.agents[agentId];
+  if (!agent) throw new Error(`Agent ${agentId} 不存在`);
+  if (agent.runtime !== "pi" || agent.piDistribution !== "builtin") {
+    throw new Error(`Agent ${agentId} 不是内置 Pi`);
+  }
+  return { configDir: loaded.configDir };
+}
+
+async function applyTargetModel(
+  env: NodeJS.ProcessEnv,
+  agentId: string,
+  model: string,
+  mutate: typeof mutateConfig,
+  inspect: typeof readProcessState,
+  upsert: typeof requestAgentUpsert,
+  markApplied: typeof markConfigApplied,
+  secret?: string,
+): Promise<{ applyState: BuiltinPiProviderApplyState; applyError?: string }> {
+  let mutated: ConfigMutationResult;
+  try {
+    mutated = mutate(env, { kind: "set-agent-model", agentId, model, requireBuiltinPi: true }, { kind: "user" });
+  } catch (error) {
+    throw new Error(sanitizeProviderLoginError(error, secret));
+  }
+  const stillBuiltin = mutated.config.agents[agentId]?.runtime === "pi"
+    && mutated.config.agents[agentId]?.piDistribution === "builtin";
+  if (!stillBuiltin) {
+    return { applyState: "pending", applyError: sanitizeProviderLoginError(new Error(`Agent ${agentId} 不是内置 Pi`), secret) };
+  }
+  const expectedSignature = runtimeConfigSignature(mutated.config, agentId);
+  const state = inspect(mutated.config.larkinHome);
+  if (state.daemon.state !== "owned" || state.supervisor.state !== "owned") {
+    return { applyState: "saved_not_applied" };
+  }
+  try {
+    const result: AgentUpsertResponse = await upsert({
+      larkinHome: mutated.config.larkinHome,
+      agentId,
+      expectedSignature,
+    });
+    if (!result.ok) {
+      return {
+        applyState: "pending",
+        applyError: sanitizeProviderLoginError(result.error || "targeted apply failed", secret),
+      };
+    }
+    markApplied(env, agentId, expectedSignature);
+    return { applyState: "applied" };
+  } catch (error) {
+    return { applyState: "pending", applyError: sanitizeProviderLoginError(error, secret) };
+  }
+}
+
+/**
+ * 为已有 builtin Pi Agent 配置已知 preset 或自定义 OpenAI 兼容端点。
+ * 凭证事务覆盖 auth.json / models.json / models-store.json；模型写入走独立 CAS。
+ * 不读取 host ~/.pi，也不验证真实 provider。
+ */
+export async function configureBuiltinPiProvider(
+  input: BuiltinPiProviderLoginInput,
+  deps: ConfigureBuiltinPiProviderDeps = {},
+): Promise<BuiltinPiProviderLoginResult> {
+  const env = input.env ?? process.env;
+  const load = deps.loadConfig ?? loadConfig;
+  const beginTransaction = deps.beginTransaction ?? beginBuiltinPiCredentialTransaction;
+  const configureModel = deps.configureModel ?? configureBuiltinPiProviderModel;
+  const createRuntime = deps.createRuntime ?? createOfficialPiModelRuntime;
+  const runLogin = deps.runLogin ?? runOfficialPiLogin;
+  const createInteraction = deps.createInteraction ?? createApiKeyOnlyInteraction;
+  const mutate = deps.mutateConfig ?? mutateConfig;
+  const inspect = deps.readProcessState ?? readProcessState;
+  const upsert = deps.requestUpsert ?? requestAgentUpsert;
+  const markApplied = deps.markApplied ?? markConfigApplied;
+
+  let selection: ValidatedBuiltinPiProviderSelection;
+  try {
+    selection = resolveBuiltinPiLoginSelection({
+      preset: input.preset,
+      apiKey: input.apiKey,
+      model: input.model,
+      baseUrl: input.baseUrl,
+    });
+  } catch (error) {
+    throw new Error(sanitizeProviderLoginError(error, input.apiKey));
+  }
+
+  const { configDir } = assertTargetBuiltinPi(env, input.agentId, load);
+  const transaction = beginTransaction(configDir, input.agentId);
+  try {
+    if (selection.preset === "custom") {
+      configureModel(configDir, input.agentId, {
+        distribution: "builtin",
+        preset: "custom",
+        model: selection.model,
+        baseUrl: selection.baseUrl,
+      });
+    }
+    const runtime = await createRuntime(configDir, input.agentId);
+    await runLogin(
+      runtime as Pick<OfficialPiAuthRuntime, "login">,
+      selection.provider,
+      "api_key",
+      createInteraction(selection.apiKey),
+    );
+    const applied = await applyTargetModel(
+      env, input.agentId, selection.model, mutate, inspect, upsert, markApplied, input.apiKey,
+    );
+    transaction.commit();
+    return {
+      agentId: input.agentId,
+      provider: selection.provider,
+      preset: selection.preset,
+      model: selection.model,
+      credentialType: "api_key",
+      applyState: applied.applyState,
+      ...(applied.applyError ? { applyError: applied.applyError } : {}),
+    };
+  } catch (error) {
+    try { transaction.rollback(); } catch { /* 原始错误优先 */ }
+    throw new Error(sanitizeProviderLoginError(error, input.apiKey));
+  }
+}
+
+export async function logoutBuiltinPiProvider(
+  input: { agentId: string; providerId: string; env?: NodeJS.ProcessEnv },
+  deps: LogoutBuiltinPiProviderDeps = {},
+): Promise<{ agentId: string; provider: string }> {
+  const env = input.env ?? process.env;
+  const load = deps.loadConfig ?? loadConfig;
+  if (!PROVIDER_ID.test(input.providerId)) throw new Error("logout 需要安全的 provider ID");
+  const { configDir } = assertTargetBuiltinPi(env, input.agentId, load);
+  const beginTransaction = deps.beginTransaction ?? beginBuiltinPiCredentialTransaction;
+  const createLogoutRuntime = deps.createLogoutRuntime ?? createOfficialPiLogoutRuntime;
+  const logout = deps.logout ?? logoutOfficialPiProvider;
+  const transaction = beginTransaction(configDir, input.agentId);
+  try {
+    const runtime = await createLogoutRuntime(configDir, input.agentId);
+    await logout(runtime, input.providerId);
+    transaction.commit();
+    return { agentId: input.agentId, provider: input.providerId };
+  } catch (error) {
+    try { transaction.rollback(); } catch { /* 原始错误优先 */ }
+    throw new Error(sanitizeProviderLoginError(error));
+  }
+}

--- a/src/runtime/runtime-readiness.ts
+++ b/src/runtime/runtime-readiness.ts
@@ -4,7 +4,7 @@ import path from "node:path";
 import { spawnSync } from "node:child_process";
 import { resolveConfigDir as resolveRootConfigDir } from "../platform/root-layout.js";
 import { applyPiPackageDirForChild, piChildDistributionFromOverrides } from "./builtin-pi-assets.js";
-import { assertBuiltinPiAgentDirectory, BUNDLED_PI_VERSION, ownedPiCatalogAgentDir, piAgentDirectory } from "./pi-provider-config.js";
+import { assertBuiltinPiAgentDirectory, BUNDLED_PI_VERSION, builtinPiProviderRecoveryNextAction, ownedPiCatalogAgentDir, piAgentDirectory } from "./pi-provider-config.js";
 import { traceProcessBoundary } from "../platform/process-boundary-trace.js";
 
 export type RuntimeReadinessState = "missing" | "unauthenticated" | "unavailable" | "incompatible" | "ready";
@@ -155,6 +155,7 @@ export function providerAuthenticationFailureReadiness(
   };
 }
 
+/** P0 分类；Pi nextAction 共用 UX preset 恢复文案，不写官方 provider ID。 */
 export function missingProviderCredentialReadiness(
   runtime: RuntimeReadiness["runtime"],
   provider?: unknown,
@@ -166,9 +167,11 @@ export function missingProviderCredentialReadiness(
     reason: label
       ? `Provider ${label} is missing from this Agent's official credential store.`
       : "The configured provider is missing from this Agent's official credential store.",
-    nextAction: label
-      ? `Add the missing ${label} credential to this Agent's official store, then retry the Agent turn.`
-      : "Add the missing provider credential to this Agent's official store, then retry the Agent turn.",
+    nextAction: runtime === "pi"
+      ? builtinPiProviderRecoveryNextAction({ providerId: label ?? undefined })
+      : label
+        ? `Add the missing ${label} credential to this Agent's official store, then retry the Agent turn.`
+        : "Add the missing provider credential to this Agent's official store, then retry the Agent turn.",
   };
 }
 
@@ -200,7 +203,10 @@ export function classifyRuntimePrerequisite(runtime: RuntimeReadiness["runtime"]
   };
   if (/no authenticated available models|login|credential|unauthenticated|unauthorized|oauth/i.test(reason)) return {
     runtime, state: "unauthenticated", ...(executable ? { executable } : {}), reason,
-    nextAction: runtime === "pi" ? "Run the official `pi` login flow, then retry." : `Authenticate ${runtime}, then retry.`,
+    // 此分类没有 distribution：外部 Pi 不能指向 Dashboard / pi-auth login。
+    nextAction: runtime === "pi"
+      ? "Run the official `pi` login flow, then retry."
+      : `Authenticate ${runtime}, then retry.`,
   };
   if (/protocol (?:version )?(?:mismatch|unsupported|incompatible)|unsupported (?:rpc|protocol|schema)|schema (?:mismatch|incompatible)|requires (?:a )?newer version/i.test(reason)) return {
     runtime, state: "incompatible", ...(executable ? { executable } : {}), reason,
@@ -254,7 +260,7 @@ export async function probeNativeRuntimeReadiness(options: ProbeNativeRuntimeRea
     } catch (error) {
       traceProcessBoundary(env, "readiness:builtin-pi-failure", { configDir: env.LARKIN_CONFIG_DIR, agentId: options.agentId, targetDir: options.agentId && env.LARKIN_CONFIG_DIR ? piAgentDirectory(env.LARKIN_CONFIG_DIR, options.agentId) : undefined, error });
       return { runtime: "pi", state: "unauthenticated", reason: error instanceof Error ? error.message : String(error),
-        nextAction: "重新运行 larkin setup，选择内置 Pi 并配置有效 API Key。" };
+        nextAction: builtinPiProviderRecoveryNextAction({ agentId: options.agentId }) };
     }
   }
   const command = selectedCommand(options);

--- a/test/e2e/builtin-pi-provider-config-mock-e2e.test.mjs
+++ b/test/e2e/builtin-pi-provider-config-mock-e2e.test.mjs
@@ -1,0 +1,58 @@
+import { test } from "bun:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { pathToFileURL } from "node:url";
+
+const ROOT = path.resolve(import.meta.dirname, "../..");
+
+test("credential-present target apply observes only the configured Agent", async () => {
+  const { configureBuiltinPiProvider } = await import(pathToFileURL(path.join(ROOT, "dist/runtime/pi-provider-login.mjs")).href);
+  const temp = fs.mkdtempSync(path.join(os.tmpdir(), "larkin-pi-provider-mock-e2e-"));
+  const target = "cli_mockTargetA1";
+  const other = "cli_mockOtherB2";
+  try {
+    fs.chmodSync(temp, 0o700);
+    fs.writeFileSync(path.join(temp, "config.json"), `${JSON.stringify({
+      version: 4, serverId: "server-mock-e2e", mentionPolicy: "require", activeAgent: target,
+      agents: {
+        [target]: { runtime: "pi", piDistribution: "builtin", model: "default", createdAt: "2026-09-04T00:00:00.000Z" },
+        [other]: { runtime: "pi", piDistribution: "builtin", model: "kimi/kimi-k2.6", createdAt: "2026-09-04T00:00:00.000Z" },
+      },
+    }, null, 2)}\n`, { mode: 0o600 });
+    for (const agentId of [target, other]) {
+      const directory = path.join(temp, "providers", "pi", agentId);
+      fs.mkdirSync(directory, { recursive: true, mode: 0o700 });
+      fs.chmodSync(directory, 0o700);
+    }
+    const otherAuth = { "moonshotai-cn": { type: "api_key", key: "sibling-secret" } };
+    fs.writeFileSync(path.join(temp, "providers", "pi", other, "auth.json"), `${JSON.stringify(otherAuth, null, 2)}\n`, { mode: 0o600 });
+    const env = { ...process.env, LARKIN_CONFIG_DIR: temp, LARKIN_HOME: temp };
+    const upserts = [];
+    const result = await configureBuiltinPiProvider({
+      agentId: target, preset: "zhipu", apiKey: "target-recovery-secret", env,
+    }, {
+      createRuntime: async () => ({}),
+      runLogin: async (_runtime, providerId) => {
+        const authFile = path.join(temp, "providers", "pi", target, "auth.json");
+        fs.writeFileSync(authFile, `${JSON.stringify({ [providerId]: { type: "api_key", key: "target-recovery-secret" } }, null, 2)}\n`, { mode: 0o600 });
+        return { type: "api_key", key: "target-recovery-secret" };
+      },
+      readProcessState: () => ({ daemon: { state: "owned" }, supervisor: { state: "owned" } }),
+      requestUpsert: async (input) => {
+        upserts.push(input.agentId);
+        return { ok: true, operationId: "op", agentId: input.agentId };
+      },
+      markApplied: () => {},
+    });
+    assert.equal(result.provider, "zai-coding-cn");
+    assert.equal(result.model, "zai-coding-cn/glm-5.2");
+    assert.equal(result.applyState, "applied");
+    assert.deepEqual(upserts, [target], "targeted hot upsert must not touch the sibling Agent");
+    assert.deepEqual(JSON.parse(fs.readFileSync(path.join(temp, "providers", "pi", other, "auth.json"), "utf8")), otherAuth);
+    const config = JSON.parse(fs.readFileSync(path.join(temp, "config.json"), "utf8"));
+    assert.equal(config.agents[other].model, "kimi/kimi-k2.6");
+    assert.equal(config.agents[target].model, "zai-coding-cn/glm-5.2");
+  } finally { fs.rmSync(temp, { recursive: true, force: true }); }
+});

--- a/test/e2e/pi-prompt-preflight-recovery-mock-e2e.test.mjs
+++ b/test/e2e/pi-prompt-preflight-recovery-mock-e2e.test.mjs
@@ -394,7 +394,9 @@ test("real Pi adapter missing-key RPC rejection terminals the ledger and project
     assert.equal(record.errorCategory, "auth");
     const status = events.filter((event) => event.type === "agent-status").at(-1);
     assert.equal(status.readiness.state, "unauthenticated");
-    assert.match(status.readiness.nextAction, /Add the missing zai-coding-cn credential to this Agent's official store/);
+    assert.match(status.readiness.nextAction, /pi-auth login zhipu --agent <App ID>/);
+    assert.match(status.readiness.nextAction, /Provider Credentials/);
+    assert.doesNotMatch(status.readiness.nextAction, /zai-coding-cn/);
     assert.equal(events.filter((event) => event.type === "delivery" && event.status === "deferred").length, 0);
 
     rejectMissing = false;

--- a/test/e2e/runtime-production-mock-e2e.test.mjs
+++ b/test/e2e/runtime-production-mock-e2e.test.mjs
@@ -900,7 +900,9 @@ test("missing-key prompt rejection terminals the HostShell ledger and projects u
     const failedStatus = store.readJson("status", {});
     assert.equal(failedStatus.runtimeReadiness.state, "unauthenticated");
     assert.match(failedStatus.runtimeReadiness.reason, /zai-coding-cn.*missing/i);
-    assert.match(failedStatus.runtimeReadiness.nextAction, /Add the missing zai-coding-cn credential to this Agent's official store/);
+    assert.match(failedStatus.runtimeReadiness.nextAction, /pi-auth login zhipu --agent <App ID>/);
+    assert.match(failedStatus.runtimeReadiness.nextAction, /Provider Credentials/);
+    assert.doesNotMatch(failedStatus.runtimeReadiness.nextAction, /zai-coding-cn/);
     assert.doesNotMatch(JSON.stringify(failedStatus.runtimeReadiness), /fixture-openai-codex|larkin setup|profile import/);
     await hostShell.ingest(otherId, { chat_id: "oc_missing_other", chat_type: "p2p", sender_id: "ou_sender",
       message_id: "om_missing_other", event_id: "evt_missing_other", content: "other",

--- a/test/frontend/dashboard-workbench.test.tsx
+++ b/test/frontend/dashboard-workbench.test.tsx
@@ -31,6 +31,14 @@ const agents = [
     ],
     feed: [{ kind: "activity", state: "idle", detail: "等待任务", at: "2026-07-24T10:00:00.000Z" }], recentErrors: [], knownChats: 1,
   },
+  {
+    agentId: "cli_AgentC3", name: "cli_AgentC3", displayName: "Pi Builtin", runtime: "pi", model: "deepseek/deepseek-v4-pro", effort: null,
+    running: true, issue: false, credentialReady: false, bot: null,
+    connection: { state: "connected", reason: "current channel" }, inbound: { state: "pending", reason: "waiting" },
+    lastActivity: { state: "idle", detail: "等待任务", ageSec: 30 }, lastDeliver: null,
+    eyeIndicator: { pendingCount: 0, oldestAgeSec: null, stuck: false }, activeReminders: 0, remindersList: [],
+    session: null, conversation: [], feed: [], recentErrors: [], knownChats: 0,
+  },
 ];
 
 const status = {
@@ -47,8 +55,10 @@ const config = (agentId?: string) => ({
   },
   runtimeOptions: ["codex", "claude", "pi", "builtin-pi"] as const,
   agents: (agentId ? agents.filter((agent) => agent.agentId === agentId) : agents).map((agent) => ({
-    agentId: agent.agentId, runtime: agent.runtime, runtimeOption: agent.runtime, model: agent.model, effort: agent.effort,
-    piDistribution: null,
+    agentId: agent.agentId, runtime: agent.runtime,
+    runtimeOption: agent.agentId === "cli_AgentC3" ? "builtin-pi" : agent.runtime,
+    model: agent.model, effort: agent.effort,
+    piDistribution: agent.agentId === "cli_AgentC3" ? "builtin" : null,
     mention: { override: agent.agentId === "cli_AgentB2" ? "require" : "inherit", effective: agent.agentId === "cli_AgentB2" ? "require" : "free", source: agent.agentId === "cli_AgentB2" ? "agent" : "global" },
     knownChats: agent.agentId === "cli_AgentB2" ? [
       { chatId: "oc_BuildRoom", displayName: "构建群", kind: "group", override: "free", effective: "free", source: "chat" },
@@ -515,5 +525,105 @@ describe("Agent-centric dashboard workbench", () => {
     await screen.findByText("只读工作区");
     expect(document.querySelector(".agent-content")).toHaveClass("workspace-active");
     expect(document.querySelector(".workspace-browser")).toBeVisible();
+  });
+
+  it("shows Provider Credentials only for builtin Pi and clears the API key after save", async () => {
+    const secret = "frontend-super-secret";
+    vi.stubGlobal("fetch", vi.fn((input: RequestInfo | URL, init?: RequestInit) => {
+      const url = new URL(String(input), "http://localhost");
+      if (url.pathname === "/api/status") return ok(status);
+      if (url.pathname === "/api/config") return ok(config(url.searchParams.get("agent") || undefined));
+      if (url.pathname === "/api/workspace") return ok({ kind: "directory", path: "", parent: null, entries: [] });
+      if (url.pathname === "/api/models/codex" || url.pathname === "/api/models/pi" || url.pathname === "/api/models/builtin-pi") {
+        return ok({ models: [{ id: "default", label: "default" }, { id: "deepseek/deepseek-v4-pro", label: "DeepSeek" }] });
+      }
+      if (url.pathname === "/api/pi-auth/providers") {
+        return ok({
+          providers: [
+            { id: "deepseek", name: "DeepSeek（推荐）", provider: "deepseek", defaultModel: "deepseek/deepseek-v4-pro", custom: false, openaiCompatible: true },
+            { id: "custom", name: "Custom OpenAI-compatible", provider: "larkin-custom", defaultModel: null, custom: true, openaiCompatible: true },
+          ],
+        });
+      }
+      if (url.pathname === "/api/pi-auth/status") {
+        return ok({ agentId: url.searchParams.get("agent"), model: "deepseek/deepseek-v4-pro", credentials: [] });
+      }
+      if (url.pathname === "/api/pi-auth/login" && init?.method === "POST") {
+        const body = JSON.parse(String(init.body));
+        expect(body.apiKey).toBe(secret);
+        expect(JSON.stringify(body)).not.toContain("?");
+        return ok({
+          ok: true, agentId: body.agentId, provider: body.preset === "custom" ? "larkin-custom" : "deepseek",
+          preset: body.preset, model: body.preset === "custom" ? `larkin-custom/${body.model}` : "deepseek/deepseek-v4-pro",
+          credentialType: "api_key", applyState: "saved_not_applied",
+        });
+      }
+      throw new Error(`unexpected request ${url}`);
+    }));
+    window.history.replaceState(null, "", "/?agent=cli_AgentB2&tab=configuration");
+    render(<App />);
+    await screen.findByRole("heading", { level: 1, name: "Builder" });
+    expect(screen.queryByRole("heading", { level: 3, name: "Provider Credentials" })).not.toBeInTheDocument();
+    await userEvent.click(screen.getByRole("option", { name: /Pi Builtin/ }));
+    expect(await screen.findByRole("heading", { level: 3, name: "Provider Credentials" })).toBeVisible();
+    await screen.findByRole("option", { name: "DeepSeek（推荐）" });
+    const key = await screen.findByLabelText("API Key");
+    expect(key).toHaveAttribute("type", "password");
+    expect(key).toHaveAttribute("autocomplete", "off");
+    expect(screen.queryByLabelText("Base URL")).not.toBeInTheDocument();
+    await userEvent.selectOptions(screen.getByLabelText("Provider"), "custom");
+    expect(await screen.findByLabelText("Base URL")).toBeVisible();
+    expect(screen.getByLabelText("Custom model")).toBeVisible();
+    await userEvent.selectOptions(screen.getByLabelText("Provider"), "deepseek");
+    await userEvent.type(key, secret);
+    expect(key).toHaveValue(secret);
+    await userEvent.click(screen.getByRole("button", { name: "保存 Provider" }));
+    await waitFor(() => expect(screen.getByLabelText("API Key")).toHaveValue(""));
+    expect(await screen.findByRole("status")).toHaveTextContent(/deepseek/);
+    expect(screen.queryByText(secret)).not.toBeInTheDocument();
+  });
+
+  it("clears the API key as soon as login settles even if status refresh stalls", async () => {
+    const secret = "frontend-stalled-secret";
+    const statusHold = deferred<{ ok: boolean; status: number; json: () => Promise<unknown> }>();
+    let loginDone = false;
+    vi.stubGlobal("fetch", vi.fn((input: RequestInfo | URL, init?: RequestInit) => {
+      const url = new URL(String(input), "http://localhost");
+      if (url.pathname === "/api/status") return ok(status);
+      if (url.pathname === "/api/config") return ok(config(url.searchParams.get("agent") || undefined));
+      if (url.pathname === "/api/workspace") return ok({ kind: "directory", path: "", parent: null, entries: [] });
+      if (url.pathname === "/api/models/codex" || url.pathname === "/api/models/pi" || url.pathname === "/api/models/builtin-pi") {
+        return ok({ models: [{ id: "default", label: "default" }, { id: "deepseek/deepseek-v4-pro", label: "DeepSeek" }] });
+      }
+      if (url.pathname === "/api/pi-auth/providers") {
+        return ok({
+          providers: [
+            { id: "deepseek", name: "DeepSeek（推荐）", provider: "deepseek", defaultModel: "deepseek/deepseek-v4-pro", custom: false, openaiCompatible: true },
+          ],
+        });
+      }
+      if (url.pathname === "/api/pi-auth/status") {
+        if (loginDone) return statusHold.promise;
+        return ok({ agentId: url.searchParams.get("agent"), model: "deepseek/deepseek-v4-pro", credentials: [] });
+      }
+      if (url.pathname === "/api/pi-auth/login" && init?.method === "POST") {
+        loginDone = true;
+        return ok({
+          ok: true, agentId: "cli_AgentC3", provider: "deepseek", preset: "deepseek",
+          model: "deepseek/deepseek-v4-pro", credentialType: "api_key", applyState: "saved_not_applied",
+        });
+      }
+      throw new Error(`unexpected request ${url}`);
+    }));
+    window.history.replaceState(null, "", "/?agent=cli_AgentC3&tab=configuration");
+    render(<App />);
+    await screen.findByRole("heading", { level: 3, name: "Provider Credentials" });
+    const key = await screen.findByLabelText("API Key");
+    await userEvent.type(key, secret);
+    await userEvent.click(screen.getByRole("button", { name: "保存 Provider" }));
+    await waitFor(() => expect(loginDone).toBe(true));
+    await waitFor(() => expect(screen.getByLabelText("API Key")).toHaveValue(""));
+    expect(screen.queryByText(secret)).not.toBeInTheDocument();
+    statusHold.resolve({ ok: true, status: 200, json: async () => ({ agentId: "cli_AgentC3", model: "deepseek/deepseek-v4-pro", credentials: [] }) });
   });
 });

--- a/test/integration/app/pi-auth-login-workflow.test.mjs
+++ b/test/integration/app/pi-auth-login-workflow.test.mjs
@@ -1,0 +1,172 @@
+import { test } from "bun:test";
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import fs from "node:fs";
+import http from "node:http";
+import os from "node:os";
+import path from "node:path";
+
+const ROOT = path.resolve(import.meta.dirname, "../../..");
+const ENTRY = path.join(ROOT, "dist/app/binary-entry.mjs");
+
+function startFakeProvider() {
+  let hits = 0;
+  const server = http.createServer((_request, response) => {
+    hits += 1;
+    response.writeHead(401, { "content-type": "application/json" });
+    response.end(JSON.stringify({ error: { message: "fake provider must not be contacted on save" } }));
+  });
+  return new Promise((resolve) => {
+    server.listen(0, "127.0.0.1", () => {
+      const { port } = server.address();
+      resolve({
+        port,
+        baseUrl: `http://127.0.0.1:${port}/v1`,
+        hits: () => hits,
+        close: () => new Promise((done) => server.close(done)),
+      });
+    });
+  });
+}
+
+test("compiled CLI login custom --api-key-stdin configures one Agent without leaking the key or touching a sibling", async () => {
+  const temp = fs.mkdtempSync(path.join(os.tmpdir(), "larkin-pi-auth-workflow-"));
+  const target = "cli_workflowTargetA1";
+  const other = "cli_workflowOtherB2";
+  const secret = "workflow-stdin-super-secret";
+  const provider = await startFakeProvider();
+  try {
+    fs.chmodSync(temp, 0o700);
+    fs.writeFileSync(path.join(temp, "config.json"), `${JSON.stringify({
+      version: 4, serverId: "server-workflow", mentionPolicy: "require", activeAgent: target,
+      agents: {
+        [target]: { runtime: "pi", piDistribution: "builtin", model: "deepseek/old-model", createdAt: "2026-09-04T00:00:00.000Z" },
+        [other]: { runtime: "pi", piDistribution: "builtin", model: "kimi/kimi-k2.6", createdAt: "2026-09-04T00:00:00.000Z" },
+      },
+    }, null, 2)}\n`, { mode: 0o600 });
+    for (const agentId of [target, other]) {
+      const directory = path.join(temp, "providers", "pi", agentId);
+      fs.mkdirSync(directory, { recursive: true, mode: 0o700 });
+      fs.chmodSync(directory, 0o700);
+    }
+    fs.writeFileSync(path.join(temp, "providers", "pi", other, "auth.json"), `${JSON.stringify({
+      "moonshotai-cn": { type: "api_key", key: "other-agent-secret" },
+    }, null, 2)}\n`, { mode: 0o600 });
+    const env = { ...process.env, LARKIN_CONFIG_DIR: temp, LARKIN_HOME: temp };
+    const login = spawnSync(process.execPath, [
+      ENTRY, "pi-auth", "login", "custom", "--agent", target,
+      "--base-url", provider.baseUrl, "--model", "fixture-model", "--api-key-stdin", "--json",
+    ], { cwd: ROOT, env, encoding: "utf8", input: `${secret}\n\n`, timeout: 30_000 });
+    assert.equal(login.status, 0, login.stderr + login.stdout);
+    const payload = JSON.parse(login.stdout);
+    assert.equal(payload.agentId, target);
+    assert.equal(payload.provider, "larkin-custom");
+    assert.equal(payload.model, "larkin-custom/fixture-model");
+    assert.equal(payload.credentialType, "api_key");
+    assert.ok(["saved_not_applied", "pending", "applied"].includes(payload.applyState));
+    assert.doesNotMatch(login.stdout + login.stderr, new RegExp(secret));
+
+    const capturedArgv = spawnSync(process.execPath, [
+      ENTRY, "pi-auth", "login", "custom", "--agent", target, "--base-url", provider.baseUrl,
+      "--model", "fixture-model", "--api-key", secret,
+    ], { cwd: ROOT, env, encoding: "utf8", timeout: 15_000 });
+    assert.notEqual(capturedArgv.status, 0);
+    assert.doesNotMatch(`${capturedArgv.stdout}\n${capturedArgv.stderr}`, new RegExp(secret));
+
+    const status = spawnSync(process.execPath, [ENTRY, "pi-auth", "status", "--agent", target, "--json"], {
+      cwd: ROOT, env, encoding: "utf8", timeout: 15_000,
+    });
+    assert.equal(status.status, 0, status.stderr);
+    const credentials = JSON.parse(status.stdout).credentials;
+    assert.ok(credentials.some((entry) => entry.providerId === "larkin-custom" && entry.credentialType === "api_key" && entry.stored));
+    assert.doesNotMatch(status.stdout + status.stderr, new RegExp(secret));
+
+    const config = JSON.parse(fs.readFileSync(path.join(temp, "config.json"), "utf8"));
+    assert.equal(config.agents[target].model, "larkin-custom/fixture-model");
+    assert.equal(config.agents[other].model, "kimi/kimi-k2.6");
+    const otherAuth = JSON.parse(fs.readFileSync(path.join(temp, "providers", "pi", other, "auth.json"), "utf8"));
+    assert.equal(otherAuth["moonshotai-cn"].key, "other-agent-secret");
+    const authPath = path.join(temp, "providers", "pi", target, "auth.json");
+    assert.equal(fs.statSync(authPath).mode & 0o777, 0o600);
+    assert.equal(fs.statSync(path.dirname(authPath)).mode & 0o777, 0o700);
+    const models = JSON.parse(fs.readFileSync(path.join(temp, "providers", "pi", target, "models.json"), "utf8"));
+    assert.equal(models.providers["larkin-custom"].baseUrl, provider.baseUrl.replace(/\/$/, ""));
+    assert.doesNotMatch(fs.readFileSync(path.join(temp, "providers", "pi", target, "models.json"), "utf8"), new RegExp(secret));
+    assert.equal(provider.hits(), 0, "save must not validate against the fake provider");
+  } finally {
+    await provider.close();
+    fs.rmSync(temp, { recursive: true, force: true });
+  }
+});
+
+test("compiled CLI login known preset --api-key-stdin binds the default model without a provider HTTP round-trip", async () => {
+  const temp = fs.mkdtempSync(path.join(os.tmpdir(), "larkin-pi-auth-preset-"));
+  const target = "cli_workflowPresetA1";
+  const other = "cli_workflowPresetB2";
+  const secret = "workflow-preset-super-secret";
+  try {
+    fs.chmodSync(temp, 0o700);
+    fs.writeFileSync(path.join(temp, "config.json"), `${JSON.stringify({
+      version: 4, serverId: "server-workflow-preset", mentionPolicy: "require", activeAgent: target,
+      agents: {
+        [target]: { runtime: "pi", piDistribution: "builtin", model: "deepseek/old-model", createdAt: "2026-09-04T00:00:00.000Z" },
+        [other]: { runtime: "pi", piDistribution: "builtin", model: "kimi/kimi-k2.6", createdAt: "2026-09-04T00:00:00.000Z" },
+      },
+    }, null, 2)}\n`, { mode: 0o600 });
+    for (const agentId of [target, other]) {
+      fs.mkdirSync(path.join(temp, "providers", "pi", agentId), { recursive: true, mode: 0o700 });
+      fs.chmodSync(path.join(temp, "providers", "pi", agentId), 0o700);
+    }
+    const env = { ...process.env, LARKIN_CONFIG_DIR: temp, LARKIN_HOME: temp, HOME: temp };
+    const login = spawnSync(process.execPath, [
+      ENTRY, "pi-auth", "login", "zhipu", "--agent", target, "--api-key-stdin", "--json",
+    ], { cwd: ROOT, env, encoding: "utf8", input: `${secret}\r\n\n`, timeout: 30_000 });
+    assert.equal(login.status, 0, login.stderr + login.stdout);
+    const payload = JSON.parse(login.stdout);
+    assert.equal(payload.provider, "zai-coding-cn");
+    assert.equal(payload.model, "zai-coding-cn/glm-5.2");
+    assert.equal(payload.credentialType, "api_key");
+    assert.doesNotMatch(login.stdout + login.stderr, new RegExp(secret));
+    const status = spawnSync(process.execPath, [ENTRY, "pi-auth", "status", "--agent", target, "--json"], {
+      cwd: ROOT, env, encoding: "utf8", timeout: 15_000,
+    });
+    assert.equal(status.status, 0, status.stderr);
+    const credentials = JSON.parse(status.stdout).credentials;
+    assert.ok(credentials.some((entry) => entry.providerId === "zai-coding-cn" && entry.stored));
+    assert.doesNotMatch(status.stdout + status.stderr, new RegExp(secret));
+    const config = JSON.parse(fs.readFileSync(path.join(temp, "config.json"), "utf8"));
+    assert.equal(config.agents[target].model, "zai-coding-cn/glm-5.2");
+    assert.equal(config.agents[other].model, "kimi/kimi-k2.6");
+  } finally { fs.rmSync(temp, { recursive: true, force: true }); }
+});
+
+test("compiled-service cancellation rolls back the target credential transaction", async () => {
+  const { configureBuiltinPiProvider } = await import(new URL(`file://${path.join(ROOT, "dist/runtime/pi-provider-login.mjs")}`).href);
+  const temp = fs.mkdtempSync(path.join(os.tmpdir(), "larkin-pi-auth-cancel-"));
+  const target = "cli_workflowCancelA1";
+  const original = { keep: { type: "api_key", key: "original-secret" } };
+  try {
+    fs.chmodSync(temp, 0o700);
+    fs.writeFileSync(path.join(temp, "config.json"), `${JSON.stringify({
+      version: 4, serverId: "server-workflow-cancel", mentionPolicy: "require", activeAgent: target,
+      agents: { [target]: { runtime: "pi", piDistribution: "builtin", model: "deepseek/old-model", createdAt: "2026-09-04T00:00:00.000Z" } },
+    }, null, 2)}\n`, { mode: 0o600 });
+    const directory = path.join(temp, "providers", "pi", target);
+    fs.mkdirSync(directory, { recursive: true, mode: 0o700 });
+    fs.chmodSync(directory, 0o700);
+    fs.writeFileSync(path.join(directory, "auth.json"), `${JSON.stringify(original, null, 2)}\n`, { mode: 0o600 });
+    const env = { ...process.env, LARKIN_CONFIG_DIR: temp, LARKIN_HOME: temp };
+    await assert.rejects(() => configureBuiltinPiProvider({
+      agentId: target, preset: "deepseek", apiKey: "cancel-workflow-secret", env,
+    }, {
+      createRuntime: async () => ({}),
+      runLogin: async () => {
+        const error = new Error("Pi auth login cancelled");
+        error.name = "AbortError";
+        throw error;
+      },
+    }), /cancelled/);
+    assert.deepEqual(JSON.parse(fs.readFileSync(path.join(directory, "auth.json"), "utf8")), original);
+    assert.equal(JSON.parse(fs.readFileSync(path.join(temp, "config.json"), "utf8")).agents[target].model, "deepseek/old-model");
+  } finally { fs.rmSync(temp, { recursive: true, force: true }); }
+});

--- a/test/integration/build/compiled-runtime-mock-e2e.test.mjs
+++ b/test/integration/build/compiled-runtime-mock-e2e.test.mjs
@@ -6,9 +6,21 @@ import net from "node:net";
 import os from "node:os";
 import path from "node:path";
 import { test } from "bun:test";
+import { BUNDLED_PI_VERSION } from "../../../dist/runtime/pi-provider-config.mjs";
+import { calculatePiCompactionSettings } from "../../../dist/runtime/pi-compaction-recovery.mjs";
 
 const ROOT = path.resolve(import.meta.dirname, "../../..");
 const enabled = process.env.LARKIN_RUN_COMPILED_RUNTIME_MOCK_E2E === "1";
+const PI_FIXTURE_CONTEXT_WINDOW = 32000;
+const piFixtureCompaction = calculatePiCompactionSettings(PI_FIXTURE_CONTEXT_WINDOW);
+const piFixtureCompactionCapabilities = {
+  reserveTokens: piFixtureCompaction.reserveTokens,
+  keepRecentTokens: piFixtureCompaction.keepRecentTokens,
+  events: ["compaction_start", "compaction_end", "agent_end", "agent_settled"],
+};
+const piFixtureSessionStats = {
+  contextUsage: { tokens: 0, contextWindow: PI_FIXTURE_CONTEXT_WINDOW },
+};
 
 function checked(command, args, options, label) {
   const result = spawnSync(command, args, { encoding: "utf8", ...options });
@@ -145,17 +157,20 @@ readline.createInterface({ input: process.stdin }).on("line", (line) => {
 
 const piFixtureSource = `import fs from "node:fs";
 import readline from "node:readline";
-if (process.argv.includes("--version")) { console.log("0.82.1"); process.exit(0); }
+if (process.argv.includes("--version")) { console.log(${JSON.stringify(BUNDLED_PI_VERSION)}); process.exit(0); }
 const marker = process.env.RUNTIME_PROTOCOL_MARKER;
 const record = (value) => fs.appendFileSync(marker, JSON.stringify(value) + "\\n");
-const model = { provider: "fixture", id: "pi-fixture", name: "Pi Fixture", reasoning: false, contextWindow: 32000 };
+const model = { provider: "fixture", id: "pi-fixture", name: "Pi Fixture", reasoning: false, contextWindow: ${PI_FIXTURE_CONTEXT_WINDOW} };
 record({ type: "launch", runtime: "pi", args: process.argv.slice(2) });
 readline.createInterface({ input: process.stdin }).on("line", (line) => {
   const request = JSON.parse(line);
   if (request.type === "get_state") process.stdout.write(JSON.stringify({ id: request.id, type: "response", command: request.type, success: true,
-    data: { sessionId: "session-compiled-pi", sessionFile: "/tmp/session-compiled-pi.jsonl", model, thinkingLevel: "off", isStreaming: false } }) + "\\n");
+    data: { sessionId: "session-compiled-pi", sessionFile: "/tmp/session-compiled-pi.jsonl", model, thinkingLevel: "off", isStreaming: false, autoCompactionEnabled: true, compactionCapabilities: ${JSON.stringify(piFixtureCompactionCapabilities)} } }) + "\\n");
   else if (request.type === "get_available_models") process.stdout.write(JSON.stringify({ id: request.id, type: "response", command: request.type, success: true,
     data: { models: [model] } }) + "\\n");
+  else if (request.type === "get_session_stats") process.stdout.write(JSON.stringify({ id: request.id, type: "response", command: request.type, success: true,
+    data: ${JSON.stringify(piFixtureSessionStats)} }) + "\\n");
+  else if (request.type === "compact") process.stdout.write(JSON.stringify({ id: request.id, type: "response", command: request.type, success: true }) + "\\n");
   else if (request.type === "prompt" || request.type === "steer") {
     record({ type: "protocol", runtime: "pi", method: request.type, request });
     process.stdout.write(JSON.stringify({ id: request.id, type: "response", command: request.type, success: true }) + "\\n");
@@ -321,8 +336,8 @@ test.skipIf(!enabled)("compiled Pi provider auth failure projects unauthenticate
     const piSource = path.join(home, "pi-auth-fixture.mjs");
     fs.writeFileSync(piSource, `import fs from "node:fs";
 import readline from "node:readline";
-if (process.argv.includes("--version")) { console.log("0.82.1"); process.exit(0); }
-const model = { provider: "bigmodel-anthropic", id: "glm-5.2", name: "GLM Fixture", reasoning: false, contextWindow: 32000 };
+if (process.argv.includes("--version")) { console.log(${JSON.stringify(BUNDLED_PI_VERSION)}); process.exit(0); }
+const model = { provider: "bigmodel-anthropic", id: "glm-5.2", name: "GLM Fixture", reasoning: false, contextWindow: ${PI_FIXTURE_CONTEXT_WINDOW} };
 let promptCount = 0;
 const output = (value) => process.stdout.write(JSON.stringify(value) + "\\n");
 const record = (value) => fs.appendFileSync(process.env.PI_AUTH_PROTOCOL_MARKER, JSON.stringify(value) + "\\n");
@@ -336,8 +351,10 @@ const successfulTurn = () => {
 readline.createInterface({ input: process.stdin }).on("line", (line) => {
   const request = JSON.parse(line);
   if (request.type === "get_state") return output({ id: request.id, type: "response", command: request.type, success: true,
-    data: { sessionId: "session-compiled-pi-auth", sessionFile: "/tmp/session.jsonl", model, thinkingLevel: "off", isStreaming: false } });
+    data: { sessionId: "session-compiled-pi-auth", sessionFile: "/tmp/session.jsonl", model, thinkingLevel: "off", isStreaming: false, autoCompactionEnabled: true, compactionCapabilities: ${JSON.stringify(piFixtureCompactionCapabilities)} } });
   if (request.type === "get_available_models") return output({ id: request.id, type: "response", command: request.type, success: true, data: { models: [model] } });
+  if (request.type === "get_session_stats") return output({ id: request.id, type: "response", command: request.type, success: true, data: ${JSON.stringify(piFixtureSessionStats)} });
+  if (request.type === "compact") return output({ id: request.id, type: "response", command: request.type, success: true });
   if (request.type === "prompt") {
     promptCount += 1;
     record({ type: "call", method: "prompt", promptCount });

--- a/test/integration/dashboard/dashboard-config-security.test.mjs
+++ b/test/integration/dashboard/dashboard-config-security.test.mjs
@@ -100,3 +100,67 @@ test("dashboard config API is sanitized, same-origin/CSRF protected, bounded, an
     fs.rmSync(root, { recursive: true, force: true });
   }
 });
+
+test("dashboard pi-auth API is loopback/CSRF protected, bounded, and never echoes an API key", async () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "larkin-dashboard-pi-auth-sec-"));
+  const port = await freePort();
+  const secret = "dashboard-security-super-secret";
+  fs.writeFileSync(path.join(root, "config.json"), `${JSON.stringify({
+    version: 4, serverId: "server-secret-internal", activeAgent: APP, mentionPolicy: "require",
+    agents: { [APP]: { runtime: "pi", piDistribution: "builtin", model: "default", createdAt: "2026-09-04T00:00:00.000Z" } },
+  })}\n`, { mode: 0o600 });
+  fs.mkdirSync(path.join(root, "providers", "pi", APP), { recursive: true, mode: 0o700 });
+  const child = spawn(process.execPath, [path.join(ROOT, "dist/app/dashboard.mjs"), "--port", String(port)], {
+    cwd: ROOT, env: { ...process.env, LARKIN_CONFIG_DIR: root }, stdio: ["ignore", "pipe", "pipe"],
+  });
+  let output = "";
+  child.stdout.on("data", (chunk) => { output += chunk; });
+  child.stderr.on("data", (chunk) => { output += chunk; });
+  try {
+    const deadline = Date.now() + 5_000;
+    while (!output.includes(`http://localhost:${port}`) && Date.now() < deadline) await new Promise((resolve) => setTimeout(resolve, 25));
+    assert.match(output, new RegExp(`http://localhost:${port}`));
+    const base = `http://localhost:${port}`;
+    const page = await fetch(`${base}/`).then((response) => response.text());
+    const csrf = JSON.parse(page.match(/"csrfCapability":("[^"]+")/)?.[1] || "null");
+    const privateHeaders = { "X-Larkin-CSRF": csrf };
+    const catalog = await fetch(`${base}/api/pi-auth/providers`, { headers: privateHeaders }).then((response) => {
+      assert.equal(response.headers.get("cache-control"), "no-store");
+      return response.json();
+    });
+    assert.ok(Array.isArray(catalog.providers));
+    assert.ok(catalog.providers.some((entry) => entry.id === "custom" && entry.openaiCompatible));
+    assert.doesNotMatch(JSON.stringify(catalog), new RegExp(secret));
+
+    const raw = JSON.stringify({ agentId: APP, preset: "deepseek", apiKey: secret });
+    const rejected = [
+      await fetch(`${base}/api/pi-auth/login`, { method: "POST", headers: { "Content-Type": "application/json" }, body: raw }),
+      await fetch(`${base}/api/pi-auth/login`, { method: "POST", headers: { "Content-Type": "application/json", Origin: "https://evil.example", "X-Larkin-CSRF": csrf }, body: raw }),
+      await fetch(`${base}/api/pi-auth/login`, { method: "POST", headers: { "Content-Type": "application/json", Origin: base, "X-Larkin-CSRF": "wrong" }, body: raw }),
+      await fetch(`${base}/api/pi-auth/login`, { method: "POST", headers: { "Content-Type": "application/json", Origin: base, "X-Larkin-CSRF": csrf }, body: JSON.stringify({ agentId: APP, preset: "deepseek", apiKey: secret, padding: "x".repeat(17_000) }) }),
+    ];
+    assert.deepEqual(rejected.map((response) => response.status), [400, 400, 400, 400]);
+    for (const response of rejected) {
+      const body = await response.text();
+      assert.doesNotMatch(body, new RegExp(secret));
+    }
+    const accepted = await fetch(`${base}/api/pi-auth/login`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json", Origin: base, "X-Larkin-CSRF": csrf },
+      body: JSON.stringify({
+        agentId: APP, preset: "custom", apiKey: secret,
+        baseUrl: "http://127.0.0.1:1/v1", model: "fixture-model",
+      }),
+    });
+    const acceptedBody = await accepted.text();
+    assert.doesNotMatch(acceptedBody, new RegExp(secret));
+    assert.doesNotMatch(output, new RegExp(secret));
+    assert.equal(accepted.headers.get("cache-control"), "no-store");
+    assert.ok([200, 400].includes(accepted.status));
+  } finally {
+    child.kill("SIGINT");
+    await Promise.race([new Promise((resolve) => child.once("exit", resolve)), new Promise((resolve) => setTimeout(resolve, 3_000))]);
+    if (child.exitCode === null && child.signalCode === null) child.kill("SIGKILL");
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});

--- a/test/integration/dashboard/dashboard-pi-auth-workflow.test.mjs
+++ b/test/integration/dashboard/dashboard-pi-auth-workflow.test.mjs
@@ -1,0 +1,134 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import http from "node:http";
+import os from "node:os";
+import path from "node:path";
+import { onTestFinished, test } from "bun:test";
+import { Readable } from "node:stream";
+import { fileURLToPath, pathToFileURL } from "node:url";
+
+const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..", "..", "..");
+const CONTROLLER = pathToFileURL(path.join(ROOT, "dist/dashboard/dashboard-config-controller.mjs")).href;
+const APP = "cli_dashboardWorkflowA1";
+const OTHER = "cli_dashboardWorkflowB2";
+
+function startFakeProvider() {
+  let hits = 0;
+  const server = http.createServer((_request, response) => {
+    hits += 1;
+    response.writeHead(401, { "content-type": "application/json" });
+    response.end(JSON.stringify({ error: { message: "fake provider must not be contacted on save" } }));
+  });
+  return new Promise((resolve) => {
+    server.listen(0, "127.0.0.1", () => {
+      const { port } = server.address();
+      resolve({
+        baseUrl: `http://127.0.0.1:${port}/v1`,
+        hits: () => hits,
+        close: () => new Promise((done) => server.close(done)),
+      });
+    });
+  });
+}
+
+function seedHome() {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "larkin-dashboard-pi-auth-wf-"));
+  fs.chmodSync(root, 0o700);
+  fs.writeFileSync(path.join(root, "config.json"), `${JSON.stringify({
+    version: 4, serverId: "server-dashboard-pi-auth-wf", mentionPolicy: "require", activeAgent: APP,
+    agents: {
+      [APP]: { runtime: "pi", piDistribution: "builtin", model: "deepseek/old", createdAt: "2026-09-04T00:00:00.000Z" },
+      [OTHER]: { runtime: "pi", piDistribution: "builtin", model: "kimi/kimi-k2.6", createdAt: "2026-09-04T00:00:00.000Z" },
+    },
+  })}\n`, { mode: 0o600 });
+  for (const agentId of [APP, OTHER]) {
+    fs.mkdirSync(path.join(root, "state", "agents", agentId), { recursive: true, mode: 0o700 });
+    fs.mkdirSync(path.join(root, "providers", "pi", agentId), { recursive: true, mode: 0o700 });
+    fs.chmodSync(path.join(root, "providers", "pi", agentId), 0o700);
+  }
+  return { root, env: { ...process.env, LARKIN_CONFIG_DIR: root, LARKIN_HOME: root, HOME: root } };
+}
+
+function captureResponse() {
+  let status = 0;
+  let headers = {};
+  let body = "";
+  return {
+    res: {
+      writeHead(value, next) { status = value; headers = next || {}; },
+      end(value = "") { body += String(value); },
+    },
+    value() { return { status, headers, body: body ? JSON.parse(body) : null }; },
+  };
+}
+
+async function get(controller, pathname) {
+  const response = captureResponse();
+  await controller.handle(
+    { method: "GET", headers: { host: "localhost:9996", "x-larkin-csrf": "test" } },
+    response.res,
+    new URL(pathname, "http://localhost"),
+  );
+  return response.value();
+}
+
+async function post(controller, pathname, body) {
+  const request = Readable.from([JSON.stringify(body)]);
+  request.method = "POST";
+  request.headers = {
+    host: "localhost:9996",
+    origin: "http://localhost:9996",
+    "content-type": "application/json",
+    "x-larkin-csrf": "test",
+  };
+  const response = captureResponse();
+  await controller.handle(request, response.res, new URL(pathname, "http://localhost"));
+  return response.value();
+}
+
+test("Dashboard login uses the real provider service and returns redacted status/model", async () => {
+  const { createDashboardConfigController } = await import(`${CONTROLLER}?wf=${Date.now()}`);
+  const f = seedHome();
+  const provider = await startFakeProvider();
+  onTestFinished(async () => {
+    await provider.close();
+    fs.rmSync(f.root, { recursive: true, force: true });
+  });
+  const controller = createDashboardConfigController({ csrfCapability: "test", env: f.env });
+  const secret = "dashboard-workflow-super-secret";
+
+  const custom = await post(controller, "/api/pi-auth/login", {
+    agentId: APP, preset: "custom", apiKey: secret, baseUrl: provider.baseUrl, model: "fixture-model",
+  });
+  assert.equal(custom.status, 200, JSON.stringify(custom.body));
+  assert.equal(custom.body.provider, "larkin-custom");
+  assert.equal(custom.body.model, "larkin-custom/fixture-model");
+  assert.equal(custom.body.credentialType, "api_key");
+  assert.equal(Object.hasOwn(custom.body, "apiKey"), false);
+  assert.doesNotMatch(JSON.stringify(custom.body), new RegExp(secret));
+  assert.equal(custom.headers["Cache-Control"], "no-store");
+  assert.equal(provider.hits(), 0);
+
+  const status = await get(controller, `/api/pi-auth/status?agent=${APP}`);
+  assert.equal(status.status, 200);
+  assert.equal(status.body.model, "larkin-custom/fixture-model");
+  assert.ok(status.body.credentials.some((entry) => entry.providerId === "larkin-custom" && entry.stored));
+  assert.doesNotMatch(JSON.stringify(status.body), new RegExp(secret));
+
+  const sibling = await get(controller, `/api/pi-auth/status?agent=${OTHER}`);
+  assert.equal(sibling.status, 200);
+  assert.equal(sibling.body.model, "kimi/kimi-k2.6");
+  assert.equal((sibling.body.credentials || []).some((entry) => entry.providerId === "larkin-custom"), false);
+
+  const known = await post(controller, "/api/pi-auth/login", {
+    agentId: APP, preset: "zhipu", apiKey: secret,
+  });
+  assert.equal(known.status, 200, JSON.stringify(known.body));
+  assert.equal(known.body.provider, "zai-coding-cn");
+  assert.equal(known.body.model, "zai-coding-cn/glm-5.2");
+  assert.doesNotMatch(JSON.stringify(known.body), new RegExp(secret));
+  const afterKnown = await get(controller, `/api/pi-auth/status?agent=${APP}`);
+  assert.equal(afterKnown.body.model, "zai-coding-cn/glm-5.2");
+  assert.ok(afterKnown.body.credentials.some((entry) => entry.providerId === "zai-coding-cn" && entry.stored));
+  assert.equal(JSON.parse(fs.readFileSync(path.join(f.root, "config.json"), "utf8")).agents[OTHER].model, "kimi/kimi-k2.6");
+});

--- a/test/unit/app/agent-config-typescript.test.mjs
+++ b/test/unit/app/agent-config-typescript.test.mjs
@@ -215,6 +215,7 @@ test("Pi distribution CLI refuses builtin without provider state before writing 
     });
     assert.equal(result.status, 1, result.stderr);
     assert.match(result.stderr, /provider 尚未.*配置/);
+    assert.doesNotMatch(result.stderr, /import-external-profile|重新运行 larkin setup/);
     assert.doesNotMatch(result.stderr, new RegExp(temp.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")));
     assert.equal(fs.readFileSync(path.join(temp, "config.json"), "utf8"), initial);
     assert.equal(fs.existsSync(snapshot), false, "failed provider preflight must not create a rollback snapshot");
@@ -686,7 +687,8 @@ test("larkin runtime accepts sibling builtin-pi and persists storage projection"
 
     const refused = run("runtime", "builtin-pi", "--agent", app);
     assert.notEqual(refused.status, 0);
-    assert.match(`${refused.stdout}\n${refused.stderr}`, /无法切换到 builtin-pi|larkin setup/);
+    assert.match(`${refused.stdout}\n${refused.stderr}`, /无法切换到 builtin-pi|pi-auth login/);
+    assert.doesNotMatch(`${refused.stdout}\n${refused.stderr}`, /import-external-profile|重新运行 larkin setup/);
     assert.equal(JSON.parse(fs.readFileSync(path.join(temp, "config.json"), "utf8")).agents[app].piDistribution, "external");
 
     const providerDir = path.join(temp, "providers", "pi", app);

--- a/test/unit/app/local-control.test.mjs
+++ b/test/unit/app/local-control.test.mjs
@@ -128,6 +128,17 @@ test("local control keeps upsert ID idempotency and coalesces only concurrent re
     assert.equal(invalid.ok, false);
     assert.match(invalid.error, /未知字段/);
     assert.doesNotMatch(output, /must-not-pass/);
+    const badSignature = await rawRequest(socket, {
+      operationId: "operation_bad_sig_1", agentId: "cli_newA1", authorization: authority.token,
+      expectedSignature: "not-a-signature",
+    });
+    assert.equal(badSignature.ok, false);
+    assert.match(badSignature.error, /expectedSignature/);
+    const signed = await requestAgentUpsert({
+      larkinHome: root, agentId: "cli_newA1", operationId: "operation_signed_1",
+      expectedSignature: `sha256:${"a".repeat(64)}`,
+    });
+    assert.equal(signed.ok, true);
 
     const resetCalls = () => fs.readFileSync(calls, "utf8").trim().split("\n").filter((line) => line.startsWith("reset:")).length;
     const [reset, concurrentReset] = await Promise.all([

--- a/test/unit/app/pi-auth-cli.test.mjs
+++ b/test/unit/app/pi-auth-cli.test.mjs
@@ -1,6 +1,6 @@
 import { test } from "bun:test";
 import assert from "node:assert/strict";
-import { spawnSync } from "node:child_process";
+import { spawn, spawnSync } from "node:child_process";
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
@@ -56,5 +56,163 @@ test("public pi-auth status is non-sensitive and logout preserves unrelated prov
     assert.doesNotMatch(logout.stdout + logout.stderr, new RegExp(`${deepseekKey}|${oauthAccess}|oauth-refresh-secret`));
     assert.equal(fs.statSync(directory).mode & 0o777, 0o700);
     assert.equal(fs.statSync(authPath).mode & 0o777, 0o600);
+  } finally { fs.rmSync(temp, { recursive: true, force: true }); }
+});
+
+test("pi-auth providers is a redacted catalog and login rejects API keys in argv", () => {
+  const temp = fs.mkdtempSync(path.join(os.tmpdir(), "larkin-pi-auth-login-cli-"));
+  const agentId = "cli_authCliB2";
+  const secret = "argv-super-secret-key";
+  try {
+    fs.chmodSync(temp, 0o700);
+    fs.writeFileSync(path.join(temp, "config.json"), `${JSON.stringify({
+      version: 4, serverId: "server-auth-cli-login", mentionPolicy: "require", activeAgent: agentId,
+      agents: { [agentId]: { runtime: "pi", piDistribution: "builtin", model: "default", createdAt: "2026-09-04T00:00:00.000Z" } },
+    }, null, 2)}\n`, { mode: 0o600 });
+    fs.mkdirSync(path.join(temp, "providers", "pi", agentId), { recursive: true, mode: 0o700 });
+    const env = { ...process.env, LARKIN_CONFIG_DIR: temp, LARKIN_HOME: temp };
+    const providers = spawnSync(process.execPath, ["dist/app/binary-entry.mjs", "pi-auth", "providers", "--json"], {
+      cwd: ROOT, env, encoding: "utf8", timeout: 15_000,
+    });
+    assert.equal(providers.status, 0, providers.stderr);
+    const catalog = JSON.parse(providers.stdout);
+    assert.ok(catalog.providers.some((entry) => entry.id === "deepseek" && entry.defaultModel === "deepseek/deepseek-v4-pro"));
+    assert.ok(catalog.providers.some((entry) => entry.id === "custom" && entry.openaiCompatible && entry.custom));
+    assert.doesNotMatch(providers.stdout, /api[_-]?key|sk-|Bearer /i);
+
+    const rejected = spawnSync(process.execPath, [
+      "dist/app/binary-entry.mjs", "pi-auth", "login", "deepseek", "--agent", agentId, "--api-key", secret,
+    ], { cwd: ROOT, env, encoding: "utf8", timeout: 15_000 });
+    assert.notEqual(rejected.status, 0);
+    assert.match(`${rejected.stdout}\n${rejected.stderr}`, /api-key-stdin|TTY prompt/i);
+    assert.doesNotMatch(`${rejected.stdout}\n${rejected.stderr}`, new RegExp(secret));
+    assert.equal(fs.existsSync(path.join(temp, "providers", "pi", agentId, "auth.json")), false);
+  } finally { fs.rmSync(temp, { recursive: true, force: true }); }
+});
+
+test("stdin API key strips every trailing newline and leaves embedded newlines rejected", async () => {
+  const { normalizeStdinApiKey } = await import(new URL(`file://${path.join(ROOT, "dist/app/pi-auth-cli.mjs")}`).href);
+  assert.equal(normalizeStdinApiKey("secret\n"), "secret");
+  assert.equal(normalizeStdinApiKey("secret\n\n"), "secret");
+  assert.equal(normalizeStdinApiKey("secret\r\n\r\n"), "secret");
+  assert.equal(normalizeStdinApiKey("secret\r\n\n"), "secret");
+  assert.equal(normalizeStdinApiKey("\uFEFFsecret\n\n"), "secret");
+  assert.equal(normalizeStdinApiKey("sec\nret\n\n"), "sec\nret");
+});
+
+function startNeverEndingKeyPipe(prefix) {
+  return spawn(process.execPath, ["-e", `
+    process.stdout.write(${JSON.stringify(prefix)} + "A".repeat(20_000));
+    setInterval(() => {
+      try { process.stdout.write("B".repeat(4096)); } catch { /* 读端关闭后停止 */ }
+    }, 10);
+  `], { stdio: ["ignore", "pipe", "pipe"] });
+}
+
+test("bounded stdin strips trailing newlines on the fd path and rejects an oversized pipe before EOF", async () => {
+  const { readStdinSecret } = await import(new URL(`file://${path.join(ROOT, "dist/app/pi-auth-cli.mjs")}`).href);
+  const temp = fs.mkdtempSync(path.join(os.tmpdir(), "larkin-pi-auth-stdin-bound-"));
+  const secret = "bounded-fd-newline-secret";
+  const sentinel = "oversize-pipe-secret-sentinel";
+  const writer = startNeverEndingKeyPipe(sentinel);
+  try {
+    fs.writeFileSync(path.join(temp, "key"), `\uFEFF${secret}\r\n\n`);
+    const fd = fs.openSync(path.join(temp, "key"), "r");
+    try {
+      assert.equal(await readStdinSecret({ fd, isTTY: false }), secret);
+    } finally { fs.closeSync(fd); }
+
+    fs.writeFileSync(path.join(temp, "oversize"), `${sentinel}${"A".repeat(20_000)}${"C".repeat(64_000)}`);
+    const oversizeFd = fs.openSync(path.join(temp, "oversize"), "r");
+    try {
+      await assert.rejects(() => readStdinSecret({ fd: oversizeFd, isTTY: false }), (error) => {
+        assert.match(String(error.message), /API Key|控制字符/);
+        assert.doesNotMatch(`${error.message}\n${JSON.stringify(error)}`, new RegExp(sentinel));
+        return true;
+      });
+    } finally { fs.closeSync(oversizeFd); }
+
+    const started = Date.now();
+    await assert.rejects(() => readStdinSecret(writer.stdout), (error) => {
+      assert.match(String(error.message), /API Key|控制字符/);
+      assert.doesNotMatch(`${error.message}\n${JSON.stringify(error)}`, new RegExp(sentinel));
+      return true;
+    });
+    assert.ok(Date.now() - started < 2_000, "must reject the oversized pipe without waiting for EOF");
+  } finally {
+    writer.kill("SIGTERM");
+    fs.rmSync(temp, { recursive: true, force: true });
+  }
+});
+
+test("oversized --api-key-stdin pipe does not persist or leak before daemon apply", async () => {
+  const temp = fs.mkdtempSync(path.join(os.tmpdir(), "larkin-pi-auth-oversize-"));
+  const agentId = "cli_authCliOversize1";
+  const sentinel = "compiled-oversize-pipe-secret";
+  fs.chmodSync(temp, 0o700);
+  fs.writeFileSync(path.join(temp, "config.json"), `${JSON.stringify({
+    version: 4, serverId: "server-auth-oversize", mentionPolicy: "require", activeAgent: agentId,
+    agents: { [agentId]: { runtime: "pi", piDistribution: "builtin", model: "default", createdAt: "2026-09-04T00:00:00.000Z" } },
+  }, null, 2)}\n`, { mode: 0o600 });
+  fs.mkdirSync(path.join(temp, "providers", "pi", agentId), { recursive: true, mode: 0o700 });
+  const login = spawn(process.execPath, [
+    path.join(ROOT, "dist/app/binary-entry.mjs"),
+    "pi-auth", "login", "deepseek", "--agent", agentId, "--api-key-stdin", "--json",
+  ], {
+    cwd: ROOT,
+    env: { ...process.env, LARKIN_CONFIG_DIR: temp, LARKIN_HOME: temp },
+    stdio: ["pipe", "pipe", "pipe"],
+  });
+  try {
+    login.stdin.write(`${sentinel}${"A".repeat(20_000)}`);
+    const pump = setInterval(() => {
+      if (!login.stdin.writableEnded) {
+        try { login.stdin.write("B".repeat(4096)); } catch { /* 子进程已退出 */ }
+      }
+    }, 10);
+    const finished = await new Promise((resolve, reject) => {
+      const timer = setTimeout(() => reject(new Error("compiled CLI hung waiting for stdin EOF")), 3_000);
+      let stdout = "";
+      let stderr = "";
+      login.stdout.on("data", (chunk) => { stdout += chunk; });
+      login.stderr.on("data", (chunk) => { stderr += chunk; });
+      login.on("error", (error) => {
+        clearTimeout(timer);
+        clearInterval(pump);
+        reject(error);
+      });
+      login.on("exit", (status) => {
+        clearTimeout(timer);
+        clearInterval(pump);
+        resolve({ status, stdout, stderr });
+      });
+    });
+    assert.notEqual(finished.status, 0);
+    assert.match(`${finished.stdout}\n${finished.stderr}`, /API Key|控制字符|api-key-stdin/i);
+    assert.doesNotMatch(`${finished.stdout}\n${finished.stderr}`, new RegExp(sentinel));
+    assert.equal(fs.existsSync(path.join(temp, "providers", "pi", agentId, "auth.json")), false);
+  } finally {
+    if (login.exitCode === null && login.signalCode === null) login.kill("SIGTERM");
+    fs.rmSync(temp, { recursive: true, force: true });
+  }
+});
+
+test("non-TTY login without --api-key-stdin is rejected and does not persist", async () => {
+  const temp = fs.mkdtempSync(path.join(os.tmpdir(), "larkin-pi-auth-nontty-"));
+  const agentId = "cli_authCliC3";
+  try {
+    fs.chmodSync(temp, 0o700);
+    fs.writeFileSync(path.join(temp, "config.json"), `${JSON.stringify({
+      version: 4, serverId: "server-auth-nontty", mentionPolicy: "require", activeAgent: agentId,
+      agents: { [agentId]: { runtime: "pi", piDistribution: "builtin", model: "default", createdAt: "2026-09-04T00:00:00.000Z" } },
+    }, null, 2)}\n`, { mode: 0o600 });
+    fs.mkdirSync(path.join(temp, "providers", "pi", agentId), { recursive: true, mode: 0o700 });
+    const { main } = await import(new URL(`file://${path.join(ROOT, "dist/app/pi-auth-cli.mjs")}`).href);
+    await assert.rejects(() => main(
+      ["login", "deepseek", "--agent", agentId],
+      { ...process.env, LARKIN_CONFIG_DIR: temp, LARKIN_HOME: temp },
+      { stdin: process.stdin, stdout: process.stdout, isTTY: false },
+    ), /api-key-stdin/);
+    assert.equal(fs.existsSync(path.join(temp, "providers", "pi", agentId, "auth.json")), false);
   } finally { fs.rmSync(temp, { recursive: true, force: true }); }
 });

--- a/test/unit/app/runtime-process-config-apply.test.mjs
+++ b/test/unit/app/runtime-process-config-apply.test.mjs
@@ -12,6 +12,9 @@ const configApi = require(path.join(ROOT, "dist", "platform", "config.cjs"));
 const { applyRuntimeAgentUpsert, loadAndSyncRuntimeAgent, markConfigAppliedAfterRuntimeReady } = await import(
   pathToFileURL(path.join(ROOT, "dist", "app", "runtime-process.mjs")).href
 );
+const runtimeAgentConfig = await import(
+  pathToFileURL(path.join(ROOT, "dist", "app", "runtime-agent-config.mjs")).href
+);
 
 test("runtime startup projects applied only after initialization resolves successfully", async () => {
   const root = fs.mkdtempSync(path.join(os.tmpdir(), "larkin-runtime-ready-"));
@@ -65,14 +68,12 @@ test("expected-signature mismatch refuses load before hydrate or profile sync", 
   } finally { fs.rmSync(root, { recursive: true, force: true }); }
 });
 
-function seedBuiltinApplyHome() {
-  const root = fs.mkdtempSync(path.join(os.tmpdir(), "larkin-runtime-upsert-race-"));
+function seedBuiltinApplyHome(label, agentId, otherId) {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), `larkin-runtime-upsert-${label}-`));
   fs.chmodSync(root, 0o700);
-  const agentId = "cli_runtimeRaceA1";
-  const otherId = "cli_runtimeRaceB2";
   const env = { ...process.env, LARKIN_CONFIG_DIR: root, LARKIN_HOME: root };
   fs.writeFileSync(path.join(root, "config.json"), `${JSON.stringify({
-    version: 4, serverId: "server-runtime-race", mentionPolicy: "require", activeAgent: agentId,
+    version: 4, serverId: `server-runtime-${label}`, mentionPolicy: "require", activeAgent: agentId,
     agents: {
       [agentId]: { runtime: "pi", piDistribution: "builtin", model: "deepseek/deepseek-v4-pro" },
       [otherId]: { runtime: "pi", piDistribution: "builtin", model: "kimi/kimi-k2.6" },
@@ -80,6 +81,7 @@ function seedBuiltinApplyHome() {
   })}\n`, { mode: 0o600 });
   const botsDir = path.join(root, "bots");
   fs.mkdirSync(botsDir, { recursive: true, mode: 0o700 });
+  fs.chmodSync(botsDir, 0o700);
   for (const id of [agentId, otherId]) {
     fs.writeFileSync(path.join(botsDir, `${id}.json`), JSON.stringify({
       appId: id, appSecret: "fixture-secret", tenant: "feishu", updatedAt: "2026-09-05T00:00:00.000Z",
@@ -89,8 +91,34 @@ function seedBuiltinApplyHome() {
   return { root, agentId, otherId, env };
 }
 
+function seedValidSignedProfile(env, agentId) {
+  const loaded = configApi.loadConfig(env);
+  const hydrated = runtimeAgentConfig.hydrateRuntimeAgent(loaded.configDir, loaded.config.agents[agentId]);
+  for (const directory of [
+    hydrated.larkConfigDir,
+    path.join(hydrated.larkConfigDir, "lark-channel"),
+    path.dirname(path.join(hydrated.stateDir, "lark-channel-source", "config.json")),
+  ]) {
+    fs.mkdirSync(directory, { recursive: true, mode: 0o700 });
+    fs.chmodSync(directory, 0o700);
+  }
+  const sourceFile = path.join(hydrated.stateDir, "lark-channel-source", "config.json");
+  const workspaceFile = path.join(hydrated.larkConfigDir, "lark-channel", "config.json");
+  fs.writeFileSync(sourceFile, `${JSON.stringify(runtimeAgentConfig.sourceProjection(hydrated, env), null, 2)}\n`, { mode: 0o600 });
+  fs.writeFileSync(workspaceFile, `${JSON.stringify({ apps: [{
+    appId: agentId,
+    appSecret: { source: "keychain", id: `appsecret:${agentId}` },
+    defaultAs: "bot",
+    strictMode: "bot",
+    users: [],
+  }] }, null, 2)}\n`, { mode: 0o600 });
+  runtimeAgentConfig.installRuntimeCommandShims(hydrated);
+  runtimeAgentConfig.validateAgentProfile(hydrated);
+  return { lockFile: path.join(loaded.configDir, "config.json.lock") };
+}
+
 test("a switch after signature validation cannot profile-sync or Host-upsert the stale Agent", async () => {
-  const { root, agentId, otherId, env } = seedBuiltinApplyHome();
+  const { root, agentId, otherId, env } = seedBuiltinApplyHome("race-20260905", "cli_runtimeRaceA1", "cli_runtimeRaceB2");
   let synced = false;
   const hostUpserts = [];
   try {
@@ -115,5 +143,42 @@ test("a switch after signature validation cannot profile-sync or Host-upsert the
     assert.equal(current.agents[agentId].piDistribution, "external");
     assert.equal(current.agents[agentId].model, "deepseek/deepseek-v4-pro");
     assert.equal(current.agents[otherId].model, "kimi/kimi-k2.6");
+  } finally { fs.rmSync(root, { recursive: true, force: true }); }
+});
+
+test("signed applyRuntimeAgentUpsert holds the config lock through one Host upsert then releases it", async () => {
+  const { root, agentId, env } = seedBuiltinApplyHome("success-20260905", "cli_runtimeOkA1", "cli_runtimeOkB2");
+  const hostUpserts = [];
+  let synced = false;
+  let lockHeldDuringUpsert = false;
+  try {
+    const { lockFile } = seedValidSignedProfile(env, agentId);
+    const expected = configApi.runtimeConfigSignature(configApi.loadConfig(env).config, agentId);
+    assert.equal(fs.existsSync(lockFile), false, "fixture setup must not leave the config lock held");
+    const agent = await applyRuntimeAgentUpsert(env, agentId, {
+      runOfficialCli: () => {
+        synced = true;
+        throw new Error("valid profile must not rebind during signed Host upsert");
+      },
+    }, { expectedSignature: expected }, (candidate) => {
+      lockHeldDuringUpsert = true;
+      assert.equal(fs.existsSync(lockFile), true, "config lock must span the Host upsert");
+      assert.throws(() => fs.openSync(lockFile, "wx", 0o600), { code: "EEXIST" });
+      hostUpserts.push({
+        agentId: candidate.agentId,
+        runtime: candidate.runtime,
+        piDistribution: candidate.piDistribution,
+      });
+    });
+    assert.equal(synced, false);
+    assert.equal(lockHeldDuringUpsert, true);
+    assert.equal(hostUpserts.length, 1);
+    assert.deepEqual(hostUpserts[0], { agentId, runtime: "pi", piDistribution: "builtin" });
+    assert.equal(agent.runtime, "pi");
+    assert.equal(agent.piDistribution, "builtin");
+    assert.equal(fs.existsSync(lockFile), false, "config lock must be released after Host upsert");
+    const after = configApi.mutateConfig(env, { kind: "set-agent-model", agentId, model: "deepseek/deepseek-v4-pro" }, { kind: "user" });
+    assert.equal(after.persisted, true);
+    assert.equal(fs.existsSync(lockFile), false);
   } finally { fs.rmSync(root, { recursive: true, force: true }); }
 });

--- a/test/unit/app/runtime-process-config-apply.test.mjs
+++ b/test/unit/app/runtime-process-config-apply.test.mjs
@@ -9,7 +9,7 @@ import { fileURLToPath, pathToFileURL } from "node:url";
 const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..", "..", "..");
 const require = createRequire(import.meta.url);
 const configApi = require(path.join(ROOT, "dist", "platform", "config.cjs"));
-const { markConfigAppliedAfterRuntimeReady } = await import(
+const { loadAndSyncRuntimeAgent, markConfigAppliedAfterRuntimeReady } = await import(
   pathToFileURL(path.join(ROOT, "dist", "app", "runtime-process.mjs")).href
 );
 
@@ -40,5 +40,27 @@ test("runtime startup projects applied only after initialization resolves succes
     loaded = configApi.loadConfig(env).config;
     assert.equal(configApi.configApplyState(env, loaded).agents[agentId].applyState, "applied",
       "successful runtime readiness may publish the matching config signature");
+  } finally { fs.rmSync(root, { recursive: true, force: true }); }
+});
+
+test("expected-signature mismatch refuses load before hydrate or profile sync", () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "larkin-runtime-upsert-cas-"));
+  const agentId = "cli_runtimeCasA1";
+  const env = { ...process.env, LARKIN_CONFIG_DIR: root, LARKIN_HOME: root };
+  let synced = false;
+  try {
+    fs.writeFileSync(path.join(root, "config.json"), `${JSON.stringify({
+      version: 4, serverId: "server-runtime-cas", mentionPolicy: "require", activeAgent: agentId,
+      agents: { [agentId]: { runtime: "pi", piDistribution: "builtin", model: "deepseek/deepseek-v4-pro" } },
+    })}\n`, { mode: 0o600 });
+    const expected = configApi.runtimeConfigSignature(configApi.loadConfig(env).config, agentId);
+    configApi.mutateConfig(env, { kind: "set-agent-pi-distribution", agentId, distribution: "external" }, { kind: "user" });
+    assert.throws(() => loadAndSyncRuntimeAgent(env, agentId, {
+      runOfficialCli: () => { synced = true; throw new Error("profile sync must not run"); },
+    }, { expectedSignature: expected }), /配置在 apply 期间发生变化|未热加载/);
+    assert.equal(synced, false);
+    const current = configApi.loadConfig(env).config.agents[agentId];
+    assert.equal(current.runtime, "pi");
+    assert.equal(current.piDistribution, "external");
   } finally { fs.rmSync(root, { recursive: true, force: true }); }
 });

--- a/test/unit/app/runtime-process-config-apply.test.mjs
+++ b/test/unit/app/runtime-process-config-apply.test.mjs
@@ -9,7 +9,7 @@ import { fileURLToPath, pathToFileURL } from "node:url";
 const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..", "..", "..");
 const require = createRequire(import.meta.url);
 const configApi = require(path.join(ROOT, "dist", "platform", "config.cjs"));
-const { loadAndSyncRuntimeAgent, markConfigAppliedAfterRuntimeReady } = await import(
+const { applyRuntimeAgentUpsert, loadAndSyncRuntimeAgent, markConfigAppliedAfterRuntimeReady } = await import(
   pathToFileURL(path.join(ROOT, "dist", "app", "runtime-process.mjs")).href
 );
 
@@ -62,5 +62,58 @@ test("expected-signature mismatch refuses load before hydrate or profile sync", 
     const current = configApi.loadConfig(env).config.agents[agentId];
     assert.equal(current.runtime, "pi");
     assert.equal(current.piDistribution, "external");
+  } finally { fs.rmSync(root, { recursive: true, force: true }); }
+});
+
+function seedBuiltinApplyHome() {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "larkin-runtime-upsert-race-"));
+  fs.chmodSync(root, 0o700);
+  const agentId = "cli_runtimeRaceA1";
+  const otherId = "cli_runtimeRaceB2";
+  const env = { ...process.env, LARKIN_CONFIG_DIR: root, LARKIN_HOME: root };
+  fs.writeFileSync(path.join(root, "config.json"), `${JSON.stringify({
+    version: 4, serverId: "server-runtime-race", mentionPolicy: "require", activeAgent: agentId,
+    agents: {
+      [agentId]: { runtime: "pi", piDistribution: "builtin", model: "deepseek/deepseek-v4-pro" },
+      [otherId]: { runtime: "pi", piDistribution: "builtin", model: "kimi/kimi-k2.6" },
+    },
+  })}\n`, { mode: 0o600 });
+  const botsDir = path.join(root, "bots");
+  fs.mkdirSync(botsDir, { recursive: true, mode: 0o700 });
+  for (const id of [agentId, otherId]) {
+    fs.writeFileSync(path.join(botsDir, `${id}.json`), JSON.stringify({
+      appId: id, appSecret: "fixture-secret", tenant: "feishu", updatedAt: "2026-09-05T00:00:00.000Z",
+    }), { mode: 0o600 });
+    fs.mkdirSync(path.join(root, "providers", "pi", id), { recursive: true, mode: 0o700 });
+  }
+  return { root, agentId, otherId, env };
+}
+
+test("a switch after signature validation cannot profile-sync or Host-upsert the stale Agent", async () => {
+  const { root, agentId, otherId, env } = seedBuiltinApplyHome();
+  let synced = false;
+  const hostUpserts = [];
+  try {
+    const expected = configApi.runtimeConfigSignature(configApi.loadConfig(env).config, agentId);
+    await assert.rejects(() => applyRuntimeAgentUpsert(env, agentId, {
+      runOfficialCli: () => {
+        synced = true;
+        throw new Error("profile sync must not run after a post-validation switch");
+      },
+    }, {
+      expectedSignature: expected,
+      afterCanonicalValidate: () => {
+        configApi.mutateConfig(env, { kind: "set-agent-pi-distribution", agentId, distribution: "external" }, { kind: "user" });
+      },
+    }, (agent) => {
+      hostUpserts.push({ runtime: agent.runtime, piDistribution: agent.piDistribution, model: agent.model, agentId: agent.agentId });
+    }), /配置在 apply 期间发生变化|未热加载/);
+    assert.equal(synced, false);
+    assert.deepEqual(hostUpserts, []);
+    const current = configApi.loadConfig(env).config;
+    assert.equal(current.agents[agentId].runtime, "pi");
+    assert.equal(current.agents[agentId].piDistribution, "external");
+    assert.equal(current.agents[agentId].model, "deepseek/deepseek-v4-pro");
+    assert.equal(current.agents[otherId].model, "kimi/kimi-k2.6");
   } finally { fs.rmSync(root, { recursive: true, force: true }); }
 });

--- a/test/unit/dashboard/dashboard-pi-auth.test.mjs
+++ b/test/unit/dashboard/dashboard-pi-auth.test.mjs
@@ -1,0 +1,281 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { onTestFinished, test } from "bun:test";
+import { Readable } from "node:stream";
+import { fileURLToPath, pathToFileURL } from "node:url";
+
+const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..", "..", "..");
+const APP = "cli_dashboardPiAuthA1";
+const OTHER = "cli_dashboardPiAuthB2";
+const CONTROLLER = pathToFileURL(path.join(ROOT, "dist/dashboard/dashboard-config-controller.mjs")).href;
+
+function fixture() {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "larkin-dashboard-pi-auth-"));
+  fs.chmodSync(root, 0o700);
+  const env = { ...process.env, LARKIN_CONFIG_DIR: root };
+  fs.writeFileSync(path.join(root, "config.json"), `${JSON.stringify({
+    version: 4, serverId: "server-dashboard-pi-auth", mentionPolicy: "require", activeAgent: APP,
+    agents: {
+      [APP]: { runtime: "pi", piDistribution: "builtin", model: "deepseek/old", createdAt: "2026-09-04T00:00:00.000Z" },
+      [OTHER]: { runtime: "codex", model: "gpt-5.6-sol", createdAt: "2026-09-04T00:00:00.000Z" },
+    },
+  })}\n`, { mode: 0o600 });
+  for (const agentId of [APP, OTHER]) {
+    const state = path.join(root, "state", "agents", agentId);
+    fs.mkdirSync(state, { recursive: true, mode: 0o700 });
+  }
+  fs.mkdirSync(path.join(root, "providers", "pi", APP), { recursive: true, mode: 0o700 });
+  return { root, env };
+}
+
+function captureResponse() {
+  let status = 0;
+  let body = "";
+  return {
+    res: {
+      writeHead(value) { status = value; },
+      end(value = "") { body += String(value); },
+    },
+    value() { return { status, body: body ? JSON.parse(body) : null }; },
+  };
+}
+
+async function get(controller, pathname, headers = { host: "localhost:9996", "x-larkin-csrf": "test" }) {
+  const response = captureResponse();
+  const handled = await controller.handle({ method: "GET", headers }, response.res, new URL(pathname, "http://localhost"));
+  return { handled, ...response.value() };
+}
+
+async function post(controller, pathname, body, headers = {
+  host: "localhost:9996",
+  origin: "http://localhost:9996",
+  "content-type": "application/json",
+  "x-larkin-csrf": "test",
+}) {
+  const request = Readable.from([JSON.stringify(body)]);
+  request.method = "POST";
+  request.headers = headers;
+  const response = captureResponse();
+  const handled = await controller.handle(request, response.res, new URL(pathname, "http://localhost"));
+  return { handled, ...response.value() };
+}
+
+test("dashboard provider catalog/status are redacted and login is target-only with cache invalidation", async () => {
+  const { createDashboardConfigController } = await import(`${CONTROLLER}?pi-auth=${Date.now()}`);
+  const f = fixture();
+  onTestFinished(() => fs.rmSync(f.root, { recursive: true, force: true }));
+  const invalidated = [];
+  const logins = [];
+  const controller = createDashboardConfigController({
+    csrfCapability: "test",
+    env: f.env,
+    piModelDirectoryResolver: {
+      async resolve() { return [{ id: "default", label: "default" }]; },
+      invalidate(agentId) { invalidated.push(agentId); },
+    },
+    listProviderCatalog: () => [{ id: "deepseek", name: "DeepSeek", provider: "deepseek", defaultModel: "deepseek/deepseek-v4-pro", custom: false, openaiCompatible: true }],
+    loadProviderStatus: async () => [{ providerId: "deepseek", providerName: "DeepSeek", credentialType: "api_key", source: "configured", stored: true }],
+    configureProvider: async (input) => {
+      logins.push({ agentId: input.agentId, preset: input.preset, hasKey: Boolean(input.apiKey), key: input.apiKey });
+      return {
+        agentId: input.agentId, provider: "deepseek", preset: input.preset,
+        model: "deepseek/deepseek-v4-pro", credentialType: "api_key", applyState: "saved_not_applied",
+      };
+    },
+    logoutProvider: async (input) => ({ agentId: input.agentId, provider: input.providerId }),
+  });
+
+  const catalog = await get(controller, "/api/pi-auth/providers");
+  assert.equal(catalog.status, 200);
+  assert.equal(catalog.body.providers[0].id, "deepseek");
+  assert.equal(JSON.stringify(catalog.body).includes("sk-"), false);
+
+  const status = await get(controller, `/api/pi-auth/status?agent=${APP}`);
+  assert.equal(status.status, 200);
+  assert.equal(status.body.agentId, APP);
+  assert.equal(status.body.credentials[0].credentialType, "api_key");
+  assert.doesNotMatch(JSON.stringify(status.body), /Bearer |sk-|apiKey/i);
+
+  const forbidden = await get(controller, "/api/pi-auth/providers", { host: "example.com", "x-larkin-csrf": "test" });
+  assert.equal(forbidden.status, 403);
+
+  const login = await post(controller, "/api/pi-auth/login", {
+    agentId: APP, preset: "deepseek", apiKey: "dashboard-secret-key",
+  });
+  assert.equal(login.status, 200, JSON.stringify(login.body));
+  assert.equal(login.body.provider, "deepseek");
+  assert.equal(login.body.applyState, "saved_not_applied");
+  assert.equal(Object.hasOwn(login.body, "apiKey"), false);
+  assert.doesNotMatch(JSON.stringify(login.body), /dashboard-secret-key/);
+  assert.deepEqual(invalidated, [APP]);
+  assert.equal(logins[0].hasKey, true);
+  assert.equal(logins[0].agentId, APP);
+
+  const extraField = await post(controller, "/api/pi-auth/login", {
+    agentId: APP, preset: "deepseek", apiKey: "x", padding: "nope",
+  });
+  assert.equal(extraField.status, 400);
+
+  const leaky = createDashboardConfigController({
+    csrfCapability: "test",
+    env: f.env,
+    configureProvider: async (input) => {
+      throw new Error(`failed key=${input.apiKey}`);
+    },
+  });
+  const leaked = await post(leaky, "/api/pi-auth/login", {
+    agentId: APP, preset: "deepseek", apiKey: "dashboard-secret-key",
+  });
+  assert.equal(leaked.status, 400);
+  assert.doesNotMatch(JSON.stringify(leaked.body), /dashboard-secret-key/);
+
+  const otherAgent = await post(controller, "/api/pi-auth/login", {
+    agentId: OTHER, preset: "deepseek", apiKey: "should-not-reach-other",
+  });
+  assert.equal(otherAgent.status, 400);
+  assert.equal(logins.length, 1, "non-builtin Agents must not enter the login service");
+  assert.doesNotMatch(JSON.stringify(otherAgent.body), /should-not-reach-other/);
+
+  const logout = await post(controller, "/api/pi-auth/logout", { agentId: APP, provider: "deepseek" });
+  assert.equal(logout.status, 200);
+  assert.deepEqual(invalidated, [APP, APP]);
+});
+
+test("Pi model directory invalidate drops only the target Agent cache", async () => {
+  const module = await import(`${CONTROLLER}?pi-invalidate=${Date.now()}`);
+  let now = 8_000;
+  const calls = [];
+  const resolver = module.createPiModelDirectoryResolver({
+    async discoverPiModelCatalog(options) {
+      calls.push(options.agentDir);
+      return { models: [], effectiveModel: "owned/model", effectiveThinkingLevel: "off", defaultSource: "settings", diagnostics: [] };
+    },
+    now: () => now,
+    ttlMs: 5 * 60_000,
+  });
+  await resolver.resolve({ agentId: APP, cwd: "/tmp/a", agentDir: "/tmp/a-dir" });
+  await resolver.resolve({ agentId: OTHER, cwd: "/tmp/b", agentDir: "/tmp/b-dir" });
+  assert.equal(calls.length, 2);
+  resolver.invalidate(APP);
+  await resolver.resolve({ agentId: APP, cwd: "/tmp/a", agentDir: "/tmp/a-dir" });
+  await resolver.resolve({ agentId: OTHER, cwd: "/tmp/b", agentDir: "/tmp/b-dir" });
+  assert.equal(calls.length, 3, "only the invalidated Agent must refresh");
+  assert.equal(calls[2], "/tmp/a-dir");
+});
+
+test("in-flight pre-login catalog resolve cannot repopulate cache after invalidate", async () => {
+  const module = await import(`${CONTROLLER}?pi-invalidate-race=${Date.now()}`);
+  let releasePositive;
+  const holdPositive = new Promise((resolve) => { releasePositive = resolve; });
+  let releaseNegative;
+  const holdNegative = new Promise((resolve) => { releaseNegative = resolve; });
+  let now = 8_000;
+  const calls = [];
+  const resolver = module.createPiModelDirectoryResolver({
+    async discoverPiModelCatalog(options) {
+      calls.push(options.agentDir);
+      const n = calls.filter((dir) => dir === options.agentDir).length;
+      if (options.agentDir === "/tmp/stale-dir") {
+        if (n === 1) await holdPositive;
+        return {
+          models: [{ id: `catalog-${n}`, label: `catalog-${n}` }],
+          effectiveModel: `catalog-${n}`, effectiveThinkingLevel: "off", defaultSource: "settings", diagnostics: [],
+        };
+      }
+      if (n === 1) await holdNegative;
+      if (n === 1) throw new Error("stale negative catalog");
+      return {
+        models: [{ id: "recovered", label: "recovered" }],
+        effectiveModel: "recovered", effectiveThinkingLevel: "off", defaultSource: "settings", diagnostics: [],
+      };
+    },
+    now: () => now,
+    ttlMs: 5 * 60_000,
+    negativeTtlMs: 30_000,
+  });
+  const stale = resolver.resolve({ agentId: APP, cwd: "/tmp/a", agentDir: "/tmp/stale-dir" });
+  const staleFail = resolver.resolve({ agentId: OTHER, cwd: "/tmp/b", agentDir: "/tmp/fail-dir" });
+  while (calls.length < 2) await new Promise((resolve) => setTimeout(resolve, 0));
+  resolver.invalidate(APP);
+  resolver.invalidate(OTHER);
+  releasePositive();
+  releaseNegative();
+  const staleResult = await stale;
+  assert.equal(staleResult.some((model) => model.id === "catalog-1"), true);
+  await assert.rejects(() => staleFail, /stale negative catalog/);
+
+  const fresh = await resolver.resolve({ agentId: APP, cwd: "/tmp/a", agentDir: "/tmp/stale-dir" });
+  assert.equal(calls.filter((dir) => dir === "/tmp/stale-dir").length, 2);
+  assert.equal(fresh.some((model) => model.id === "catalog-2"), true);
+  assert.equal(fresh.some((model) => model.id === "catalog-1"), false);
+  now += 1;
+  const cached = await resolver.resolve({ agentId: APP, cwd: "/tmp/a", agentDir: "/tmp/stale-dir" });
+  assert.equal(calls.filter((dir) => dir === "/tmp/stale-dir").length, 2);
+  assert.deepEqual(cached.map((model) => model.id).filter((id) => id !== "default"), ["catalog-2"]);
+
+  const recovered = await resolver.resolve({ agentId: OTHER, cwd: "/tmp/b", agentDir: "/tmp/fail-dir" });
+  assert.equal(calls.filter((dir) => dir === "/tmp/fail-dir").length, 2);
+  assert.equal(recovered.some((model) => model.id === "recovered"), true);
+});
+
+test("targeted then global invalidate cannot admit a stale in-flight catalog result", async () => {
+  const module = await import(`${CONTROLLER}?pi-invalidate-generation=${Date.now()}`);
+  let releaseStale;
+  const holdStale = new Promise((resolve) => { releaseStale = resolve; });
+  let now = 8_000;
+  const calls = [];
+  const resolver = module.createPiModelDirectoryResolver({
+    async discoverPiModelCatalog(options) {
+      calls.push(options.agentDir);
+      const n = calls.filter((dir) => dir === options.agentDir).length;
+      if (n === 1) await holdStale;
+      return {
+        models: [{ id: `catalog-${n}`, label: `catalog-${n}` }],
+        effectiveModel: `catalog-${n}`, effectiveThinkingLevel: "off", defaultSource: "settings", diagnostics: [],
+      };
+    },
+    now: () => now,
+    ttlMs: 5 * 60_000,
+  });
+  const stale = resolver.resolve({ agentId: APP, cwd: "/tmp/a", agentDir: "/tmp/generation-dir" });
+  while (calls.length < 1) await new Promise((resolve) => setTimeout(resolve, 0));
+  resolver.invalidate(APP);
+  resolver.invalidate();
+  releaseStale();
+  const staleResult = await stale;
+  assert.equal(staleResult.some((model) => model.id === "catalog-1"), true);
+
+  const fresh = await resolver.resolve({ agentId: APP, cwd: "/tmp/a", agentDir: "/tmp/generation-dir" });
+  assert.equal(calls.length, 2);
+  assert.equal(fresh.some((model) => model.id === "catalog-2"), true);
+  assert.equal(fresh.some((model) => model.id === "catalog-1"), false);
+  now += 1;
+  const cached = await resolver.resolve({ agentId: APP, cwd: "/tmp/a", agentDir: "/tmp/generation-dir" });
+  assert.equal(calls.length, 2);
+  assert.deepEqual(cached.map((model) => model.id).filter((id) => id !== "default"), ["catalog-2"]);
+});
+
+test("login applyError response redacts the submitted API key", async () => {
+  const { createDashboardConfigController } = await import(`${CONTROLLER}?pi-apply-error=${Date.now()}`);
+  const f = fixture();
+  onTestFinished(() => fs.rmSync(f.root, { recursive: true, force: true }));
+  const secret = "dashboard-apply-secret-key";
+  const controller = createDashboardConfigController({
+    csrfCapability: "test",
+    env: f.env,
+    configureProvider: async (input) => ({
+      agentId: input.agentId, provider: "deepseek", preset: input.preset,
+      model: "deepseek/deepseek-v4-pro", credentialType: "api_key", applyState: "pending",
+      applyError: `targeted upsert failed key=${input.apiKey}`,
+    }),
+  });
+  const login = await post(controller, "/api/pi-auth/login", {
+    agentId: APP, preset: "deepseek", apiKey: secret,
+  });
+  assert.equal(login.status, 200, JSON.stringify(login.body));
+  assert.equal(login.body.applyState, "pending");
+  assert.match(login.body.applyError, /\[redacted\]/);
+  assert.doesNotMatch(JSON.stringify(login.body), new RegExp(secret));
+});

--- a/test/unit/dashboard/dashboard-workbench-source.test.mjs
+++ b/test/unit/dashboard/dashboard-workbench-source.test.mjs
@@ -63,6 +63,8 @@ test("dashboard uses flat sections and two bounded Workspace scroll regions", ()
   assert.match(app, /className="metrics-band"/);
   assert.match(app, /className="content-section/);
   assert.match(app, /className="config-section"/);
+  assert.match(app, /Provider Credentials/);
+  assert.match(app, /isBuiltinPiAgent/);
   assert.match(app, /className="logs-section"/);
   assert.doesNotMatch(app, /className="(?:metric-card|content-card|config-card|logs-panel)/,
     "major content areas must not return to card-wall primitives");

--- a/test/unit/feishu/host-runtime-lifecycle.test.mjs
+++ b/test/unit/feishu/host-runtime-lifecycle.test.mjs
@@ -261,11 +261,13 @@ test("HostShell keeps durable missing-key auth across ready status and reset", a
       await new Promise((resolve) => setTimeout(resolve, 5));
     }
     assert.equal(store.readJson("status", {}).runtimeReadiness.state, "unauthenticated");
-    assert.match(store.readJson("status", {}).runtimeReadiness.nextAction, /official store/);
+    assert.match(store.readJson("status", {}).runtimeReadiness.nextAction, /pi-auth login zhipu --agent <App ID>/);
+    assert.match(store.readJson("status", {}).runtimeReadiness.nextAction, /Provider Credentials/);
     const reset = await host.resetSession(agentId, 0);
     assert.equal(reset.resetCommitted, true);
     assert.equal(store.readJson("status", {}).runtimeReadiness.state, "unauthenticated");
-    assert.doesNotMatch(JSON.stringify(store.readJson("status", {}).runtimeReadiness), /pi-auth login|larkin setup|profile import/);
+    assert.doesNotMatch(JSON.stringify(store.readJson("status", {}).runtimeReadiness), /larkin setup|profile import|import-external-profile/);
+    assert.doesNotMatch(store.readJson("status", {}).runtimeReadiness.nextAction, /zai-coding-cn/);
   } finally {
     await host.shutdown("missing-key persist test complete");
     fs.rmSync(root, { recursive: true, force: true });

--- a/test/unit/platform/config-management.test.mjs
+++ b/test/unit/platform/config-management.test.mjs
@@ -242,7 +242,11 @@ test("user-facing runtime siblings project to stored pi + piDistribution", () =>
     const beforeBytes = fs.readFileSync(file);
     assert.throws(
       () => configApi.mutateConfig(env, { kind: "set-agent-runtime", agentId: APP, runtime: "builtin-pi", model: "default" }, { kind: "user" }),
-      /无法切换到 builtin-pi|larkin setup/,
+      (error) => {
+        assert.match(error.message, /无法切换到 builtin-pi|pi-auth login/);
+        assert.doesNotMatch(error.message, /import-external-profile|重新运行 larkin setup/);
+        return true;
+      },
     );
     assert.deepEqual(fs.readFileSync(file), beforeBytes);
 
@@ -268,6 +272,33 @@ test("user-facing runtime siblings project to stored pi + piDistribution", () =>
     const legacyView = configApi.safeConfigView(configApi.loadConfig(env).config, APP).agents[0];
     assert.equal(legacyView.runtime, "pi");
     assert.equal(legacyView.runtimeOption, "pi");
+  } finally { fs.rmSync(root, { recursive: true, force: true }); }
+});
+
+test("requireBuiltinPi model mutation refuses a concurrent runtime switch", () => {
+  const { root, file } = fixture();
+  try {
+    const stored = JSON.parse(fs.readFileSync(file, "utf8"));
+    stored.version = 4;
+    stored.mentionPolicy = "require";
+    stored.agents[APP] = { runtime: "pi", model: "default", piDistribution: "builtin" };
+    stored.agents[OTHER] = { runtime: "pi", model: "kimi/kimi-k2.6", piDistribution: "builtin" };
+    fs.writeFileSync(file, `${JSON.stringify(stored, null, 2)}\n`, { mode: 0o600 });
+    seedBuiltinPiAuth(root, APP);
+    const env = { LARKIN_CONFIG_DIR: root };
+    configApi.mutateConfig(env, { kind: "set-agent-runtime", agentId: APP, runtime: "codex", model: "gpt-5.6-sol" }, { kind: "user" });
+    const switched = JSON.parse(fs.readFileSync(file, "utf8"));
+    assert.throws(
+      () => configApi.mutateConfig(env, {
+        kind: "set-agent-model", agentId: APP, model: "deepseek/deepseek-v4-pro", requireBuiltinPi: true,
+      }, { kind: "user" }),
+      /不是内置 Pi/,
+    );
+    const after = JSON.parse(fs.readFileSync(file, "utf8"));
+    assert.equal(after.agents[APP].runtime, "codex");
+    assert.equal(after.agents[APP].model, "gpt-5.6-sol");
+    assert.equal(after.agents[OTHER].model, "kimi/kimi-k2.6");
+    assert.equal(switched.agents[APP].model, after.agents[APP].model);
   } finally { fs.rmSync(root, { recursive: true, force: true }); }
 });
 

--- a/test/unit/runtime/pi-provider-config.test.mjs
+++ b/test/unit/runtime/pi-provider-config.test.mjs
@@ -9,6 +9,9 @@ import {
   stageBuiltinPiProvider,
   validateBuiltinPiProviderSelection,
   validatePiBaseUrl,
+  isPiLoopbackHostname,
+  presetIdForOfficialProvider,
+  builtinPiProviderRecoveryNextAction,
 } from "../../../dist/runtime/pi-provider-config.mjs";
 
 test("Pi provider presets keep the requested setup order and audited official endpoints", () => {
@@ -55,6 +58,15 @@ test("Pi provider presets keep the requested setup order and audited official en
 test("custom Pi endpoint validation rejects credentials, unsafe schemes, API leaf paths, and unsafe models", () => {
   assert.equal(validatePiBaseUrl("https://gateway.example/v1/"), "https://gateway.example/v1");
   assert.equal(validatePiBaseUrl("http://127.0.0.1:8080/v1"), "http://127.0.0.1:8080/v1");
+  assert.equal(isPiLoopbackHostname("[::1]"), true);
+  assert.equal(isPiLoopbackHostname("::1"), true);
+  assert.equal(validatePiBaseUrl("http://[::1]:8080/v1"), "http://[::1]:8080/v1");
+  assert.equal(presetIdForOfficialProvider("zai-coding-cn"), "zhipu");
+  assert.equal(presetIdForOfficialProvider("larkin-custom"), "custom");
+  const recovery = builtinPiProviderRecoveryNextAction({ agentId: "cli_recoverA1", providerId: "zai-coding-cn" });
+  assert.match(recovery, /pi-auth login zhipu --agent cli_recoverA1/);
+  assert.match(recovery, /Provider Credentials/);
+  assert.doesNotMatch(recovery, /zai-coding-cn|larkin setup|import-external-profile|~\/\.pi/);
   for (const value of [
     "http://gateway.example/v1",
     "https://key@gateway.example/v1",

--- a/test/unit/runtime/pi-provider-login.test.mjs
+++ b/test/unit/runtime/pi-provider-login.test.mjs
@@ -323,6 +323,66 @@ test("a post-mutation runtime switch cannot hot-reload the switched Agent", asyn
   } finally { fs.rmSync(temp, { recursive: true, force: true }); }
 });
 
+test("a post-validation switch before Host upsert cannot hot-attach stale builtin config", async () => {
+  const { configureBuiltinPiProvider } = await loadLogin();
+  const { mutateConfig, runtimeConfigSignature } = await import(`${pathToFileURL(path.join(ROOT, "dist/platform/config.mjs")).href}?t=${Date.now()}`);
+  const { applyRuntimeAgentUpsert } = await import(`${pathToFileURL(path.join(ROOT, "dist/app/runtime-process.mjs")).href}?t=${Date.now()}`);
+  const { temp, target, other, env } = seedHome();
+  const secret = "post-validate-host-upsert-secret";
+  const hostUpserts = [];
+  const appliedMarks = [];
+  let expectedAfterMutate;
+  try {
+    const result = await configureBuiltinPiProvider({
+      agentId: target, preset: "deepseek", apiKey: secret, env,
+    }, {
+      createRuntime: async () => ({}),
+      runLogin: async (_runtime, providerId) => {
+        writeLogin(path.join(temp, "providers", "pi", target, "auth.json"), providerId, secret);
+        return { type: "api_key", key: secret };
+      },
+      mutateConfig: (mutateEnv, mutation, authority) => {
+        const mutated = mutateConfig(mutateEnv, mutation, authority);
+        expectedAfterMutate = runtimeConfigSignature(mutated.config, target);
+        return mutated;
+      },
+      readProcessState: () => ({ daemon: { state: "owned" }, supervisor: { state: "owned" } }),
+      requestUpsert: async (input) => {
+        try {
+          await applyRuntimeAgentUpsert(env, input.agentId, {
+            runOfficialCli: () => { throw new Error("profile sync must not run after a post-validation switch"); },
+          }, {
+            expectedSignature: input.expectedSignature,
+            afterCanonicalValidate: () => {
+              mutateConfig(env, { kind: "set-agent-pi-distribution", agentId: target, distribution: "external" }, { kind: "user" });
+            },
+          }, (agent) => {
+            hostUpserts.push({ agentId: agent.agentId, runtime: agent.runtime, piDistribution: agent.piDistribution });
+          });
+          return { ok: true, operationId: "op", agentId: input.agentId };
+        } catch (error) {
+          return { ok: false, operationId: "op", agentId: input.agentId,
+            error: error instanceof Error ? error.message : String(error) };
+        }
+      },
+      markApplied: (_env, agentId, signature) => { appliedMarks.push({ agentId, signature }); },
+    });
+    assert.equal(result.applyState, "pending");
+    assert.match(result.applyError, /配置在 apply 期间发生变化|未热加载/);
+    assert.doesNotMatch(JSON.stringify(result), new RegExp(secret));
+    assert.match(expectedAfterMutate, /^sha256:[a-f0-9]{64}$/);
+    assert.deepEqual(hostUpserts, []);
+    assert.deepEqual(appliedMarks, []);
+    const config = JSON.parse(fs.readFileSync(path.join(temp, "config.json"), "utf8"));
+    assert.equal(config.agents[target].runtime, "pi");
+    assert.equal(config.agents[target].piDistribution, "external");
+    assert.equal(config.agents[target].model, "deepseek/deepseek-v4-pro");
+    assert.equal(config.agents[other].model, "kimi/kimi-k2.6");
+    const auth = JSON.parse(fs.readFileSync(path.join(temp, "providers", "pi", target, "auth.json"), "utf8"));
+    assert.equal(auth.deepseek.key, secret);
+  } finally { fs.rmSync(temp, { recursive: true, force: true }); }
+});
+
 test("a concurrent runtime switch cannot bind a builtin model or upsert the switched Agent", async () => {
   const { configureBuiltinPiProvider } = await loadLogin();
   const { mutateConfig } = await import(`${pathToFileURL(path.join(ROOT, "dist/platform/config.mjs")).href}?t=${Date.now()}`);

--- a/test/unit/runtime/pi-provider-login.test.mjs
+++ b/test/unit/runtime/pi-provider-login.test.mjs
@@ -1,0 +1,354 @@
+import { test } from "bun:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+const ROOT = path.resolve(import.meta.dirname, "../../..");
+
+async function loadLogin() {
+  return import(`${pathToFileURL(path.join(ROOT, "dist/runtime/pi-provider-login.mjs")).href}?t=${Date.now()}`);
+}
+
+function pathToFileURL(file) {
+  return new URL(`file://${file}`);
+}
+
+function seedHome(options = {}) {
+  const temp = fs.mkdtempSync(path.join(os.tmpdir(), "larkin-pi-provider-login-"));
+  fs.chmodSync(temp, 0o700);
+  const target = options.targetId || "cli_loginTargetA1";
+  const other = options.otherId || "cli_loginOtherB2";
+  const agents = {
+    [target]: { runtime: "pi", piDistribution: "builtin", model: "deepseek/old-model", createdAt: "2026-09-04T00:00:00.000Z" },
+    [other]: { runtime: "pi", piDistribution: "builtin", model: "kimi/kimi-k2.6", createdAt: "2026-09-04T00:00:00.000Z" },
+  };
+  if (options.extraAgents) Object.assign(agents, options.extraAgents);
+  fs.writeFileSync(path.join(temp, "config.json"), `${JSON.stringify({
+    version: 4, serverId: "server-login", mentionPolicy: "require", activeAgent: target, agents,
+  }, null, 2)}\n`, { mode: 0o600 });
+  for (const agentId of Object.keys(agents)) {
+    const directory = path.join(temp, "providers", "pi", agentId);
+    fs.mkdirSync(directory, { recursive: true, mode: 0o700 });
+    fs.chmodSync(directory, 0o700);
+  }
+  if (options.otherAuth) {
+    fs.writeFileSync(path.join(temp, "providers", "pi", other, "auth.json"), `${JSON.stringify(options.otherAuth, null, 2)}\n`, { mode: 0o600 });
+  }
+  if (options.targetAuth) {
+    fs.writeFileSync(path.join(temp, "providers", "pi", target, "auth.json"), `${JSON.stringify(options.targetAuth, null, 2)}\n`, { mode: 0o600 });
+  }
+  const env = { ...process.env, LARKIN_CONFIG_DIR: temp, LARKIN_HOME: temp };
+  return { temp, target, other, env };
+}
+
+function writeLogin(authFile, providerId, key) {
+  const current = fs.existsSync(authFile) ? JSON.parse(fs.readFileSync(authFile, "utf8")) : {};
+  current[providerId] = { type: "api_key", key };
+  fs.writeFileSync(authFile, `${JSON.stringify(current, null, 2)}\n`, { mode: 0o600 });
+}
+
+test("known preset login writes only the target Agent, binds the default model, and skips upsert when daemon is not owned", async () => {
+  const { configureBuiltinPiProvider } = await loadLogin();
+  const { temp, target, other, env } = seedHome({
+    otherAuth: { "moonshotai-cn": { type: "api_key", key: "keep-other-secret" } },
+    targetAuth: { unrelated: { type: "api_key", key: "keep-target-unrelated" } },
+  });
+  try {
+    const upserts = [];
+    const result = await configureBuiltinPiProvider({
+      agentId: target, preset: "deepseek", apiKey: "target-login-secret", env,
+    }, {
+      createRuntime: async () => ({}),
+      runLogin: async (_runtime, providerId) => {
+        writeLogin(path.join(temp, "providers", "pi", target, "auth.json"), providerId, "target-login-secret");
+        return { type: "api_key", key: "target-login-secret" };
+      },
+      readProcessState: () => ({ daemon: { state: "absent" }, supervisor: { state: "absent" } }),
+      requestUpsert: async (input) => { upserts.push(input); return { ok: true }; },
+    });
+    assert.deepEqual({
+      agentId: result.agentId, provider: result.provider, model: result.model,
+      credentialType: result.credentialType, applyState: result.applyState,
+    }, {
+      agentId: target, provider: "deepseek", model: "deepseek/deepseek-v4-pro",
+      credentialType: "api_key", applyState: "saved_not_applied",
+    });
+    assert.equal(upserts.length, 0);
+    const auth = JSON.parse(fs.readFileSync(path.join(temp, "providers", "pi", target, "auth.json"), "utf8"));
+    assert.equal(auth.deepseek.key, "target-login-secret");
+    assert.equal(auth.unrelated.key, "keep-target-unrelated");
+    const otherAuth = JSON.parse(fs.readFileSync(path.join(temp, "providers", "pi", other, "auth.json"), "utf8"));
+    assert.deepEqual(otherAuth, { "moonshotai-cn": { type: "api_key", key: "keep-other-secret" } });
+    const config = JSON.parse(fs.readFileSync(path.join(temp, "config.json"), "utf8"));
+    assert.equal(config.agents[target].model, "deepseek/deepseek-v4-pro");
+    assert.equal(config.agents[other].model, "kimi/kimi-k2.6");
+    assert.equal(fs.statSync(path.join(temp, "providers", "pi", target)).mode & 0o777, 0o700);
+    assert.equal(fs.statSync(path.join(temp, "providers", "pi", target, "auth.json")).mode & 0o777, 0o600);
+  } finally { fs.rmSync(temp, { recursive: true, force: true }); }
+});
+
+test("custom OpenAI-compatible login writes models.json without the secret and rolls back on login failure", async () => {
+  const { configureBuiltinPiProvider } = await loadLogin();
+  const { temp, target, env } = seedHome({
+    targetAuth: { keep: { type: "api_key", key: "original-secret" } },
+  });
+  const modelsBefore = { providers: { keep: { baseUrl: "https://keep.example/v1" } } };
+  fs.writeFileSync(path.join(temp, "providers", "pi", target, "models.json"), `${JSON.stringify(modelsBefore, null, 2)}\n`, { mode: 0o600 });
+  try {
+    await assert.rejects(() => configureBuiltinPiProvider({
+      agentId: target, preset: "custom", apiKey: "custom-super-secret",
+      baseUrl: "https://gateway.example/v1", model: "acme-code", env,
+    }, {
+      createRuntime: async () => ({}),
+      runLogin: async () => { throw new Error(`login failed key=custom-super-secret`); },
+    }), (error) => {
+      assert.match(error.message, /login failed|redacted/i);
+      assert.doesNotMatch(error.message, /custom-super-secret/);
+      return true;
+    });
+    assert.deepEqual(JSON.parse(fs.readFileSync(path.join(temp, "providers", "pi", target, "auth.json"), "utf8")), {
+      keep: { type: "api_key", key: "original-secret" },
+    });
+    assert.deepEqual(JSON.parse(fs.readFileSync(path.join(temp, "providers", "pi", target, "models.json"), "utf8")), modelsBefore);
+    const config = JSON.parse(fs.readFileSync(path.join(temp, "config.json"), "utf8"));
+    assert.equal(config.agents[target].model, "deepseek/old-model");
+  } finally { fs.rmSync(temp, { recursive: true, force: true }); }
+});
+
+test("custom login success binds larkin-custom/<model> and surfaces pending apply without claiming a running change", async () => {
+  const { configureBuiltinPiProvider } = await loadLogin();
+  const { temp, target, other, env } = seedHome();
+  try {
+    const upserts = [];
+    const result = await configureBuiltinPiProvider({
+      agentId: target, preset: "custom", apiKey: "custom-ok-secret",
+      baseUrl: "http://127.0.0.1:8123/v1", model: "fixture-model", env,
+    }, {
+      createRuntime: async () => ({}),
+      runLogin: async (_runtime, providerId) => {
+        writeLogin(path.join(temp, "providers", "pi", target, "auth.json"), providerId, "custom-ok-secret");
+        return { type: "api_key", key: "custom-ok-secret" };
+      },
+      readProcessState: () => ({ daemon: { state: "owned" }, supervisor: { state: "owned" } }),
+      requestUpsert: async (input) => {
+        upserts.push(input.agentId);
+        return { ok: false, error: "agent busy" };
+      },
+    });
+    assert.equal(result.provider, "larkin-custom");
+    assert.equal(result.model, "larkin-custom/fixture-model");
+    assert.equal(result.applyState, "pending");
+    assert.match(result.applyError, /busy/i);
+    assert.deepEqual(upserts, [target]);
+    const models = JSON.parse(fs.readFileSync(path.join(temp, "providers", "pi", target, "models.json"), "utf8"));
+    assert.equal(models.providers["larkin-custom"].baseUrl, "http://127.0.0.1:8123/v1");
+    assert.doesNotMatch(fs.readFileSync(path.join(temp, "providers", "pi", target, "models.json"), "utf8"), /custom-ok-secret/);
+    assert.equal(fs.existsSync(path.join(temp, "providers", "pi", other, "auth.json")), false);
+    const config = JSON.parse(fs.readFileSync(path.join(temp, "config.json"), "utf8"));
+    assert.equal(config.agents[other].model, "kimi/kimi-k2.6");
+  } finally { fs.rmSync(temp, { recursive: true, force: true }); }
+});
+
+test("non-builtin Agents and host fallback are rejected", async () => {
+  const { configureBuiltinPiProvider, sanitizeProviderLoginError } = await loadLogin();
+  const { temp, target, env } = seedHome({
+    extraAgents: { cli_codexA1: { runtime: "codex", model: "gpt-5.6-sol", createdAt: "2026-09-04T00:00:00.000Z" } },
+  });
+  const home = path.join(temp, "home");
+  const hostAuth = path.join(home, ".pi", "auth.json");
+  fs.mkdirSync(path.dirname(hostAuth), { recursive: true, mode: 0o700 });
+  const hostBytes = `${JSON.stringify({ deepseek: { type: "api_key", key: "host-global-secret" } }, null, 2)}\n`;
+  fs.writeFileSync(hostAuth, hostBytes, { mode: 0o600 });
+  env.HOME = home;
+  env.USERPROFILE = home;
+  try {
+    await assert.rejects(() => configureBuiltinPiProvider({
+      agentId: "cli_codexA1", preset: "deepseek", apiKey: "should-not-store", env,
+    }), /不是内置 Pi/);
+    assert.equal(fs.existsSync(path.join(temp, "providers", "pi", "cli_codexA1", "auth.json")), false);
+    const result = await configureBuiltinPiProvider({
+      agentId: target, preset: "deepseek", apiKey: "target-only-secret", env,
+    }, {
+      createRuntime: async () => ({}),
+      runLogin: async (_runtime, providerId) => {
+        writeLogin(path.join(temp, "providers", "pi", target, "auth.json"), providerId, "target-only-secret");
+        return { type: "api_key", key: "target-only-secret" };
+      },
+      readProcessState: () => ({ daemon: { state: "absent" }, supervisor: { state: "absent" } }),
+      requestUpsert: async () => ({ ok: true }),
+    });
+    assert.equal(result.provider, "deepseek");
+    assert.equal(fs.readFileSync(hostAuth, "utf8"), hostBytes, "host ~/.pi must remain unread and unchanged");
+    assert.doesNotMatch(fs.readFileSync(path.join(temp, "providers", "pi", target, "auth.json"), "utf8"), /host-global-secret/);
+    const leaked = sanitizeProviderLoginError(new Error("failed Authorization: Bearer should-not-store api_key=should-not-store"), "should-not-store");
+    assert.doesNotMatch(leaked, /should-not-store/);
+  } finally { fs.rmSync(temp, { recursive: true, force: true }); }
+});
+
+test("login cancels roll back owned credential files and leaves sibling Agents untouched", async () => {
+  const { configureBuiltinPiProvider } = await loadLogin();
+  const { temp, target, other, env } = seedHome({
+    targetAuth: { keep: { type: "api_key", key: "original-secret" } },
+    otherAuth: { "moonshotai-cn": { type: "api_key", key: "keep-other-secret" } },
+  });
+  const modelsBefore = { providers: { keep: { baseUrl: "https://keep.example/v1" } } };
+  fs.writeFileSync(path.join(temp, "providers", "pi", target, "models.json"), `${JSON.stringify(modelsBefore, null, 2)}\n`, { mode: 0o600 });
+  try {
+    await assert.rejects(() => configureBuiltinPiProvider({
+      agentId: target, preset: "custom", apiKey: "cancel-secret",
+      baseUrl: "http://127.0.0.1:1/v1", model: "fixture-model", env,
+    }, {
+      createRuntime: async () => ({}),
+      runLogin: async () => {
+        const error = new Error("Pi auth login cancelled");
+        error.name = "AbortError";
+        throw error;
+      },
+    }), /cancelled|redacted/i);
+    assert.deepEqual(JSON.parse(fs.readFileSync(path.join(temp, "providers", "pi", target, "auth.json"), "utf8")), {
+      keep: { type: "api_key", key: "original-secret" },
+    });
+    assert.deepEqual(JSON.parse(fs.readFileSync(path.join(temp, "providers", "pi", target, "models.json"), "utf8")), modelsBefore);
+    assert.deepEqual(JSON.parse(fs.readFileSync(path.join(temp, "providers", "pi", other, "auth.json"), "utf8")), {
+      "moonshotai-cn": { type: "api_key", key: "keep-other-secret" },
+    });
+    const config = JSON.parse(fs.readFileSync(path.join(temp, "config.json"), "utf8"));
+    assert.equal(config.agents[target].model, "deepseek/old-model");
+  } finally { fs.rmSync(temp, { recursive: true, force: true }); }
+});
+
+test("targeted apply errors redact the submitted API key", async () => {
+  const { configureBuiltinPiProvider } = await loadLogin();
+  const { temp, target, env } = seedHome();
+  const secret = "apply-error-super-secret";
+  try {
+    const upserted = await configureBuiltinPiProvider({
+      agentId: target, preset: "deepseek", apiKey: secret, env,
+    }, {
+      createRuntime: async () => ({}),
+      runLogin: async (_runtime, providerId) => {
+        writeLogin(path.join(temp, "providers", "pi", target, "auth.json"), providerId, secret);
+        return { type: "api_key", key: secret };
+      },
+      readProcessState: () => ({ daemon: { state: "owned" }, supervisor: { state: "owned" } }),
+      requestUpsert: async () => ({ ok: false, error: `upsert failed key=${secret}` }),
+    });
+    assert.equal(upserted.applyState, "pending");
+    assert.match(upserted.applyError, /\[redacted\]/);
+    assert.doesNotMatch(upserted.applyError, new RegExp(secret));
+
+    const thrown = await configureBuiltinPiProvider({
+      agentId: target, preset: "deepseek", apiKey: secret, env,
+    }, {
+      createRuntime: async () => ({}),
+      runLogin: async (_runtime, providerId) => {
+        writeLogin(path.join(temp, "providers", "pi", target, "auth.json"), providerId, secret);
+        return { type: "api_key", key: secret };
+      },
+      readProcessState: () => ({ daemon: { state: "owned" }, supervisor: { state: "owned" } }),
+      requestUpsert: async () => { throw new Error(`hot upsert exploded ${secret}`); },
+    });
+    assert.equal(thrown.applyState, "pending");
+    assert.match(thrown.applyError, /\[redacted\]/);
+    assert.doesNotMatch(thrown.applyError, new RegExp(secret));
+  } finally { fs.rmSync(temp, { recursive: true, force: true }); }
+});
+
+test("a post-mutation runtime switch cannot hot-reload the switched Agent", async () => {
+  const { configureBuiltinPiProvider } = await loadLogin();
+  const { mutateConfig, runtimeConfigSignature } = await import(`${pathToFileURL(path.join(ROOT, "dist/platform/config.mjs")).href}?t=${Date.now()}`);
+  const { loadAndSyncRuntimeAgent } = await import(`${pathToFileURL(path.join(ROOT, "dist/app/runtime-process.mjs")).href}?t=${Date.now()}`);
+  const { temp, target, other, env } = seedHome();
+  const secret = "post-mutate-toctou-secret";
+  const upserts = [];
+  const reloads = [];
+  const appliedMarks = [];
+  let expectedAfterMutate;
+  try {
+    const result = await configureBuiltinPiProvider({
+      agentId: target, preset: "deepseek", apiKey: secret, env,
+    }, {
+      createRuntime: async () => ({}),
+      runLogin: async (_runtime, providerId) => {
+        writeLogin(path.join(temp, "providers", "pi", target, "auth.json"), providerId, secret);
+        return { type: "api_key", key: secret };
+      },
+      mutateConfig: (mutateEnv, mutation, authority) => {
+        const mutated = mutateConfig(mutateEnv, mutation, authority);
+        expectedAfterMutate = runtimeConfigSignature(mutated.config, target);
+        return mutated;
+      },
+      readProcessState: () => ({ daemon: { state: "owned" }, supervisor: { state: "owned" } }),
+      requestUpsert: async (input) => {
+        mutateConfig(env, { kind: "set-agent-pi-distribution", agentId: target, distribution: "external" }, { kind: "user" });
+        upserts.push({
+          agentId: input.agentId,
+          expectedSignature: input.expectedSignature,
+          other: input.agentId === other,
+        });
+        try {
+          const agent = loadAndSyncRuntimeAgent(env, input.agentId, {
+            runOfficialCli: () => {
+              reloads.push("synced");
+              throw new Error("profile sync must not run after a runtime switch");
+            },
+          }, { expectedSignature: input.expectedSignature });
+          reloads.push(agent.runtime, agent.piDistribution);
+          return { ok: true, operationId: "op", agentId: input.agentId };
+        } catch (error) {
+          reloads.push("rejected");
+          return { ok: false, operationId: "op", agentId: input.agentId,
+            error: error instanceof Error ? error.message : String(error) };
+        }
+      },
+      markApplied: (_env, agentId, signature) => { appliedMarks.push({ agentId, signature }); },
+    });
+    assert.equal(result.applyState, "pending");
+    assert.match(result.applyError, /配置在 apply 期间发生变化|未热加载/);
+    assert.doesNotMatch(JSON.stringify(result), new RegExp(secret));
+    assert.equal(upserts.length, 1);
+    assert.equal(upserts[0].agentId, target);
+    assert.equal(upserts[0].expectedSignature, expectedAfterMutate);
+    assert.match(upserts[0].expectedSignature, /^sha256:[a-f0-9]{64}$/);
+    assert.deepEqual(reloads, ["rejected"]);
+    assert.deepEqual(appliedMarks, []);
+    const config = JSON.parse(fs.readFileSync(path.join(temp, "config.json"), "utf8"));
+    assert.equal(config.agents[target].runtime, "pi");
+    assert.equal(config.agents[target].piDistribution, "external");
+    assert.equal(config.agents[target].model, "deepseek/deepseek-v4-pro");
+    assert.equal(config.agents[other].model, "kimi/kimi-k2.6");
+    const auth = JSON.parse(fs.readFileSync(path.join(temp, "providers", "pi", target, "auth.json"), "utf8"));
+    assert.equal(auth.deepseek.key, secret);
+  } finally { fs.rmSync(temp, { recursive: true, force: true }); }
+});
+
+test("a concurrent runtime switch cannot bind a builtin model or upsert the switched Agent", async () => {
+  const { configureBuiltinPiProvider } = await loadLogin();
+  const { mutateConfig } = await import(`${pathToFileURL(path.join(ROOT, "dist/platform/config.mjs")).href}?t=${Date.now()}`);
+  const { temp, target, other, env } = seedHome();
+  const upserts = [];
+  try {
+    await assert.rejects(() => configureBuiltinPiProvider({
+      agentId: target, preset: "deepseek", apiKey: "toctou-secret", env,
+    }, {
+      createRuntime: async () => ({}),
+      runLogin: async (_runtime, providerId) => {
+        writeLogin(path.join(temp, "providers", "pi", target, "auth.json"), providerId, "toctou-secret");
+        return { type: "api_key", key: "toctou-secret" };
+      },
+      mutateConfig: (mutateEnv, mutation, authority) => {
+        mutateConfig(mutateEnv, { kind: "set-agent-runtime", agentId: target, runtime: "codex", model: "gpt-5.6-sol" }, { kind: "user" });
+        return mutateConfig(mutateEnv, mutation, authority);
+      },
+      readProcessState: () => ({ daemon: { state: "owned" }, supervisor: { state: "owned" } }),
+      requestUpsert: async (input) => { upserts.push(input.agentId); return { ok: true }; },
+    }), /不是内置 Pi/);
+    const config = JSON.parse(fs.readFileSync(path.join(temp, "config.json"), "utf8"));
+    assert.equal(config.agents[target].runtime, "codex");
+    assert.equal(config.agents[target].model, "gpt-5.6-sol");
+    assert.equal(config.agents[other].model, "kimi/kimi-k2.6");
+    assert.deepEqual(upserts, []);
+    assert.equal(fs.existsSync(path.join(temp, "providers", "pi", target, "auth.json")), false);
+  } finally { fs.rmSync(temp, { recursive: true, force: true }); }
+});

--- a/test/unit/runtime/runtime-adapters.test.mjs
+++ b/test/unit/runtime/runtime-adapters.test.mjs
@@ -1410,8 +1410,10 @@ test("Pi provider failures preserve safe actionable categories", () => {
   }
   const missing = classifyPiProviderError({ message: "No API key found for zai-coding-cn" }, { distribution: "builtin" });
   assert.match(missing.reason, /zai-coding-cn.*missing/i);
-  assert.match(missing.nextAction, /Add the missing zai-coding-cn credential to this Agent's official store/);
-  assert.doesNotMatch(missing.reason + missing.nextAction, /larkin setup|profile import|pi-auth login|Dashboard|fixture-secret/i);
+  assert.match(missing.nextAction, /pi-auth login zhipu --agent <App ID>/);
+  assert.match(missing.nextAction, /Provider Credentials/);
+  assert.doesNotMatch(missing.reason + missing.nextAction, /larkin setup|profile import|import-external-profile|fixture-secret/i);
+  assert.doesNotMatch(missing.nextAction, /zai-coding-cn/);
   assert.equal(classifyPiProviderError({ message: "No API key found for zai-coding-cn" }).category, "provider");
   assert.equal(classifyPiProviderError({ message: "No API key found for zai-coding-cn" }, { distribution: "external" }).category, "provider");
   const unknown = classifyPiProviderError({ provider: "gateway", code: "server_error", status: 502,
@@ -1470,8 +1472,9 @@ test("Pi prompt rejection of an explicit missing credential is terminal auth", a
     assert.equal(failure.retryable, false);
     assert.equal(failure.willRetry, false);
     assert.equal(failure.upstream.provider, "zai-coding-cn");
-    assert.match(failure.nextAction, /Add the missing zai-coding-cn credential to this Agent's official store/);
-    assert.doesNotMatch(JSON.stringify(failure), /fixture-secret|larkin setup|profile import|pi-auth login/i);
+    assert.match(failure.nextAction, /pi-auth login zhipu --agent <App ID>/);
+    assert.doesNotMatch(JSON.stringify(failure), /fixture-secret|larkin setup|profile import|import-external-profile/i);
+    assert.doesNotMatch(failure.nextAction, /zai-coding-cn/);
     assert.equal(classifyPiMissingCredentialRejection(message)?.provider, "zai-coding-cn");
   }
   const transientSdk = { sessionId: "pi-transient", prompt() { throw new Error("fetch failed: provider overloaded"); },

--- a/test/unit/runtime/runtime-host.test.mjs
+++ b/test/unit/runtime/runtime-host.test.mjs
@@ -1715,7 +1715,9 @@ test("missing-key prompt rejection terminals once as auth and stays unauthentica
     const downgraded = events.filter((event) => event.type === "agent-status" && event.agentId === failedId).at(-1);
     assert.equal(downgraded.status, "error");
     assert.equal(downgraded.readiness.state, "unauthenticated");
-    assert.match(downgraded.readiness.nextAction, /Add the missing zai-coding-cn credential to this Agent's official store/);
+    assert.match(downgraded.readiness.nextAction, /pi-auth login zhipu --agent <App ID>/);
+    assert.match(downgraded.readiness.nextAction, /Provider Credentials/);
+    assert.doesNotMatch(downgraded.readiness.nextAction, /zai-coding-cn/);
     assert.doesNotMatch(JSON.stringify(downgraded), /fixture-openai-codex|fixture-global|larkin setup|profile import/);
     assert.equal(events.filter((event) => event.type === "delivery" && event.messageId === "om_missing_key"
       && event.status === "deferred").length, 0);

--- a/test/unit/runtime/runtime-readiness.test.mjs
+++ b/test/unit/runtime/runtime-readiness.test.mjs
@@ -12,6 +12,7 @@ import {
   probeNativeRuntimeReadiness,
   readinessForPersistedAuthFailure,
 } from "../../../dist/runtime/runtime-readiness.mjs";
+import { builtinPiProviderRecoveryNextAction } from "../../../dist/runtime/pi-provider-config.mjs";
 
 for (const runtime of ["codex", "claude", "pi"]) {
   test(`${runtime} readiness classifies an unresolved configured command as missing`, async () => {
@@ -62,8 +63,20 @@ test("missing-credential classifier matches only the explicit absent-key or abse
   const readiness = missingProviderCredentialReadiness("pi", "zai-coding-cn");
   assert.equal(readiness.state, "unauthenticated");
   assert.match(readiness.reason, /zai-coding-cn/);
-  assert.match(readiness.nextAction, /Add the missing zai-coding-cn credential to this Agent's official store/);
-  assert.doesNotMatch(readiness.nextAction, /larkin setup|profile import|pi-auth login|Dashboard/);
+  assert.match(readiness.nextAction, /pi-auth login zhipu --agent <App ID>/);
+  assert.match(readiness.nextAction, /Provider Credentials/);
+  assert.doesNotMatch(readiness.nextAction, /zai-coding-cn|larkin setup|import-external-profile|official store/);
+});
+
+test("UX recovery helper maps official provider IDs to CLI presets without replacing P0 classifiers", () => {
+  const recovery = builtinPiProviderRecoveryNextAction({ agentId: "cli_recoverA1", providerId: "zai-coding-cn" });
+  assert.match(recovery, /pi-auth login zhipu --agent cli_recoverA1/);
+  assert.match(recovery, /Provider Credentials/);
+  assert.doesNotMatch(recovery, /zai-coding-cn|larkin setup|import-external-profile|official store/);
+  const classified = classifyRuntimePrerequisite("pi", new Error("no authenticated available models"));
+  assert.equal(classified.state, "unauthenticated");
+  assert.match(classified.nextAction, /official `pi` login/);
+  assert.doesNotMatch(classified.nextAction, /Dashboard|Provider Credentials|pi-auth login|larkin setup/);
 });
 
 test("scoped auth persistence prefers current generic over a legacy missing-provider string", () => {
@@ -96,8 +109,12 @@ test("scoped auth persistence prefers current generic over a legacy missing-prov
   assert.equal(authFailureAppliesTo({ ...builtinZai, model: "openai-codex/gpt-5" }, genericZai), false);
   assert.equal(authFailureAppliesTo({ ...builtinZai, model: "openai-codex/gpt-5" }, generic), true,
     "unbound generic is conservative fallback only when the upstream provider was unavailable");
+  assert.match(readinessForPersistedAuthFailure(missing).nextAction, /pi-auth login zhipu --agent <App ID>/);
+  assert.match(readinessForPersistedAuthFailure(missing).nextAction, /Provider Credentials/);
+  assert.doesNotMatch(readinessForPersistedAuthFailure(missing).nextAction, /zai-coding-cn|official store/);
   assert.match(readinessForPersistedAuthFailure(generic).nextAction, /login|API-key resolver/);
-  assert.doesNotMatch(readinessForPersistedAuthFailure(generic).nextAction, /official store/);
+  assert.doesNotMatch(readinessForPersistedAuthFailure(generic).nextAction, /official store|pi-auth login zhipu/);
+  assert.match(readinessForPersistedAuthFailure(genericZai).nextAction, /login|API-key resolver/);
 });
 
 function writeReadinessPi(root, { failIfDirty = false } = {}) {


### PR DESCRIPTION
## Summary
- Add per-Agent builtin Pi Provider/API Key configuration for Dashboard and CLI, including custom OpenAI-compatible Base URL/model.
- Keep official Pi credential storage private, transactional and target-scoped; reject API keys in argv and bound stdin reads.
- Serialize signed hot apply from canonical signature validation through profile synchronization and awaited Host upsert. Concurrent config drift is rejected before stale attach; locks release on success and failure.
- Align the opt-in compiled Pi fixtures with the authoritative bundled version, compaction handshake and session-stat protocol. Product guards and test assertions remain intact.

## Validation at eb523557539568e6d15fc4492220060eac53d70b
- Independent Pi evaluator accepted the original post-validation/pre-upsert P1 fix at this exact head after focused tests and async lock pressure checks.
- `bun run test`: PASS (typecheck/build; frontend 28; unit 976 pass/1 skip; integration 210 pass/18 skip; E2E 24 pass; no failures).
- `LARKIN_RUN_COMPILED_RUNTIME_MOCK_E2E=1 bun test --max-concurrency 1 test/integration/build/compiled-runtime-mock-e2e.test.mjs`: 2 pass/0 fail with temporary compiled artifacts and synthetic Runtime/provider events.
- `bun run licenses:check`, `bun run publication:check:tree`, `bun run publication:check`, `git diff --check`: PASS.
- Isolated browser workflow: builtin-only form, password/autocomplete attributes, preset model display and custom-field toggling pass; no external browser requests.
- [Exact-head Source checks + both Windows gates](https://github.com/eddiearc/larkin/actions/runs/33956196849): SUCCESS, including trusted publication/credential scans and native Windows standalone smoke.

## Boundaries / delivery gates
- Saving credentials does not validate a real remote key. All verification used isolated synthetic state; no real credentials, host Pi profile, production daemon, Inbox or Feishu mutation.
- Signed apply holds the existing global config lock; a concurrent sibling config mutation can require retry while apply is pending. No sibling runtime reload occurs.
- Package remains 0.4.28. Required patch/version release and safe installation/activation are held for the separately tracked release plan; do not merge unversioned without an explicit policy exception.
- This PR does not resolve the separate Inbox Audit policy choices in PR #187.
