### PR TITLE
fix(runtime): recover and bound external Pi startup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.5.3
+
+External Pi initialization now runs with bounded concurrency and recovers from isolated startup-probe timeouts through the existing retry policy. Shutdown waits for pending initialization and closes late sessions. Generic Runtime and delivery failures show unavailable instead of incompatible, while explicit prerequisite failures and useful provider diagnostics are preserved. Recovery workflow tests wait for delivery consumption and Inbox watermarks to converge and isolate temporary state.
+
 ## 0.5.2
 
 External pi now runs with the user's own Pi home; compaction settings move to the Agent workspace's `.pi/settings.json`; 0.5.0/0.5.1 started external pi with an empty agent dir and saw no logins. Stock pi 0.84.x does not emit `get_state.compactionCapabilities` (that handshake only existed for the bundled build); Larkin accepts the absence and keeps native compaction via the workspace settings file, while a present handshake must still match exactly.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "larkin",
-  "version": "0.5.2",
+  "version": "0.5.3",
   "private": false,
   "larkinPackageRole": "npm-published",
   "files": [

--- a/src/feishu/host-shell.ts
+++ b/src/feishu/host-shell.ts
@@ -34,6 +34,7 @@ import {
   RuntimePrerequisiteError,
   type PersistedAuthFailure,
 } from "../runtime/runtime-readiness.js";
+import { safeProviderDiagnostic } from "../runtime/provider-error-classifier.js";
 import { readDocumentCommentSubscription, verifyCallbackProbe, type EffectiveDocumentCommentSubscription } from "../platform/callback-capability.js";
 import { loadConfig, resolveMentionPolicy } from "../platform/config.js";
 import { processCommandToken } from "../app/internal-command.js";
@@ -197,6 +198,9 @@ export function memberNamesFromPayloads(payloads: readonly unknown[]): Record<st
 }
 
 function errorMessage(error: unknown): string { return error instanceof Error ? error.message : String(error); }
+function safeRuntimeStatusDiagnostic(error: unknown): string {
+  return safeProviderDiagnostic(error, "Runtime entered an error state", 500);
+}
 function agentConfigSignature(agent: ConfiguredAgent): string {
   return JSON.stringify({
     agentId: agent.agentId, runtime: agent.runtime, model: agent.model, effort: agent.effort ?? null,
@@ -1340,7 +1344,7 @@ export function createHostShell({
         } else {
           projectFallbackRuntimeReadiness(agent, observedAt, message.status === "error" ? {
             state: "unavailable",
-            reason: message.error || "Runtime entered an error state",
+            reason: safeRuntimeStatusDiagnostic(message.error),
             nextAction: "Inspect the Runtime status error, correct the Runtime availability issue, then retry.",
           } : {
             state: "missing",
@@ -1362,7 +1366,7 @@ export function createHostShell({
         }, 5_000);
         redeliveryTimer.unref?.();
       }
-      if (message.status === "error" && message.error) hostState.recordStatusError(agent, message.error);
+      if (message.status === "error" && message.error) hostState.recordStatusError(agent, safeRuntimeStatusDiagnostic(message.error));
       if (message.status === "error" || message.status === "inactive") {
         processingEyes.clear(agent, `agent-status:${message.status}`);
       }

--- a/src/feishu/host-shell.ts
+++ b/src/feishu/host-shell.ts
@@ -330,6 +330,38 @@ export function createHostShell({
     }
     hostState.updateStatus(agent, { runtimeReadiness: { runtime: agent.runtime, state: "ready", observedAt } });
   };
+  const projectFallbackRuntimeReadiness = (
+    agent: ConfiguredAgent,
+    observedAt: string,
+    fallback: { state: "missing" | "unavailable"; reason: string; nextAction?: string },
+    preserveCurrentUnavailableDiagnostic = false,
+  ): void => {
+    const failure = unresolvedCurrentAuth(agent);
+    if (failure) {
+      hostState.updateStatus(agent, {
+        runtimeReadiness: { ...readinessForPersistedAuthFailure(failure), observedAt },
+      });
+      return;
+    }
+    const currentReadiness = hostState.readStatus(agent).runtimeReadiness as {
+      runtime?: string; state?: string; observedAt?: string; reason?: unknown; nextAction?: unknown;
+    } | undefined;
+    const observedMs = Date.parse(String(currentReadiness?.observedAt || ""));
+    const daemonStartedMs = Date.parse(daemonStartedAt);
+    const currentEpoch = currentReadiness?.runtime === agent.runtime
+      && Number.isFinite(observedMs) && Number.isFinite(daemonStartedMs) && observedMs >= daemonStartedMs;
+    if (currentEpoch && (currentReadiness?.state === "missing" || currentReadiness?.state === "unauthenticated" || currentReadiness?.state === "incompatible")) return;
+    if (currentEpoch && preserveCurrentUnavailableDiagnostic && currentReadiness?.state === "unavailable"
+      && typeof currentReadiness.reason === "string" && currentReadiness.reason.trim()) {
+      hostState.updateStatus(agent, {
+        runtimeReadiness: { ...currentReadiness, runtime: agent.runtime, state: "unavailable", observedAt },
+      });
+      return;
+    }
+    hostState.updateStatus(agent, {
+      runtimeReadiness: { runtime: agent.runtime, ...fallback, observedAt },
+    });
+  };
   const recordInboundDeliveryFailure = (
     agent: ConfiguredAgent,
     code: "non_retryable_receipt" | "runtime_delivery_exception" | "runtime_delivery_event",
@@ -337,13 +369,10 @@ export function createHostShell({
     const at = new Date().toISOString();
     const reason = "Inbound Runtime delivery failed non-retryably; durable Inbox/ledger state is retained for recovery.";
     const nextAction = "Inspect the delivery/status error, correct the Runtime or canonical Inbox state, then restart to replay safely.";
-    const currentReadiness = hostState.readStatus(agent).runtimeReadiness as { state?: string } | undefined;
     hostState.updateStatus(agent, {
       inboundDeliveryHealth: { state: "error", code, at, reason, nextAction },
-      ...(currentReadiness?.state === "unauthenticated" ? {} : {
-        runtimeReadiness: { runtime: agent.runtime, state: "incompatible" as const, reason, nextAction },
-      }),
     });
+    projectFallbackRuntimeReadiness(agent, at, { state: "unavailable", reason, nextAction }, true);
     hostState.recordStatusError(agent, `${reason} ${nextAction} code=${code}`);
   };
   const agentStates = new Map<string, AgentStateRecord>();
@@ -1305,14 +1334,20 @@ export function createHostShell({
     if (message.type === "agent-status") {
       log("agent:status", message.agentId, message.status);
       const observedAt = new Date().toISOString();
-      if (message.status === "error" || message.status === "inactive") hostState.updateStatus(agent, {
-        runtimeReadiness: message.readiness?.state && message.readiness.state !== "ready" ? { ...message.readiness, observedAt } : {
-          runtime: agent.runtime,
-          state: message.status === "error" ? "incompatible" : "missing",
-          reason: message.status === "error" ? message.error || "Runtime entered an error state" : "Runtime is inactive",
-          observedAt,
-        },
-      });
+      if (message.status === "error" || message.status === "inactive") {
+        if (message.readiness?.state && message.readiness.state !== "ready") {
+          hostState.updateStatus(agent, { runtimeReadiness: { ...message.readiness, observedAt } });
+        } else {
+          projectFallbackRuntimeReadiness(agent, observedAt, message.status === "error" ? {
+            state: "unavailable",
+            reason: message.error || "Runtime entered an error state",
+            nextAction: "Inspect the Runtime status error, correct the Runtime availability issue, then retry.",
+          } : {
+            state: "missing",
+            reason: "Runtime is inactive",
+          });
+        }
+      }
       else if (message.readiness) {
         if (message.readiness.state === "ready" && unresolvedCurrentAuth(agent)) {
           projectReadyUnlessUnresolvedAuth(agent, observedAt);

--- a/src/runtime/provider-error-classifier.ts
+++ b/src/runtime/provider-error-classifier.ts
@@ -20,6 +20,20 @@ export const CANONICAL_CONTEXT_WINDOW_MESSAGE =
 export const INTERNAL_CONTEXT_WINDOW_PROJECTION_REASON =
   "provider rejected the input because the context window was exceeded";
 
+/** Redact credentials and local filesystem locations from provider diagnostics kept in status. */
+export function safeProviderDiagnostic(value: unknown, fallback: string, max = 2_000): string {
+  const source = typeof value === "string" ? value : fallback;
+  return source
+    .replace(/\b(?:authorization|proxy-authorization)\s*[:=]\s*(?:Bearer\s+)?[^\s,;]+/gi, (match) => `${match.split(/[:=]/, 1)[0]}=[redacted]`)
+    .replace(/\b(?:cookie|set-cookie)\s*[:=]\s*(?:[^;\s,]+(?:\s*;\s*[^;\s,]+)*)/gi, (match) => `${match.split(/[:=]/, 1)[0]}=[redacted]`)
+    .replace(/\b(?:api[_ -]?key|access[_ -]?token|refresh[_ -]?token|token|secret|password)\s*[:=]\s*[^\s,;]+/gi, (match) => `${match.split(/[:=]/, 1)[0]}=[redacted]`)
+    .replace(/(["'](?:authorization|cookie|api[_-]?key|access[_-]?token|refresh[_-]?token|token|secret|password)["']\s*:\s*)["'][^"']*["']/gi, "$1\"[redacted]\"")
+    .replace(/Bearer\s+[A-Za-z0-9._~+\/-]+/gi, "Bearer [redacted]")
+    .replace(/\b(?:sk|ghp|github_pat)-?[A-Za-z0-9_-]{8,}\b/g, "[redacted]")
+    .replace(/(^|[\s"'=])(?:\/(?:Users|home|private|var|tmp|etc)\/[^\s"']+|[A-Za-z]:[\\/][^\s"']+)/g, "$1[redacted-path]")
+    .replace(/[\r\n\t]+/g, " ").replace(/\s+/g, " ").trim().slice(0, max) || fallback;
+}
+
 /** Build the one structured provider-error shape shared by ingestion and recovery. */
 export function buildStrictProviderErrorInput(source: ProviderErrorSource): StrictProviderErrorInput {
   const upstream = source.upstream && typeof source.upstream === "object" && !Array.isArray(source.upstream)

--- a/src/runtime/runtime-adapters.ts
+++ b/src/runtime/runtime-adapters.ts
@@ -109,6 +109,28 @@ export interface NativeRuntimeAdapterDependencies {
   env?: NodeJS.ProcessEnv;
 }
 
+const PI_INITIALIZATION_CONCURRENCY = 2;
+
+/** Limits short-lived Pi startup handshakes without serializing live sessions. */
+function createInitializationLimiter(limit: number): <T>(operation: () => Promise<T>) => Promise<T> {
+  let active = 0;
+  const waiters: Array<() => void> = [];
+  const release = (): void => {
+    const next = waiters.shift();
+    if (next) next();
+    else active -= 1;
+  };
+  return async <T>(operation: () => Promise<T>): Promise<T> => {
+    if (active >= limit) await new Promise<void>((resolve) => waiters.push(resolve));
+    else active += 1;
+    try {
+      return await operation();
+    } finally {
+      release();
+    }
+  };
+}
+
 type Listener = (event: NormalizedRuntimeEvent) => void;
 
 interface CodexTurnOwnership {
@@ -1126,11 +1148,17 @@ async function createPiRpcBackend(input: RuntimeSessionCreate, dependencies: Nat
   commandArgs.push(...extensionArgs);
   let probedModel: PiProbeResult | null = null;
   if (productionSpawn) {
-    // 隔离探测用户自己的 Pi home（无 PI_CODING_AGENT_DIR），再把 15% reserve 写到工作区项目设置。
-    probedModel = await discoverEffectivePiContextWindow(
-      input, command, commandPrefix, requestedModel,
-      childEnv, spawn, dependencies.piRpcClientOptions,
-    );
+    try {
+      // Isolated probes must share the same prerequisite contract as the
+      // session handshake, so a cold-start timeout can use bounded recovery.
+      probedModel = await discoverEffectivePiContextWindow(
+        input, command, commandPrefix, requestedModel,
+        childEnv, spawn, dependencies.piRpcClientOptions,
+      );
+    } catch (error) {
+      if (error instanceof RuntimePrerequisiteError) throw error;
+      throw new RuntimePrerequisiteError(classifyRuntimePrerequisite("pi", error, command));
+    }
     writeOwnedPiSettings(input.workspaceDir, calculatePiCompactionSettings(probedModel.contextWindow));
   }
   const child = spawn(command, commandArgs, {
@@ -1197,6 +1225,7 @@ export function createNativeRuntimeAdapter(id: RuntimeId | string, dependencies:
       ? dependencies.codexCommand ?? dependencies.env?.LARKIN_CODEX_COMMAND ?? "codex"
       : dependencies.claudeCommand ?? dependencies.env?.LARKIN_CLAUDE_COMMAND ?? "claude";
   const codexCommand = dependencies.codexCommand ?? dependencies.env?.LARKIN_CODEX_COMMAND ?? "codex";
+  const runPiInitialization = createInitializationLimiter(PI_INITIALIZATION_CONCURRENCY);
   let codexUpdateAttempt: Promise<{ recovered: boolean; reason: string }> | null = null;
   let codexUpdateAttempted = false;
   const runCodexUpdate = (): Promise<{ recovered: boolean; reason: string }> => new Promise((resolve) => {
@@ -1286,9 +1315,9 @@ export function createNativeRuntimeAdapter(id: RuntimeId | string, dependencies:
         if (readiness.state !== "ready") throw new RuntimePrerequisiteError(readiness);
       }
       if (id === "pi") {
-        return new PiSession(await (dependencies.createPiSession
-        ? dependencies.createPiSession(input)
-        : createPiRpcBackend(input, { ...dependencies, piCommand: resolvedExecutable! }, spawn, productionSpawn)));
+        return runPiInitialization(async () => new PiSession(await (dependencies.createPiSession
+          ? dependencies.createPiSession(input)
+          : createPiRpcBackend(input, { ...dependencies, piCommand: resolvedExecutable! }, spawn, productionSpawn))));
       }
       if (id === "codex") {
         const codexInput = dependencies.codexModelOverride?.trim()

--- a/src/runtime/runtime-adapters.ts
+++ b/src/runtime/runtime-adapters.ts
@@ -38,6 +38,7 @@ import {
   buildStrictProviderErrorInput,
   classifyStrictProviderError,
   INTERNAL_CONTEXT_WINDOW_PROJECTION_REASON,
+  safeProviderDiagnostic,
 } from "./provider-error-classifier.js";
 import {
   assertEffectivePiCompactionSettings,
@@ -869,14 +870,7 @@ interface PiProviderErrorDetails {
 }
 
 function safeProviderText(value: unknown, fallback: string): string {
-  const source = typeof value === "string" ? value : fallback;
-  return source
-    .replace(/\b(?:authorization|proxy-authorization)\s*[:=]\s*(?:Bearer\s+)?[^\s,;]+/gi, (match) => `${match.split(/[:=]/, 1)[0]}=[redacted]`)
-    .replace(/\b(?:cookie|set-cookie|api[_ -]?key|access[_ -]?token|refresh[_ -]?token|secret)\s*[:=]\s*[^\s,;]+/gi, (match) => `${match.split(/[:=]/, 1)[0]}=[redacted]`)
-    .replace(/(["'](?:authorization|cookie|api[_-]?key|access[_-]?token|refresh[_-]?token|token|secret)["']\s*:\s*)["'][^"']*["']/gi, "$1\"[redacted]\"")
-    .replace(/Bearer\s+[A-Za-z0-9._~+\/-]+/gi, "Bearer [redacted]")
-    .replace(/\bsk-[A-Za-z0-9_-]{8,}\b/g, "[redacted]")
-    .replace(/[\r\n\t]+/g, " ").replace(/\s+/g, " ").trim().slice(0, 2_000) || fallback;
+  return safeProviderDiagnostic(value, fallback);
 }
 
 function piAssistantProviderError(message: Record<string, any>): PiProviderErrorDetails {

--- a/src/runtime/runtime-host.ts
+++ b/src/runtime/runtime-host.ts
@@ -1674,33 +1674,40 @@ export function createRuntimeHost(options: {
 
   const ensureSession = async (agent: ManagedAgent): Promise<RuntimeSession> => {
     if (agent.disabledReason) throw new Error(agent.disabledReason);
+    if (agent.stopped) throw new Error("runtime Agent is stopped");
     if (agent.session) return agent.session;
     if (agent.starting) return agent.starting;
-    const probeEnv = runtimeEnv(agent.config);
-    await assertOfficialCliReady(agent.config, probeEnv);
-    const readiness = agent.adapter.probe ? await agent.adapter.probe({ agentId: agent.config.agentId,
-      workspaceDir: agent.config.workspaceDir, stateDir: agent.config.stateDir,
-      env: { LARKIN_PI_COMMAND: process.env.LARKIN_PI_COMMAND, LARKIN_CODEX_COMMAND: process.env.LARKIN_CODEX_COMMAND,
-        LARKIN_CLAUDE_COMMAND: process.env.LARKIN_CLAUDE_COMMAND, ...probeEnv } })
-      : { runtime: agent.adapter.id, state: "ready" as const };
-    if (!agent.authFailureActive) agent.readiness = readiness;
-    if (readiness.state !== "ready") throw new RuntimePrerequisiteError(readiness);
-    const standingPrompt = options.promptBuilder.build({
-      agentId: agent.config.agentId, name: agent.config.displayName || agent.config.name,
-      description: agent.config.description || "", runtime: agent.adapter.id,
-      cli: agentCliPromptCapabilities("larkin"), previousSession: agent.previousSession,
-    });
-    const generation = ++agent.generation;
     let completedSession: RuntimeSession | null = null;
-    const sessionEnv = runtimeEnv(agent.config, `${agent.launchId}:${generation}`);
-    agent.starting = agent.adapter.createSession({
-      agentId: agent.config.agentId, model: agent.config.model, reasoningEffort: agent.config.effort || null,
-      workspaceDir: agent.config.workspaceDir, stateDir: agent.config.stateDir,
-      resumeSessionId: agent.config.sessionId || null, standingPrompt,
-      env: sessionEnv,
-    }).then((session) => {
+    agent.starting = (async () => {
+      const probeEnv = runtimeEnv(agent.config);
+      await assertOfficialCliReady(agent.config, probeEnv);
+      if (agent.stopped) throw new Error("runtime Agent is stopped");
+      const readiness = agent.adapter.probe ? await agent.adapter.probe({ agentId: agent.config.agentId,
+        workspaceDir: agent.config.workspaceDir, stateDir: agent.config.stateDir,
+        env: { LARKIN_PI_COMMAND: process.env.LARKIN_PI_COMMAND, LARKIN_CODEX_COMMAND: process.env.LARKIN_CODEX_COMMAND,
+          LARKIN_CLAUDE_COMMAND: process.env.LARKIN_CLAUDE_COMMAND, ...probeEnv } })
+        : { runtime: agent.adapter.id, state: "ready" as const };
+      if (!agent.authFailureActive) agent.readiness = readiness;
+      if (readiness.state !== "ready") throw new RuntimePrerequisiteError(readiness);
+      if (agent.stopped) throw new Error("runtime Agent is stopped");
+      const standingPrompt = options.promptBuilder.build({
+        agentId: agent.config.agentId, name: agent.config.displayName || agent.config.name,
+        description: agent.config.description || "", runtime: agent.adapter.id,
+        cli: agentCliPromptCapabilities("larkin"), previousSession: agent.previousSession,
+      });
+      const generation = ++agent.generation;
+      const sessionEnv = runtimeEnv(agent.config, `${agent.launchId}:${generation}`);
+      const session = await agent.adapter.createSession({
+        agentId: agent.config.agentId, model: agent.config.model, reasoningEffort: agent.config.effort || null,
+        workspaceDir: agent.config.workspaceDir, stateDir: agent.config.stateDir,
+        resumeSessionId: agent.config.sessionId || null, standingPrompt,
+        env: sessionEnv,
+      });
       completedSession = session;
-      if (agent.stopped || generation !== agent.generation) { void session.close("stale creation"); throw new Error("stale runtime session creation"); }
+      if (agent.stopped || generation !== agent.generation) {
+        await session.close("stale creation");
+        throw new Error("stale runtime session creation");
+      }
       agent.session = session;
       agent.piSessionOwner = sessionEnv[PI_SUBAGENT_SESSION_OWNER_ENV];
       session.subscribe((event) => observe(agent, session, event));
@@ -1717,7 +1724,7 @@ export function createRuntimeHost(options: {
       agent.stabilityTimer = setTimeout(() => markSessionStable(agent, session), retryPolicy.stableWindowMs);
       agent.stabilityTimer.unref?.();
       return session;
-    }).finally(() => {
+    })().finally(() => {
       agent.starting = null;
       if (completedSession && !agent.session && !agent.stopped) {
         scheduleRecreate(agent, agent.recreateReason || "runtime closed during session initialization");
@@ -2275,15 +2282,18 @@ export function createRuntimeHost(options: {
         emitConsumed(agent, [...startupConsumed, ...persist(agent)]);
         try {
           await ensureSession(agent);
+          if (agent.stopped) return;
           reconcileSubagentLedger(agent, { forceMissing: true, missingReason: "runtime restarted" });
           enqueueUndeliveredTerminalWakes(agent);
           await recoverStalePiCompaction(agent);
           const startupSession = agent.session;
           const proactive = startupSession ? proactivelyCompactPiAtIdle(agent, startupSession) : null;
           if (proactive) await proactive;
+          if (agent.stopped) return;
           activeCount += 1;
           await retryPending(agent);
         } catch (error) {
+          if (agent.stopped) return;
           const reason = error instanceof Error ? error.message : String(error);
           const transient = error instanceof RuntimePrerequisiteError && error.readiness.state === "unavailable";
           agent.disabledReason = transient ? null : reason;
@@ -2294,6 +2304,7 @@ export function createRuntimeHost(options: {
           emit({ type: "agent-status", agentId: config.agentId, status: "error", error: reason,
             ...(error instanceof RuntimePrerequisiteError ? { readiness: error.readiness } : {}) });
         }
+        if (agent.stopped) return;
         const visibleQuarantines = startupQuarantined.filter(({ record }) => agent.records.get(record.deliveryId)?.status === "error");
         for (const { record, code } of visibleQuarantines) emit({ type: "delivery", agentId: config.agentId,
           deliveryId: record.deliveryId, messageId: record.messageId, status: "error", reason: replayFailureReason(code) });
@@ -2374,13 +2385,19 @@ export function createRuntimeHost(options: {
     },
     async stop(agentId, reason): Promise<void> {
       const agent = managed.get(agentId); if (!agent) return; agent.stopped = true;
+      const starting = agent.starting;
       if (agent.poller) clearInterval(agent.poller);
       if (agent.retryTimer) clearTimeout(agent.retryTimer);
       if (agent.stabilityTimer) clearTimeout(agent.stabilityTimer);
       if (agent.backgroundCompletionRetryTimer) clearTimeout(agent.backgroundCompletionRetryTimer);
       if (agent.subagentReconcileTimer) clearInterval(agent.subagentReconcileTimer);
       if (agent.busy) await agent.session?.cancel(reason);
-      await agent.session?.close(reason); managed.delete(agentId);
+      await agent.session?.close(reason);
+      // A queued Pi initializer cannot be cancelled through the public adapter
+      // contract. Drain it before removing the Agent; ensureSession sees stopped
+      // and closes any session created after this point.
+      await starting?.catch(() => {});
+      managed.delete(agentId);
       emit({ type: "agent-status", agentId, status: "inactive" });
     },
     async shutdown(reason): Promise<void> { await Promise.allSettled([...managed.keys()].map((id) => this.stop(id, reason))); },

--- a/test/e2e/pi-prompt-preflight-recovery-mock-e2e.test.mjs
+++ b/test/e2e/pi-prompt-preflight-recovery-mock-e2e.test.mjs
@@ -14,6 +14,10 @@ import { createNativeRuntimeAdapter } from "../../dist/runtime/runtime-adapters.
 import { PiCompactionBreaker } from "../../dist/runtime/pi-compaction-recovery.mjs";
 import { createRuntimeHost } from "../../dist/runtime/runtime-host.mjs";
 
+function isolatedPiInput(input, root) {
+  return { ...input, env: { ...input.env, LARKIN_CONFIG_DIR: root, LARKIN_HOME: root, HOME: path.join(root, "home") } };
+}
+
 class PreflightPiProcess extends EventEmitter {
   stdout = new PassThrough();
   stderr = new PassThrough();
@@ -139,7 +143,7 @@ test("production-shaped Pi RPC Mock proves native retry lifecycle is correlated 
     return true;
   }, end() {} };
   const native = createNativeRuntimeAdapter("pi", { spawn: () => child });
-  const adapter = { id: native.id, capabilities: native.capabilities, probe: async () => ({ runtime: "pi", state: "ready" }), createSession: (input) => native.createSession(input) };
+  const adapter = { id: native.id, capabilities: native.capabilities, probe: async () => ({ runtime: "pi", state: "ready" }), createSession: (input) => native.createSession(isolatedPiInput(input, root)) };
   const host = createRuntimeHost({ adapterFor: () => adapter, promptBuilder: new ContextPromptBuilder(), stateStoreFor: () => store,
     assertOfficialCliReady: () => {}, retryPolicy: { baseDelayMs: 2, maxDelayMs: 2, maxAttempts: 1 } });
   const target = "chat:oc_native_retry";
@@ -208,7 +212,7 @@ function recoveryHost(root, scenario, sessions, store, target = `chat:oc_${scena
     const child = new RecoveryPiProcess(sessions.length, scenario, () => store.pollInbox({ target })); sessions.push(child); return child;
   }, piRpcClientOptions: { requestTimeoutMs: 50, inputTimeoutMs: 100, inputProgressTimeoutMs: 100, inputMaxTimeoutMs: 500 } });
   const adapter = { id: native.id, capabilities: native.capabilities, probe: async () => ({ runtime: "pi", state: "ready" }),
-    createSession: (input) => native.createSession(input) };
+    createSession: (input) => native.createSession(isolatedPiInput(input, root)) };
   return createRuntimeHost({ adapterFor: () => adapter, promptBuilder: new ContextPromptBuilder(), stateStoreFor: () => store,
     assertOfficialCliReady: () => {}, retryPolicy: { baseDelayMs: 2, maxDelayMs: 2, maxAttempts: 1 } });
 }
@@ -297,7 +301,7 @@ test("external Pi production-order preflight timeout stays bounded, pending, obs
     piRpcClientOptions: { requestTimeoutMs: 5, inputTimeoutMs: 15, inputProgressTimeoutMs: 25, inputMaxTimeoutMs: 50 },
   });
   const adapter = { id: native.id, capabilities: native.capabilities,
-    probe: async () => ({ runtime: "pi", state: "ready" }), createSession: (input) => native.createSession(input) };
+    probe: async () => ({ runtime: "pi", state: "ready" }), createSession: (input) => native.createSession(isolatedPiInput(input, root)) };
   const host = createRuntimeHost({ adapterFor: () => adapter, promptBuilder: new ContextPromptBuilder(),
     stateStoreFor: () => store, telemetry, retryPolicy: { baseDelayMs: 2, maxDelayMs: 2, maxAttempts: 0 },
     assertOfficialCliReady: () => {} });

--- a/test/integration/app/session-recovery-workflow.test.mjs
+++ b/test/integration/app/session-recovery-workflow.test.mjs
@@ -28,16 +28,24 @@ function runPublicCli(root, args) {
 
 test("isolated public workflow refuses ordinary reset, recovers four deliveries, and preserves stable identities", { timeout: 15_000 }, async () => {
   const root = fs.mkdtempSync(path.join(os.tmpdir(), "larkin-public-context-workflow-"));
+  const workflowTmp = fs.mkdtempSync(path.join(os.tmpdir(), "larkin-workflow-tmp-"));
   const calls = path.join(root, "calls.log");
   const agentId = "cli_newA1";
   fs.writeFileSync(calls, "", { mode: 0o600 });
   fs.writeFileSync(path.join(root, "config.json"), JSON.stringify({ version: 3, serverId: "server-workflow",
     activeAgent: agentId, agents: { [agentId]: { runtime: "pi", model: "fixture-model" } } }), { mode: 0o600 });
-  const harness = spawn(process.execPath, [path.join(ROOT, "test/support/local-control-harness.mjs"), "app/runtime-process.mjs"], {
-    cwd: ROOT, env: { ...process.env, LARKIN_HOME: root, LARKIN_CONFIG_DIR: root, LARKIN_CONTROL_CALLS: calls,
-      LARKIN_RECOVERY_WORKFLOW: "1", LARKIN_CONTROL_DELAY_MS: "0", TMPDIR: fs.mkdtempSync(path.join(os.tmpdir(), "larkin-workflow-tmp-")) },
-    stdio: ["ignore", "pipe", "pipe"],
-  });
+  let harness;
+  try {
+    harness = spawn(process.execPath, [path.join(ROOT, "test/support/local-control-harness.mjs"), "app/runtime-process.mjs"], {
+      cwd: ROOT, env: { ...process.env, LARKIN_HOME: root, LARKIN_CONFIG_DIR: root, LARKIN_CONTROL_CALLS: calls,
+        LARKIN_RECOVERY_WORKFLOW: "1", LARKIN_CONTROL_DELAY_MS: "0", TMPDIR: workflowTmp },
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+  } catch (error) {
+    fs.rmSync(workflowTmp, { recursive: true, force: true });
+    fs.rmSync(root, { recursive: true, force: true });
+    throw error;
+  }
   let output = "";
   harness.stdout.on("data", (chunk) => { output += chunk; });
   harness.stderr.on("data", (chunk) => { output += chunk; });
@@ -73,7 +81,17 @@ test("isolated public workflow refuses ordinary reset, recovers four deliveries,
     ]);
     const store = createAgentStateStore(root, agentId);
     const consumedDeadline = Date.now() + 3_000;
-    while (store.readNdjson("inbox").length !== 0 && Date.now() < consumedDeadline) await new Promise((resolve) => setTimeout(resolve, 25));
+    let inboxState = store.readJson("inboxState", { targets: {} });
+    while (Date.now() < consumedDeadline) {
+      const inboxEmpty = store.readNdjson("inbox").length === 0;
+      inboxState = store.readJson("inboxState", { targets: {} });
+      const ledgerState = store.readJson("runtimeDeliveries", { records: [] });
+      const consumedCount = Array.isArray(ledgerState.records)
+        ? ledgerState.records.filter((record) => record.messageId?.startsWith("om_workflow_context_") && record.status === "consumed").length
+        : 0;
+      if (inboxEmpty && inboxState.targets?.["chat:oc_workflow_context"]?.model_seen_seq === 4 && consumedCount === 4) break;
+      await new Promise((resolve) => setTimeout(resolve, 25));
+    }
     assert.equal(store.readNdjson("inbox").length, 0);
     const ledger = store.readJson("runtimeDeliveries", { records: [] });
     assert.deepEqual(ledger.records.filter((record) => record.messageId.startsWith("om_workflow_context_")).map((record) => record.status), ["consumed", "consumed", "consumed", "consumed"]);
@@ -81,7 +99,6 @@ test("isolated public workflow refuses ordinary reset, recovers four deliveries,
       ["workflow-delivery-0", "workflow-input-0"], ["workflow-delivery-1", "workflow-input-1"],
       ["workflow-delivery-2", "workflow-input-2"], ["workflow-delivery-3", "workflow-input-3"],
     ]);
-    const inboxState = store.readJson("inboxState", { targets: {} });
     assert.equal(inboxState.targets["chat:oc_workflow_context"].model_seen_seq, 4);
 
     const repeated = runPublicCli(root, ["session", "recover", "--agent", agentId, "--reason", "context-overflow", "--json", "--wait-ready", "0"]);
@@ -92,6 +109,7 @@ test("isolated public workflow refuses ordinary reset, recovers four deliveries,
     assert.doesNotMatch(repeated.stdout, /workflow-delivery|workflow-input|om_workflow|\/private|\/tmp|secret|credential|synthetic/);
   } finally {
     if (harness.exitCode === null) { harness.kill("SIGTERM"); await once(harness, "exit"); }
+    fs.rmSync(workflowTmp, { recursive: true, force: true });
     fs.rmSync(root, { recursive: true, force: true });
   }
 });

--- a/test/unit/feishu/host-runtime-delivery-health.test.mjs
+++ b/test/unit/feishu/host-runtime-delivery-health.test.mjs
@@ -13,7 +13,8 @@ for (const { mode, explicitReadiness, runtimeError } of [
   { mode: "throw-after-persist", explicitReadiness: "unauthenticated" },
   { mode: "async-input-error", explicitReadiness: "incompatible" },
   { mode: "generic-error", explicitReadiness: null },
-  { mode: "provider-403-delivery", explicitReadiness: null, runtimeError: "provider request failed with HTTP 403" },
+  { mode: "provider-403-delivery", explicitReadiness: null,
+    runtimeError: "provider request failed with HTTP 403 Authorization: Bearer issue124-status-token\nCookie: session=issue124-status-cookie\n/Users/issue124/private/settings.json" },
 ]) {
   test(`HostShell ${mode} keeps Inbox durable and degrades visible health without raw Runtime error data`, { timeout: 10_000 }, async () => {
     const root = fs.mkdtempSync(path.join(os.tmpdir(), `larkin-host-delivery-health-${mode}-`));
@@ -105,7 +106,7 @@ for (const { mode, explicitReadiness, runtimeError } of [
       const errorDeliveryLog = (status.deliverLog || []).filter((entry) => entry.status === "error");
       const visible = JSON.stringify({ health: status.inboundDeliveryHealth, readiness: status.runtimeReadiness,
         recentErrors: status.recentErrors, errorDeliveryLog, logs });
-      assert.doesNotMatch(visible, /issue124-super-secret|raw rejected payload|raw asynchronous|unsafe next action|raw inbound body/);
+      assert.doesNotMatch(visible, /issue124-super-secret|issue124-status-token|issue124-status-cookie|Users\/issue124|raw rejected payload|raw asynchronous|unsafe next action|raw inbound body/);
 
       await host.ingest(agentId, event);
       assert.equal(deliveries, 1, "transport duplicate must not create a second delivery attempt");

--- a/test/unit/feishu/host-runtime-delivery-health.test.mjs
+++ b/test/unit/feishu/host-runtime-delivery-health.test.mjs
@@ -8,7 +8,13 @@ import { createHostShell } from "../../../dist/feishu/host-shell.mjs";
 
 const testManagedCli = () => ({ command: { command: "/test/official-lark-cli", argsPrefix: [], version: "1.0.80" }, env: {} });
 
-for (const mode of ["error-receipt", "throw-after-persist", "async-input-error"]) {
+for (const { mode, explicitReadiness, runtimeError } of [
+  { mode: "error-receipt", explicitReadiness: "missing" },
+  { mode: "throw-after-persist", explicitReadiness: "unauthenticated" },
+  { mode: "async-input-error", explicitReadiness: "incompatible" },
+  { mode: "generic-error", explicitReadiness: null },
+  { mode: "provider-403-delivery", explicitReadiness: null, runtimeError: "provider request failed with HTTP 403" },
+]) {
   test(`HostShell ${mode} keeps Inbox durable and degrades visible health without raw Runtime error data`, { timeout: 10_000 }, async () => {
     const root = fs.mkdtempSync(path.join(os.tmpdir(), `larkin-host-delivery-health-${mode}-`));
     const agentId = `cli_issue124Health${mode === "error-receipt" ? "Receipt" : mode === "throw-after-persist" ? "Throw" : "Async"}A1`;
@@ -56,6 +62,13 @@ for (const mode of ["error-receipt", "throw-after-persist", "async-input-error"]
     try {
       await host.start();
       assert.equal(store.readJson("status", {}).runtimeReadiness.state, "ready");
+      if (explicitReadiness) {
+        listener({ type: "agent-status", agentId, status: "error", readiness: {
+          runtime: "codex", state: explicitReadiness,
+          reason: `explicit ${explicitReadiness} prerequisite`, nextAction: `resolve explicit ${explicitReadiness} prerequisite`,
+        } });
+      }
+      if (runtimeError) listener({ type: "agent-status", agentId, status: "error", error: runtimeError, readiness: { runtime: "codex", state: "ready" } });
       await host.ingest(agentId, event);
       assert.equal(deliveries, 1);
       if (mode === "async-input-error") {
@@ -75,12 +88,20 @@ for (const mode of ["error-receipt", "throw-after-persist", "async-input-error"]
       assert.equal(inboxState.targets[rows[0].target].model_seen_seq, 0, "delivery failure must not mark Agent model-seen");
 
       const status = store.readJson("status", {});
-      assert.equal(status.runtimeReadiness.state, "incompatible");
+      assert.equal(status.runtimeReadiness.state, explicitReadiness || "unavailable");
       assert.equal(status.inboundDeliveryHealth.state, "error");
-      const expectedCode = mode === "error-receipt" ? "non_retryable_receipt"
-        : mode === "throw-after-persist" ? "runtime_delivery_exception" : "runtime_delivery_event";
+      const expectedCode = mode === "throw-after-persist" ? "runtime_delivery_exception"
+        : mode === "async-input-error" ? "runtime_delivery_event" : "non_retryable_receipt";
       assert.equal(status.inboundDeliveryHealth.code, expectedCode);
-      assert.match(status.runtimeReadiness.nextAction, /inspect.*restart.*replay/i);
+      if (explicitReadiness) {
+        assert.equal(status.runtimeReadiness.reason, `explicit ${explicitReadiness} prerequisite`);
+        assert.equal(status.runtimeReadiness.nextAction, `resolve explicit ${explicitReadiness} prerequisite`);
+      } else if (runtimeError) {
+        assert.match(status.runtimeReadiness.reason, /HTTP 403/);
+        assert.match(status.runtimeReadiness.nextAction, /inspect.*retry/i);
+      } else {
+        assert.match(status.runtimeReadiness.nextAction, /inspect.*restart.*replay/i);
+      }
       const errorDeliveryLog = (status.deliverLog || []).filter((entry) => entry.status === "error");
       const visible = JSON.stringify({ health: status.inboundDeliveryHealth, readiness: status.runtimeReadiness,
         recentErrors: status.recentErrors, errorDeliveryLog, logs });

--- a/test/unit/feishu/host-runtime-lifecycle.test.mjs
+++ b/test/unit/feishu/host-runtime-lifecycle.test.mjs
@@ -264,6 +264,11 @@ test("HostShell keeps durable missing-key auth across ready status and reset", a
     assert.match(store.readJson("status", {}).runtimeReadiness.nextAction, /external `pi` CLI/);
     assert.match(store.readJson("status", {}).runtimeReadiness.nextAction, /zai-coding-cn/);
     assert.doesNotMatch(store.readJson("status", {}).runtimeReadiness.nextAction, /pi-auth|Provider Credentials/);
+    listener({ type: "agent-status", agentId, status: "error", error: "provider request failed with HTTP 403", readiness: { runtime: "pi", state: "ready" } });
+    const terminal = store.readJson("status", {}).runtimeReadiness;
+    assert.equal(terminal.state, "unauthenticated", "a scoped persisted auth failure must not fall back to generic availability");
+    assert.match(terminal.nextAction, /zai-coding-cn/);
+    assert.match(JSON.stringify(store.readJson("status", {}).recentErrors), /HTTP 403/);
     const reset = await host.resetSession(agentId, 0);
     assert.equal(reset.resetCommitted, true);
     assert.equal(store.readJson("status", {}).runtimeReadiness.state, "unauthenticated");
@@ -768,9 +773,33 @@ test("production HostShell clears eyes on inactive/error and ignores heartbeat a
 
     await ingest("error");
     listener({ type: "agent-status", agentId, status: "active" });
-    listener({ type: "agent-status", agentId, status: "error", error: "runtime failed", readiness: { runtime: "pi", state: "ready" } });
+    listener({ type: "agent-status", agentId, status: "error", error: "provider request failed with HTTP 403", readiness: { runtime: "pi", state: "ready" } });
     assert.equal(deletes().length, 2);
-    assert.equal(JSON.parse(fs.readFileSync(path.join(agent.stateDir, "status.json"), "utf8")).runtimeReadiness.state, "incompatible");
+    const runtimeFailure = JSON.parse(fs.readFileSync(path.join(agent.stateDir, "status.json"), "utf8")).runtimeReadiness;
+    assert.equal(runtimeFailure.state, "unavailable");
+    assert.match(runtimeFailure.reason, /HTTP 403/);
+    assert.match(runtimeFailure.nextAction, /inspect.*retry/i);
+
+    for (const readiness of [
+      { runtime: "pi", state: "missing", reason: "pi executable is absent", nextAction: "Install pi." },
+      { runtime: "pi", state: "unauthenticated", reason: "provider login expired", nextAction: "Log in again." },
+      { runtime: "pi", state: "incompatible", reason: "pi version is unsupported", nextAction: "Upgrade pi." },
+    ]) {
+      listener({ type: "agent-status", agentId, status: "error", error: "generic terminal error", readiness });
+      const explicit = JSON.parse(fs.readFileSync(path.join(agent.stateDir, "status.json"), "utf8")).runtimeReadiness;
+      assert.equal(explicit.state, readiness.state);
+      assert.equal(explicit.reason, readiness.reason);
+      assert.equal(explicit.nextAction, readiness.nextAction);
+    }
+
+    const statusPath = path.join(agent.stateDir, "status.json");
+    const staleStatus = JSON.parse(fs.readFileSync(statusPath, "utf8"));
+    staleStatus.runtimeReadiness = { runtime: "pi", state: "unauthenticated", reason: "stale provider login", observedAt: "2000-01-01T00:00:00.000Z" };
+    fs.writeFileSync(statusPath, JSON.stringify(staleStatus));
+    listener({ type: "agent-status", agentId, status: "error", error: "current Runtime failure", readiness: { runtime: "pi", state: "ready" } });
+    const currentFallback = JSON.parse(fs.readFileSync(statusPath, "utf8")).runtimeReadiness;
+    assert.equal(currentFallback.state, "unavailable");
+    assert.equal(currentFallback.reason, "current Runtime failure");
 
     await ingest("heartbeat");
     listener({ type: "activity", agentId, activity: "idle", activityKind: "idle", isHeartbeat: true });

--- a/test/unit/runtime/runtime-adapters.test.mjs
+++ b/test/unit/runtime/runtime-adapters.test.mjs
@@ -21,6 +21,7 @@ import {
   buildCanonicalPiSubagentNotificationContent,
 } from "../../../dist/runtime/pi-subagents-notification.mjs";
 import { classifyStrictProviderError } from "../../../dist/runtime/provider-error-classifier.mjs";
+import { RuntimePrerequisiteError } from "../../../dist/runtime/runtime-readiness.mjs";
 
 const fakeProcesses = new Set();
 const temporaryRoots = new Set();
@@ -106,8 +107,9 @@ process.stdin.on("data", (chunk) => {
     if (newline < 0) break;
     const line = buffer.slice(0, newline); buffer = buffer.slice(newline + 1);
     const request = JSON.parse(line); record({ kind: "request", probe, type: request.type });
-    if (request.type === "get_state") respond(request, state());
-    else if (request.type === "get_available_models") respond(request, {
+    if (request.type === "get_state") {
+      if (!(${JSON.stringify(mode)} === "probe-timeout" && args.includes("--no-extensions"))) respond(request, state());
+    } else if (request.type === "get_available_models") respond(request, {
       models: process.env.PI_CODING_AGENT_DIR ? [] : [{ provider: "test-provider", id: "test-model" }],
     });
     else if (request.type === "prompt" || request.type === "steer" || request.type === "compact") respond(request, {});
@@ -896,6 +898,27 @@ test("Pi adapter maps prompt, steer and abort to its process backend", async () 
   assert.deepEqual(calls, [["prompt", "one"], ["steer", "two"], ["abort"]]);
 });
 
+test("Pi initialization caps eight concurrent adapters and releases a failed permit", async () => {
+  let active = 0;
+  let maximum = 0;
+  const adapter = createNativeRuntimeAdapter("pi", { createPiSession: async (input) => {
+    active += 1;
+    maximum = Math.max(maximum, active);
+    await new Promise((resolve) => setTimeout(resolve, 5));
+    active -= 1;
+    if (input.agentId === "cli_piInit0") throw new Error("fixture startup failure");
+    return {
+      sessionId: input.agentId,
+      prompt: async () => {}, steer: async () => {}, abort: async () => {},
+    };
+  } });
+  const results = await Promise.allSettled(Array.from({ length: 8 }, (_, index) =>
+    adapter.createSession(create({ agentId: `cli_piInit${index}` }))));
+  assert.equal(maximum, 2);
+  assert.equal(results.filter((result) => result.status === "rejected").length, 1);
+  assert.equal(results.filter((result) => result.status === "fulfilled").length, 7);
+});
+
 test.each(["win32", "linux"])("Pi retains all -e extension args on simulated %s", (platform) => {
   const args = resolvePiProcessExtensionArgs({
     distribution: "external", piCommand: "external-pi", env: {}, platform,
@@ -971,7 +994,12 @@ test("inherited PI_PACKAGE_DIR does not drop production extension version probes
   const { command, commandArgs, log } = makeProductionPiCommand(root);
   const input = create({
     workspaceDir: path.join(root, "workspace"), stateDir: path.join(root, "state"), model: "test-provider/test-model",
-    env: { LARKIN_PI_TEST_LOG: log },
+    env: {
+      HOME: path.join(root, "home"),
+      LARKIN_HOME: path.join(root, "config"),
+      LARKIN_CONFIG_DIR: path.join(root, "config"),
+      LARKIN_PI_TEST_LOG: log,
+    },
   });
   fs.mkdirSync(input.workspaceDir, { recursive: true });
   let session;
@@ -1031,6 +1059,37 @@ test("production Pi child env strips inherited PI_CODING_AGENT_DIR and still sta
     assert.equal(fs.existsSync(path.join(input.stateDir, "pi-agent")), false);
   } finally {
     await session?.close("strip PI_CODING_AGENT_DIR test complete").catch(() => {});
+  }
+});
+
+test("production Pi isolated get_state timeout is an unavailable prerequisite", async () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "larkin-pi-probe-timeout-"));
+  const { command, commandArgs, log } = makeProductionPiCommand(root, "probe-timeout");
+  const input = create({
+    workspaceDir: path.join(root, "workspace"), stateDir: path.join(root, "state"), model: "test-provider/test-model",
+    env: {
+      HOME: path.join(root, "home"),
+      LARKIN_HOME: path.join(root, "config"),
+      LARKIN_CONFIG_DIR: path.join(root, "config"),
+      LARKIN_PI_TEST_LOG: log,
+    },
+  });
+  fs.mkdirSync(input.workspaceDir, { recursive: true });
+  try {
+    const adapter = createNativeRuntimeAdapter("pi", {
+      piCommand: command, piCommandArgs: commandArgs,
+      resolvePiProcessExtensionArgs: () => [],
+      piRpcClientOptions: { requestTimeoutMs: 20, shutdownGraceMs: 20 },
+    });
+    assert.equal((await adapter.probe(input)).state, "ready");
+    await assert.rejects(adapter.createSession(input), (error) => {
+      assert.ok(error instanceof RuntimePrerequisiteError);
+      assert.equal(error.readiness.state, "unavailable");
+      assert.match(error.readiness.reason || "", /get_state timed out/i);
+      return true;
+    });
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true });
   }
 });
 

--- a/test/unit/runtime/runtime-host.test.mjs
+++ b/test/unit/runtime/runtime-host.test.mjs
@@ -17,6 +17,7 @@ import { RuntimePrerequisiteError } from "../../../dist/runtime/runtime-readines
 import { calculatePiCompactionSettings } from "../../../dist/runtime/pi-compaction-recovery.mjs";
 import { createAgentStateStore } from "../../../dist/agent/agent-state-store.mjs";
 import { ProcessingEyeOrchestrator } from "../../../dist/feishu/host-processing-eye.mjs";
+import { createNativeRuntimeAdapter } from "../../../dist/runtime/runtime-adapters.mjs";
 
 function cleanupSharedImplicitPiState() {
   const implicit = path.join("/tmp", ".larkin");
@@ -200,7 +201,11 @@ test("RuntimeHost does not proactively compact at the strict threshold", async (
   }
   const session = new EqualSession();
   const adapter = { id: "pi", capabilities: {}, async createSession() { return session; } };
-  const host = createRuntimeHost({ adapterFor: () => adapter, promptBuilder: new ContextPromptBuilder() });
+  const host = createRuntimeHost({
+    adapterFor: () => adapter,
+    promptBuilder: new ContextPromptBuilder(),
+    assertOfficialCliReady: async () => {},
+  });
   try {
     await host.start([{ agentId: "cli_piProactiveEqualA1", name: "equal", runtime: "pi", model: "model", workspaceDir: "/tmp", stateDir: root }]);
     session.emit({ type: "turn-end" });
@@ -1046,6 +1051,38 @@ test("RuntimeHost retries unavailable readiness through bounded recreate instead
   assert.equal(probes, 2);
   assert.equal((await host.deliver("cli_transientPiA1", { message_id: "om_after_retry" })).status, "accepted");
   await host.shutdown("done");
+});
+
+test("RuntimeHost shutdown drains queued Pi initializers and closes every late session", async () => {
+  let active = 0;
+  let maximum = 0;
+  const closed = [];
+  const nativeAdapter = createNativeRuntimeAdapter("pi", { createPiSession: async (input) => {
+    active += 1;
+    maximum = Math.max(maximum, active);
+    await new Promise((resolve) => setTimeout(resolve, 5));
+    active -= 1;
+    return {
+      sessionId: input.agentId,
+      prompt: async () => {}, steer: async () => {}, abort: async () => {},
+      dispose: async () => { closed.push(input.agentId); },
+    };
+  } });
+  const adapter = { ...nativeAdapter, async probe() { return { runtime: "pi", state: "ready" }; } };
+  const host = createRuntimeHost({
+    adapterFor: () => adapter,
+    promptBuilder: new ContextPromptBuilder(),
+    assertOfficialCliReady: async () => {},
+  });
+  const configs = Array.from({ length: 8 }, (_, index) => ({
+    agentId: `cli_shutdownPi${index}`, name: `shutdown-${index}`, runtime: "pi", model: "model", workspaceDir: "/tmp",
+  }));
+  const startup = host.start(configs);
+  await new Promise((resolve) => setImmediate(resolve));
+  await host.shutdown("test shutdown");
+  await assert.rejects(startup, /No runtime Agent started/);
+  assert.equal(maximum, 2);
+  assert.deepEqual(closed.sort(), configs.map((config) => config.agentId).sort());
 });
 
 test("RuntimeHost stops recreate when the latest probe changes from unavailable to fatal", async () => {


### PR DESCRIPTION
External Pi cold-start probe timeouts escaped readiness classification, so affected Agents stopped recovering and appeared as `incompatible`. This change classifies both initialization stages, limits concurrent Pi initialization to two, and drains pending initialization during shutdown. Generic HostShell failures now show `unavailable` with sanitized provider diagnostics while preserving explicit prerequisite and scoped authentication states.

The recovery CLI regression now waits for all four deliveries, the empty Inbox and the consumption watermark to converge. Related mock recovery fixtures explicitly isolate their homes and clean temporary files. Version advances once from 0.5.2 to 0.5.3.

Validation:
- Full local suite before the final diagnostic extraction: frontend 27, unit/module 947 (1 skipped), integration 206 (16 skipped), E2E 22; no failures.
- Final integrated head: typecheck/build and 210 focused runtime, HostShell, public recovery workflow and mock E2E tests passed.
- License check, publication tree/history checks and diff checks passed; independent Terra review accepted runtime/recovery changes and closed the diagnostic-redaction finding after regression tests.
- Actual external Pi 0.84.4: opt-in catalog/management CLI/session construction test passed with isolated Larkin state and no prompt.
- Live provider billing and real Feishu sends are not part of these tests. Provider account failures still require account-side remediation.
