### PR TITLE
fix(agent): gate inbox audit wakes on canonical eligibility

### DIFF
--- a/src/agent/inbox-audit-heartbeat.ts
+++ b/src/agent/inbox-audit-heartbeat.ts
@@ -1,6 +1,16 @@
 import { RUNTIME_REMINDER_TARGET } from "./inbox-projection.js";
 
 export const INBOX_AUDIT_CADENCE_MS = 15 * 60_000;
+export const MAX_INBOX_AUDIT_DIAGNOSTIC_CHARS = 120;
+
+export function boundedInboxAuditDiagnostic(error: unknown): string {
+  const code = error && typeof error === "object" && "code" in error && typeof (error as { code: unknown }).code === "string"
+    ? (error as { code: string }).code
+    : "";
+  const raw = error instanceof Error ? error.message : String(error);
+  const text = raw.replace(/[\u0000-\u001f\u007f]+/g, " ").replace(/\s+/g, " ").trim();
+  return [code, text].filter(Boolean).join(" ").slice(0, MAX_INBOX_AUDIT_DIAGNOSTIC_CHARS);
+}
 
 interface AuditAgent { agentId: string }
 interface AuditStateStore {
@@ -68,7 +78,7 @@ export class InboxAuditHeartbeat {
         const appended = this.options.stateStore(agent).appendCanonicalInboxOnce(envelope);
         if (appended.status === "appended") await this.options.runtimeHost.deliver(agent.agentId, appended.envelope as object);
       } catch (error) {
-        this.options.log?.(`inbox audit heartbeat failed agent=${agent.agentId}: ${error instanceof Error ? error.message : String(error)}`);
+        this.options.log?.(`inbox audit heartbeat failed agent=${agent.agentId}: ${boundedInboxAuditDiagnostic(error)}`);
       }
     }
   }

--- a/src/agent/inbox-audit-heartbeat.ts
+++ b/src/agent/inbox-audit-heartbeat.ts
@@ -20,6 +20,7 @@ export class InboxAuditHeartbeat {
     agents: readonly AuditAgent[];
     stateStore(agent: AuditAgent): AuditStateStore;
     runtimeHost: AuditRuntime;
+    shouldDispatch(agent: AuditAgent): boolean;
     log?: (...parts: unknown[]) => void;
     cadenceMs?: number;
     setTimer?: typeof setTimeout;
@@ -54,15 +55,16 @@ export class InboxAuditHeartbeat {
   private async fire(): Promise<void> {
     const now = this.options.now ?? Date.now;
     for (const agent of this.options.agents) {
-      const message_id = `rem_inbox_audit_${now()}_${++this.sequence}_${agent.agentId}`;
-      const envelope = {
-        kind: "reminder",
-        message_id,
-        target: RUNTIME_REMINDER_TARGET,
-        wake: true,
-        content: "Internal inbox audit wake. Poll runtime:reminder, then run larkin inbox audit --json. No finding stays silent.",
-      };
       try {
+        if (!this.options.shouldDispatch(agent)) continue;
+        const message_id = `rem_inbox_audit_${now()}_${++this.sequence}_${agent.agentId}`;
+        const envelope = {
+          kind: "reminder",
+          message_id,
+          target: RUNTIME_REMINDER_TARGET,
+          wake: true,
+          content: "Internal inbox audit wake. Poll runtime:reminder, then run larkin inbox audit --json. No finding stays silent.",
+        };
         const appended = this.options.stateStore(agent).appendCanonicalInboxOnce(envelope);
         if (appended.status === "appended") await this.options.runtimeHost.deliver(agent.agentId, appended.envelope as object);
       } catch (error) {

--- a/src/agent/inbox-audit-heartbeat.ts
+++ b/src/agent/inbox-audit-heartbeat.ts
@@ -4,12 +4,13 @@ export const INBOX_AUDIT_CADENCE_MS = 15 * 60_000;
 export const MAX_INBOX_AUDIT_DIAGNOSTIC_CHARS = 120;
 
 export function boundedInboxAuditDiagnostic(error: unknown): string {
+  const max = MAX_INBOX_AUDIT_DIAGNOSTIC_CHARS;
   const code = error && typeof error === "object" && "code" in error && typeof (error as { code: unknown }).code === "string"
-    ? (error as { code: string }).code
+    ? (error as { code: string }).code.slice(0, max)
     : "";
   const raw = error instanceof Error ? error.message : String(error);
-  const text = raw.replace(/[\u0000-\u001f\u007f]+/g, " ").replace(/\s+/g, " ").trim();
-  return [code, text].filter(Boolean).join(" ").slice(0, MAX_INBOX_AUDIT_DIAGNOSTIC_CHARS);
+  const text = String(raw).slice(0, max).replace(/[\u0000-\u001f\u007f]+/g, " ").replace(/\s+/g, " ").trim();
+  return [code, text].filter(Boolean).join(" ").slice(0, max);
 }
 
 interface AuditAgent { agentId: string }

--- a/src/agent/missed-outbound-scan.ts
+++ b/src/agent/missed-outbound-scan.ts
@@ -45,7 +45,9 @@ function load(file: string): AuditRegistry {
   let fd: number | undefined;
   let bytes: Buffer;
   try {
-    fd = fs.openSync(file, fs.constants.O_RDONLY | (fs.constants.O_NOFOLLOW || 0));
+    fd = fs.openSync(file, fs.constants.O_RDONLY
+      | (fs.constants.O_NOFOLLOW || 0)
+      | (fs.constants.O_NONBLOCK || 0));
     const stat = fs.fstatSync(fd);
     if (!stat.isFile()) throw new Error("inbox audit registry is not a regular file");
     const buffer = Buffer.alloc(MAX_INBOX_AUDIT_REGISTRY_BYTES + 1);

--- a/src/agent/missed-outbound-scan.ts
+++ b/src/agent/missed-outbound-scan.ts
@@ -68,16 +68,17 @@ function save(file: string, registry: AuditRegistry): void {
   fs.chmodSync(file, 0o600);
 }
 
-/** Record only an authoritative human group/topic source; DMs and bots are ignored. */
+/** Record only an originally wake-eligible authoritative human group/topic source. */
 export function observeInboxAuditTarget(file: string, agentId: string, event: {
   chat_id?: string;
   chat_type?: string;
   thread_id?: string | null;
   message_id?: string;
+  wake?: boolean;
   _sender_is_bot?: boolean;
   _scan_authority?: boolean;
 }, now = new Date()): boolean {
-  if (event._scan_authority !== true || event._sender_is_bot !== false || event.chat_type !== "group") return false;
+  if (event.wake !== true || event._scan_authority !== true || event._sender_is_bot !== false || event.chat_type !== "group") return false;
   const parsed = parseTarget(event);
   if (!parsed) return false;
   const registry = load(file);
@@ -87,6 +88,10 @@ export function observeInboxAuditTarget(file: string, agentId: string, event: {
   registry.targets = registry.targets.slice(0, MAX_STORED_TARGETS);
   save(file, registry);
   return true;
+}
+
+export function hasInboxAuditTargets(file: string, agentId: string): boolean {
+  return load(file).targets.some((row) => row.agent_id === agentId);
 }
 
 function instruction(target: InboxAuditTarget): string {

--- a/src/agent/missed-outbound-scan.ts
+++ b/src/agent/missed-outbound-scan.ts
@@ -12,8 +12,8 @@ export const INBOX_AUDIT_LEGACY_MIGRATION_NON_GOAL = "New versions no longer cre
 // cannot accumulate an unbounded work list.
 export const MAX_INBOX_AUDIT_TARGETS = 96;
 const MAX_STORED_TARGETS = MAX_INBOX_AUDIT_TARGETS;
-// Periodic heartbeat reads this file. Bound the read and fail closed instead of
-// parsing or slicing an oversized registry, which would hide or destroy rows.
+// Periodic heartbeat reads this file through a cap+1 fd buffer. Fail closed
+// instead of parsing, slicing, or rewriting an oversized registry.
 export const MAX_INBOX_AUDIT_REGISTRY_BYTES = 64 * 1024;
 export const MAX_INBOX_AUDIT_REGISTRY_ROWS = MAX_INBOX_AUDIT_TARGETS;
 const CHAT = /^oc_[A-Za-z0-9]+$/;
@@ -42,17 +42,27 @@ function parseTarget(event: { chat_id?: string; thread_id?: string | null; messa
 }
 
 function load(file: string): AuditRegistry {
+  let fd: number | undefined;
   let bytes: Buffer;
   try {
-    const stat = fs.statSync(file);
+    fd = fs.openSync(file, fs.constants.O_RDONLY | (fs.constants.O_NOFOLLOW || 0));
+    const stat = fs.fstatSync(fd);
     if (!stat.isFile()) throw new Error("inbox audit registry is not a regular file");
-    if (stat.size > MAX_INBOX_AUDIT_REGISTRY_BYTES) throw new Error("inbox audit registry exceeds the bounded byte limit");
-    bytes = fs.readFileSync(file);
+    const buffer = Buffer.alloc(MAX_INBOX_AUDIT_REGISTRY_BYTES + 1);
+    let offset = 0;
+    while (offset < buffer.length) {
+      const read = fs.readSync(fd, buffer, offset, buffer.length - offset, offset);
+      if (read === 0) break;
+      offset += read;
+    }
+    if (offset > MAX_INBOX_AUDIT_REGISTRY_BYTES) throw new Error("inbox audit registry exceeds the bounded byte limit");
+    bytes = buffer.subarray(0, offset);
   } catch (error) {
     if ((error as NodeJS.ErrnoException).code === "ENOENT") return { version: 1, targets: [] };
     throw error;
+  } finally {
+    if (fd !== undefined) fs.closeSync(fd);
   }
-  if (bytes.length > MAX_INBOX_AUDIT_REGISTRY_BYTES) throw new Error("inbox audit registry exceeds the bounded byte limit");
   const value = JSON.parse(bytes.toString("utf8")) as Partial<AuditRegistry>;
   if (value?.version !== 1 || !Array.isArray(value.targets)) return { version: 1, targets: [] };
   if (value.targets.length > MAX_INBOX_AUDIT_REGISTRY_ROWS) throw new Error("inbox audit registry exceeds the bounded row limit");
@@ -72,9 +82,16 @@ function load(file: string): AuditRegistry {
 }
 
 function save(file: string, registry: AuditRegistry): void {
+  if (registry.targets.length > MAX_INBOX_AUDIT_REGISTRY_ROWS) {
+    throw new Error("inbox audit registry exceeds the bounded row limit");
+  }
+  const serialized = `${JSON.stringify(registry)}\n`;
+  if (Buffer.byteLength(serialized) > MAX_INBOX_AUDIT_REGISTRY_BYTES) {
+    throw new Error("inbox audit registry exceeds the bounded byte limit");
+  }
   fs.mkdirSync(path.dirname(file), { recursive: true, mode: 0o700 });
   const temporary = path.join(path.dirname(file), `.${path.basename(file)}.${process.pid}.${Date.now()}.tmp`);
-  fs.writeFileSync(temporary, `${JSON.stringify(registry)}\n`, { mode: 0o600 });
+  fs.writeFileSync(temporary, serialized, { mode: 0o600 });
   fs.renameSync(temporary, file);
   fs.chmodSync(file, 0o600);
 }

--- a/src/agent/missed-outbound-scan.ts
+++ b/src/agent/missed-outbound-scan.ts
@@ -12,6 +12,10 @@ export const INBOX_AUDIT_LEGACY_MIGRATION_NON_GOAL = "New versions no longer cre
 // cannot accumulate an unbounded work list.
 export const MAX_INBOX_AUDIT_TARGETS = 96;
 const MAX_STORED_TARGETS = MAX_INBOX_AUDIT_TARGETS;
+// Periodic heartbeat reads this file. Bound the read and fail closed instead of
+// parsing or slicing an oversized registry, which would hide or destroy rows.
+export const MAX_INBOX_AUDIT_REGISTRY_BYTES = 64 * 1024;
+export const MAX_INBOX_AUDIT_REGISTRY_ROWS = MAX_INBOX_AUDIT_TARGETS;
 const CHAT = /^oc_[A-Za-z0-9]+$/;
 const THREAD = /^omt_[A-Za-z0-9]+$/;
 const ANCHOR = /^om_[A-Za-z0-9_-]+$/;
@@ -38,13 +42,20 @@ function parseTarget(event: { chat_id?: string; thread_id?: string | null; messa
 }
 
 function load(file: string): AuditRegistry {
-  let value: Partial<AuditRegistry>;
-  try { value = JSON.parse(fs.readFileSync(file, "utf8")) as Partial<AuditRegistry>; }
-  catch (error) {
+  let bytes: Buffer;
+  try {
+    const stat = fs.statSync(file);
+    if (!stat.isFile()) throw new Error("inbox audit registry is not a regular file");
+    if (stat.size > MAX_INBOX_AUDIT_REGISTRY_BYTES) throw new Error("inbox audit registry exceeds the bounded byte limit");
+    bytes = fs.readFileSync(file);
+  } catch (error) {
     if ((error as NodeJS.ErrnoException).code === "ENOENT") return { version: 1, targets: [] };
     throw error;
   }
+  if (bytes.length > MAX_INBOX_AUDIT_REGISTRY_BYTES) throw new Error("inbox audit registry exceeds the bounded byte limit");
+  const value = JSON.parse(bytes.toString("utf8")) as Partial<AuditRegistry>;
   if (value?.version !== 1 || !Array.isArray(value.targets)) return { version: 1, targets: [] };
+  if (value.targets.length > MAX_INBOX_AUDIT_REGISTRY_ROWS) throw new Error("inbox audit registry exceeds the bounded row limit");
   return { version: 1, targets: value.targets.flatMap((row): StoredTarget[] => {
     if (!row || typeof row !== "object") return [];
     const candidate = row as Partial<StoredTarget>;

--- a/src/feishu/host-shell.ts
+++ b/src/feishu/host-shell.ts
@@ -19,7 +19,7 @@ import {
 import { ProcessingEyeOrchestrator } from "./host-processing-eye.js";
 import { projectInboxEnvelope, targetKeyOfInboxEnvelope } from "../agent/inbox-projection.js";
 import { HostReminderOrchestrator } from "../agent/host-reminder-orchestrator.js";
-import { InboxAuditHeartbeat } from "../agent/inbox-audit-heartbeat.js";
+import { boundedInboxAuditDiagnostic, InboxAuditHeartbeat } from "../agent/inbox-audit-heartbeat.js";
 import { hasInboxAuditTargets, inboxAuditRegistryFile, observeInboxAuditTarget } from "../agent/missed-outbound-scan.js";
 import { HostChannelBusiness } from "./host-channel-business.js";
 import { HostInteractionOrchestrator } from "./interaction-orchestrator.js";
@@ -530,7 +530,7 @@ export function createHostShell({
         try {
           observeInboxAuditTarget(auditRegistry, agent.agentId, { ...event, wake });
         } catch (error) {
-          log(`inbox audit target 未持久化: ${(error as Error).message}`);
+          log(`inbox audit target 未持久化: ${boundedInboxAuditDiagnostic(error)}`);
         }
         if (append.status === "duplicate_consumed") return null;
         const inboxEnvelope = append.envelope;

--- a/src/feishu/host-shell.ts
+++ b/src/feishu/host-shell.ts
@@ -20,7 +20,7 @@ import { ProcessingEyeOrchestrator } from "./host-processing-eye.js";
 import { projectInboxEnvelope, targetKeyOfInboxEnvelope } from "../agent/inbox-projection.js";
 import { HostReminderOrchestrator } from "../agent/host-reminder-orchestrator.js";
 import { InboxAuditHeartbeat } from "../agent/inbox-audit-heartbeat.js";
-import { inboxAuditRegistryFile, observeInboxAuditTarget } from "../agent/missed-outbound-scan.js";
+import { hasInboxAuditTargets, inboxAuditRegistryFile, observeInboxAuditTarget } from "../agent/missed-outbound-scan.js";
 import { HostChannelBusiness } from "./host-channel-business.js";
 import { HostInteractionOrchestrator } from "./interaction-orchestrator.js";
 import { targetFor, type FeishuInboundEvent } from "./message-policy.js";
@@ -485,13 +485,14 @@ export function createHostShell({
   };
   for (const agent of agents) prepareAgentState(agent);
   const reminder = new HostReminderOrchestrator({ agents, stateStore, envelopeProjector, deliveryTarget: runtimeHost, log });
+  const auditRegistry = inboxAuditRegistryFile(larkinHome);
   const inboxAudit = new InboxAuditHeartbeat({
     agents,
     stateStore,
     runtimeHost,
+    shouldDispatch: (agent) => hasInboxAuditTargets(auditRegistry, agent.agentId),
     log,
   });
-  const auditRegistry = inboxAuditRegistryFile(larkinHome);
   const seenEventIds = new Set<string>();
   const inFlightEventIds = new Set<string>();
   const onFeishuMessage = async (agent: ConfiguredAgent, event: FeishuInboundEvent, options?: { wake?: boolean }): Promise<void> => {
@@ -527,7 +528,7 @@ export function createHostShell({
         // append/dedupe decision is durable. Agent model-seen state is untouched.
         if (event.event_id) seenEventIds.add(eventKey);
         try {
-          observeInboxAuditTarget(auditRegistry, agent.agentId, event);
+          observeInboxAuditTarget(auditRegistry, agent.agentId, { ...event, wake });
         } catch (error) {
           log(`inbox audit target 未持久化: ${(error as Error).message}`);
         }

--- a/test/unit/agent/missed-outbound-scan.test.mjs
+++ b/test/unit/agent/missed-outbound-scan.test.mjs
@@ -5,6 +5,7 @@ import path from "node:path";
 import { spawnSync } from "node:child_process";
 import { test } from "bun:test";
 import {
+  hasInboxAuditTargets,
   inboxAuditRegistryFile,
   MAX_INBOX_AUDIT_TARGETS,
   observeInboxAuditTarget,
@@ -31,8 +32,13 @@ test("audit registry retains only authoritative human group/topic targets with t
   const root = fs.mkdtempSync(path.join(os.tmpdir(), "larkin-inbox-audit-"));
   try {
     const file = inboxAuditRegistryFile(root);
-    const common = { chat_id: CHAT, chat_type: "group", _scan_authority: true, _sender_is_bot: false };
+    const common = { chat_id: CHAT, chat_type: "group", wake: true, _scan_authority: true, _sender_is_bot: false };
+    assert.equal(hasInboxAuditTargets(file, "cli_audit"), false);
+    assert.equal(observeInboxAuditTarget(file, "cli_audit", { ...common, wake: false, message_id: "om_unmentioned" }), false);
+    assert.equal(hasInboxAuditTargets(file, "cli_audit"), false);
     assert.equal(observeInboxAuditTarget(file, "cli_audit", { ...common, message_id: "om_chat" }), true);
+    assert.equal(hasInboxAuditTargets(file, "cli_audit"), true);
+    assert.equal(hasInboxAuditTargets(file, "cli_unrelated"), false);
     assert.equal(observeInboxAuditTarget(file, "cli_audit", { ...common, thread_id: "omt_topic", message_id: "om_topic" }), true);
     assert.equal(observeInboxAuditTarget(file, "cli_audit", { ...common, chat_type: "p2p", message_id: "om_dm" }), false);
     assert.equal(observeInboxAuditTarget(file, "cli_audit", { ...common, _sender_is_bot: true, message_id: "om_bot" }), false);
@@ -57,7 +63,7 @@ test("controlled audit sink routes only a concrete thread finding to its om_ anc
     const file = inboxAuditRegistryFile(root);
     const traceFile = path.join(root, "provider-writes.ndjson");
     fs.writeFileSync(traceFile, "", { mode: 0o600 });
-    const common = { chat_id: CHAT, chat_type: "group", _scan_authority: true, _sender_is_bot: false };
+    const common = { chat_id: CHAT, chat_type: "group", wake: true, _scan_authority: true, _sender_is_bot: false };
     assert.equal(observeInboxAuditTarget(file, "cli_audit", {
       ...common, thread_id: "omt_auditthread", message_id: "om_audit_thread_anchor",
     }), true);
@@ -85,7 +91,7 @@ test("controlled audit sink routes only a concrete thread finding to its om_ anc
   } finally { fs.rmSync(root, { recursive: true, force: true }); }
 });
 
-test("one Host timer callback delivers targetless runtime audit wakes to multiple agents", async () => {
+test("one Host timer callback wakes only Agents with an eligible audit target", async () => {
   const timers = [];
   const inbox = [];
   const deliveries = [];
@@ -93,6 +99,7 @@ test("one Host timer callback delivers targetless runtime audit wakes to multipl
     agents: [{ agentId: "cli_auditOne" }, { agentId: "cli_auditTwo" }],
     stateStore: () => ({ appendCanonicalInboxOnce(envelope) { inbox.push(envelope); return { status: "appended", envelope }; } }),
     runtimeHost: { async deliver(agentId, envelope) { deliveries.push({ agentId, envelope }); } },
+    shouldDispatch: (agent) => agent.agentId === "cli_auditTwo",
     now: () => 1234,
     setTimer(callback, delay) { timers.push({ callback, delay }); return { unref() {} }; },
     clearTimer() {},
@@ -103,8 +110,35 @@ test("one Host timer callback delivers targetless runtime audit wakes to multipl
   assert.equal(timers[0].delay, 15 * 60_000);
   await timers[0].callback();
   assert.equal(timers.length, 2, "callback re-arms one successor timer");
-  assert.equal(deliveries.length, 2);
+  assert.deepEqual(deliveries.map((row) => row.agentId), ["cli_auditTwo"]);
+  assert.equal(inbox.length, 1, "an Agent without an eligible audit target receives no model wake");
   assert.equal(inbox.every((row) => row.target === "runtime:reminder" && row.kind === "reminder"), true);
   assert.equal(inbox.every((row) => !Object.hasOwn(row, "deliveryTarget") && !Object.hasOwn(row, "deliveryAnchor")), true);
+  heartbeat.stop();
+});
+
+test("an Agent-scoped audit predicate failure fails closed and does not block a healthy sibling", async () => {
+  const timers = [];
+  const inbox = [];
+  const deliveries = [];
+  const logs = [];
+  const heartbeat = new InboxAuditHeartbeat({
+    agents: [{ agentId: "cli_brokenAudit" }, { agentId: "cli_healthyAudit" }],
+    stateStore: () => ({ appendCanonicalInboxOnce(envelope) { inbox.push(envelope); return { status: "appended", envelope }; } }),
+    runtimeHost: { async deliver(agentId) { deliveries.push(agentId); } },
+    shouldDispatch(agent) {
+      if (agent.agentId === "cli_brokenAudit") throw new Error("fixture registry unavailable");
+      return true;
+    },
+    log: (...parts) => logs.push(parts.join(" ")),
+    setTimer(callback) { timers.push(callback); return { unref() {} }; },
+    clearTimer() {},
+  });
+  heartbeat.start();
+  await timers[0]();
+  assert.deepEqual(deliveries, ["cli_healthyAudit"]);
+  assert.equal(inbox.length, 1);
+  assert.equal(logs.length, 1);
+  assert.match(logs[0], /cli_brokenAudit.*fixture registry unavailable/);
   heartbeat.stop();
 });

--- a/test/unit/agent/missed-outbound-scan.test.mjs
+++ b/test/unit/agent/missed-outbound-scan.test.mjs
@@ -197,6 +197,7 @@ test("registry load uses a cap+1 fd buffer and never readFileSyncs the registry"
   assert.match(source, /MAX_INBOX_AUDIT_REGISTRY_BYTES \+ 1/);
   assert.match(source, /readSync\(/);
   assert.match(source, /fstatSync\(/);
+  assert.match(source, /O_NONBLOCK/);
   assert.match(source, /isFile\(\)/);
   assert.equal(/readFileSync\(/.test(source), false, "load/save must not call readFileSync");
   const root = fs.mkdtempSync(path.join(os.tmpdir(), "larkin-inbox-audit-fd-"));
@@ -222,6 +223,44 @@ test("hasInboxAuditTargets fails closed when the registry path is not a regular 
     assert.throws(() => hasInboxAuditTargets(file, "cli_audit"), /regular file|EISDIR/);
   } finally { fs.rmSync(root, { recursive: true, force: true }); }
 });
+
+const POSIX_FIFO_HARNESS = process.platform !== "win32"
+  && Number(fs.constants.O_NONBLOCK) > 0
+  && Boolean(Bun.which("mkfifo"));
+
+test.skipIf(!POSIX_FIFO_HARNESS)("hasInboxAuditTargets rejects a POSIX FIFO without blocking siblings", () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "larkin-inbox-audit-fifo-"));
+  const file = inboxAuditRegistryFile(root);
+  const probe = path.join(root, "fifo-probe.mjs");
+  const childTimeoutMs = 2_000;
+  try {
+    fs.mkdirSync(path.dirname(file), { recursive: true, mode: 0o700 });
+    const created = spawnSync("mkfifo", ["-m", "0600", file], { encoding: "utf8" });
+    assert.equal(created.status, 0, created.stderr || created.error?.message);
+    assert.equal(fs.lstatSync(file).isFIFO(), true);
+    fs.writeFileSync(probe, `import { hasInboxAuditTargets } from ${JSON.stringify(new URL("../../../src/agent/missed-outbound-scan.ts", import.meta.url).href)};
+try {
+  hasInboxAuditTargets(process.argv[2], "cli_audit");
+  process.exit(2);
+} catch (error) {
+  const text = error instanceof Error ? error.message : String(error);
+  const code = error && typeof error === "object" && "code" in error ? String(error.code) : "";
+  process.exit(/regular file/.test(text) || code === "ENXIO" || code === "EAGAIN" ? 0 : 3);
+}
+`);
+    const child = spawnSync(process.execPath, [probe, file], {
+      encoding: "utf8",
+      timeout: childTimeoutMs,
+      killSignal: "SIGKILL",
+    });
+    assert.notEqual(child.signal, "SIGKILL", "FIFO open must return before the hard timeout");
+    assert.equal(child.error, undefined, child.error?.message);
+    assert.equal(child.status, 0, child.stderr || child.stdout);
+  } finally {
+    try { fs.unlinkSync(file); } catch { /* probe or mkfifo may have left the fifo */ }
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+}, { timeout: 5_000 });
 
 test("observe rejects a serialized registry the load cap would refuse and keeps the prior file", () => {
   const root = fs.mkdtempSync(path.join(os.tmpdir(), "larkin-inbox-audit-save-"));

--- a/test/unit/agent/missed-outbound-scan.test.mjs
+++ b/test/unit/agent/missed-outbound-scan.test.mjs
@@ -14,6 +14,7 @@ import {
   readInboxAuditTargets,
 } from "../../../src/agent/missed-outbound-scan.ts";
 import {
+  boundedInboxAuditDiagnostic,
   InboxAuditHeartbeat,
   MAX_INBOX_AUDIT_DIAGNOSTIC_CHARS,
 } from "../../../src/agent/inbox-audit-heartbeat.ts";
@@ -189,6 +190,74 @@ test("hasInboxAuditTargets fails closed on oversized rows without rewriting the 
     }), /bounded row limit/);
     assert.equal(fs.readFileSync(file, "utf8"), original, "failed observe must not slice or rewrite extra rows");
   } finally { fs.rmSync(root, { recursive: true, force: true }); }
+});
+
+test("registry load uses a cap+1 fd buffer and never readFileSyncs the registry", () => {
+  const source = fs.readFileSync(new URL("../../../src/agent/missed-outbound-scan.ts", import.meta.url), "utf8");
+  assert.match(source, /MAX_INBOX_AUDIT_REGISTRY_BYTES \+ 1/);
+  assert.match(source, /readSync\(/);
+  assert.match(source, /fstatSync\(/);
+  assert.match(source, /isFile\(\)/);
+  assert.equal(/readFileSync\(/.test(source), false, "load/save must not call readFileSync");
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "larkin-inbox-audit-fd-"));
+  try {
+    const file = inboxAuditRegistryFile(root);
+    const original = Buffer.concat([
+      Buffer.from(`${JSON.stringify({ version: 1, targets: [] })}\n`),
+      Buffer.alloc(MAX_INBOX_AUDIT_REGISTRY_BYTES, 0x78),
+    ]);
+    fs.mkdirSync(path.dirname(file), { recursive: true, mode: 0o700 });
+    fs.writeFileSync(file, original, { mode: 0o600 });
+    assert.ok(original.length > MAX_INBOX_AUDIT_REGISTRY_BYTES);
+    assert.throws(() => hasInboxAuditTargets(file, "cli_audit"), /bounded byte limit/);
+    assert.equal(fs.readFileSync(file).equals(original), true, "capped overflow read must leave the registry intact");
+  } finally { fs.rmSync(root, { recursive: true, force: true }); }
+});
+
+test("hasInboxAuditTargets fails closed when the registry path is not a regular file", () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "larkin-inbox-audit-dir-"));
+  try {
+    const file = inboxAuditRegistryFile(root);
+    fs.mkdirSync(file, { recursive: true, mode: 0o700 });
+    assert.throws(() => hasInboxAuditTargets(file, "cli_audit"), /regular file|EISDIR/);
+  } finally { fs.rmSync(root, { recursive: true, force: true }); }
+});
+
+test("observe rejects a serialized registry the load cap would refuse and keeps the prior file", () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "larkin-inbox-audit-save-"));
+  try {
+    const file = inboxAuditRegistryFile(root);
+    const common = { chat_id: CHAT, chat_type: "group", wake: true, _scan_authority: true, _sender_is_bot: false };
+    assert.equal(observeInboxAuditTarget(file, "cli_audit", { ...common, message_id: "om_keep" }), true);
+    const prior = fs.readFileSync(file);
+    assert.ok(prior.length > 0 && prior.length <= MAX_INBOX_AUDIT_REGISTRY_BYTES);
+    assert.throws(() => observeInboxAuditTarget(file, `cli_${"x".repeat(MAX_INBOX_AUDIT_REGISTRY_BYTES)}`, {
+      ...common, message_id: "om_overflow",
+    }), /bounded byte limit/);
+    assert.deepEqual(fs.readFileSync(file), prior, "oversized serialize must not replace the prior registry");
+    assert.deepEqual(readInboxAuditTargets(file, "cli_audit").targets.map((row) => row.anchor), ["om_keep"]);
+  } finally { fs.rmSync(root, { recursive: true, force: true }); }
+});
+
+test("diagnostic normalization bounds input before regex or join", () => {
+  const marker = "secret-should-not-repeat";
+  const huge = `boom\n\n${"x".repeat(8_000)}\n${marker}`;
+  const error = new Error(huge);
+  error.code = `E${"Y".repeat(8_000)}`;
+  const lengths = [];
+  const originalReplace = String.prototype.replace;
+  String.prototype.replace = function replace(...args) {
+    lengths.push(this.length);
+    return originalReplace.apply(this, args);
+  };
+  try {
+    const diagnostic = boundedInboxAuditDiagnostic(error);
+    assert.ok(diagnostic.length <= MAX_INBOX_AUDIT_DIAGNOSTIC_CHARS);
+    assert.equal(diagnostic.includes(marker), false);
+    assert.equal(lengths.every((length) => length <= MAX_INBOX_AUDIT_DIAGNOSTIC_CHARS), true);
+  } finally {
+    String.prototype.replace = originalReplace;
+  }
 });
 
 test("heartbeat diagnostics stay bounded when a registry error message is huge", async () => {

--- a/test/unit/agent/missed-outbound-scan.test.mjs
+++ b/test/unit/agent/missed-outbound-scan.test.mjs
@@ -7,11 +7,16 @@ import { test } from "bun:test";
 import {
   hasInboxAuditTargets,
   inboxAuditRegistryFile,
+  MAX_INBOX_AUDIT_REGISTRY_BYTES,
+  MAX_INBOX_AUDIT_REGISTRY_ROWS,
   MAX_INBOX_AUDIT_TARGETS,
   observeInboxAuditTarget,
   readInboxAuditTargets,
 } from "../../../src/agent/missed-outbound-scan.ts";
-import { InboxAuditHeartbeat } from "../../../src/agent/inbox-audit-heartbeat.ts";
+import {
+  InboxAuditHeartbeat,
+  MAX_INBOX_AUDIT_DIAGNOSTIC_CHARS,
+} from "../../../src/agent/inbox-audit-heartbeat.ts";
 
 const CHAT = "oc_7961b9d7be893b46520a926b90cf46eb";
 const ROUTING_SINK = path.resolve(import.meta.dirname, "../../support/inbox-audit-routing-sink.mjs");
@@ -140,5 +145,75 @@ test("an Agent-scoped audit predicate failure fails closed and does not block a 
   assert.equal(inbox.length, 1);
   assert.equal(logs.length, 1);
   assert.match(logs[0], /cli_brokenAudit.*fixture registry unavailable/);
+  heartbeat.stop();
+});
+
+test("hasInboxAuditTargets fails closed on oversized bytes without truncating the registry", () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "larkin-inbox-audit-bytes-"));
+  try {
+    const file = inboxAuditRegistryFile(root);
+    const padding = "x".repeat(MAX_INBOX_AUDIT_REGISTRY_BYTES);
+    const original = `${JSON.stringify({ version: 1, targets: [], padding })}\n`;
+    fs.mkdirSync(path.dirname(file), { recursive: true, mode: 0o700 });
+    fs.writeFileSync(file, original, { mode: 0o600 });
+    assert.ok(fs.statSync(file).size > MAX_INBOX_AUDIT_REGISTRY_BYTES);
+    assert.throws(() => hasInboxAuditTargets(file, "cli_audit"), /bounded byte limit/);
+    assert.equal(fs.readFileSync(file, "utf8"), original, "oversized registry bytes must stay intact");
+    assert.throws(() => readInboxAuditTargets(file, "cli_audit"), /bounded byte limit/);
+    assert.throws(() => observeInboxAuditTarget(file, "cli_audit", {
+      chat_id: CHAT, chat_type: "group", wake: true, _scan_authority: true, _sender_is_bot: false, message_id: "om_keep",
+    }), /bounded byte limit/);
+    assert.equal(fs.readFileSync(file, "utf8"), original, "failed observe must not rewrite an oversized registry");
+  } finally { fs.rmSync(root, { recursive: true, force: true }); }
+});
+
+test("hasInboxAuditTargets fails closed on oversized rows without rewriting the registry", () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "larkin-inbox-audit-rows-"));
+  try {
+    const file = inboxAuditRegistryFile(root);
+    const original = `${JSON.stringify({
+      version: 1,
+      targets: Array.from({ length: MAX_INBOX_AUDIT_REGISTRY_ROWS + 1 }, (_row, index) => ({
+        agent_id: "cli_audit",
+        target: `chat:${CHAT}`,
+        anchor: `om_row${index}`,
+        observed_at: "2026-09-05T00:00:00.000Z",
+      })),
+    })}\n`;
+    fs.mkdirSync(path.dirname(file), { recursive: true, mode: 0o700 });
+    fs.writeFileSync(file, original, { mode: 0o600 });
+    assert.throws(() => hasInboxAuditTargets(file, "cli_audit"), /bounded row limit/);
+    assert.equal(fs.readFileSync(file, "utf8"), original, "oversized registry rows must stay intact");
+    assert.throws(() => observeInboxAuditTarget(file, "cli_audit", {
+      chat_id: CHAT, chat_type: "group", wake: true, _scan_authority: true, _sender_is_bot: false, message_id: "om_keep",
+    }), /bounded row limit/);
+    assert.equal(fs.readFileSync(file, "utf8"), original, "failed observe must not slice or rewrite extra rows");
+  } finally { fs.rmSync(root, { recursive: true, force: true }); }
+});
+
+test("heartbeat diagnostics stay bounded when a registry error message is huge", async () => {
+  const timers = [];
+  const logs = [];
+  const marker = "secret-should-not-repeat";
+  const huge = `registry boom ${"x".repeat(8_000)} ${marker}`;
+  const heartbeat = new InboxAuditHeartbeat({
+    agents: [{ agentId: "cli_brokenAudit" }, { agentId: "cli_healthyAudit" }],
+    stateStore: () => ({ appendCanonicalInboxOnce(envelope) { return { status: "appended", envelope }; } }),
+    runtimeHost: { async deliver() {} },
+    shouldDispatch(agent) {
+      if (agent.agentId === "cli_brokenAudit") throw new Error(huge);
+      return false;
+    },
+    log: (...parts) => logs.push(parts.join(" ")),
+    setTimer(callback) { timers.push(callback); return { unref() {} }; },
+    clearTimer() {},
+  });
+  heartbeat.start();
+  await timers[0]();
+  assert.equal(logs.length, 1);
+  assert.match(logs[0], /cli_brokenAudit/);
+  assert.ok(logs[0].length <= `inbox audit heartbeat failed agent=cli_brokenAudit: `.length + MAX_INBOX_AUDIT_DIAGNOSTIC_CHARS);
+  assert.equal(logs[0].includes(marker), false);
+  assert.equal(logs[0].includes("x".repeat(200)), false);
   heartbeat.stop();
 });

--- a/test/unit/feishu/inbox-audit-require-host.test.mjs
+++ b/test/unit/feishu/inbox-audit-require-host.test.mjs
@@ -3,6 +3,7 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { test } from "bun:test";
+import { INBOX_AUDIT_CADENCE_MS } from "../../../src/agent/inbox-audit-heartbeat.ts";
 import { createHostShell } from "../../../dist/feishu/host-shell.mjs";
 import { inboxAuditRegistryFile, readInboxAuditTargets } from "../../../dist/agent/missed-outbound-scan.mjs";
 
@@ -50,6 +51,125 @@ test("Host ingest records only originally wake=true group traffic into the audit
     assert.deepEqual(audit.targets.map((row) => row.anchor), ["om_mentioned"]);
     assert.equal(audit.targets[0].target, `chat:${CHAT}`);
   } finally {
+    await host.shutdown("cleanup");
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});
+
+function inboxRows(root, agentId) {
+  const file = path.join(root, "state", "agents", agentId, "feishu-inbox.ndjson");
+  if (!fs.existsSync(file)) return [];
+  return fs.readFileSync(file, "utf8").trim().split("\n").filter(Boolean).map(JSON.parse);
+}
+
+async function waitFor(predicate, label, timeoutMs = 2_000) {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    if (await predicate()) return;
+    await new Promise((resolve) => setTimeout(resolve, 10));
+  }
+  throw new Error(label);
+}
+
+test("Host channel decideWake persists Inbox then Host heartbeat wakes only the sibling with a retained target", async () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "larkin-inbox-audit-host-timer-"));
+  const eligibleId = "cli_inboxAuditWakeA1";
+  const siblingId = "cli_inboxAuditWakeB2";
+  const agentFor = (agentId) => ({
+    agentId, name: agentId, runtime: "codex", model: "gpt", feishuAppId: agentId,
+    feishuAppSecret: "fixture-secret", feishuProfile: agentId, feishuDomain: "https://open.feishu.cn",
+    workspaceDir: path.join(root, "agents", agentId), stateDir: path.join(root, "state", "agents", agentId),
+    larkConfigDir: path.join(root, "state", "agents", agentId, "lark-cli-config"),
+  });
+  const env = {
+    LARKIN_HOME: root, LARKIN_CONFIG_DIR: root, LARKIN_SERVER_ID: "server-inbox-audit-host-timer",
+    LARKIN_AGENTS_CONFIG: JSON.stringify([agentFor(eligibleId), agentFor(siblingId)]),
+    LARKIN_INBOUND_DROUGHT_SEC: "0",
+  };
+  const deliveries = [];
+  const runtimeHost = {
+    subscribe() { return () => {}; },
+    async start() {},
+    async deliver(agentId, envelope) {
+      deliveries.push({ agentId, envelope });
+      return { status: "accepted" };
+    },
+    async stop() {},
+    async shutdown() {},
+  };
+  const handlersByApp = new Map();
+  const channelPackage = {
+    createLarkChannel(options) {
+      const channel = {
+        botIdentity: { openId: `ou_${options.appId}`, name: options.appId },
+        rawClient: { async request() { return { bot: { open_id: `ou_${options.appId}`, app_name: options.appId } }; } },
+        dispatcher: { register() {} },
+        on(handlers) { handlersByApp.set(options.appId, handlers); },
+        async connect() {},
+        async disconnect() {},
+      };
+      return channel;
+    },
+  };
+  const auditTimers = [];
+  const realSetTimeout = globalThis.setTimeout;
+  const realClearTimeout = globalThis.clearTimeout;
+  globalThis.setTimeout = (callback, delay, ...args) => {
+    if (delay === INBOX_AUDIT_CADENCE_MS) {
+      const handle = { callback, delay, unref() {} };
+      auditTimers.push(handle);
+      return handle;
+    }
+    return realSetTimeout(callback, delay, ...args);
+  };
+  globalThis.clearTimeout = (handle) => {
+    if (handle && typeof handle === "object" && handle.delay === INBOX_AUDIT_CADENCE_MS) return;
+    return realClearTimeout(handle);
+  };
+  const host = createHostShell({
+    env, runtimeHost, channelPackage, eventSourceStartDelayMs: 0,
+    managedCliForAgent: testManagedCli,
+    execFileImpl(_command, _args, _options, callback) {
+      callback(null, JSON.stringify({ ok: true, data: { items: [{ member_id: "ou_human", name: "Human" }] } }), "");
+      return {};
+    },
+  });
+  try {
+    await host.start();
+    await waitFor(() => handlersByApp.size === 2, "Host-installed channels did not register");
+    assert.equal(auditTimers.length, 1, "Host must install one inbox-audit timer at the production cadence");
+    assert.equal(auditTimers[0].delay, INBOX_AUDIT_CADENCE_MS);
+
+    handlersByApp.get(eligibleId).message({
+      chatId: CHAT, chatType: "group", senderId: "ou_human", messageId: "om_mentioned",
+      content: "hello @bot", mentionedBot: true, senderIsBot: false,
+    });
+    handlersByApp.get(siblingId).message({
+      chatId: CHAT, chatType: "group", senderId: "ou_human", messageId: "om_quiet",
+      content: "ordinary context", mentionedBot: false, senderIsBot: false,
+    });
+
+    await waitFor(() => inboxRows(root, eligibleId).some((row) => row.message_id === "om_mentioned")
+      && inboxRows(root, siblingId).some((row) => row.message_id === "om_quiet"),
+    "channel decideWake did not persist durable Inbox");
+
+    const registry = inboxAuditRegistryFile(root);
+    assert.deepEqual(readInboxAuditTargets(registry, eligibleId).targets.map((row) => row.anchor), ["om_mentioned"]);
+    assert.equal(readInboxAuditTargets(registry, siblingId).targets.length, 0);
+    assert.equal(inboxRows(root, siblingId).some((row) => row.message_id === "om_quiet"), true);
+    const inbound = deliveries.filter((row) => row.envelope?.kind !== "reminder");
+    assert.deepEqual(inbound.map((row) => row.agentId), [eligibleId]);
+
+    await auditTimers[0].callback();
+    const reminders = deliveries.filter((row) => row.envelope?.kind === "reminder" || row.envelope?.target === "runtime:reminder");
+    assert.deepEqual(reminders.map((row) => row.agentId), [eligibleId]);
+    assert.equal(reminders.length, 1);
+    assert.equal(reminders[0].envelope.kind, "reminder");
+    assert.equal(reminders[0].envelope.target, "runtime:reminder");
+    assert.equal(inboxRows(root, siblingId).some((row) => row.kind === "reminder"), false);
+  } finally {
+    globalThis.setTimeout = realSetTimeout;
+    globalThis.clearTimeout = realClearTimeout;
     await host.shutdown("cleanup");
     fs.rmSync(root, { recursive: true, force: true });
   }

--- a/test/unit/feishu/inbox-audit-require-host.test.mjs
+++ b/test/unit/feishu/inbox-audit-require-host.test.mjs
@@ -1,0 +1,56 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { test } from "bun:test";
+import { createHostShell } from "../../../dist/feishu/host-shell.mjs";
+import { inboxAuditRegistryFile, readInboxAuditTargets } from "../../../dist/agent/missed-outbound-scan.mjs";
+
+const CHAT = "oc_7961b9d7be893b46520a926b90cf46eb";
+const testManagedCli = () => ({ command: { command: "/test/official-lark-cli", argsPrefix: [], version: "1.0.80" }, env: {} });
+
+test("Host ingest records only originally wake=true group traffic into the audit registry", async () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "larkin-inbox-audit-host-"));
+  const agentId = "cli_inboxAuditHostA1";
+  const agent = {
+    agentId, name: agentId, runtime: "codex", model: "gpt", feishuAppId: agentId,
+    feishuAppSecret: "fixture-secret", feishuProfile: agentId, feishuDomain: "https://open.feishu.cn",
+    workspaceDir: path.join(root, "agents", agentId), stateDir: path.join(root, "state", "agents", agentId),
+    larkConfigDir: path.join(root, "state", "agents", agentId, "lark-cli-config"),
+  };
+  const env = {
+    LARKIN_HOME: root, LARKIN_CONFIG_DIR: root, LARKIN_SERVER_ID: "server-inbox-audit-host",
+    LARKIN_AGENTS_CONFIG: JSON.stringify([agent]),
+  };
+  const runtimeHost = {
+    subscribe() { return () => {}; },
+    async start() {},
+    async deliver() { return { status: "accepted" }; },
+    async stop() {},
+    async shutdown() {},
+  };
+  const host = createHostShell({
+    env, runtimeHost, eventSourceStartDelayMs: 60_000,
+    managedCliForAgent: testManagedCli,
+    execFileImpl(_command, _args, _options, callback) {
+      callback(null, JSON.stringify({ ok: true, data: { items: [{ member_id: "ou_human", name: "Human" }] } }), "");
+      return {};
+    },
+  });
+  const event = {
+    chat_id: CHAT, chat_type: "group", sender_id: "ou_human", message_id: "om_unmentioned",
+    event_id: "ev_unmentioned", content: "hello", thread_id: null,
+    _mentioned_bot: false, _mention_all: false, _sender_is_bot: false, _scan_authority: true,
+  };
+  try {
+    await host.ingest(agentId, event, { wake: false });
+    assert.equal(readInboxAuditTargets(inboxAuditRegistryFile(root), agentId).targets.length, 0);
+    await host.ingest(agentId, { ...event, message_id: "om_mentioned", event_id: "ev_mentioned" }, { wake: true });
+    const audit = readInboxAuditTargets(inboxAuditRegistryFile(root), agentId);
+    assert.deepEqual(audit.targets.map((row) => row.anchor), ["om_mentioned"]);
+    assert.equal(audit.targets[0].target, `chat:${CHAT}`);
+  } finally {
+    await host.shutdown("cleanup");
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
## Summary
- Policy-neutral repair for issue #186: record an Inbox Audit target only when Host already decided `wake=true`, and have the Host-installed heartbeat dispatch only Agents that still have a retained v1 target (including a healthy sibling).
- Bound the periodic registry load: regular-file `cap+1` fd read, `O_NONBLOCK` where supported so a FIFO cannot freeze heartbeat/siblings, fail closed without silent truncation, and reject oversized serialized output before replacing the prior file. Diagnostics slice before regex/join.
- Does **not** change current default-on behavior, cadence, v1 registry/read semantics, or completion/ack policy. Does **not** merge or adopt PR #187 (default-off and CLI-read-as-completion stay with the blocked parent task).
- `package.json` remains **0.4.28**. The 0.4.29 bump is reserved for ready PR #193.

## Test plan
- [x] Focused `missed-outbound-scan` + Host channel `decideWake` → durable Inbox → Host-installed heartbeat tests
- [x] Independent review `larkin-ux-final-review` accepted exact head `e0e5fef14fc34f2a63858c4c0aa7c3bb074c17a9`
- [x] Full local gate at that SHA (pass/skip separated): frontend 26 pass; unit 963 pass / 1 skip; integration 205 pass / 18 skip; E2E 23 pass; typecheck/build/licenses/publication PASS
- [ ] Reviewers: do not merge PR #187 with this change; do not bump or release from this PR


Made with [Cursor](https://cursor.com)