### PR TITLE
fix(runtime): accept external pi 0.84.2 or newer (0.5.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.5.1
+
+External pi is accepted at 0.84.2 or newer instead of exactly 0.84.2; 0.5.0 refused newer pi and left every migrated Agent not ready.
+
 ## 0.5.0
 
 BREAKING — builtin Pi is removed. Larkin supports only externally installed `pi`, `codex`, and `claude`. If the selected runtime is not installed, setup, runtime switch, and readiness fail with an explicit missing-install message.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "larkin",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "private": false,
   "larkinPackageRole": "npm-published",
   "files": [

--- a/src/runtime/pi-compaction-recovery.ts
+++ b/src/runtime/pi-compaction-recovery.ts
@@ -2,7 +2,8 @@ import crypto from "node:crypto";
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
-export const PINNED_PI_VERSION = "0.84.2";
+/** External `pi` must be this version or newer; handshake still guards protocol compatibility. */
+export const MINIMUM_PI_VERSION = "0.84.2";
 
 /** Fallback values used while importing a Pi profile, before Pi reports its model. */
 export const PI_CONTEXT_WINDOW = 272_000;
@@ -256,16 +257,45 @@ export function readOwnedPiSettings(directory: string): EffectivePiSettings {
   return { compaction: { enabled, reserveTokens: values.reserveTokens, keepRecentTokens: values.keepRecentTokens } };
 }
 
-export function parsePiExecutableVersion(output: string): typeof PINNED_PI_VERSION {
+const PI_VERSION_LINE = /^(?:pi(?:-coding-agent)?(?:\s+version)?\s+v?)?(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)$/i;
+const PI_VERSION_CORE = /^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-([0-9A-Za-z.-]+))?$/;
+
+function comparePiNumericVersions(left: string, right: string): number {
+  const leftParts = left.split(".").map(Number);
+  const rightParts = right.split(".").map(Number);
+  for (let index = 0; index < 3; index += 1) {
+    if (leftParts[index] !== rightParts[index]) return Math.sign(leftParts[index] - rightParts[index]);
+  }
+  return 0;
+}
+
+export function olderThanMinimumPiVersionMessage(version: string): string {
+  return `Pi executable version ${version} is older than the minimum ${MINIMUM_PI_VERSION}`;
+}
+
+function assertSupportedPiVersion(version: unknown): string {
+  if (typeof version !== "string") throw new Error(`Pi executable version ${MINIMUM_PI_VERSION} or newer is required`);
+  const raw = version.trim();
+  const match = PI_VERSION_CORE.exec(raw);
+  if (!match) throw new Error(`Pi executable version ${raw || "missing"} is not a supported version`);
+  const numeric = `${match[1]}.${match[2]}.${match[3]}`;
+  if (comparePiNumericVersions(numeric, MINIMUM_PI_VERSION) < 0) {
+    if (match[4]) throw new Error(`Pi executable version ${raw} is unsupported`);
+    throw new Error(olderThanMinimumPiVersionMessage(numeric));
+  }
+  return numeric;
+}
+
+export function parsePiExecutableVersion(output: string): string {
   const lines = output.split(/\r?\n/).map((line) => line.trim()).filter(Boolean);
   if (lines.length !== 1) throw new Error("Pi executable version output must contain exactly one version line");
-  const line = lines[0];
-  // Pi's bare version is canonical; permit only the fixed official display prefix.
-  const escapedVersion = PINNED_PI_VERSION.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
-  if (!new RegExp(`^(?:${escapedVersion}|pi(?:-coding-agent)?(?:\\s+version)?\\s+v?${escapedVersion})$`, "i").test(line)) {
-    throw new Error(`Pi executable version must be exactly ${PINNED_PI_VERSION}`);
+  const match = PI_VERSION_LINE.exec(lines[0]);
+  if (!match) throw new Error("Pi executable version output is not a supported version line");
+  const version = `${match[1]}.${match[2]}.${match[3]}`;
+  if (comparePiNumericVersions(version, MINIMUM_PI_VERSION) < 0) {
+    throw new Error(olderThanMinimumPiVersionMessage(version));
   }
-  return PINNED_PI_VERSION;
+  return version;
 }
 
 export interface PiCapabilityProbe {
@@ -282,7 +312,7 @@ export interface PiCapabilityProbe {
 }
 
 export function verifyPiCapabilities(capabilities: PiCapabilityProbe): void {
-  if (capabilities.version !== PINNED_PI_VERSION) throw new Error(`trusted Pi version ${PINNED_PI_VERSION} is required`);
+  assertSupportedPiVersion(capabilities.version);
   if (capabilities.trustedProtocol === true) {
     throw new Error("external Pi cannot use a trusted protocol bypass");
   }

--- a/src/runtime/pi-compaction-recovery.ts
+++ b/src/runtime/pi-compaction-recovery.ts
@@ -279,8 +279,10 @@ function assertSupportedPiVersion(version: unknown): string {
   const match = PI_VERSION_CORE.exec(raw);
   if (!match) throw new Error(`Pi executable version ${raw || "missing"} is not a supported version`);
   const numeric = `${match[1]}.${match[2]}.${match[3]}`;
+  if (match[4]) {
+    throw new Error(`Pi executable version ${raw} is unsupported: SemVer ${raw} < ${numeric}; Larkin supports stable external pi only`);
+  }
   if (comparePiNumericVersions(numeric, MINIMUM_PI_VERSION) < 0) {
-    if (match[4]) throw new Error(`Pi executable version ${raw} is unsupported`);
     throw new Error(olderThanMinimumPiVersionMessage(numeric));
   }
   return numeric;

--- a/src/runtime/runtime-adapters.ts
+++ b/src/runtime/runtime-adapters.ts
@@ -43,7 +43,7 @@ import {
 import {
   assertEffectivePiCompactionSettings,
   assertNoProjectPiCompactionOverride,
-  PINNED_PI_VERSION,
+  MINIMUM_PI_VERSION,
   calculatePiCompactionSettings,
   parsePiExecutableVersion,
   prepareOwnedPiDirectory,
@@ -1126,7 +1126,7 @@ async function createPiRpcBackend(input: RuntimeSessionCreate, dependencies: Nat
     ? parsePiExecutableVersion(String(spawnSync(command, [...commandPrefix, "--version"], {
       cwd: input.workspaceDir, env: childEnv, encoding: "utf8", timeout: 5_000,
     }).stdout || ""))
-    : PINNED_PI_VERSION;
+    : MINIMUM_PI_VERSION;
   const extensionInput = { piCommand: command, env: childEnv, platform: process.platform };
   // 假 spawn 不需要真实 extension 路径；默认 resolver 会 spawnSync(`pi --version`)。
   const extensionArgs = dependencies.resolvePiProcessExtensionArgs

--- a/src/runtime/runtime-readiness.ts
+++ b/src/runtime/runtime-readiness.ts
@@ -1,6 +1,7 @@
 import fs from "node:fs";
 import path from "node:path";
 import { spawnSync } from "node:child_process";
+import { MINIMUM_PI_VERSION, parsePiExecutableVersion } from "./pi-compaction-recovery.js";
 
 export type RuntimeReadinessState = "missing" | "unauthenticated" | "unavailable" | "incompatible" | "ready";
 
@@ -172,6 +173,14 @@ export function classifyRuntimePrerequisite(runtime: RuntimeReadiness["runtime"]
     runtime, state: "unauthenticated", ...(executable ? { executable } : {}), reason,
     nextAction: runtimeLoginNextAction(runtime),
   };
+  if (/older than the minimum|not a supported version(?: line)?|version output must contain exactly one/i.test(reason)) {
+    return {
+      runtime, state: "incompatible", ...(executable ? { executable } : {}), reason,
+      nextAction: runtime === "pi"
+        ? `Upgrade pi to ${MINIMUM_PI_VERSION} or newer`
+        : `Upgrade ${runtime}, then retry.`,
+    };
+  }
   if (/protocol (?:version )?(?:mismatch|unsupported|incompatible)|unsupported (?:rpc|protocol|schema)|schema (?:mismatch|incompatible)|requires (?:a )?newer version/i.test(reason)) {
     return {
       runtime, state: "incompatible", ...(executable ? { executable } : {}), reason,
@@ -227,7 +236,18 @@ export async function probeNativeRuntimeReadiness(options: ProbeNativeRuntimeRea
       nextAction: runtimeInstallNextAction(options.runtime),
     };
   }
-  const version = executableVersion(executable, env, options.commandArgs);
+  let version = executableVersion(executable, env, options.commandArgs);
+  if (options.runtime === "pi") {
+    try {
+      const probe = spawnSync(executable, [...options.commandArgs ?? [], "--version"], {
+        env, encoding: "utf8", timeout: 5_000, maxBuffer: 64 * 1024,
+      });
+      version = parsePiExecutableVersion(String(probe.stdout || ""));
+    } catch (error) {
+      const classified = classifyRuntimePrerequisite("pi", error, executable);
+      return { ...classified, executable, ...(version ? { version } : {}) };
+    }
+  }
   try {
     if (options.runtime === "pi") {
       const { discoverPiModelCatalog } = await import("./pi-model-catalog.js");

--- a/test/integration/build/compiled-runtime-mock-e2e.test.mjs
+++ b/test/integration/build/compiled-runtime-mock-e2e.test.mjs
@@ -6,7 +6,7 @@ import net from "node:net";
 import os from "node:os";
 import path from "node:path";
 import { test } from "bun:test";
-import { PINNED_PI_VERSION, calculatePiCompactionSettings } from "../../../dist/runtime/pi-compaction-recovery.mjs";
+import { MINIMUM_PI_VERSION, calculatePiCompactionSettings } from "../../../dist/runtime/pi-compaction-recovery.mjs";
 
 const ROOT = path.resolve(import.meta.dirname, "../../..");
 const enabled = process.env.LARKIN_RUN_COMPILED_RUNTIME_MOCK_E2E === "1";
@@ -156,7 +156,7 @@ readline.createInterface({ input: process.stdin }).on("line", (line) => {
 
 const piFixtureSource = `import fs from "node:fs";
 import readline from "node:readline";
-if (process.argv.includes("--version")) { console.log(${JSON.stringify(PINNED_PI_VERSION)}); process.exit(0); }
+if (process.argv.includes("--version")) { console.log("0.84.4"); process.exit(0); }
 const marker = process.env.RUNTIME_PROTOCOL_MARKER;
 const record = (value) => fs.appendFileSync(marker, JSON.stringify(value) + "\\n");
 const model = { provider: "fixture", id: "pi-fixture", name: "Pi Fixture", reasoning: false, contextWindow: ${PI_FIXTURE_CONTEXT_WINDOW} };
@@ -335,7 +335,7 @@ test.skipIf(!enabled)("compiled Pi provider auth failure projects unauthenticate
     const piSource = path.join(home, "pi-auth-fixture.mjs");
     fs.writeFileSync(piSource, `import fs from "node:fs";
 import readline from "node:readline";
-if (process.argv.includes("--version")) { console.log(${JSON.stringify(PINNED_PI_VERSION)}); process.exit(0); }
+if (process.argv.includes("--version")) { console.log(${JSON.stringify(MINIMUM_PI_VERSION)}); process.exit(0); }
 const model = { provider: "bigmodel-anthropic", id: "glm-5.2", name: "GLM Fixture", reasoning: false, contextWindow: ${PI_FIXTURE_CONTEXT_WINDOW} };
 let promptCount = 0;
 const output = (value) => process.stdout.write(JSON.stringify(value) + "\\n");

--- a/test/unit/runtime/pi-compaction-recovery.test.mjs
+++ b/test/unit/runtime/pi-compaction-recovery.test.mjs
@@ -118,9 +118,15 @@ test("external capability guard fails closed and accepts only the required Pi pr
     reserveTokens: 40_800, keepRecentTokens: 20_000, compactRpc: true,
     events: ["compaction_start", "compaction_end", "agent_end", "agent_settled"],
   };
-  for (const version of ["0.84.2", "0.84.4", "0.85.0", "1.0.0", "0.84.2-beta"]) {
+  for (const version of ["0.84.2", "0.84.4", "0.85.0", "1.0.0"]) {
     assert.doesNotThrow(() => verifyPiCapabilities({ ...handshake, version }));
   }
+  assert.throws(() => verifyPiCapabilities({ ...handshake, version: "0.84.2-beta" }), {
+    message: "Pi executable version 0.84.2-beta is unsupported: SemVer 0.84.2-beta < 0.84.2; Larkin supports stable external pi only",
+  });
+  assert.throws(() => verifyPiCapabilities({ ...handshake, version: "0.85.0-rc.1" }), {
+    message: "Pi executable version 0.85.0-rc.1 is unsupported: SemVer 0.85.0-rc.1 < 0.85.0; Larkin supports stable external pi only",
+  });
   assert.throws(() => verifyPiCapabilities({ ...handshake, version: "0.84.1" }), {
     message: "Pi executable version 0.84.1 is older than the minimum 0.84.2",
   });

--- a/test/unit/runtime/pi-compaction-recovery.test.mjs
+++ b/test/unit/runtime/pi-compaction-recovery.test.mjs
@@ -92,25 +92,39 @@ test("owned Pi directory is 0700, current-user owned, and never a symlink", () =
   fs.rmSync(root, { recursive: true, force: true });
 });
 
-test("Pi executable version parsing rejects spoofed suffixes and extra tokens", () => {
+test("Pi executable version parsing accepts the minimum and newer display forms", () => {
   assert.equal(parsePiExecutableVersion("0.84.2\n"), "0.84.2");
-  assert.equal(parsePiExecutableVersion("pi-coding-agent version v0.84.2\n"), "0.84.2");
+  assert.equal(parsePiExecutableVersion("0.84.4\n"), "0.84.4");
+  assert.equal(parsePiExecutableVersion("pi 0.84.4\n"), "0.84.4");
+  assert.equal(parsePiExecutableVersion("pi-coding-agent version v0.84.4\n"), "0.84.4");
+  assert.equal(parsePiExecutableVersion("PI-CODING-AGENT VERSION V0.85.0\n"), "0.85.0");
+  assert.equal(parsePiExecutableVersion("1.0.0\n"), "1.0.0");
+  assert.throws(
+    () => parsePiExecutableVersion("0.84.1\n"),
+    { message: "Pi executable version 0.84.1 is older than the minimum 0.84.2" },
+  );
+  assert.throws(
+    () => parsePiExecutableVersion("0.83.9\n"),
+    { message: "Pi executable version 0.83.9 is older than the minimum 0.84.2" },
+  );
   for (const output of ["0.84.2-beta", "0.84.2 dirty", "0.84.2 extra", "pi 0.84.2 extra", "0.84.2\nattacker", "v0.84.2", "0x84x2", "0-84-2"]) {
-    assert.throws(() => parsePiExecutableVersion(output), /exactly|version/i);
+    assert.throws(() => parsePiExecutableVersion(output), /version/i);
   }
 });
 
 test("external capability guard fails closed and accepts only the required Pi protocol", () => {
-  assert.doesNotThrow(() => verifyPiCapabilities({
-    distribution: "external", version: "0.84.2", contextWindow: 272_000, autoCompactionEnabled: true,
+  const handshake = {
+    distribution: "external", contextWindow: 272_000, autoCompactionEnabled: true,
     reserveTokens: 40_800, keepRecentTokens: 20_000, compactRpc: true,
     events: ["compaction_start", "compaction_end", "agent_end", "agent_settled"],
-  }));
-  assert.throws(() => verifyPiCapabilities({
-    distribution: "external", version: "0.82.0", contextWindow: 272_000, autoCompactionEnabled: true,
-    reserveTokens: 40_800, keepRecentTokens: 20_000, compactRpc: true,
-    events: ["compaction_start", "compaction_end", "agent_end", "agent_settled"],
-  }), /version|capabilit/i);
+  };
+  for (const version of ["0.84.2", "0.84.4", "0.85.0", "1.0.0", "0.84.2-beta"]) {
+    assert.doesNotThrow(() => verifyPiCapabilities({ ...handshake, version }));
+  }
+  assert.throws(() => verifyPiCapabilities({ ...handshake, version: "0.84.1" }), {
+    message: "Pi executable version 0.84.1 is older than the minimum 0.84.2",
+  });
+  assert.throws(() => verifyPiCapabilities({ ...handshake, version: "0.82.0" }), /older than the minimum/i);
   assert.throws(() => verifyPiCapabilities({
     distribution: "external", version: "0.84.2", contextWindow: 128_000, autoCompactionEnabled: true,
     reserveTokens: 40_800, keepRecentTokens: 20_000, compactRpc: true,

--- a/test/unit/runtime/runtime-adapters.test.mjs
+++ b/test/unit/runtime/runtime-adapters.test.mjs
@@ -62,7 +62,7 @@ const create = (overrides = {}) => ({
   ...overrides,
 });
 
-function makeProductionPiCommand(root, mode = "stable") {
+function makeProductionPiCommand(root, mode = "stable", version = "0.84.2") {
   const log = path.join(root, "pi-rpc.log");
   const script = path.join(root, "fake-pi.mjs");
   fs.writeFileSync(script, `import fs from "node:fs";
@@ -77,7 +77,7 @@ if (args.includes("--version")) {
     const theme = process.env.PI_PACKAGE_DIR + "/dist/modes/interactive/theme/dark.json";
     if (!fs.existsSync(theme)) process.exit(1);
   }
-  process.stdout.write("0.84.2\\n");
+  process.stdout.write(${JSON.stringify(`${version}\n`)});
   process.exit(0);
 }
 const respond = (request, data) => process.stdout.write(JSON.stringify({ type: "response", id: request.id, command: request.type, success: true, data }) + "\\n");
@@ -990,6 +990,27 @@ test("inherited PI_PACKAGE_DIR does not drop production extension version probes
   } finally {
     await session?.close("inherited extension probe test complete").catch(() => {});
     fs.rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("production Pi session starts when external pi reports 0.84.4", async () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "larkin-pi-production-0844-"));
+  const { command, commandArgs, log } = makeProductionPiCommand(root, "stable", "0.84.4");
+  const input = create({
+    workspaceDir: path.join(root, "workspace"), stateDir: path.join(root, "state"), model: "test-provider/test-model",
+    env: { LARKIN_PI_TEST_LOG: log },
+  });
+  fs.mkdirSync(input.workspaceDir, { recursive: true });
+  let session;
+  try {
+    const adapter = createNativeRuntimeAdapter("pi", {
+      piCommand: command, piCommandArgs: commandArgs, resolvePiProcessExtensionArgs: () => ["-e", "fixture-extension"],
+      piRpcClientOptions: { requestTimeoutMs: 1_000, shutdownGraceMs: 100 },
+    });
+    session = await adapter.createSession(input);
+    assert.equal(session.effectiveModel, "test-provider/test-model");
+  } finally {
+    await session?.close("0.84.4 session start test complete").catch(() => {});
   }
 });
 

--- a/test/unit/runtime/runtime-readiness.test.mjs
+++ b/test/unit/runtime/runtime-readiness.test.mjs
@@ -43,6 +43,17 @@ test("readiness keeps unknown failures unavailable and reserves incompatible for
   assert.equal(classifyRuntimePrerequisite("pi", new Error("RPC protocol version mismatch")).state, "incompatible");
 });
 
+test("Pi readiness classifies an older executable as incompatible", () => {
+  const readiness = classifyRuntimePrerequisite(
+    "pi",
+    new Error("Pi executable version 0.84.1 is older than the minimum 0.84.2"),
+    "/usr/local/bin/pi",
+  );
+  assert.equal(readiness.state, "incompatible");
+  assert.equal(readiness.reason, "Pi executable version 0.84.1 is older than the minimum 0.84.2");
+  assert.equal(readiness.nextAction, "Upgrade pi to 0.84.2 or newer");
+});
+
 test("missing-credential classifier matches only the explicit absent-key or absent-login shape", () => {
   for (const message of [
     "No API key found for zai-coding-cn",
@@ -96,7 +107,7 @@ test("scoped auth persistence matches runtime and provider without a builtin dis
   assert.match(readinessForPersistedAuthFailure(generic).nextAction, /external `pi` CLI/);
 });
 
-function writeReadinessRuntime(root, { authenticated = true, runtime = "pi" } = {}) {
+function writeReadinessRuntime(root, { authenticated = true, runtime = "pi", version = "0.84.2" } = {}) {
   const marker = path.join(root, `readiness-${runtime}.ndjson`);
   const script = path.join(root, `readiness-${runtime}.mjs`);
   fs.writeFileSync(marker, "");
@@ -107,7 +118,7 @@ const marker = ${JSON.stringify(marker)};
 const args = process.argv.slice(2);
 fs.appendFileSync(marker, JSON.stringify({ args }) + "\\n");
 if (args.includes("--version")) {
-  process.stdout.write("0.84.2\\n");
+  process.stdout.write(${JSON.stringify(`${version}\n`)});
   process.exit(0);
 }
 const model = { provider: "plain", id: "chat", name: "Chat", reasoning: false, contextWindow: 32000 };
@@ -167,6 +178,35 @@ test("Pi readiness is unauthenticated when the probe reports no authenticated mo
     assert.equal(readiness.state, "unauthenticated", JSON.stringify(readiness));
     assert.match(readiness.nextAction || "", /external `pi` CLI/);
     assert.doesNotMatch(JSON.stringify(readiness), FORBIDDEN);
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("Pi readiness is ready when external pi reports 0.84.4", async () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "larkin-readiness-newer-"));
+  const { script } = writeReadinessRuntime(root, { version: "0.84.4" });
+  try {
+    const readiness = await probeNativeRuntimeReadiness({
+      runtime: "pi", cwd: root, command: process.execPath, commandArgs: [script],
+    });
+    assert.equal(readiness.state, "ready", JSON.stringify(readiness));
+    assert.equal(readiness.version, "0.84.4");
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("Pi readiness is incompatible when external pi reports 0.84.1", async () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "larkin-readiness-older-"));
+  const { script } = writeReadinessRuntime(root, { version: "0.84.1" });
+  try {
+    const readiness = await probeNativeRuntimeReadiness({
+      runtime: "pi", cwd: root, command: process.execPath, commandArgs: [script],
+    });
+    assert.equal(readiness.state, "incompatible", JSON.stringify(readiness));
+    assert.equal(readiness.reason, "Pi executable version 0.84.1 is older than the minimum 0.84.2");
+    assert.equal(readiness.nextAction, "Upgrade pi to 0.84.2 or newer");
   } finally {
     fs.rmSync(root, { recursive: true, force: true });
   }


### PR DESCRIPTION
## Summary

Hotfix for 0.5.0. After PR #196 removed the bundled Pi, every runtime session and readiness probe still enforced the old bundled pin `Pi executable version must be exactly 0.84.2`. On a host with `pi` 0.84.4 the daemon logged `Runtime Host 启动失败: No runtime Agent started: ... must be exactly 0.84.2` and all migrated Agents stayed not ready (observed on the owner's machine right after installing v0.5.0).

- `MINIMUM_PI_VERSION = "0.84.2"`; `parsePiExecutableVersion` returns the real semver and rejects only older/garbled output; `verifyPiCapabilities` accepts >= minimum. The runtime compaction handshake (reserve/keep tokens, compactRpc, events, trustedProtocol rejection) is unchanged and remains the compatibility guard.
- Readiness: an older `pi` projects `incompatible` with `Upgrade pi to 0.84.2 or newer`; 0.84.4 is `ready`.
- Version 0.5.1, CHANGELOG entry.

## Validation

- `bun run typecheck && bun run build && bun run test && git diff --check`: unit 931 pass, integration 206 pass / 16 skip, e2e 22 pass.
- Opt-in `LARKIN_RUN_COMPILED_RUNTIME_MOCK_E2E=1` (fixture emits 0.84.4): 2 pass.
- Real host `pi` 0.84.4 (isolated HOME, ~/.pi untouched): extension bundles load via `pi --mode rpc -e`, `parsePiExecutableVersion("0.84.4\n") -> "0.84.4"`.

Task: coding-context `larkin.remove-builtin-pi-distribution` (release follow-through).

Made with [Cursor](https://cursor.com)