### PR TITLE
feat: make Inbox Audit opt-in with reliable completion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 0.5.4
+
+Inbox Audit is now optional and off by default. The Dashboard and CLI support global and per-Agent switches and inspection gaps. Saving a gap updates scheduling without replacing Runtime sessions; editing a gap alone does not enable auditing. Only originally wake-eligible human group/topic work is audited.
+
+Audit reads no longer mark work complete. Agents explicitly confirm a receipt after checking; receipts are scoped to an observation generation, and durable canonical sequence ordering protects newer work from stale completion or deferred registration. Contended registrations are retried durably. Unproven legacy audit-index rows are ignored while ordinary Inbox and conversation history remain intact.
+
 ## 0.5.3
 
 External Pi initialization now runs with bounded concurrency and recovers from isolated startup-probe timeouts through the existing retry policy. Shutdown waits for pending initialization and closes late sessions. Generic Runtime and delivery failures show unavailable instead of incompatible, while explicit prerequisite failures and useful provider diagnostics are preserved. Recovery workflow tests wait for delivery consumption and Inbox watermarks to converge and isolate temporary state.

--- a/README.md
+++ b/README.md
@@ -93,6 +93,21 @@ During setup, choose one of the three externally installed runtimes: Pi (`pi`), 
 
 `larkin setup --model <id>` optionally stores a catalog model for that runtime. After setup, use `larkin model` and `larkin runtime` to inspect or switch. For Pi, Larkin talks to your installed `pi --mode rpc`, verifies the RPC handshake and compaction capability contract, and injects its supported extensions through `pi -e` (background subagents and the 60-second foreground bash timeout guard).
 
+### Optional Inbox Audit
+
+Inbox Audit is **off by default**. In the Dashboard, use **Global settings → Inbox 巡检** to configure the switch and inspection gap, or the selected Agent's **Configuration → Inbox 巡检** to override either value. The gap defaults to 15 minutes and supports 1 minute to 24 hours. Saving a gap alone keeps auditing disabled; saved settings survive restart and update later scheduling without replacing the Agent Runtime session.
+
+The same settings are available through the CLI:
+
+```bash
+larkin config inbox-audit global on --interval 15m
+larkin config inbox-audit agent off --agent <App-ID>
+larkin config inbox-audit agent inherit --agent <App-ID> --interval inherit
+larkin config inbox-audit global off
+```
+
+When enabled, audit only revisits originally wake-eligible human group/topic work and does not wake a model for an empty work list. Reading an audit list does not complete it: the managed Agent follows the returned inspection instructions and explicitly confirms the receipt after checking. A failed check remains retryable; newer messages cannot be completed by an older receipt. Old audit-index records without proven eligibility or observation identity are ignored; ordinary Inbox messages and conversation history are preserved.
+
 <details>
 <summary>Windows support and optional autostart</summary>
 

--- a/evals/inbox-audit-flow/scenarios.json
+++ b/evals/inbox-audit-flow/scenarios.json
@@ -7,7 +7,7 @@
   },
   "grader": {
     "name": "inbox-audit-flow-trace-grader",
-    "version": 1,
+    "version": 2,
     "threshold": 1,
     "rubric": [
       "audit reads and completions use the actual public candidate CLI",

--- a/evals/inbox-audit-flow/scenarios.json
+++ b/evals/inbox-audit-flow/scenarios.json
@@ -21,30 +21,30 @@
   "scenarios": [
     {
       "id": "no-finding",
-      "task": "Run {gateway} audit-read --root {root} --agent-id {agent_id} --source-root {source_root}. Check the exact synthetic history target with {gateway} history --root {root} --agent-id {agent_id} --target <returned-target> --anchor <returned-anchor>. When your check is finished, confirm the returned receipt with {gateway} audit-complete --root {root} --agent-id {agent_id} --source-root {source_root} --receipt <returned-receipt> --outcome no-finding. Do not send a reply when there is no finding.",
-      "fixture": { "anchor": "om_eval_no_finding", "target": "chat:oc_eval_audit_no_finding", "history": "no-finding" },
+      "task": "Run {gateway} audit-read --root {root} --agent-id {agent_id} --source-root {source_root}. Use the returned target and anchor to query synthetic history with {gateway} history --root {root} --agent-id {agent_id} --target <returned-target> --anchor <returned-anchor>. Follow the returned instruction: if history indicates a finding, use the synthetic reply action with the exact target and anchor; otherwise send nothing. Then complete using the returned receipt and the outcome that matches the work performed.",
+      "fixture": { "anchor": "om_eval_no_finding", "target": "chat:oc_EvalAuditA1", "history": { "finding": false, "messages": [] } },
       "required_actions": ["audit_read", "fake_history", "audit_complete"],
       "forbidden_actions": ["fake_send"],
       "completion_outcome": "no-finding"
     },
     {
       "id": "handled-finding",
-      "task": "Run {gateway} audit-read --root {root} --agent-id {agent_id} --source-root {source_root}. Check the exact synthetic history target with {gateway} history --root {root} --agent-id {agent_id} --target <returned-target> --anchor <returned-anchor>. If the history confirms a missed outbound, reply with {gateway} reply --root {root} --agent-id {agent_id} --target <returned-target> --anchor <returned-anchor> --text <your concise reply>, then confirm the returned receipt with {gateway} audit-complete --root {root} --agent-id {agent_id} --source-root {source_root} --receipt <returned-receipt> --outcome handled.",
-      "fixture": { "anchor": "om_eval_handled", "target": "thread:oc_eval_audit_handled:omt_eval_handled", "history": "handled-finding" },
+      "task": "Run {gateway} audit-read --root {root} --agent-id {agent_id} --source-root {source_root}. Use the returned target and anchor to query synthetic history with {gateway} history --root {root} --agent-id {agent_id} --target <returned-target> --anchor <returned-anchor>. Follow the returned instruction: if history indicates a finding, use the synthetic reply action with the exact target and anchor; otherwise send nothing. Then complete using the returned receipt and the outcome that matches the work performed.",
+      "fixture": { "anchor": "om_eval_handled", "target": "thread:oc_EvalAuditH1:omt_EvalHandledA1", "history": { "finding": true, "messages": [{ "anchor": "om_eval_handled", "status": "missed" }] } },
       "required_actions": ["audit_read", "fake_history", "fake_send", "audit_complete"],
       "completion_outcome": "handled"
     },
     {
       "id": "failure-after-read",
       "task": "Run {gateway} audit-read --root {root} --agent-id {agent_id} --source-root {source_root}, then simulate a caller failure immediately after the read. Do not complete the receipt. A later verification read must still show the same pending target.",
-      "fixture": { "anchor": "om_eval_failure_after_read", "target": "chat:oc_eval_audit_failure", "history": "failure-after-read" },
+      "fixture": { "anchor": "om_eval_failure_after_read", "target": "chat:oc_EvalAuditF1", "history": { "finding": false, "messages": [] } },
       "required_actions": ["audit_read", "verification_audit_read"],
       "forbidden_actions": ["audit_complete", "fake_send"]
     },
     {
       "id": "stale-receipt",
       "task": "Run {gateway} audit-read --root {root} --agent-id {agent_id} --source-root {source_root}. The fixture will then advance to a newer anchor. Attempt to complete using the old receipt and verify that the newer target remains pending.",
-      "fixture": { "anchor": "om_eval_stale_old", "new_anchor": "om_eval_stale_new", "target": "chat:oc_eval_audit_stale", "history": "stale-receipt" },
+      "fixture": { "anchor": "om_eval_stale_old", "new_anchor": "om_eval_stale_new", "target": "chat:oc_EvalAuditS1", "history": { "finding": false, "messages": [] } },
       "required_actions": ["audit_read", "fixture_advance_anchor", "audit_complete", "verification_audit_read"],
       "completion_reason": "stale"
     }

--- a/evals/inbox-audit-flow/scenarios.json
+++ b/evals/inbox-audit-flow/scenarios.json
@@ -1,0 +1,52 @@
+{
+  "dataset": "inbox-audit-flow",
+  "version": 1,
+  "runtime": {
+    "adapter": "declared-by-caller",
+    "model": "declared-by-parent"
+  },
+  "grader": {
+    "name": "inbox-audit-flow-trace-grader",
+    "version": 1,
+    "threshold": 1,
+    "rubric": [
+      "audit reads and completions use the actual public candidate CLI",
+      "a no-finding flow reads synthetic history before completing no-finding and sends nothing",
+      "a handled flow reads synthetic history, replies to the exact returned target and anchor, then completes handled",
+      "a caller failure after read leaves the target pending for a later read",
+      "a stale receipt cannot complete a newer anchor revision",
+      "empty traces, failed completions, and wrong-target replies do not receive credit"
+    ]
+  },
+  "scenarios": [
+    {
+      "id": "no-finding",
+      "task": "Run {gateway} audit-read --root {root} --agent-id {agent_id} --source-root {source_root}. Check the exact synthetic history target with {gateway} history --root {root} --agent-id {agent_id} --target <returned-target> --anchor <returned-anchor>. When your check is finished, confirm the returned receipt with {gateway} audit-complete --root {root} --agent-id {agent_id} --source-root {source_root} --receipt <returned-receipt> --outcome no-finding. Do not send a reply when there is no finding.",
+      "fixture": { "anchor": "om_eval_no_finding", "target": "chat:oc_eval_audit_no_finding", "history": "no-finding" },
+      "required_actions": ["audit_read", "fake_history", "audit_complete"],
+      "forbidden_actions": ["fake_send"],
+      "completion_outcome": "no-finding"
+    },
+    {
+      "id": "handled-finding",
+      "task": "Run {gateway} audit-read --root {root} --agent-id {agent_id} --source-root {source_root}. Check the exact synthetic history target with {gateway} history --root {root} --agent-id {agent_id} --target <returned-target> --anchor <returned-anchor>. If the history confirms a missed outbound, reply with {gateway} reply --root {root} --agent-id {agent_id} --target <returned-target> --anchor <returned-anchor> --text <your concise reply>, then confirm the returned receipt with {gateway} audit-complete --root {root} --agent-id {agent_id} --source-root {source_root} --receipt <returned-receipt> --outcome handled.",
+      "fixture": { "anchor": "om_eval_handled", "target": "thread:oc_eval_audit_handled:omt_eval_handled", "history": "handled-finding" },
+      "required_actions": ["audit_read", "fake_history", "fake_send", "audit_complete"],
+      "completion_outcome": "handled"
+    },
+    {
+      "id": "failure-after-read",
+      "task": "Run {gateway} audit-read --root {root} --agent-id {agent_id} --source-root {source_root}, then simulate a caller failure immediately after the read. Do not complete the receipt. A later verification read must still show the same pending target.",
+      "fixture": { "anchor": "om_eval_failure_after_read", "target": "chat:oc_eval_audit_failure", "history": "failure-after-read" },
+      "required_actions": ["audit_read", "verification_audit_read"],
+      "forbidden_actions": ["audit_complete", "fake_send"]
+    },
+    {
+      "id": "stale-receipt",
+      "task": "Run {gateway} audit-read --root {root} --agent-id {agent_id} --source-root {source_root}. The fixture will then advance to a newer anchor. Attempt to complete using the old receipt and verify that the newer target remains pending.",
+      "fixture": { "anchor": "om_eval_stale_old", "new_anchor": "om_eval_stale_new", "target": "chat:oc_eval_audit_stale", "history": "stale-receipt" },
+      "required_actions": ["audit_read", "fixture_advance_anchor", "audit_complete", "verification_audit_read"],
+      "completion_reason": "stale"
+    }
+  ]
+}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "larkin",
-  "version": "0.5.3",
+  "version": "0.5.4",
   "private": false,
   "larkinPackageRole": "npm-published",
   "files": [

--- a/src/agent/agent-cli-capabilities.ts
+++ b/src/agent/agent-cli-capabilities.ts
@@ -32,7 +32,7 @@ export function agentCliPromptCapabilities(executable = "larkin"): AgentCliCapab
     operations.map((operation) => ({
       command: `${group} ${operation}`,
       purpose: group === "inbox" ? (operation === "check" ? "Read pending target summaries without consuming messages."
-        : operation === "audit" ? "Read bounded observed group/topic audit targets and instructions."
+        : operation === "audit" ? "Read bounded observed group/topic audit targets; inspect first, then explicitly confirm the returned receipt."
           : "Poll full messages and direct-ack the returned batch.") :
         group === "comment" ? "Reply once to the exact cloud-document comment bound by a polled Inbox message id." :
         group === "reminder" ? "Manage this Agent's durable reminders." :

--- a/src/agent/config-cli-contract.ts
+++ b/src/agent/config-cli-contract.ts
@@ -1,4 +1,4 @@
-export const CONFIG_CLI_OPERATIONS = Object.freeze(["show", "runtime", "model", "effort", "mention", "apply"] as const);
+export const CONFIG_CLI_OPERATIONS = Object.freeze(["show", "runtime", "model", "effort", "mention", "inbox-audit", "apply"] as const);
 
 export const CONFIG_CLI_USAGE = Object.freeze([
   "larkin config show [--agent <App ID>] [--chat <oc_id>] [--json]",
@@ -8,6 +8,8 @@ export const CONFIG_CLI_USAGE = Object.freeze([
   "larkin config mention global <require|free>",
   "larkin config mention agent <inherit|require|free> [--agent <App ID>]",
   "larkin config mention chat <oc_id> <inherit|require|free> [--agent <App ID>]",
+  "larkin config inbox-audit global <on|off> [--interval <15m|1h>]",
+  "larkin config inbox-audit agent <inherit|on|off> [--agent <App ID>] [--interval <15m|inherit>]",
   "larkin config apply [--agent <App ID>]",
 ]);
 

--- a/src/agent/inbox-audit-heartbeat.ts
+++ b/src/agent/inbox-audit-heartbeat.ts
@@ -7,67 +7,85 @@ interface AuditStateStore {
   appendCanonicalInboxOnce(value: unknown): { status: "appended" | "duplicate_pending" | "duplicate_consumed"; envelope: unknown };
 }
 interface AuditRuntime { deliver(agentId: string, envelope: object): Promise<unknown> | unknown }
+export interface InboxAuditSchedule { enabled: boolean; intervalMs: number }
 type Timer = ReturnType<typeof setTimeout>;
 
-/** One Host-owned timer fans a targetless internal wake to each active Agent. */
+function safeIntervalMs(intervalMs: number): number {
+  if (!Number.isSafeInteger(intervalMs) || intervalMs < 1) throw new Error("inbox audit cadence must be a positive integer");
+  return intervalMs;
+}
+
+/** One Host-owned timer per Agent; disabled Agents are re-armed without a model wake. */
 export class InboxAuditHeartbeat {
-  private timer: Timer | null = null;
+  private readonly timers = new Map<string, Timer>();
   private running = false;
   private sequence = 0;
-  private readonly cadenceMs: number;
 
   constructor(private readonly options: {
     agents: readonly AuditAgent[];
     stateStore(agent: AuditAgent): AuditStateStore;
     runtimeHost: AuditRuntime;
     log?: (...parts: unknown[]) => void;
-    cadenceMs?: number;
     setTimer?: typeof setTimeout;
     clearTimer?: typeof clearTimeout;
     now?: () => number;
+    schedule(agent: AuditAgent): InboxAuditSchedule;
+    /** Skip model wake when audit is disabled or there is no pending originally-wake=true work. */
+    shouldDispatch(agent: AuditAgent): boolean;
   }) {
-    this.cadenceMs = options.cadenceMs ?? INBOX_AUDIT_CADENCE_MS;
-    if (!Number.isSafeInteger(this.cadenceMs) || this.cadenceMs < 1) throw new Error("inbox audit cadence must be a positive integer");
+    for (const agent of options.agents) safeIntervalMs(options.schedule(agent).intervalMs);
   }
 
   start(): void {
     if (this.running) return;
     this.running = true;
-    this.schedule();
+    for (const agent of this.options.agents) this.arm(agent);
   }
 
   stop(): void {
     this.running = false;
-    if (this.timer) (this.options.clearTimer ?? clearTimeout)(this.timer);
-    this.timer = null;
+    const clearTimer = this.options.clearTimer ?? clearTimeout;
+    for (const timer of this.timers.values()) clearTimer(timer);
+    this.timers.clear();
   }
 
-  private schedule(): void {
-    if (!this.running || this.timer) return;
-    this.timer = (this.options.setTimer ?? setTimeout)(() => {
-      this.timer = null;
-      return this.fire().finally(() => { if (this.running) this.schedule(); });
-    }, this.cadenceMs);
-    this.timer.unref?.();
+  private arm(agent: AuditAgent): void {
+    if (!this.running || this.timers.has(agent.agentId)) return;
+    let intervalMs = INBOX_AUDIT_CADENCE_MS;
+    try { intervalMs = safeIntervalMs(this.options.schedule(agent).intervalMs); }
+    catch (error) {
+      this.options.log?.(`inbox audit schedule failed agent=${agent.agentId}: ${error instanceof Error ? error.message : String(error)}`);
+    }
+    const timer = (this.options.setTimer ?? setTimeout)(() => {
+      this.timers.delete(agent.agentId);
+      return this.fire(agent).finally(() => { if (this.running) this.arm(agent); });
+    }, intervalMs);
+    timer.unref?.();
+    this.timers.set(agent.agentId, timer);
   }
 
-  private async fire(): Promise<void> {
+  private async fire(agent: AuditAgent): Promise<void> {
+    try {
+      const schedule = this.options.schedule(agent);
+      if (!schedule.enabled || !this.options.shouldDispatch(agent)) return;
+    } catch (error) {
+      this.options.log?.(`inbox audit schedule failed agent=${agent.agentId}: ${error instanceof Error ? error.message : String(error)}`);
+      return;
+    }
     const now = this.options.now ?? Date.now;
-    for (const agent of this.options.agents) {
-      const message_id = `rem_inbox_audit_${now()}_${++this.sequence}_${agent.agentId}`;
-      const envelope = {
-        kind: "reminder",
-        message_id,
-        target: RUNTIME_REMINDER_TARGET,
-        wake: true,
-        content: "Internal inbox audit wake. Poll runtime:reminder, then run larkin inbox audit --json. No finding stays silent.",
-      };
-      try {
-        const appended = this.options.stateStore(agent).appendCanonicalInboxOnce(envelope);
-        if (appended.status === "appended") await this.options.runtimeHost.deliver(agent.agentId, appended.envelope as object);
-      } catch (error) {
-        this.options.log?.(`inbox audit heartbeat failed agent=${agent.agentId}: ${error instanceof Error ? error.message : String(error)}`);
-      }
+    const message_id = `rem_inbox_audit_${now()}_${++this.sequence}_${agent.agentId}`;
+    const envelope = {
+      kind: "reminder",
+      message_id,
+      target: RUNTIME_REMINDER_TARGET,
+      wake: true,
+      content: "Internal inbox audit wake. Poll runtime:reminder, then run larkin inbox audit --json. No finding stays silent.",
+    };
+    try {
+      const appended = this.options.stateStore(agent).appendCanonicalInboxOnce(envelope);
+      if (appended.status === "appended") await this.options.runtimeHost.deliver(agent.agentId, appended.envelope as object);
+    } catch (error) {
+      this.options.log?.(`inbox audit heartbeat failed agent=${agent.agentId}: ${error instanceof Error ? error.message : String(error)}`);
     }
   }
 }

--- a/src/agent/inbox-audit-heartbeat.ts
+++ b/src/agent/inbox-audit-heartbeat.ts
@@ -1,6 +1,17 @@
 import { RUNTIME_REMINDER_TARGET } from "./inbox-projection.js";
 
 export const INBOX_AUDIT_CADENCE_MS = 15 * 60_000;
+export const MAX_INBOX_AUDIT_DIAGNOSTIC_CHARS = 120;
+
+export function boundedInboxAuditDiagnostic(error: unknown): string {
+  const max = MAX_INBOX_AUDIT_DIAGNOSTIC_CHARS;
+  const code = error && typeof error === "object" && "code" in error && typeof (error as { code: unknown }).code === "string"
+    ? (error as { code: string }).code.slice(0, max)
+    : "";
+  const raw = error instanceof Error ? error.message : String(error);
+  const text = String(raw).slice(0, max).replace(/[\u0000-\u001f\u007f]+/g, " ").replace(/\s+/g, " ").trim();
+  return [code, text].filter(Boolean).join(" ").slice(0, max);
+}
 
 interface AuditAgent { agentId: string }
 interface AuditStateStore {
@@ -54,7 +65,7 @@ export class InboxAuditHeartbeat {
     let intervalMs = INBOX_AUDIT_CADENCE_MS;
     try { intervalMs = safeIntervalMs(this.options.schedule(agent).intervalMs); }
     catch (error) {
-      this.options.log?.(`inbox audit schedule failed agent=${agent.agentId}: ${error instanceof Error ? error.message : String(error)}`);
+      this.options.log?.(`inbox audit schedule failed agent=${agent.agentId}: ${boundedInboxAuditDiagnostic(error)}`);
     }
     const timer = (this.options.setTimer ?? setTimeout)(() => {
       this.timers.delete(agent.agentId);
@@ -69,7 +80,7 @@ export class InboxAuditHeartbeat {
       const schedule = this.options.schedule(agent);
       if (!schedule.enabled || !this.options.shouldDispatch(agent)) return;
     } catch (error) {
-      this.options.log?.(`inbox audit schedule failed agent=${agent.agentId}: ${error instanceof Error ? error.message : String(error)}`);
+      this.options.log?.(`inbox audit schedule failed agent=${agent.agentId}: ${boundedInboxAuditDiagnostic(error)}`);
       return;
     }
     const now = this.options.now ?? Date.now;
@@ -85,7 +96,7 @@ export class InboxAuditHeartbeat {
       const appended = this.options.stateStore(agent).appendCanonicalInboxOnce(envelope);
       if (appended.status === "appended") await this.options.runtimeHost.deliver(agent.agentId, appended.envelope as object);
     } catch (error) {
-      this.options.log?.(`inbox audit heartbeat failed agent=${agent.agentId}: ${error instanceof Error ? error.message : String(error)}`);
+      this.options.log?.(`inbox audit heartbeat failed agent=${agent.agentId}: ${boundedInboxAuditDiagnostic(error)}`);
     }
   }
 }

--- a/src/agent/inbox-audit-heartbeat.ts
+++ b/src/agent/inbox-audit-heartbeat.ts
@@ -1,3 +1,5 @@
+import * as fs from "node:fs";
+import * as path from "node:path";
 import { RUNTIME_REMINDER_TARGET } from "./inbox-projection.js";
 
 export const INBOX_AUDIT_CADENCE_MS = 15 * 60_000;
@@ -6,17 +8,14 @@ export const MAX_INBOX_AUDIT_DIAGNOSTIC_CHARS = 120;
 export function boundedInboxAuditDiagnostic(error: unknown): string {
   const max = MAX_INBOX_AUDIT_DIAGNOSTIC_CHARS;
   const code = error && typeof error === "object" && "code" in error && typeof (error as { code: unknown }).code === "string"
-    ? (error as { code: string }).code.slice(0, max)
-    : "";
+    ? (error as { code: string }).code.slice(0, max) : "";
   const raw = error instanceof Error ? error.message : String(error);
   const text = String(raw).slice(0, max).replace(/[\u0000-\u001f\u007f]+/g, " ").replace(/\s+/g, " ").trim();
   return [code, text].filter(Boolean).join(" ").slice(0, max);
 }
 
 interface AuditAgent { agentId: string }
-interface AuditStateStore {
-  appendCanonicalInboxOnce(value: unknown): { status: "appended" | "duplicate_pending" | "duplicate_consumed"; envelope: unknown };
-}
+interface AuditStateStore { appendCanonicalInboxOnce(value: unknown): { status: "appended" | "duplicate_pending" | "duplicate_consumed"; envelope: unknown } }
 interface AuditRuntime { deliver(agentId: string, envelope: object): Promise<unknown> | unknown }
 export interface InboxAuditSchedule { enabled: boolean; intervalMs: number }
 type Timer = ReturnType<typeof setTimeout>;
@@ -26,11 +25,14 @@ function safeIntervalMs(intervalMs: number): number {
   return intervalMs;
 }
 
-/** One Host-owned timer per Agent; disabled Agents are re-armed without a model wake. */
+/** A Host-owned, config-file-reactive single timer per enabled Agent. */
 export class InboxAuditHeartbeat {
   private readonly timers = new Map<string, Timer>();
+  private readonly generations = new Map<string, number>();
   private running = false;
   private sequence = 0;
+  private watcher: fs.FSWatcher | null = null;
+  private refreshTimer: Timer | null = null;
 
   constructor(private readonly options: {
     agents: readonly AuditAgent[];
@@ -41,8 +43,10 @@ export class InboxAuditHeartbeat {
     clearTimer?: typeof clearTimeout;
     now?: () => number;
     schedule(agent: AuditAgent): InboxAuditSchedule;
-    /** Skip model wake when audit is disabled or there is no pending originally-wake=true work. */
     shouldDispatch(agent: AuditAgent): boolean;
+    /** Config saves are observed without replacing Runtime sessions. */
+    configFile?: string;
+    watch?: typeof fs.watch;
   }) {
     for (const agent of options.agents) safeIntervalMs(options.schedule(agent).intervalMs);
   }
@@ -50,7 +54,8 @@ export class InboxAuditHeartbeat {
   start(): void {
     if (this.running) return;
     this.running = true;
-    for (const agent of this.options.agents) this.arm(agent);
+    for (const agent of this.options.agents) this.reschedule(agent);
+    this.watchConfig();
   }
 
   stop(): void {
@@ -58,24 +63,67 @@ export class InboxAuditHeartbeat {
     const clearTimer = this.options.clearTimer ?? clearTimeout;
     for (const timer of this.timers.values()) clearTimer(timer);
     this.timers.clear();
+    if (this.refreshTimer) clearTimer(this.refreshTimer);
+    this.refreshTimer = null;
+    this.watcher?.close();
+    this.watcher = null;
   }
 
-  private arm(agent: AuditAgent): void {
-    if (!this.running || this.timers.has(agent.agentId)) return;
-    let intervalMs = INBOX_AUDIT_CADENCE_MS;
-    try { intervalMs = safeIntervalMs(this.options.schedule(agent).intervalMs); }
-    catch (error) {
-      this.options.log?.(`inbox audit schedule failed agent=${agent.agentId}: ${boundedInboxAuditDiagnostic(error)}`);
-    }
-    const timer = (this.options.setTimer ?? setTimeout)(() => {
-      this.timers.delete(agent.agentId);
-      return this.fire(agent).finally(() => { if (this.running) this.arm(agent); });
-    }, intervalMs);
+  /** Safe for a Host config watcher or a direct in-process config mutation hook. */
+  refresh(): void {
+    if (!this.running) return;
+    for (const agent of this.options.agents) this.reschedule(agent);
+  }
+
+  private watchConfig(): void {
+    if (!this.options.configFile || this.watcher) return;
+    const file = path.resolve(this.options.configFile);
+    const parent = path.dirname(file);
+    const basename = path.basename(file);
+    try {
+      this.watcher = (this.options.watch ?? fs.watch)(parent, (_event, changed) => {
+        if (changed && String(changed) !== basename) return;
+        this.scheduleRefresh();
+      });
+    } catch (error) { this.options.log?.(`inbox audit config watch failed: ${boundedInboxAuditDiagnostic(error)}`); }
+  }
+
+  private scheduleRefresh(): void {
+    if (!this.running || this.refreshTimer) return;
+    this.refreshTimer = (this.options.setTimer ?? setTimeout)(() => {
+      this.refreshTimer = null;
+      this.refresh();
+    }, 30);
+    this.refreshTimer.unref?.();
+  }
+
+  private reschedule(agent: AuditAgent): void {
+    const clearTimer = this.options.clearTimer ?? clearTimeout;
+    const prior = this.timers.get(agent.agentId);
+    if (prior) clearTimer(prior);
+    this.timers.delete(agent.agentId);
+    const generation = (this.generations.get(agent.agentId) ?? 0) + 1;
+    this.generations.set(agent.agentId, generation);
+    let schedule: InboxAuditSchedule;
+    try { schedule = this.options.schedule(agent); safeIntervalMs(schedule.intervalMs); }
+    catch (error) { this.options.log?.(`inbox audit schedule failed agent=${agent.agentId}: ${boundedInboxAuditDiagnostic(error)}`); return; }
+    // Disabled means no future audit timer or model wake at all.
+    if (!schedule.enabled || !this.running) return;
+    let timer!: Timer;
+    timer = (this.options.setTimer ?? setTimeout)(() => {
+      // A cancelled callback can still be queued. It must not remove the
+      // replacement timer installed by a newer config revision.
+      if (this.timers.get(agent.agentId) === timer) this.timers.delete(agent.agentId);
+      void this.fire(agent, generation).finally(() => {
+        if (this.running && this.generations.get(agent.agentId) === generation) this.reschedule(agent);
+      });
+    }, schedule.intervalMs);
     timer.unref?.();
     this.timers.set(agent.agentId, timer);
   }
 
-  private async fire(agent: AuditAgent): Promise<void> {
+  private async fire(agent: AuditAgent, generation: number): Promise<void> {
+    if (this.generations.get(agent.agentId) !== generation) return;
     try {
       const schedule = this.options.schedule(agent);
       if (!schedule.enabled || !this.options.shouldDispatch(agent)) return;
@@ -85,18 +133,11 @@ export class InboxAuditHeartbeat {
     }
     const now = this.options.now ?? Date.now;
     const message_id = `rem_inbox_audit_${now()}_${++this.sequence}_${agent.agentId}`;
-    const envelope = {
-      kind: "reminder",
-      message_id,
-      target: RUNTIME_REMINDER_TARGET,
-      wake: true,
-      content: "Internal inbox audit wake. Poll runtime:reminder, then run larkin inbox audit --json. No finding stays silent.",
-    };
+    const envelope = { kind: "reminder", message_id, target: RUNTIME_REMINDER_TARGET, wake: true,
+      content: "Internal inbox audit wake. Poll runtime:reminder, then run larkin inbox audit --json. Inspect first and explicitly complete its receipt; no finding stays silent." };
     try {
       const appended = this.options.stateStore(agent).appendCanonicalInboxOnce(envelope);
       if (appended.status === "appended") await this.options.runtimeHost.deliver(agent.agentId, appended.envelope as object);
-    } catch (error) {
-      this.options.log?.(`inbox audit heartbeat failed agent=${agent.agentId}: ${boundedInboxAuditDiagnostic(error)}`);
-    }
+    } catch (error) { this.options.log?.(`inbox audit heartbeat failed agent=${agent.agentId}: ${boundedInboxAuditDiagnostic(error)}`); }
   }
 }

--- a/src/agent/missed-outbound-scan.ts
+++ b/src/agent/missed-outbound-scan.ts
@@ -8,8 +8,7 @@ import * as path from "node:path";
  * or deleted automatically.
  */
 export const INBOX_AUDIT_LEGACY_MIGRATION_NON_GOAL = "New versions no longer create missed-outbound loops; existing indistinguishable historical loops are not migrated or deleted automatically.";
-// Audits return every retained target. Storage remains bounded so a heartbeat
-// cannot accumulate an unbounded work list.
+// Pending audits are bounded so a heartbeat cannot accumulate an unbounded work list.
 export const MAX_INBOX_AUDIT_TARGETS = 96;
 const MAX_STORED_TARGETS = MAX_INBOX_AUDIT_TARGETS;
 const CHAT = /^oc_[A-Za-z0-9]+$/;
@@ -22,8 +21,14 @@ export interface InboxAuditTarget {
   observed_at: string;
 }
 
-interface StoredTarget extends InboxAuditTarget { agent_id: string }
-interface AuditRegistry { version: 1; targets: StoredTarget[] }
+type AuditStatus = "pending" | "completed";
+interface StoredTarget extends InboxAuditTarget {
+  agent_id: string;
+  status: AuditStatus;
+  completed_at?: string;
+  completed_anchor?: string;
+}
+interface AuditRegistry { version: 2; targets: StoredTarget[] }
 
 export function inboxAuditRegistryFile(larkinHome: string): string {
   return path.join(larkinHome, "inbox-audit.json");
@@ -37,15 +42,22 @@ function parseTarget(event: { chat_id?: string; thread_id?: string | null; messa
   return { target: threadId ? `thread:${chatId}:${threadId}` : `chat:${chatId}`, anchor };
 }
 
+function emptyRegistry(): AuditRegistry {
+  return { version: 2, targets: [] };
+}
+
 function load(file: string): AuditRegistry {
-  let value: Partial<AuditRegistry>;
-  try { value = JSON.parse(fs.readFileSync(file, "utf8")) as Partial<AuditRegistry>; }
+  let value: { version?: unknown; targets?: unknown };
+  try { value = JSON.parse(fs.readFileSync(file, "utf8")) as { version?: unknown; targets?: unknown }; }
   catch (error) {
-    if ((error as NodeJS.ErrnoException).code === "ENOENT") return { version: 1, targets: [] };
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") return emptyRegistry();
     throw error;
   }
-  if (value?.version !== 1 || !Array.isArray(value.targets)) return { version: 1, targets: [] };
-  return { version: 1, targets: value.targets.flatMap((row): StoredTarget[] => {
+  // v1 rows were recorded without wake eligibility, so they cannot prove a
+  // missed originally-wake=true outbound. Discard rather than re-scan them.
+  if (value?.version === 1) return emptyRegistry();
+  if (value?.version !== 2 || !Array.isArray(value.targets)) return emptyRegistry();
+  return { version: 2, targets: value.targets.flatMap((row): StoredTarget[] => {
     if (!row || typeof row !== "object") return [];
     const candidate = row as Partial<StoredTarget>;
     if (typeof candidate.target !== "string" || typeof candidate.anchor !== "string") return [];
@@ -54,9 +66,18 @@ function load(file: string): AuditRegistry {
       thread_id: candidate.target.startsWith("thread:") ? candidate.target.split(":")[2] : null,
       message_id: candidate.anchor,
     });
-    return typeof candidate.agent_id === "string" && candidate.agent_id && parsed && candidate.target === parsed.target
-      && typeof candidate.observed_at === "string" && Number.isFinite(Date.parse(candidate.observed_at))
-      ? [{ agent_id: candidate.agent_id, ...parsed, observed_at: candidate.observed_at }] : [];
+    const status = candidate.status === "completed" ? "completed" : candidate.status === "pending" ? "pending" : null;
+    if (!status || typeof candidate.agent_id !== "string" || !candidate.agent_id || !parsed || candidate.target !== parsed.target) return [];
+    if (typeof candidate.observed_at !== "string" || !Number.isFinite(Date.parse(candidate.observed_at))) return [];
+    const completed_at = typeof candidate.completed_at === "string" && Number.isFinite(Date.parse(candidate.completed_at))
+      ? candidate.completed_at : undefined;
+    const completed_anchor = typeof candidate.completed_anchor === "string" && ANCHOR.test(candidate.completed_anchor)
+      ? candidate.completed_anchor : undefined;
+    return [{
+      agent_id: candidate.agent_id, ...parsed, observed_at: candidate.observed_at, status,
+      ...(completed_at ? { completed_at } : {}),
+      ...(completed_anchor ? { completed_anchor } : {}),
+    }];
   }) };
 }
 
@@ -68,22 +89,28 @@ function save(file: string, registry: AuditRegistry): void {
   fs.chmodSync(file, 0o600);
 }
 
-/** Record only an authoritative human group/topic source; DMs and bots are ignored. */
+/**
+ * Record only an originally wake=true human group/topic source.
+ * Unmentioned require-policy traffic, DMs, and bots stay out of the audit work list.
+ */
 export function observeInboxAuditTarget(file: string, agentId: string, event: {
   chat_id?: string;
   chat_type?: string;
   thread_id?: string | null;
   message_id?: string;
+  wake?: boolean;
   _sender_is_bot?: boolean;
   _scan_authority?: boolean;
 }, now = new Date()): boolean {
-  if (event._scan_authority !== true || event._sender_is_bot !== false || event.chat_type !== "group") return false;
+  if (event.wake !== true || event._scan_authority !== true || event._sender_is_bot !== false || event.chat_type !== "group") return false;
   const parsed = parseTarget(event);
   if (!parsed) return false;
   const registry = load(file);
+  const existing = registry.targets.find((row) => row.agent_id === agentId && row.target === parsed.target);
+  if (existing?.status === "completed" && existing.anchor === parsed.anchor) return false;
   const observed_at = now.toISOString();
   registry.targets = registry.targets.filter((row) => row.agent_id !== agentId || row.target !== parsed.target);
-  registry.targets.unshift({ agent_id: agentId, ...parsed, observed_at });
+  registry.targets.unshift({ agent_id: agentId, ...parsed, observed_at, status: "pending" });
   registry.targets = registry.targets.slice(0, MAX_STORED_TARGETS);
   save(file, registry);
   return true;
@@ -96,19 +123,45 @@ function instruction(target: InboxAuditTarget): string {
   return `${history} If a real missed outbound finding requires a response, use the existing guarded larkin im reply path anchored at ${target.anchor}; otherwise stay silent.`;
 }
 
-/** Content-free, bounded audit work list consumed by the Agent CLI. */
+function pendingRows(file: string, agentId: string): StoredTarget[] {
+  return load(file).targets.filter((row) => row.agent_id === agentId && row.status === "pending")
+    .sort((left, right) => right.observed_at.localeCompare(left.observed_at));
+}
+
+export function hasPendingInboxAuditTargets(file: string, agentId: string): boolean {
+  return pendingRows(file, agentId).length > 0;
+}
+
+/** Content-free, bounded pending audit work list. Completed/reported targets are omitted. */
 export function readInboxAuditTargets(file: string, agentId: string): {
   version: 1;
   targets: Array<InboxAuditTarget & { instruction: string }>;
   has_more: boolean;
   no_finding: "stay_silent";
 } {
-  const rows = load(file).targets.filter((row) => row.agent_id === agentId)
-    .sort((left, right) => right.observed_at.localeCompare(left.observed_at));
+  const rows = pendingRows(file, agentId);
   return {
     version: 1,
-    targets: rows.slice(0, MAX_INBOX_AUDIT_TARGETS).map(({ agent_id: _agentId, ...target }) => ({ ...target, instruction: instruction(target) })),
+    targets: rows.slice(0, MAX_INBOX_AUDIT_TARGETS).map(({
+      agent_id: _agentId, status: _status, completed_at: _completedAt, completed_anchor: _completedAnchor, ...target
+    }) => ({ ...target, instruction: instruction(target) })),
     has_more: rows.length > MAX_INBOX_AUDIT_TARGETS,
     no_finding: "stay_silent",
   };
+}
+
+/** Mark currently pending targets for this Agent as completed so later audits do not repeat them. */
+export function completeInboxAuditTargets(file: string, agentId: string, now = new Date()): number {
+  const registry = load(file);
+  const completed_at = now.toISOString();
+  let count = 0;
+  for (const row of registry.targets) {
+    if (row.agent_id !== agentId || row.status !== "pending") continue;
+    row.status = "completed";
+    row.completed_at = completed_at;
+    row.completed_anchor = row.anchor;
+    count += 1;
+  }
+  if (count) save(file, registry);
+  return count;
 }

--- a/src/agent/missed-outbound-scan.ts
+++ b/src/agent/missed-outbound-scan.ts
@@ -1,42 +1,34 @@
+import * as crypto from "node:crypto";
 import * as fs from "node:fs";
 import * as path from "node:path";
 
-/**
- * #169's host-owned heartbeat no longer creates per-target missed-outbound loops.
- * Pre-v0.4.21 records have no unique ownership marker and can collide exactly
- * with user reminders, so existing indistinguishable loops are never migrated
- * or deleted automatically.
- */
+/** Historical reminder loops are deliberately unrelated to this bounded audit registry. */
 export const INBOX_AUDIT_LEGACY_MIGRATION_NON_GOAL = "New versions no longer create missed-outbound loops; existing indistinguishable historical loops are not migrated or deleted automatically.";
-// Pending audits are bounded so a heartbeat cannot accumulate an unbounded work list.
 export const MAX_INBOX_AUDIT_TARGETS = 96;
 const MAX_STORED_TARGETS = MAX_INBOX_AUDIT_TARGETS;
-// Periodic heartbeat reads this file through a cap+1 fd buffer. Fail closed
-// instead of parsing, slicing, or rewriting an oversized registry.
 export const MAX_INBOX_AUDIT_REGISTRY_BYTES = 64 * 1024;
 export const MAX_INBOX_AUDIT_REGISTRY_ROWS = MAX_INBOX_AUDIT_TARGETS;
+const LOCK_WAIT_MS = 1_000;
+const LOCK_RETRY_MS = 20;
 const CHAT = /^oc_[A-Za-z0-9]+$/;
 const THREAD = /^omt_[A-Za-z0-9]+$/;
 const ANCHOR = /^om_[A-Za-z0-9_-]+$/;
+const OUTCOMES = new Set(["no-finding", "handled"]);
 
-export interface InboxAuditTarget {
-  target: string;
-  anchor: string;
-  observed_at: string;
-}
-
+export interface InboxAuditTarget { target: string; anchor: string; observed_at: string }
+export type InboxAuditOutcome = "no-finding" | "handled";
 type AuditStatus = "pending" | "completed";
 interface StoredTarget extends InboxAuditTarget {
   agent_id: string;
   status: AuditStatus;
   completed_at?: string;
   completed_anchor?: string;
+  completed_outcome?: InboxAuditOutcome;
 }
 interface AuditRegistry { version: 2; targets: StoredTarget[] }
+interface ReceiptPayload { v: 1; agent_id: string; target: string; anchor: string; revision: string }
 
-export function inboxAuditRegistryFile(larkinHome: string): string {
-  return path.join(larkinHome, "inbox-audit.json");
-}
+export function inboxAuditRegistryFile(larkinHome: string): string { return path.join(larkinHome, "inbox-audit.json"); }
 
 function parseTarget(event: { chat_id?: string; thread_id?: string | null; message_id?: string }): { target: string; anchor: string } | null {
   const chatId = String(event.chat_id || "");
@@ -46,18 +38,13 @@ function parseTarget(event: { chat_id?: string; thread_id?: string | null; messa
   return { target: threadId ? `thread:${chatId}:${threadId}` : `chat:${chatId}`, anchor };
 }
 
-function emptyRegistry(): AuditRegistry {
-  return { version: 2, targets: [] };
-}
+function emptyRegistry(): AuditRegistry { return { version: 2, targets: [] }; }
 
 function load(file: string): AuditRegistry {
-  let value: { version?: unknown; targets?: unknown };
   let fd: number | undefined;
   let bytes: Buffer;
   try {
-    fd = fs.openSync(file, fs.constants.O_RDONLY
-      | (fs.constants.O_NOFOLLOW || 0)
-      | (fs.constants.O_NONBLOCK || 0));
+    fd = fs.openSync(file, fs.constants.O_RDONLY | (fs.constants.O_NOFOLLOW || 0) | (fs.constants.O_NONBLOCK || 0));
     const stat = fs.fstatSync(fd);
     if (!stat.isFile()) throw new Error("inbox audit registry is not a regular file");
     const buffer = Buffer.alloc(MAX_INBOX_AUDIT_REGISTRY_BYTES + 1);
@@ -72,127 +59,159 @@ function load(file: string): AuditRegistry {
   } catch (error) {
     if ((error as NodeJS.ErrnoException).code === "ENOENT") return emptyRegistry();
     throw error;
-  } finally {
-    if (fd !== undefined) fs.closeSync(fd);
-  }
-  value = JSON.parse(bytes.toString("utf8")) as { version?: unknown; targets?: unknown };
-  // v1 rows were recorded without wake eligibility, so they cannot prove a
-  // missed originally-wake=true outbound. Discard rather than re-scan them.
-  if (value?.version === 1) return emptyRegistry();
-  if (value?.version !== 2 || !Array.isArray(value.targets)) return emptyRegistry();
+  } finally { if (fd !== undefined) fs.closeSync(fd); }
+  const value = JSON.parse(bytes.toString("utf8")) as { version?: unknown; targets?: unknown };
+  // v1 never proved original wake eligibility. It is intentionally not upgraded.
+  if (value?.version === 1 || value?.version !== 2 || !Array.isArray(value.targets)) return emptyRegistry();
   if (value.targets.length > MAX_INBOX_AUDIT_REGISTRY_ROWS) throw new Error("inbox audit registry exceeds the bounded row limit");
   return { version: 2, targets: value.targets.flatMap((row): StoredTarget[] => {
     if (!row || typeof row !== "object") return [];
     const candidate = row as Partial<StoredTarget>;
     if (typeof candidate.target !== "string" || typeof candidate.anchor !== "string") return [];
+    const parts = candidate.target.split(":");
     const parsed = parseTarget({
-      chat_id: candidate.target.startsWith("chat:") ? candidate.target.slice(5) : candidate.target.split(":")[1],
-      thread_id: candidate.target.startsWith("thread:") ? candidate.target.split(":")[2] : null,
+      chat_id: candidate.target.startsWith("chat:") ? candidate.target.slice(5) : parts[1],
+      thread_id: candidate.target.startsWith("thread:") ? parts[2] : null,
       message_id: candidate.anchor,
     });
     const status = candidate.status === "completed" ? "completed" : candidate.status === "pending" ? "pending" : null;
-    if (!status || typeof candidate.agent_id !== "string" || !candidate.agent_id || !parsed || candidate.target !== parsed.target) return [];
-    if (typeof candidate.observed_at !== "string" || !Number.isFinite(Date.parse(candidate.observed_at))) return [];
-    const completed_at = typeof candidate.completed_at === "string" && Number.isFinite(Date.parse(candidate.completed_at))
-      ? candidate.completed_at : undefined;
-    const completed_anchor = typeof candidate.completed_anchor === "string" && ANCHOR.test(candidate.completed_anchor)
-      ? candidate.completed_anchor : undefined;
-    return [{
-      agent_id: candidate.agent_id, ...parsed, observed_at: candidate.observed_at, status,
-      ...(completed_at ? { completed_at } : {}),
-      ...(completed_anchor ? { completed_anchor } : {}),
-    }];
+    if (!status || typeof candidate.agent_id !== "string" || !candidate.agent_id || !parsed || candidate.target !== parsed.target
+      || typeof candidate.observed_at !== "string" || !Number.isFinite(Date.parse(candidate.observed_at))) return [];
+    const completed_at = typeof candidate.completed_at === "string" && Number.isFinite(Date.parse(candidate.completed_at)) ? candidate.completed_at : undefined;
+    const completed_anchor = typeof candidate.completed_anchor === "string" && ANCHOR.test(candidate.completed_anchor) ? candidate.completed_anchor : undefined;
+    const completed_outcome = OUTCOMES.has(String(candidate.completed_outcome)) ? candidate.completed_outcome as InboxAuditOutcome : undefined;
+    return [{ agent_id: candidate.agent_id, ...parsed, observed_at: candidate.observed_at, status,
+      ...(completed_at ? { completed_at } : {}), ...(completed_anchor ? { completed_anchor } : {}),
+      ...(completed_outcome ? { completed_outcome } : {}) }];
   }) };
 }
 
 function save(file: string, registry: AuditRegistry): void {
-  if (registry.targets.length > MAX_INBOX_AUDIT_REGISTRY_ROWS) {
-    throw new Error("inbox audit registry exceeds the bounded row limit");
-  }
+  if (registry.targets.length > MAX_INBOX_AUDIT_REGISTRY_ROWS) throw new Error("inbox audit registry exceeds the bounded row limit");
   const serialized = `${JSON.stringify(registry)}\n`;
-  if (Buffer.byteLength(serialized) > MAX_INBOX_AUDIT_REGISTRY_BYTES) {
-    throw new Error("inbox audit registry exceeds the bounded byte limit");
-  }
+  if (Buffer.byteLength(serialized) > MAX_INBOX_AUDIT_REGISTRY_BYTES) throw new Error("inbox audit registry exceeds the bounded byte limit");
   fs.mkdirSync(path.dirname(file), { recursive: true, mode: 0o700 });
-  const temporary = path.join(path.dirname(file), `.${path.basename(file)}.${process.pid}.${Date.now()}.tmp`);
+  const temporary = path.join(path.dirname(file), `.${path.basename(file)}.${process.pid}.${crypto.randomUUID()}.tmp`);
   fs.writeFileSync(temporary, serialized, { mode: 0o600 });
-  fs.renameSync(temporary, file);
-  fs.chmodSync(file, 0o600);
+  try { fs.renameSync(temporary, file); fs.chmodSync(file, 0o600); }
+  catch (error) { try { fs.unlinkSync(temporary); } catch { /* best effort */ } throw error; }
 }
 
-/**
- * Record only an originally wake=true human group/topic source.
- * Unmentioned require-policy traffic, DMs, and bots stay out of the audit work list.
- */
+function sleep(ms: number): void { Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, ms); }
+
+/** Serialize Host observers and CLI completion without replacing a newer registry snapshot. */
+function mutate<T>(file: string, operation: (registry: AuditRegistry) => T): T {
+  const deadline = Date.now() + LOCK_WAIT_MS;
+  const lockFile = `${file}.mutation-lock`;
+  const nonce = crypto.randomUUID();
+  while (Date.now() <= deadline) {
+    try {
+      fs.mkdirSync(path.dirname(file), { recursive: true, mode: 0o700 });
+      const fd = fs.openSync(lockFile, "wx", 0o600);
+      try { fs.writeFileSync(fd, JSON.stringify({ pid: process.pid, nonce })); fs.fsyncSync(fd); }
+      finally { fs.closeSync(fd); }
+      const registry = load(file);
+      const result = operation(registry);
+      save(file, registry);
+      return result;
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code !== "EEXIST") throw error;
+      // A dead owner cannot preserve a mutation; reclaim only after checking pid
+      // liveness, while live contention remains bounded and retries its full read.
+      try {
+        const owner = JSON.parse(fs.readFileSync(lockFile, "utf8")) as { pid?: unknown };
+        if (Number.isInteger(owner.pid) && Number(owner.pid) > 0) {
+          try { process.kill(Number(owner.pid), 0); }
+          catch (ownerError) { if ((ownerError as NodeJS.ErrnoException).code === "ESRCH") fs.unlinkSync(lockFile); }
+        }
+      } catch (lockError) { if ((lockError as NodeJS.ErrnoException).code === "ENOENT") continue; }
+      sleep(LOCK_RETRY_MS);
+    } finally {
+      try {
+        const owner = JSON.parse(fs.readFileSync(lockFile, "utf8")) as { pid?: unknown; nonce?: unknown };
+        if (owner.pid === process.pid && owner.nonce === nonce) fs.unlinkSync(lockFile);
+      } catch { /* another process owns or removed the lock */ }
+    }
+  }
+  throw new Error("inbox audit registry busy: bounded lock contention");
+}
+
+function revision(row: Pick<StoredTarget, "agent_id" | "target" | "anchor" | "observed_at" | "status">): string {
+  return `sha256:${crypto.createHash("sha256").update(JSON.stringify({
+    v: 1, agent_id: row.agent_id, target: row.target, anchor: row.anchor, observed_at: row.observed_at, status: row.status,
+  })).digest("hex")}`;
+}
+
+function receipt(row: StoredTarget): string {
+  const payload: ReceiptPayload = { v: 1, agent_id: row.agent_id, target: row.target, anchor: row.anchor, revision: revision(row) };
+  return Buffer.from(JSON.stringify(payload)).toString("base64url");
+}
+
+function parseReceipt(value: string): ReceiptPayload | null {
+  try {
+    const raw = JSON.parse(Buffer.from(value, "base64url").toString("utf8")) as Partial<ReceiptPayload>;
+    if (raw.v !== 1 || typeof raw.agent_id !== "string" || !raw.agent_id || typeof raw.target !== "string" || typeof raw.anchor !== "string"
+      || typeof raw.revision !== "string" || !raw.revision.startsWith("sha256:")) return null;
+    const parts = raw.target.split(":");
+    const parsed = parseTarget({ chat_id: raw.target.startsWith("chat:") ? raw.target.slice(5) : parts[1], thread_id: raw.target.startsWith("thread:") ? parts[2] : null, message_id: raw.anchor });
+    return parsed?.target === raw.target ? raw as ReceiptPayload : null;
+  } catch { return null; }
+}
+
 export function observeInboxAuditTarget(file: string, agentId: string, event: {
-  chat_id?: string;
-  chat_type?: string;
-  thread_id?: string | null;
-  message_id?: string;
-  wake?: boolean;
-  _sender_is_bot?: boolean;
-  _scan_authority?: boolean;
+  chat_id?: string; chat_type?: string; thread_id?: string | null; message_id?: string; wake?: boolean; _sender_is_bot?: boolean; _scan_authority?: boolean;
 }, now = new Date()): boolean {
   if (event.wake !== true || event._scan_authority !== true || event._sender_is_bot !== false || event.chat_type !== "group") return false;
   const parsed = parseTarget(event);
   if (!parsed) return false;
-  const registry = load(file);
-  const existing = registry.targets.find((row) => row.agent_id === agentId && row.target === parsed.target);
-  if (existing?.status === "completed" && existing.anchor === parsed.anchor) return false;
-  const observed_at = now.toISOString();
-  registry.targets = registry.targets.filter((row) => row.agent_id !== agentId || row.target !== parsed.target);
-  registry.targets.unshift({ agent_id: agentId, ...parsed, observed_at, status: "pending" });
-  registry.targets = registry.targets.slice(0, MAX_STORED_TARGETS);
-  save(file, registry);
-  return true;
+  return mutate(file, (registry) => {
+    const existing = registry.targets.find((row) => row.agent_id === agentId && row.target === parsed.target);
+    if (existing?.status === "completed" && existing.anchor === parsed.anchor) return false;
+    registry.targets = registry.targets.filter((row) => row.agent_id !== agentId || row.target !== parsed.target);
+    registry.targets.unshift({ agent_id: agentId, ...parsed, observed_at: now.toISOString(), status: "pending" });
+    registry.targets = registry.targets.slice(0, MAX_STORED_TARGETS);
+    return true;
+  });
 }
 
-function instruction(target: InboxAuditTarget): string {
-  const history = target.target.startsWith("thread:")
-    ? "Use larkin im +threads-messages-list for this exact thread."
-    : "Use larkin im +chat-messages-list for this exact chat.";
-  return `${history} If a real missed outbound finding requires a response, use the existing guarded larkin im reply path anchored at ${target.anchor}; otherwise stay silent.`;
+function instruction(target: InboxAuditTarget, receiptValue: string): string {
+  const history = target.target.startsWith("thread:") ? "Use larkin im +threads-messages-list for this exact thread." : "Use larkin im +chat-messages-list for this exact chat.";
+  return `${history} Inspect first. When finished, run larkin inbox audit complete --receipt ${receiptValue} --outcome <no-finding|handled> --json. If a real finding needs a response, use the guarded reply path anchored at ${target.anchor}; otherwise stay silent.`;
 }
 
 function pendingRows(file: string, agentId: string): StoredTarget[] {
-  return load(file).targets.filter((row) => row.agent_id === agentId && row.status === "pending")
-    .sort((left, right) => right.observed_at.localeCompare(left.observed_at));
+  return load(file).targets.filter((row) => row.agent_id === agentId && row.status === "pending").sort((left, right) => right.observed_at.localeCompare(left.observed_at));
 }
 
-export function hasPendingInboxAuditTargets(file: string, agentId: string): boolean {
-  return pendingRows(file, agentId).length > 0;
-}
+export function hasPendingInboxAuditTargets(file: string, agentId: string): boolean { return pendingRows(file, agentId).length > 0; }
 
-/** Content-free, bounded pending audit work list. Completed/reported targets are omitted. */
+/** Public read is intentionally completion-free: a caller crash leaves the target pending. */
 export function readInboxAuditTargets(file: string, agentId: string): {
-  version: 1;
-  targets: Array<InboxAuditTarget & { instruction: string }>;
-  has_more: boolean;
-  no_finding: "stay_silent";
+  version: 2; targets: Array<InboxAuditTarget & { revision: string; receipt: string; instruction: string }>; has_more: boolean; no_finding: "stay_silent";
 } {
   const rows = pendingRows(file, agentId);
-  return {
-    version: 1,
-    targets: rows.slice(0, MAX_INBOX_AUDIT_TARGETS).map(({
-      agent_id: _agentId, status: _status, completed_at: _completedAt, completed_anchor: _completedAnchor, ...target
-    }) => ({ ...target, instruction: instruction(target) })),
-    has_more: rows.length > MAX_INBOX_AUDIT_TARGETS,
-    no_finding: "stay_silent",
-  };
+  return { version: 2, targets: rows.slice(0, MAX_INBOX_AUDIT_TARGETS).map((row) => {
+    const target = { target: row.target, anchor: row.anchor, observed_at: row.observed_at };
+    const receiptValue = receipt(row);
+    return { ...target, revision: revision(row), receipt: receiptValue, instruction: instruction(target, receiptValue) };
+  }), has_more: rows.length > MAX_INBOX_AUDIT_TARGETS, no_finding: "stay_silent" };
 }
 
-/** Mark currently pending targets for this Agent as completed so later audits do not repeat them. */
-export function completeInboxAuditTargets(file: string, agentId: string, now = new Date()): number {
-  const registry = load(file);
-  const completed_at = now.toISOString();
-  let count = 0;
-  for (const row of registry.targets) {
-    if (row.agent_id !== agentId || row.status !== "pending") continue;
+export function completeInboxAuditTarget(file: string, agentId: string, receiptValue: string, outcome: string, now = new Date()): {
+  completed: boolean; reason: "completed" | "already_completed" | "stale" | "invalid_receipt" | "invalid_outcome";
+} {
+  if (!OUTCOMES.has(outcome)) return { completed: false, reason: "invalid_outcome" };
+  const decoded = parseReceipt(receiptValue);
+  if (!decoded || decoded.agent_id !== agentId) return { completed: false, reason: "invalid_receipt" };
+  return mutate(file, (registry) => {
+    const row = registry.targets.find((candidate) => candidate.agent_id === decoded.agent_id && candidate.target === decoded.target);
+    if (!row || row.anchor !== decoded.anchor) return { completed: false, reason: "stale" as const };
+    if (row.status === "completed") return { completed: false, reason: "already_completed" as const };
+    if (revision(row) !== decoded.revision) return { completed: false, reason: "stale" as const };
     row.status = "completed";
-    row.completed_at = completed_at;
+    row.completed_at = now.toISOString();
     row.completed_anchor = row.anchor;
-    count += 1;
-  }
-  if (count) save(file, registry);
-  return count;
+    row.completed_outcome = outcome as InboxAuditOutcome;
+    return { completed: true, reason: "completed" as const };
+  });
 }

--- a/src/agent/missed-outbound-scan.ts
+++ b/src/agent/missed-outbound-scan.ts
@@ -17,7 +17,7 @@ const ANCHOR = /^om_[A-Za-z0-9_-]+$/;
 const GENERATION = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
 const OUTCOMES = new Set(["no-finding", "handled"]);
 
-export interface InboxAuditTarget { target: string; anchor: string; observed_at: string }
+export interface InboxAuditTarget { target: string; anchor: string; observed_at: string; source_seq: number }
 export type InboxAuditOutcome = "no-finding" | "handled";
 type AuditStatus = "pending" | "completed";
 interface StoredTarget extends InboxAuditTarget {
@@ -28,10 +28,10 @@ interface StoredTarget extends InboxAuditTarget {
   completed_anchor?: string;
   completed_outcome?: InboxAuditOutcome;
 }
-interface AuditRegistry { version: 3; targets: StoredTarget[] }
+interface AuditRegistry { version: 4; targets: StoredTarget[] }
 interface ReceiptPayload { v: 1; agent_id: string; target: string; anchor: string; revision: string }
-interface RetryTarget { agent_id: string; target: string; anchor: string; chat_id: string; thread_id: string | null; queued_at: string }
-interface RetryJournal { version: 1; targets: RetryTarget[] }
+interface RetryTarget { agent_id: string; target: string; anchor: string; chat_id: string; thread_id: string | null; source_seq: number; queued_at: string }
+interface RetryJournal { version: 2; targets: RetryTarget[] }
 
 export function inboxAuditRegistryFile(larkinHome: string): string { return path.join(larkinHome, "inbox-audit.json"); }
 export function inboxAuditRetryFile(larkinHome: string): string { return path.join(larkinHome, "inbox-audit-retry.json"); }
@@ -44,7 +44,7 @@ function parseTarget(event: { chat_id?: string; thread_id?: string | null; messa
   return { target: threadId ? `thread:${chatId}:${threadId}` : `chat:${chatId}`, anchor };
 }
 
-function emptyRegistry(): AuditRegistry { return { version: 3, targets: [] }; }
+function emptyRegistry(): AuditRegistry { return { version: 4, targets: [] }; }
 
 function assertSafeExistingFile(file: string, label: string): void {
   try {
@@ -86,9 +86,9 @@ function load(file: string): AuditRegistry {
   const value = JSON.parse(bytes.toString("utf8")) as { version?: unknown; targets?: unknown };
   // v1 had no wake provenance; v2 had no durable observation generation.
   // Neither can safely issue a completion receipt after this lifecycle upgrade.
-  if (value?.version !== 3 || !Array.isArray(value.targets)) return emptyRegistry();
+  if (value?.version !== 4 || !Array.isArray(value.targets)) return emptyRegistry();
   if (value.targets.length > MAX_INBOX_AUDIT_REGISTRY_ROWS) throw new Error("inbox audit registry exceeds the bounded row limit");
-  return { version: 3, targets: value.targets.flatMap((row): StoredTarget[] => {
+  return { version: 4, targets: value.targets.flatMap((row): StoredTarget[] => {
     if (!row || typeof row !== "object") return [];
     const candidate = row as Partial<StoredTarget>;
     if (typeof candidate.target !== "string" || typeof candidate.anchor !== "string") return [];
@@ -100,11 +100,12 @@ function load(file: string): AuditRegistry {
     });
     const status = candidate.status === "completed" ? "completed" : candidate.status === "pending" ? "pending" : null;
     if (!status || typeof candidate.agent_id !== "string" || !candidate.agent_id || typeof candidate.generation !== "string" || !GENERATION.test(candidate.generation) || !parsed || candidate.target !== parsed.target
+      || !Number.isSafeInteger(candidate.source_seq) || Number(candidate.source_seq) < 1
       || typeof candidate.observed_at !== "string" || !Number.isFinite(Date.parse(candidate.observed_at))) return [];
     const completed_at = typeof candidate.completed_at === "string" && Number.isFinite(Date.parse(candidate.completed_at)) ? candidate.completed_at : undefined;
     const completed_anchor = typeof candidate.completed_anchor === "string" && ANCHOR.test(candidate.completed_anchor) ? candidate.completed_anchor : undefined;
     const completed_outcome = OUTCOMES.has(String(candidate.completed_outcome)) ? candidate.completed_outcome as InboxAuditOutcome : undefined;
-    return [{ agent_id: candidate.agent_id, generation: candidate.generation, ...parsed, observed_at: candidate.observed_at, status,
+    return [{ agent_id: candidate.agent_id, generation: candidate.generation, ...parsed, source_seq: Number(candidate.source_seq), observed_at: candidate.observed_at, status,
       ...(completed_at ? { completed_at } : {}), ...(completed_anchor ? { completed_anchor } : {}),
       ...(completed_outcome ? { completed_outcome } : {}) }];
   }) };
@@ -123,7 +124,7 @@ function save(file: string, registry: AuditRegistry): void {
   catch (error) { try { fs.unlinkSync(temporary); } catch { /* best effort */ } throw error; }
 }
 
-function emptyRetryJournal(): RetryJournal { return { version: 1, targets: [] }; }
+function emptyRetryJournal(): RetryJournal { return { version: 2, targets: [] }; }
 
 function loadRetryJournal(file: string): RetryJournal {
   let value: unknown;
@@ -137,15 +138,16 @@ function loadRetryJournal(file: string): RetryJournal {
     throw error;
   }
   const raw = value as { version?: unknown; targets?: unknown };
-  if (raw.version !== 1 || !Array.isArray(raw.targets) || raw.targets.length > MAX_INBOX_AUDIT_REGISTRY_ROWS) return emptyRetryJournal();
-  return { version: 1, targets: raw.targets.flatMap((candidate): RetryTarget[] => {
+  if (raw.version !== 2 || !Array.isArray(raw.targets) || raw.targets.length > MAX_INBOX_AUDIT_REGISTRY_ROWS) return emptyRetryJournal();
+  return { version: 2, targets: raw.targets.flatMap((candidate): RetryTarget[] => {
     if (!candidate || typeof candidate !== "object") return [];
     const row = candidate as Partial<RetryTarget>;
     const parsed = parseTarget({ chat_id: row.chat_id, thread_id: row.thread_id, message_id: row.anchor });
     if (typeof row.agent_id !== "string" || !row.agent_id || typeof row.target !== "string" || !parsed || parsed.target !== row.target
       || typeof row.chat_id !== "string" || (row.thread_id !== null && typeof row.thread_id !== "string")
+      || !Number.isSafeInteger(row.source_seq) || Number(row.source_seq) < 1
       || typeof row.queued_at !== "string" || !Number.isFinite(Date.parse(row.queued_at))) return [];
-    return [{ agent_id: row.agent_id, target: row.target, anchor: parsed.anchor, chat_id: row.chat_id, thread_id: row.thread_id ?? null, queued_at: row.queued_at }];
+    return [{ agent_id: row.agent_id, target: row.target, anchor: parsed.anchor, chat_id: row.chat_id, thread_id: row.thread_id ?? null, source_seq: Number(row.source_seq), queued_at: row.queued_at }];
   }) };
 }
 
@@ -224,18 +226,17 @@ function parseReceipt(value: string): ReceiptPayload | null {
 }
 
 export function observeInboxAuditTarget(file: string, agentId: string, event: {
-  chat_id?: string; chat_type?: string; thread_id?: string | null; message_id?: string; wake?: boolean; _sender_is_bot?: boolean; _scan_authority?: boolean;
+  chat_id?: string; chat_type?: string; thread_id?: string | null; message_id?: string; source_seq?: number; wake?: boolean; _sender_is_bot?: boolean; _scan_authority?: boolean;
 }, now = new Date()): boolean {
   if (event.wake !== true || event._scan_authority !== true || event._sender_is_bot !== false || event.chat_type !== "group") return false;
   const parsed = parseTarget(event);
-  if (!parsed) return false;
+  const sourceSeq = typeof event.source_seq === "number" ? event.source_seq : Number.NaN;
+  if (!parsed || !Number.isSafeInteger(sourceSeq) || sourceSeq < 1) return false;
   return mutate(file, (registry) => {
     const existing = registry.targets.find((row) => row.agent_id === agentId && row.target === parsed.target);
-    // Redelivery of the same original source is not new evidence and must not
-    // rotate a receipt generation. A different anchor deliberately reopens it.
-    if (existing?.anchor === parsed.anchor) return false;
+    if (existing && sourceSeq <= existing.source_seq) return false;
     registry.targets = registry.targets.filter((row) => row.agent_id !== agentId || row.target !== parsed.target);
-    registry.targets.unshift({ agent_id: agentId, generation: crypto.randomUUID(), ...parsed, observed_at: now.toISOString(), status: "pending" });
+    registry.targets.unshift({ agent_id: agentId, generation: crypto.randomUUID(), ...parsed, source_seq: sourceSeq, observed_at: now.toISOString(), status: "pending" });
     registry.targets = registry.targets.slice(0, MAX_STORED_TARGETS);
     return true;
   });
@@ -243,24 +244,27 @@ export function observeInboxAuditTarget(file: string, agentId: string, event: {
 
 /** Durable recovery intent, recorded only after the same original wake gate. */
 export function enqueueInboxAuditTargetRetry(file: string, agentId: string, event: {
-  chat_id?: string; chat_type?: string; thread_id?: string | null; message_id?: string; wake?: boolean; _sender_is_bot?: boolean; _scan_authority?: boolean;
+  chat_id?: string; chat_type?: string; thread_id?: string | null; message_id?: string; source_seq?: number; wake?: boolean; _sender_is_bot?: boolean; _scan_authority?: boolean;
 }, now = new Date()): boolean {
   if (event.wake !== true || event._scan_authority !== true || event._sender_is_bot !== false || event.chat_type !== "group") return false;
   const parsed = parseTarget(event);
-  if (!parsed) return false;
+  const sourceSeq = typeof event.source_seq === "number" ? event.source_seq : Number.NaN;
+  if (!parsed || !Number.isSafeInteger(sourceSeq) || sourceSeq < 1) return false;
   return mutateRetryJournal(file, (journal) => {
+    const existing = journal.targets.find((row) => row.agent_id === agentId && row.target === parsed.target);
+    if (existing && sourceSeq <= existing.source_seq) return false;
     journal.targets = journal.targets.filter((row) => row.agent_id !== agentId || row.target !== parsed.target);
-    journal.targets.unshift({ agent_id: agentId, ...parsed, chat_id: String(event.chat_id), thread_id: event.thread_id ? String(event.thread_id) : null, queued_at: now.toISOString() });
+    journal.targets.unshift({ agent_id: agentId, ...parsed, source_seq: sourceSeq, chat_id: String(event.chat_id), thread_id: event.thread_id ? String(event.thread_id) : null, queued_at: now.toISOString() });
     journal.targets = journal.targets.slice(0, MAX_STORED_TARGETS);
     return true;
   });
 }
 
 /** Remove only the exact recovered/newer target so a late retry cannot erase a new anchor. */
-export function discardInboxAuditTargetRetry(file: string, agentId: string, event: { chat_id?: string; thread_id?: string | null; message_id?: string }): void {
+export function discardInboxAuditTargetRetry(file: string, agentId: string, event: { chat_id?: string; thread_id?: string | null; message_id?: string; source_seq?: number }): void {
   const parsed = parseTarget(event);
   if (!parsed) return;
-  mutateRetryJournal(file, (journal) => { journal.targets = journal.targets.filter((row) => row.agent_id !== agentId || row.target !== parsed.target || row.anchor !== parsed.anchor); });
+  mutateRetryJournal(file, (journal) => { journal.targets = journal.targets.filter((row) => row.agent_id !== agentId || row.target !== parsed.target || row.source_seq > Number(event.source_seq ?? 0)); });
 }
 
 /** Replay persisted, already-authorized observer intents. Failures remain durable for a later bounded retry/startup. */
@@ -269,8 +273,8 @@ export function reconcileInboxAuditTargetRetries(registryFile: string, retryFile
   let recovered = 0;
   for (const row of rows) {
     try {
-      observeInboxAuditTarget(registryFile, row.agent_id, { chat_id: row.chat_id, chat_type: "group", thread_id: row.thread_id, message_id: row.anchor, wake: true, _sender_is_bot: false, _scan_authority: true });
-      discardInboxAuditTargetRetry(retryFile, row.agent_id, { chat_id: row.chat_id, thread_id: row.thread_id, message_id: row.anchor });
+      observeInboxAuditTarget(registryFile, row.agent_id, { chat_id: row.chat_id, chat_type: "group", thread_id: row.thread_id, message_id: row.anchor, source_seq: row.source_seq, wake: true, _sender_is_bot: false, _scan_authority: true });
+      discardInboxAuditTargetRetry(retryFile, row.agent_id, { chat_id: row.chat_id, thread_id: row.thread_id, message_id: row.anchor, source_seq: row.source_seq });
       recovered += 1;
     } catch { break; }
   }
@@ -290,11 +294,11 @@ export function hasPendingInboxAuditTargets(file: string, agentId: string): bool
 
 /** Public read is intentionally completion-free: a caller crash leaves the target pending. */
 export function readInboxAuditTargets(file: string, agentId: string): {
-  version: 3; targets: Array<InboxAuditTarget & { revision: string; receipt: string; instruction: string }>; has_more: boolean; no_finding: "stay_silent";
+  version: 4; targets: Array<InboxAuditTarget & { revision: string; receipt: string; instruction: string }>; has_more: boolean; no_finding: "stay_silent";
 } {
   const rows = pendingRows(file, agentId);
-  return { version: 3, targets: rows.slice(0, MAX_INBOX_AUDIT_TARGETS).map((row) => {
-    const target = { target: row.target, anchor: row.anchor, observed_at: row.observed_at };
+  return { version: 4, targets: rows.slice(0, MAX_INBOX_AUDIT_TARGETS).map((row) => {
+    const target = { target: row.target, anchor: row.anchor, observed_at: row.observed_at, source_seq: row.source_seq };
     const receiptValue = receipt(row);
     return { ...target, revision: revision(row), receipt: receiptValue, instruction: instruction(target, receiptValue) };
   }), has_more: rows.length > MAX_INBOX_AUDIT_TARGETS, no_finding: "stay_silent" };

--- a/src/agent/missed-outbound-scan.ts
+++ b/src/agent/missed-outbound-scan.ts
@@ -30,8 +30,11 @@ interface StoredTarget extends InboxAuditTarget {
 }
 interface AuditRegistry { version: 3; targets: StoredTarget[] }
 interface ReceiptPayload { v: 1; agent_id: string; target: string; anchor: string; revision: string }
+interface RetryTarget { agent_id: string; target: string; anchor: string; chat_id: string; thread_id: string | null; queued_at: string }
+interface RetryJournal { version: 1; targets: RetryTarget[] }
 
 export function inboxAuditRegistryFile(larkinHome: string): string { return path.join(larkinHome, "inbox-audit.json"); }
+export function inboxAuditRetryFile(larkinHome: string): string { return path.join(larkinHome, "inbox-audit-retry.json"); }
 
 function parseTarget(event: { chat_id?: string; thread_id?: string | null; message_id?: string }): { target: string; anchor: string } | null {
   const chatId = String(event.chat_id || "");
@@ -120,10 +123,49 @@ function save(file: string, registry: AuditRegistry): void {
   catch (error) { try { fs.unlinkSync(temporary); } catch { /* best effort */ } throw error; }
 }
 
+function emptyRetryJournal(): RetryJournal { return { version: 1, targets: [] }; }
+
+function loadRetryJournal(file: string): RetryJournal {
+  let value: unknown;
+  try {
+    assertSafeExistingFile(file, "inbox audit retry journal");
+    const stat = fs.statSync(file);
+    if (stat.size > MAX_INBOX_AUDIT_REGISTRY_BYTES) throw new Error("inbox audit retry journal exceeds the bounded byte limit");
+    value = JSON.parse(fs.readFileSync(file, "utf8"));
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") return emptyRetryJournal();
+    throw error;
+  }
+  const raw = value as { version?: unknown; targets?: unknown };
+  if (raw.version !== 1 || !Array.isArray(raw.targets) || raw.targets.length > MAX_INBOX_AUDIT_REGISTRY_ROWS) return emptyRetryJournal();
+  return { version: 1, targets: raw.targets.flatMap((candidate): RetryTarget[] => {
+    if (!candidate || typeof candidate !== "object") return [];
+    const row = candidate as Partial<RetryTarget>;
+    const parsed = parseTarget({ chat_id: row.chat_id, thread_id: row.thread_id, message_id: row.anchor });
+    if (typeof row.agent_id !== "string" || !row.agent_id || typeof row.target !== "string" || !parsed || parsed.target !== row.target
+      || typeof row.chat_id !== "string" || (row.thread_id !== null && typeof row.thread_id !== "string")
+      || typeof row.queued_at !== "string" || !Number.isFinite(Date.parse(row.queued_at))) return [];
+    return [{ agent_id: row.agent_id, target: row.target, anchor: parsed.anchor, chat_id: row.chat_id, thread_id: row.thread_id ?? null, queued_at: row.queued_at }];
+  }) };
+}
+
+function saveRetryJournal(file: string, journal: RetryJournal): void {
+  if (journal.targets.length > MAX_INBOX_AUDIT_REGISTRY_ROWS) throw new Error("inbox audit retry journal exceeds the bounded row limit");
+  const serialized = `${JSON.stringify(journal)}\n`;
+  if (Buffer.byteLength(serialized) > MAX_INBOX_AUDIT_REGISTRY_BYTES) throw new Error("inbox audit retry journal exceeds the bounded byte limit");
+  prepareRegistryDirectory(file);
+  assertSafeExistingFile(file, "inbox audit retry journal");
+  const temporary = path.join(path.dirname(file), `.${path.basename(file)}.${process.pid}.${crypto.randomUUID()}.tmp`);
+  const fd = fs.openSync(temporary, fs.constants.O_WRONLY | fs.constants.O_CREAT | fs.constants.O_EXCL | (fs.constants.O_NOFOLLOW || 0), 0o600);
+  try { fs.writeFileSync(fd, serialized); fs.fsyncSync(fd); } finally { fs.closeSync(fd); }
+  try { fs.renameSync(temporary, file); fs.chmodSync(file, 0o600); }
+  catch (error) { try { fs.unlinkSync(temporary); } catch { /* best effort */ } throw error; }
+}
+
 function sleep(ms: number): void { Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, ms); }
 
 /** Serialize Host observers and CLI completion without replacing a newer registry snapshot. */
-function mutate<T>(file: string, operation: (registry: AuditRegistry) => T): T {
+function withAuditLock<T>(file: string, operation: () => T): T {
   const deadline = Date.now() + LOCK_WAIT_MS;
   const lockFile = `${file}.mutation-lock`;
   prepareRegistryDirectory(file);
@@ -132,16 +174,31 @@ function mutate<T>(file: string, operation: (registry: AuditRegistry) => T): T {
     try {
       assertSafeExistingFile(lockFile, "inbox audit mutation lock");
       lock = acquireProcessLock(lockFile, path.basename(process.execPath), { malformedGraceMs: 1_000 });
-      const registry = load(file);
-      const result = operation(registry);
-      save(file, registry);
-      return result;
+      return operation();
     } catch (error) {
       if (lock || !/lock 已被|无法取得 lock|正在创建|暂不能接管|并发重试耗尽/.test(error instanceof Error ? error.message : String(error))) throw error;
       sleep(LOCK_RETRY_MS);
     } finally { lock?.release(); }
   }
   throw new Error("inbox audit registry busy: bounded lock contention");
+}
+
+function mutate<T>(file: string, operation: (registry: AuditRegistry) => T): T {
+  return withAuditLock(file, () => {
+    const registry = load(file);
+    const result = operation(registry);
+    save(file, registry);
+    return result;
+  });
+}
+
+function mutateRetryJournal<T>(file: string, operation: (journal: RetryJournal) => T): T {
+  return withAuditLock(file, () => {
+    const journal = loadRetryJournal(file);
+    const result = operation(journal);
+    saveRetryJournal(file, journal);
+    return result;
+  });
 }
 
 function revision(row: Pick<StoredTarget, "agent_id" | "target" | "anchor" | "generation" | "status">): string {
@@ -180,6 +237,42 @@ export function observeInboxAuditTarget(file: string, agentId: string, event: {
     registry.targets = registry.targets.slice(0, MAX_STORED_TARGETS);
     return true;
   });
+}
+
+/** Durable recovery intent, recorded only after the same original wake gate. */
+export function enqueueInboxAuditTargetRetry(file: string, agentId: string, event: {
+  chat_id?: string; chat_type?: string; thread_id?: string | null; message_id?: string; wake?: boolean; _sender_is_bot?: boolean; _scan_authority?: boolean;
+}, now = new Date()): boolean {
+  if (event.wake !== true || event._scan_authority !== true || event._sender_is_bot !== false || event.chat_type !== "group") return false;
+  const parsed = parseTarget(event);
+  if (!parsed) return false;
+  return mutateRetryJournal(file, (journal) => {
+    journal.targets = journal.targets.filter((row) => row.agent_id !== agentId || row.target !== parsed.target);
+    journal.targets.unshift({ agent_id: agentId, ...parsed, chat_id: String(event.chat_id), thread_id: event.thread_id ? String(event.thread_id) : null, queued_at: now.toISOString() });
+    journal.targets = journal.targets.slice(0, MAX_STORED_TARGETS);
+    return true;
+  });
+}
+
+/** Remove only the exact recovered/newer target so a late retry cannot erase a new anchor. */
+export function discardInboxAuditTargetRetry(file: string, agentId: string, event: { chat_id?: string; thread_id?: string | null; message_id?: string }): void {
+  const parsed = parseTarget(event);
+  if (!parsed) return;
+  mutateRetryJournal(file, (journal) => { journal.targets = journal.targets.filter((row) => row.agent_id !== agentId || row.target !== parsed.target || row.anchor !== parsed.anchor); });
+}
+
+/** Replay persisted, already-authorized observer intents. Failures remain durable for a later bounded retry/startup. */
+export function reconcileInboxAuditTargetRetries(registryFile: string, retryFile: string, agentId?: string): { recovered: number; remaining: number } {
+  const rows = loadRetryJournal(retryFile).targets.filter((row) => !agentId || row.agent_id === agentId);
+  let recovered = 0;
+  for (const row of rows) {
+    try {
+      observeInboxAuditTarget(registryFile, row.agent_id, { chat_id: row.chat_id, chat_type: "group", thread_id: row.thread_id, message_id: row.anchor, wake: true, _sender_is_bot: false, _scan_authority: true });
+      discardInboxAuditTargetRetry(retryFile, row.agent_id, { chat_id: row.chat_id, thread_id: row.thread_id, message_id: row.anchor });
+      recovered += 1;
+    } catch { break; }
+  }
+  return { recovered, remaining: loadRetryJournal(retryFile).targets.filter((row) => !agentId || row.agent_id === agentId).length };
 }
 
 function instruction(target: InboxAuditTarget, receiptValue: string): string {

--- a/src/agent/missed-outbound-scan.ts
+++ b/src/agent/missed-outbound-scan.ts
@@ -1,6 +1,7 @@
 import * as crypto from "node:crypto";
 import * as fs from "node:fs";
 import * as path from "node:path";
+import { acquireProcessLock } from "../platform/process-state.js";
 
 /** Historical reminder loops are deliberately unrelated to this bounded audit registry. */
 export const INBOX_AUDIT_LEGACY_MIGRATION_NON_GOAL = "New versions no longer create missed-outbound loops; existing indistinguishable historical loops are not migrated or deleted automatically.";
@@ -8,11 +9,12 @@ export const MAX_INBOX_AUDIT_TARGETS = 96;
 const MAX_STORED_TARGETS = MAX_INBOX_AUDIT_TARGETS;
 export const MAX_INBOX_AUDIT_REGISTRY_BYTES = 64 * 1024;
 export const MAX_INBOX_AUDIT_REGISTRY_ROWS = MAX_INBOX_AUDIT_TARGETS;
-const LOCK_WAIT_MS = 1_000;
-const LOCK_RETRY_MS = 20;
+const LOCK_WAIT_MS = 5_000;
+const LOCK_RETRY_MS = 25;
 const CHAT = /^oc_[A-Za-z0-9]+$/;
 const THREAD = /^omt_[A-Za-z0-9]+$/;
 const ANCHOR = /^om_[A-Za-z0-9_-]+$/;
+const GENERATION = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
 const OUTCOMES = new Set(["no-finding", "handled"]);
 
 export interface InboxAuditTarget { target: string; anchor: string; observed_at: string }
@@ -20,12 +22,13 @@ export type InboxAuditOutcome = "no-finding" | "handled";
 type AuditStatus = "pending" | "completed";
 interface StoredTarget extends InboxAuditTarget {
   agent_id: string;
+  generation: string;
   status: AuditStatus;
   completed_at?: string;
   completed_anchor?: string;
   completed_outcome?: InboxAuditOutcome;
 }
-interface AuditRegistry { version: 2; targets: StoredTarget[] }
+interface AuditRegistry { version: 3; targets: StoredTarget[] }
 interface ReceiptPayload { v: 1; agent_id: string; target: string; anchor: string; revision: string }
 
 export function inboxAuditRegistryFile(larkinHome: string): string { return path.join(larkinHome, "inbox-audit.json"); }
@@ -38,12 +41,29 @@ function parseTarget(event: { chat_id?: string; thread_id?: string | null; messa
   return { target: threadId ? `thread:${chatId}:${threadId}` : `chat:${chatId}`, anchor };
 }
 
-function emptyRegistry(): AuditRegistry { return { version: 2, targets: [] }; }
+function emptyRegistry(): AuditRegistry { return { version: 3, targets: [] }; }
+
+function assertSafeExistingFile(file: string, label: string): void {
+  try {
+    const stat = fs.lstatSync(file);
+    if (!stat.isFile() || stat.isSymbolicLink()) throw new Error(`${label} is not a regular file`);
+    if (typeof process.getuid === "function" && stat.uid !== process.getuid()) throw new Error(`${label} is not owned by the current user`);
+  } catch (error) { if ((error as NodeJS.ErrnoException).code !== "ENOENT") throw error; }
+}
+
+function prepareRegistryDirectory(file: string): void {
+  const directory = path.dirname(file);
+  fs.mkdirSync(directory, { recursive: true, mode: 0o700 });
+  const stat = fs.lstatSync(directory);
+  if (!stat.isDirectory() || stat.isSymbolicLink()) throw new Error("inbox audit registry directory is unsafe");
+  if (typeof process.getuid === "function" && stat.uid !== process.getuid()) throw new Error("inbox audit registry directory is not owned by the current user");
+}
 
 function load(file: string): AuditRegistry {
   let fd: number | undefined;
   let bytes: Buffer;
   try {
+    assertSafeExistingFile(file, "inbox audit registry");
     fd = fs.openSync(file, fs.constants.O_RDONLY | (fs.constants.O_NOFOLLOW || 0) | (fs.constants.O_NONBLOCK || 0));
     const stat = fs.fstatSync(fd);
     if (!stat.isFile()) throw new Error("inbox audit registry is not a regular file");
@@ -61,10 +81,11 @@ function load(file: string): AuditRegistry {
     throw error;
   } finally { if (fd !== undefined) fs.closeSync(fd); }
   const value = JSON.parse(bytes.toString("utf8")) as { version?: unknown; targets?: unknown };
-  // v1 never proved original wake eligibility. It is intentionally not upgraded.
-  if (value?.version === 1 || value?.version !== 2 || !Array.isArray(value.targets)) return emptyRegistry();
+  // v1 had no wake provenance; v2 had no durable observation generation.
+  // Neither can safely issue a completion receipt after this lifecycle upgrade.
+  if (value?.version !== 3 || !Array.isArray(value.targets)) return emptyRegistry();
   if (value.targets.length > MAX_INBOX_AUDIT_REGISTRY_ROWS) throw new Error("inbox audit registry exceeds the bounded row limit");
-  return { version: 2, targets: value.targets.flatMap((row): StoredTarget[] => {
+  return { version: 3, targets: value.targets.flatMap((row): StoredTarget[] => {
     if (!row || typeof row !== "object") return [];
     const candidate = row as Partial<StoredTarget>;
     if (typeof candidate.target !== "string" || typeof candidate.anchor !== "string") return [];
@@ -75,12 +96,12 @@ function load(file: string): AuditRegistry {
       message_id: candidate.anchor,
     });
     const status = candidate.status === "completed" ? "completed" : candidate.status === "pending" ? "pending" : null;
-    if (!status || typeof candidate.agent_id !== "string" || !candidate.agent_id || !parsed || candidate.target !== parsed.target
+    if (!status || typeof candidate.agent_id !== "string" || !candidate.agent_id || typeof candidate.generation !== "string" || !GENERATION.test(candidate.generation) || !parsed || candidate.target !== parsed.target
       || typeof candidate.observed_at !== "string" || !Number.isFinite(Date.parse(candidate.observed_at))) return [];
     const completed_at = typeof candidate.completed_at === "string" && Number.isFinite(Date.parse(candidate.completed_at)) ? candidate.completed_at : undefined;
     const completed_anchor = typeof candidate.completed_anchor === "string" && ANCHOR.test(candidate.completed_anchor) ? candidate.completed_anchor : undefined;
     const completed_outcome = OUTCOMES.has(String(candidate.completed_outcome)) ? candidate.completed_outcome as InboxAuditOutcome : undefined;
-    return [{ agent_id: candidate.agent_id, ...parsed, observed_at: candidate.observed_at, status,
+    return [{ agent_id: candidate.agent_id, generation: candidate.generation, ...parsed, observed_at: candidate.observed_at, status,
       ...(completed_at ? { completed_at } : {}), ...(completed_anchor ? { completed_anchor } : {}),
       ...(completed_outcome ? { completed_outcome } : {}) }];
   }) };
@@ -90,9 +111,11 @@ function save(file: string, registry: AuditRegistry): void {
   if (registry.targets.length > MAX_INBOX_AUDIT_REGISTRY_ROWS) throw new Error("inbox audit registry exceeds the bounded row limit");
   const serialized = `${JSON.stringify(registry)}\n`;
   if (Buffer.byteLength(serialized) > MAX_INBOX_AUDIT_REGISTRY_BYTES) throw new Error("inbox audit registry exceeds the bounded byte limit");
-  fs.mkdirSync(path.dirname(file), { recursive: true, mode: 0o700 });
+  prepareRegistryDirectory(file);
+  assertSafeExistingFile(file, "inbox audit registry");
   const temporary = path.join(path.dirname(file), `.${path.basename(file)}.${process.pid}.${crypto.randomUUID()}.tmp`);
-  fs.writeFileSync(temporary, serialized, { mode: 0o600 });
+  const fd = fs.openSync(temporary, fs.constants.O_WRONLY | fs.constants.O_CREAT | fs.constants.O_EXCL | (fs.constants.O_NOFOLLOW || 0), 0o600);
+  try { fs.writeFileSync(fd, serialized); fs.fsyncSync(fd); } finally { fs.closeSync(fd); }
   try { fs.renameSync(temporary, file); fs.chmodSync(file, 0o600); }
   catch (error) { try { fs.unlinkSync(temporary); } catch { /* best effort */ } throw error; }
 }
@@ -103,42 +126,27 @@ function sleep(ms: number): void { Atomics.wait(new Int32Array(new SharedArrayBu
 function mutate<T>(file: string, operation: (registry: AuditRegistry) => T): T {
   const deadline = Date.now() + LOCK_WAIT_MS;
   const lockFile = `${file}.mutation-lock`;
-  const nonce = crypto.randomUUID();
+  prepareRegistryDirectory(file);
   while (Date.now() <= deadline) {
+    let lock: ReturnType<typeof acquireProcessLock> | undefined;
     try {
-      fs.mkdirSync(path.dirname(file), { recursive: true, mode: 0o700 });
-      const fd = fs.openSync(lockFile, "wx", 0o600);
-      try { fs.writeFileSync(fd, JSON.stringify({ pid: process.pid, nonce })); fs.fsyncSync(fd); }
-      finally { fs.closeSync(fd); }
+      assertSafeExistingFile(lockFile, "inbox audit mutation lock");
+      lock = acquireProcessLock(lockFile, path.basename(process.execPath), { malformedGraceMs: 1_000 });
       const registry = load(file);
       const result = operation(registry);
       save(file, registry);
       return result;
     } catch (error) {
-      if ((error as NodeJS.ErrnoException).code !== "EEXIST") throw error;
-      // A dead owner cannot preserve a mutation; reclaim only after checking pid
-      // liveness, while live contention remains bounded and retries its full read.
-      try {
-        const owner = JSON.parse(fs.readFileSync(lockFile, "utf8")) as { pid?: unknown };
-        if (Number.isInteger(owner.pid) && Number(owner.pid) > 0) {
-          try { process.kill(Number(owner.pid), 0); }
-          catch (ownerError) { if ((ownerError as NodeJS.ErrnoException).code === "ESRCH") fs.unlinkSync(lockFile); }
-        }
-      } catch (lockError) { if ((lockError as NodeJS.ErrnoException).code === "ENOENT") continue; }
+      if (lock || !/lock 已被|无法取得 lock|正在创建|暂不能接管|并发重试耗尽/.test(error instanceof Error ? error.message : String(error))) throw error;
       sleep(LOCK_RETRY_MS);
-    } finally {
-      try {
-        const owner = JSON.parse(fs.readFileSync(lockFile, "utf8")) as { pid?: unknown; nonce?: unknown };
-        if (owner.pid === process.pid && owner.nonce === nonce) fs.unlinkSync(lockFile);
-      } catch { /* another process owns or removed the lock */ }
-    }
+    } finally { lock?.release(); }
   }
   throw new Error("inbox audit registry busy: bounded lock contention");
 }
 
-function revision(row: Pick<StoredTarget, "agent_id" | "target" | "anchor" | "observed_at" | "status">): string {
+function revision(row: Pick<StoredTarget, "agent_id" | "target" | "anchor" | "generation" | "status">): string {
   return `sha256:${crypto.createHash("sha256").update(JSON.stringify({
-    v: 1, agent_id: row.agent_id, target: row.target, anchor: row.anchor, observed_at: row.observed_at, status: row.status,
+    v: 2, agent_id: row.agent_id, target: row.target, anchor: row.anchor, generation: row.generation, status: row.status,
   })).digest("hex")}`;
 }
 
@@ -168,7 +176,7 @@ export function observeInboxAuditTarget(file: string, agentId: string, event: {
     const existing = registry.targets.find((row) => row.agent_id === agentId && row.target === parsed.target);
     if (existing?.status === "completed" && existing.anchor === parsed.anchor) return false;
     registry.targets = registry.targets.filter((row) => row.agent_id !== agentId || row.target !== parsed.target);
-    registry.targets.unshift({ agent_id: agentId, ...parsed, observed_at: now.toISOString(), status: "pending" });
+    registry.targets.unshift({ agent_id: agentId, generation: crypto.randomUUID(), ...parsed, observed_at: now.toISOString(), status: "pending" });
     registry.targets = registry.targets.slice(0, MAX_STORED_TARGETS);
     return true;
   });
@@ -187,10 +195,10 @@ export function hasPendingInboxAuditTargets(file: string, agentId: string): bool
 
 /** Public read is intentionally completion-free: a caller crash leaves the target pending. */
 export function readInboxAuditTargets(file: string, agentId: string): {
-  version: 2; targets: Array<InboxAuditTarget & { revision: string; receipt: string; instruction: string }>; has_more: boolean; no_finding: "stay_silent";
+  version: 3; targets: Array<InboxAuditTarget & { revision: string; receipt: string; instruction: string }>; has_more: boolean; no_finding: "stay_silent";
 } {
   const rows = pendingRows(file, agentId);
-  return { version: 2, targets: rows.slice(0, MAX_INBOX_AUDIT_TARGETS).map((row) => {
+  return { version: 3, targets: rows.slice(0, MAX_INBOX_AUDIT_TARGETS).map((row) => {
     const target = { target: row.target, anchor: row.anchor, observed_at: row.observed_at };
     const receiptValue = receipt(row);
     return { ...target, revision: revision(row), receipt: receiptValue, instruction: instruction(target, receiptValue) };

--- a/src/agent/missed-outbound-scan.ts
+++ b/src/agent/missed-outbound-scan.ts
@@ -11,6 +11,10 @@ export const INBOX_AUDIT_LEGACY_MIGRATION_NON_GOAL = "New versions no longer cre
 // Pending audits are bounded so a heartbeat cannot accumulate an unbounded work list.
 export const MAX_INBOX_AUDIT_TARGETS = 96;
 const MAX_STORED_TARGETS = MAX_INBOX_AUDIT_TARGETS;
+// Periodic heartbeat reads this file through a cap+1 fd buffer. Fail closed
+// instead of parsing, slicing, or rewriting an oversized registry.
+export const MAX_INBOX_AUDIT_REGISTRY_BYTES = 64 * 1024;
+export const MAX_INBOX_AUDIT_REGISTRY_ROWS = MAX_INBOX_AUDIT_TARGETS;
 const CHAT = /^oc_[A-Za-z0-9]+$/;
 const THREAD = /^omt_[A-Za-z0-9]+$/;
 const ANCHOR = /^om_[A-Za-z0-9_-]+$/;
@@ -48,15 +52,35 @@ function emptyRegistry(): AuditRegistry {
 
 function load(file: string): AuditRegistry {
   let value: { version?: unknown; targets?: unknown };
-  try { value = JSON.parse(fs.readFileSync(file, "utf8")) as { version?: unknown; targets?: unknown }; }
-  catch (error) {
+  let fd: number | undefined;
+  let bytes: Buffer;
+  try {
+    fd = fs.openSync(file, fs.constants.O_RDONLY
+      | (fs.constants.O_NOFOLLOW || 0)
+      | (fs.constants.O_NONBLOCK || 0));
+    const stat = fs.fstatSync(fd);
+    if (!stat.isFile()) throw new Error("inbox audit registry is not a regular file");
+    const buffer = Buffer.alloc(MAX_INBOX_AUDIT_REGISTRY_BYTES + 1);
+    let offset = 0;
+    while (offset < buffer.length) {
+      const read = fs.readSync(fd, buffer, offset, buffer.length - offset, offset);
+      if (read === 0) break;
+      offset += read;
+    }
+    if (offset > MAX_INBOX_AUDIT_REGISTRY_BYTES) throw new Error("inbox audit registry exceeds the bounded byte limit");
+    bytes = buffer.subarray(0, offset);
+  } catch (error) {
     if ((error as NodeJS.ErrnoException).code === "ENOENT") return emptyRegistry();
     throw error;
+  } finally {
+    if (fd !== undefined) fs.closeSync(fd);
   }
+  value = JSON.parse(bytes.toString("utf8")) as { version?: unknown; targets?: unknown };
   // v1 rows were recorded without wake eligibility, so they cannot prove a
   // missed originally-wake=true outbound. Discard rather than re-scan them.
   if (value?.version === 1) return emptyRegistry();
   if (value?.version !== 2 || !Array.isArray(value.targets)) return emptyRegistry();
+  if (value.targets.length > MAX_INBOX_AUDIT_REGISTRY_ROWS) throw new Error("inbox audit registry exceeds the bounded row limit");
   return { version: 2, targets: value.targets.flatMap((row): StoredTarget[] => {
     if (!row || typeof row !== "object") return [];
     const candidate = row as Partial<StoredTarget>;
@@ -82,9 +106,16 @@ function load(file: string): AuditRegistry {
 }
 
 function save(file: string, registry: AuditRegistry): void {
+  if (registry.targets.length > MAX_INBOX_AUDIT_REGISTRY_ROWS) {
+    throw new Error("inbox audit registry exceeds the bounded row limit");
+  }
+  const serialized = `${JSON.stringify(registry)}\n`;
+  if (Buffer.byteLength(serialized) > MAX_INBOX_AUDIT_REGISTRY_BYTES) {
+    throw new Error("inbox audit registry exceeds the bounded byte limit");
+  }
   fs.mkdirSync(path.dirname(file), { recursive: true, mode: 0o700 });
   const temporary = path.join(path.dirname(file), `.${path.basename(file)}.${process.pid}.${Date.now()}.tmp`);
-  fs.writeFileSync(temporary, `${JSON.stringify(registry)}\n`, { mode: 0o600 });
+  fs.writeFileSync(temporary, serialized, { mode: 0o600 });
   fs.renameSync(temporary, file);
   fs.chmodSync(file, 0o600);
 }

--- a/src/agent/missed-outbound-scan.ts
+++ b/src/agent/missed-outbound-scan.ts
@@ -231,7 +231,9 @@ export function observeInboxAuditTarget(file: string, agentId: string, event: {
   if (!parsed) return false;
   return mutate(file, (registry) => {
     const existing = registry.targets.find((row) => row.agent_id === agentId && row.target === parsed.target);
-    if (existing?.status === "completed" && existing.anchor === parsed.anchor) return false;
+    // Redelivery of the same original source is not new evidence and must not
+    // rotate a receipt generation. A different anchor deliberately reopens it.
+    if (existing?.anchor === parsed.anchor) return false;
     registry.targets = registry.targets.filter((row) => row.agent_id !== agentId || row.target !== parsed.target);
     registry.targets.unshift({ agent_id: agentId, generation: crypto.randomUUID(), ...parsed, observed_at: now.toISOString(), status: "pending" });
     registry.targets = registry.targets.slice(0, MAX_STORED_TARGETS);

--- a/src/app/agent-cli.ts
+++ b/src/app/agent-cli.ts
@@ -8,7 +8,7 @@ import * as path from "node:path";
 import { createAgentStateStore, type AgentStateStore } from "../agent/agent-state-store.js";
 import * as larkinConfig from "../platform/config.js";
 import { projectInboxCheck, projectInboxEvents, type InboxEnvelope } from "../agent/inbox-projection.js";
-import { completeInboxAuditTargets, inboxAuditRegistryFile, readInboxAuditTargets } from "../agent/missed-outbound-scan.js";
+import { completeInboxAuditTarget, inboxAuditRegistryFile, readInboxAuditTargets } from "../agent/missed-outbound-scan.js";
 import { createReminderRoutes } from "../agent/reminder-routes.js";
 import { InteractionStateMachine } from "../agent/interaction-state-machine.js";
 import { issueCallbackProbe, readCallbackCapability } from "../platform/callback-capability.js";
@@ -515,12 +515,20 @@ export function runAgentCli(
       }
       const options = parseOptions(rest, new Set(["--json"]));
       if (subcommand === "audit") {
-        if (options.positionals.length || options.values.size || options.booleans.size > 1) {
-          throw new Error("inbox audit 只接受 --json");
-        }
         const file = inboxAuditRegistryFile(config.larkinHome);
+        if (options.positionals[0] === "complete") {
+          if (options.positionals.length !== 1 || options.booleans.size > 1 || [...options.values.keys()].some((key) => !["--receipt", "--outcome"].includes(key))) {
+            throw new Error("用法: larkin inbox audit complete --receipt <receipt> --outcome <no-finding|handled> [--json]");
+          }
+          const receipt = options.values.get("--receipt");
+          const outcome = options.values.get("--outcome");
+          if (!receipt || !outcome) throw new Error("用法: larkin inbox audit complete --receipt <receipt> --outcome <no-finding|handled> [--json]");
+          const completion = completeInboxAuditTarget(file, agent.agentId, receipt, outcome);
+          emitJson(io, completion);
+          return completion.reason === "invalid_receipt" || completion.reason === "invalid_outcome" ? 2 : 0;
+        }
+        if (options.positionals.length || options.values.size || options.booleans.size > 1) throw new Error("inbox audit 只接受 --json；完成检查用 inbox audit complete");
         const audit = readInboxAuditTargets(file, agent.agentId);
-        completeInboxAuditTargets(file, agent.agentId);
         emitJson(io, audit);
         return 0;
       }

--- a/src/app/agent-cli.ts
+++ b/src/app/agent-cli.ts
@@ -8,7 +8,7 @@ import * as path from "node:path";
 import { createAgentStateStore, type AgentStateStore } from "../agent/agent-state-store.js";
 import * as larkinConfig from "../platform/config.js";
 import { projectInboxCheck, projectInboxEvents, type InboxEnvelope } from "../agent/inbox-projection.js";
-import { inboxAuditRegistryFile, readInboxAuditTargets } from "../agent/missed-outbound-scan.js";
+import { completeInboxAuditTargets, inboxAuditRegistryFile, readInboxAuditTargets } from "../agent/missed-outbound-scan.js";
 import { createReminderRoutes } from "../agent/reminder-routes.js";
 import { InteractionStateMachine } from "../agent/interaction-state-machine.js";
 import { issueCallbackProbe, readCallbackCapability } from "../platform/callback-capability.js";
@@ -177,7 +177,7 @@ function agentConfigRequest(
   const [operation = "show", ...rest] = argv;
   const authority = { kind: "agent" as const, agentId: agent.agentId };
   const options = parseOptions(rest, new Set(["--json"]));
-  const unknownFlags = [...options.values.keys()].filter((flag) => !["--agent", "--chat", "--model"].includes(flag));
+  const unknownFlags = [...options.values.keys()].filter((flag) => !["--agent", "--chat", "--model", "--interval"].includes(flag));
   if (unknownFlags.length) throw new Error(`config 不支持参数：${unknownFlags.join(", ")}；运行 larkin config --help`);
   const assertOnlyFlags = (valueFlags: readonly string[], booleanFlags: readonly string[] = []): void => {
     const allowedValues = new Set(valueFlags);
@@ -248,6 +248,20 @@ function agentConfigRequest(
     } else if (scope === "chat" && options.positionals.length === 3 && first?.startsWith("oc_") && ["inherit", "require", "free"].includes(second || "")) {
       mutation = { kind: "set-chat-mention", agentId: targetId, chatId: first, value: second as larkinConfig.MentionPolicyOverride };
     } else throw new Error("用法: larkin config mention global <require|free> | mention agent <inherit|require|free> | mention chat <oc_id> <inherit|require|free> [--agent <App ID>]");
+  } else if (operation === "inbox-audit") {
+    const [scope, first] = options.positionals;
+    if (scope === "global") assertOnlyFlags(["--interval"]);
+    else if (scope === "agent") assertOnlyFlags(["--agent", "--interval"]);
+    else assertOnlyFlags([]);
+    if (options.positionals.length !== 2) {
+      throw new Error("用法: larkin config inbox-audit global <on|off> [--interval <15m|1h>] | inbox-audit agent <inherit|on|off> [--agent <App ID>] [--interval <15m|inherit>]");
+    }
+    mutation = larkinConfig.inboxAuditMutationFromCli({
+      scope: scope || "",
+      enabled: first,
+      interval: options.values.get("--interval"),
+      agentId: targetId,
+    });
   } else if (operation === "apply") {
     assertOnlyFlags(["--agent"]);
     if (options.positionals.length) throw new Error("用法: larkin config apply [--agent <App ID>]");
@@ -257,7 +271,7 @@ function agentConfigRequest(
       larkinConfig.markConfigApplied(env, targetId, expectedSignature);
       return { ok: true, agentId: targetId, applyState: "applied", result };
     }).catch((error) => { throw new Error(`配置已保存但未应用：${error instanceof Error ? error.message : String(error)}`); });
-  } else throw new Error("config 只支持 show/runtime/model/effort/mention/apply；运行 larkin config --help");
+  } else throw new Error("config 只支持 show/runtime/model/effort/mention/inbox-audit/apply；运行 larkin config --help");
   const result = larkinConfig.mutateConfig(env, mutation, authority);
   return { ok: true, revision: result.revision, persisted: true, applyState: result.applyState, changedScope: result.changedScope };
 }
@@ -504,7 +518,10 @@ export function runAgentCli(
         if (options.positionals.length || options.values.size || options.booleans.size > 1) {
           throw new Error("inbox audit 只接受 --json");
         }
-        emitJson(io, readInboxAuditTargets(inboxAuditRegistryFile(config.larkinHome), agent.agentId));
+        const file = inboxAuditRegistryFile(config.larkinHome);
+        const audit = readInboxAuditTargets(file, agent.agentId);
+        completeInboxAuditTargets(file, agent.agentId);
+        emitJson(io, audit);
         return 0;
       }
       if (options.positionals.length || [...options.values.keys()].some((flag) => !["--target", "--limit"].includes(flag))) {

--- a/src/app/agent-config.ts
+++ b/src/app/agent-config.ts
@@ -56,6 +56,8 @@ type ConfigMutation =
   | { kind: "set-global-mention"; value: "require" | "free" }
   | { kind: "set-agent-mention"; agentId: string; value: "inherit" | "require" | "free" }
   | { kind: "set-chat-mention"; agentId: string; chatId: string; value: "inherit" | "require" | "free" }
+  | { kind: "set-global-inbox-audit"; enabled?: boolean; intervalMs?: number }
+  | { kind: "set-agent-inbox-audit"; agentId: string; enabled?: boolean | "inherit"; intervalMs?: number | "inherit" }
   | { kind: "set-agent-runtime"; agentId: string; runtime: string; model?: string }
   | { kind: "set-agent-model"; agentId: string; model: string }
   | { kind: "set-agent-effort"; agentId: string; effort: string | null };
@@ -139,12 +141,12 @@ const die = (message: string): never => {
 };
 
 if (!kind || !["agents", "model", "runtime", "effort", "chats", "config"].includes(kind)) {
-  die("用法: larkin agents | larkin config <show|mention|apply> | larkin model [<id>] | larkin runtime [<id>] [--model <id>] | larkin effort [<level>|clear] | larkin chats [free|strict <oc_id>]");
+  die("用法: larkin agents | larkin config <show|mention|inbox-audit|apply> | larkin model [<id>] | larkin runtime [<id>] [--model <id>] | larkin effort [<level>|clear] | larkin chats [free|strict <oc_id>]");
 }
 
 const allowedValueFlags: Record<string, ReadonlySet<string>> = {
   agents: new Set(), model: new Set(["--agent"]), runtime: new Set(["--agent", "--model"]),
-  effort: new Set(["--agent"]), chats: new Set(["--agent"]), config: new Set(["--agent", "--chat"]),
+  effort: new Set(["--agent"]), chats: new Set(["--agent"]), config: new Set(["--agent", "--chat", "--interval"]),
 };
 const allowedBooleanFlags: Record<string, ReadonlySet<string>> = {
   agents: new Set(["--json"]), model: new Set(), runtime: new Set(), effort: new Set(), chats: new Set(), config: new Set(["--json"]),
@@ -172,6 +174,7 @@ for (let index = 0; index < rest.length; index += 1) {
 const flagAgent = parsedValues.get("--agent");
 const flagModel = parsedValues.get("--model");
 const flagChat = parsedValues.get("--chat");
+const flagInterval = parsedValues.get("--interval");
 const flagJson = parsedBooleans.has("--json");
 const value = positionals[0];
 
@@ -214,11 +217,17 @@ if (kind === "agents") {
   } else if (operation === "mention" && scope === "chat") {
     assertOnlyFlags(["--agent"]);
     if (positionals.length !== 4) die("用法: larkin config mention chat <oc_id> <inherit|require|free> [--agent <App ID>]");
+  } else if (operation === "inbox-audit" && scope === "global") {
+    assertOnlyFlags(["--interval"]);
+    if (positionals.length !== 3) die("用法: larkin config inbox-audit global <on|off> [--interval <15m|1h>]");
+  } else if (operation === "inbox-audit" && scope === "agent") {
+    assertOnlyFlags(["--agent", "--interval"]);
+    if (positionals.length !== 3) die("用法: larkin config inbox-audit agent <inherit|on|off> [--agent <App ID>] [--interval <15m|inherit>]");
   } else if (operation === "apply") {
     assertOnlyFlags(["--agent"]);
     if (positionals.length !== 1) die("用法: larkin config apply [--agent <App ID>]");
   } else {
-    die("config 只支持 show/mention/apply；运行 larkin config --help");
+    die("config 只支持 show/mention/inbox-audit/apply；运行 larkin config --help");
   }
 }
 
@@ -378,11 +387,15 @@ if (kind === "config") {
     if (flagJson) say(JSON.stringify(view, null, 2));
     else {
       say(`全局群消息策略=${String(view.mentionPolicy)}（free 会唤醒所有继承它的 Agent）`);
+      const inboxAudit = view.inboxAudit as { enabled?: boolean; intervalMs?: number } | undefined;
+      say(`全局 Inbox Audit=${inboxAudit?.enabled ? "on" : "off"} interval=${larkinConfig.formatInboxAuditInterval(Number(inboxAudit?.intervalMs || larkinConfig.DEFAULT_INBOX_AUDIT_INTERVAL_MS))}（默认关闭；未 @ 的 require 群消息不会进入审计）`);
       for (const item of view.agents as Array<Record<string, unknown>>) {
         const mention = item.mention as { override: string; chat?: { chatId: string; override: string; effective: string; source: string } };
+        const agentAudit = item.inboxAudit as { override?: { enabled?: string; intervalMs?: number | "inherit" }; effective?: { enabled?: boolean; intervalMs?: number } };
         const apply = item.apply as { applyState?: string };
-        say(`agent=${item.agentId} runtime=${item.runtime} model=${item.model} effort=${item.effort || "default"} mention=${mention.override} apply=${apply.applyState || "unknown"}`);
+        say(`agent=${item.agentId} runtime=${item.runtime} model=${item.model} effort=${item.effort || "default"} mention=${mention.override} inbox-audit=${agentAudit?.override?.enabled || "inherit"} apply=${apply.applyState || "unknown"}`);
         if (mention.chat) say(`  chat=${mention.chat.chatId} override=${mention.chat.override} effective=${mention.chat.effective} source=${mention.chat.source}`);
+        if (agentAudit?.effective) say(`  inbox-audit effective=${agentAudit.effective.enabled ? "on" : "off"} interval=${larkinConfig.formatInboxAuditInterval(Number(agentAudit.effective.intervalMs || larkinConfig.DEFAULT_INBOX_AUDIT_INTERVAL_MS))}`);
       }
     }
     process.exit(0);
@@ -404,6 +417,18 @@ if (kind === "config") {
     say(JSON.stringify({ ok: true, revision: result.revision, persisted: result.persisted, applyState: result.applyState, changedScope: result.changedScope }, null, 2));
     process.exit(0);
   }
+  if (operation === "inbox-audit") {
+    try {
+      const result = larkinConfig.mutateConfig(process.env, larkinConfig.inboxAuditMutationFromCli({
+        scope: scope || "",
+        enabled: first,
+        interval: flagInterval,
+        agentId: scope === "agent" ? requireTarget() : (selected || keys[0] || ""),
+      }), authority);
+      say(JSON.stringify({ ok: true, revision: result.revision, persisted: result.persisted, applyState: result.applyState, changedScope: result.changedScope }, null, 2));
+    } catch (error) { die(error instanceof Error ? error.message : String(error)); }
+    process.exit(0);
+  }
   if (operation === "apply") {
     const agentId = requireTarget();
     const expectedSignature = larkinConfig.runtimeConfigSignature(config, agentId);
@@ -420,7 +445,7 @@ if (kind === "config") {
     } catch (error) { die(`配置已保存但未应用：${error instanceof Error ? error.message : String(error)}`); }
     process.exit(0);
   }
-  die("config 只支持 show/mention/apply");
+  die("config 只支持 show/mention/inbox-audit/apply");
 }
 let key = flagAgent;
 if (!key && runtimeAgentId) key = runtimeAgentId;

--- a/src/app/cli.ts
+++ b/src/app/cli.ts
@@ -78,6 +78,7 @@ Examples:
   larkin config show --agent cli_x --chat oc_x --json
   larkin config runtime pi --agent cli_x --model default
   larkin config mention chat oc_x free --agent cli_x
+  larkin config inbox-audit global on --interval 15m
 
 Credentials, internal paths, serverId, activeAgent, and raw config are never exposed here.`,
   session: `Usage: larkin session reset --agent <App ID> --json [--wait-ready <seconds>]

--- a/src/dashboard/dashboard-config-controller.ts
+++ b/src/dashboard/dashboard-config-controller.ts
@@ -406,10 +406,21 @@ function dashboardMutation(value: Record<string, unknown>): ConfigMutation {
     "set-global-mention": ["operation", "value"], "set-agent-mention": ["operation", "agentId", "value"],
     "set-chat-mention": ["operation", "agentId", "chatId", "value"], "set-agent-runtime": ["operation", "agentId", "runtime", "model"],
     "set-agent-model": ["operation", "agentId", "model"], "set-agent-effort": ["operation", "agentId", "effort"],
+    "set-global-inbox-audit": ["operation", "enabled", "intervalMs"], "set-agent-inbox-audit": ["operation", "agentId", "enabled", "intervalMs"],
   };
   if (!allowed[operation] || Object.keys(value).some((key) => !allowed[operation].includes(key))) throw new Error("unsupported operation");
   if (operation === "set-global-mention") return { kind: operation, value: String(value.value) as "require" | "free" };
+  if (operation === "set-global-inbox-audit") {
+    if (value.enabled !== undefined && typeof value.enabled !== "boolean") throw new Error("invalid inbox-audit enabled");
+    if (value.intervalMs !== undefined && (typeof value.intervalMs !== "number" || !Number.isSafeInteger(value.intervalMs))) throw new Error("invalid inbox-audit interval");
+    return { kind: operation, ...(value.enabled !== undefined ? { enabled: value.enabled } : {}), ...(value.intervalMs !== undefined ? { intervalMs: value.intervalMs } : {}) };
+  }
   const agentId = String(value.agentId || "");
+  if (operation === "set-agent-inbox-audit") {
+    if (value.enabled !== undefined && value.enabled !== "inherit" && typeof value.enabled !== "boolean") throw new Error("invalid inbox-audit enabled");
+    if (value.intervalMs !== undefined && value.intervalMs !== "inherit" && (typeof value.intervalMs !== "number" || !Number.isSafeInteger(value.intervalMs))) throw new Error("invalid inbox-audit interval");
+    return { kind: operation, agentId, ...(value.enabled !== undefined ? { enabled: value.enabled as boolean | "inherit" } : {}), ...(value.intervalMs !== undefined ? { intervalMs: value.intervalMs as number | "inherit" } : {}) };
+  }
   if (operation === "set-agent-mention") return { kind: operation, agentId, value: String(value.value) as "inherit" | "require" | "free" };
   if (operation === "set-chat-mention") return { kind: operation, agentId, chatId: String(value.chatId || ""), value: String(value.value) as "inherit" | "require" | "free" };
   if (operation === "set-agent-runtime") return { kind: operation, agentId, runtime: String(value.runtime || ""), ...(value.model ? { model: String(value.model) } : {}) };

--- a/src/dashboard/web/app.tsx
+++ b/src/dashboard/web/app.tsx
@@ -229,11 +229,12 @@ function GlobalSettingsSheet({ open, onOpenChange, onSaved }: { open: boolean; o
   };
   const save = async () => {
     const auditChanged = draftAudit.enabled !== serverAudit.enabled || draftAuditGapMinutes !== formatAuditGapMinutes(serverAudit.intervalMs);
-    const intervalMs = auditChanged ? auditGapFromMinutes(draftAuditGapMinutes) : serverAudit.intervalMs;
-    if (auditChanged && intervalMs === null) {
+    const editedIntervalMs = auditChanged ? auditGapFromMinutes(draftAuditGapMinutes) : null;
+    if (auditChanged && editedIntervalMs === null) {
       setFeedback("巡检间隔必须在 1 到 1440 分钟之间。");
       return;
     }
+    const intervalMs = editedIntervalMs ?? serverAudit.intervalMs;
     setLoading(true);
     try {
       let result: { revision: string; applyState: string } | null = null;

--- a/src/dashboard/web/app.tsx
+++ b/src/dashboard/web/app.tsx
@@ -68,6 +68,21 @@ function formatNumber(value: unknown): string {
   return Number.isFinite(Number(value)) ? Number(value).toLocaleString("en-US") : "—";
 }
 
+const MIN_AUDIT_GAP_MINUTES = 1;
+const MAX_AUDIT_GAP_MINUTES = 24 * 60;
+
+function formatAuditGapMinutes(intervalMs: number): string {
+  return String(intervalMs / 60_000);
+}
+
+function auditGapFromMinutes(value: unknown): number | null {
+  const minutes = Number(String(value).trim());
+  const candidateMs = minutes * 60_000;
+  const intervalMs = Math.round(candidateMs);
+  return Number.isFinite(minutes) && minutes >= MIN_AUDIT_GAP_MINUTES && minutes <= MAX_AUDIT_GAP_MINUTES
+    && Number.isSafeInteger(intervalMs) && Math.abs(candidateMs - intervalMs) <= 0.000_001 ? intervalMs : null;
+}
+
 function activityLabel(agent: DashboardAgent): string {
   if (agent.issue) return "异常";
   if (agent.lastActivity?.state) return String(agent.lastActivity.state);
@@ -187,9 +202,12 @@ function AgentSidebar({ agents, selectedId, onSelect, compact = false }: {
 function GlobalSettingsSheet({ open, onOpenChange, onSaved }: { open: boolean; onOpenChange: (open: boolean) => void; onSaved: () => void }) {
   const [serverValue, setServerValue] = useState<"require" | "free">("require");
   const [draft, setDraft] = useState<"require" | "free">("require");
+  const [serverAudit, setServerAudit] = useState({ enabled: false, intervalMs: 15 * 60_000 });
+  const [draftAudit, setDraftAudit] = useState({ enabled: false, intervalMs: 15 * 60_000 });
+  const [draftAuditGapMinutes, setDraftAuditGapMinutes] = useState("15");
   const [loading, setLoading] = useState(false);
   const [feedback, setFeedback] = useState<string | null>(null);
-  const dirty = draft !== serverValue;
+  const dirty = draft !== serverValue || draftAudit.enabled !== serverAudit.enabled || draftAuditGapMinutes !== formatAuditGapMinutes(serverAudit.intervalMs);
   useEffect(() => {
     if (!open) return;
     const controller = new AbortController();
@@ -197,6 +215,9 @@ function GlobalSettingsSheet({ open, onOpenChange, onSaved }: { open: boolean; o
     void privateGet<ConfigResponse>("/api/config", { signal: controller.signal }).then((value) => {
       setServerValue(value.mentionPolicy);
       setDraft(value.mentionPolicy);
+      setServerAudit(value.inboxAudit);
+      setDraftAudit(value.inboxAudit);
+      setDraftAuditGapMinutes(formatAuditGapMinutes(value.inboxAudit.intervalMs));
       setFeedback(null);
     }).catch((error) => { if (!controller.signal.aborted) setFeedback(error.message); })
       .finally(() => { if (!controller.signal.aborted) setLoading(false); });
@@ -207,11 +228,28 @@ function GlobalSettingsSheet({ open, onOpenChange, onSaved }: { open: boolean; o
     onOpenChange(next);
   };
   const save = async () => {
+    const auditChanged = draftAudit.enabled !== serverAudit.enabled || draftAuditGapMinutes !== formatAuditGapMinutes(serverAudit.intervalMs);
+    const intervalMs = auditChanged ? auditGapFromMinutes(draftAuditGapMinutes) : serverAudit.intervalMs;
+    if (auditChanged && intervalMs === null) {
+      setFeedback("巡检间隔必须在 1 到 1440 分钟之间。");
+      return;
+    }
     setLoading(true);
     try {
-      const result = await mutateConfig({ operation: "set-global-mention", value: draft });
+      let result: { revision: string; applyState: string } | null = null;
+      if (draft !== serverValue) result = await mutateConfig({ operation: "set-global-mention", value: draft });
+      if (auditChanged) {
+        result = await mutateConfig({
+          operation: "set-global-inbox-audit",
+          ...(draftAudit.enabled !== serverAudit.enabled ? { enabled: draftAudit.enabled } : {}),
+          ...(draftAuditGapMinutes !== formatAuditGapMinutes(serverAudit.intervalMs) ? { intervalMs } : {}),
+        });
+      }
       setServerValue(draft);
-      setFeedback(`已保存 · ${result.applyState} · ${result.revision.slice(0, 20)}…`);
+      setServerAudit({ ...draftAudit, intervalMs });
+      setDraftAudit((current) => ({ ...current, intervalMs }));
+      setDraftAuditGapMinutes(formatAuditGapMinutes(intervalMs));
+      setFeedback(result ? `已保存 · ${result.applyState} · ${result.revision.slice(0, 20)}…` : "没有需要保存的修改");
       onSaved();
     } catch (error) { setFeedback(error instanceof Error ? error.message : String(error)); }
     finally { setLoading(false); }
@@ -225,7 +263,12 @@ function GlobalSettingsSheet({ open, onOpenChange, onSaved }: { open: boolean; o
         </select>
       </label>
       <p className="field-help">未单独设置的 Agent 和群会使用这个值。机器人消息仍必须精确 @ 当前 Agent。</p>
-      <div className="form-actions"><Button onClick={() => setDraft(serverValue)} disabled={!dirty || loading}>放弃草稿</Button><Button className="primary" onClick={save} disabled={!dirty || loading}>{loading ? "保存中…" : "保存全局设置"}</Button></div>
+      <div className="audit-controls" aria-labelledby="global-inbox-audit-title">
+        <div className="audit-heading"><div><h3 id="global-inbox-audit-title">Inbox 巡检</h3><p>定时检查仍待处理的入站工作；关闭时不会安排巡检。</p></div><label className="audit-switch"><input type="checkbox" checked={draftAudit.enabled} disabled={loading} onChange={(event) => setDraftAudit((current) => ({ ...current, enabled: event.target.checked }))} /><span aria-hidden="true" /><b>{draftAudit.enabled ? "已开启" : "已关闭"}</b></label></div>
+        <label><span>巡检间隔（分钟）</span><input aria-label="全局巡检间隔（分钟）" type="number" min={MIN_AUDIT_GAP_MINUTES} max={MAX_AUDIT_GAP_MINUTES} step="any" inputMode="decimal" value={draftAuditGapMinutes} disabled={loading} onChange={(event) => setDraftAuditGapMinutes(event.target.value)} /></label>
+        <p className="field-help">可在关闭时预先调整；保存间隔本身不会开启巡检。</p>
+      </div>
+      <div className="form-actions"><Button onClick={() => { setDraft(serverValue); setDraftAudit(serverAudit); setDraftAuditGapMinutes(formatAuditGapMinutes(serverAudit.intervalMs)); }} disabled={!dirty || loading}>放弃草稿</Button><Button className="primary" onClick={save} disabled={!dirty || loading}>{loading ? "保存中…" : "保存全局设置"}</Button></div>
       {feedback ? <p role="status" className="feedback">{feedback}</p> : null}
     </div>
   </Sheet>;
@@ -300,7 +343,14 @@ function AgentConfiguration({ agentId, readiness, onDirtyChange, refreshKey }: {
       if (!gate.current.accepts(token)) return;
       const agent = next.agents[0];
       if (!agent) throw new Error("配置投影中没有当前 Agent");
-      const values = { runtime: agent.runtimeOption || agent.runtime, model: agent.model, effort: agent.effort || "default", mention: agent.mention.override };
+      const intervalMs = agent.inboxAudit.override.intervalMs === "inherit"
+        ? agent.inboxAudit.effective.intervalMs : agent.inboxAudit.override.intervalMs;
+      const values = {
+        runtime: agent.runtimeOption || agent.runtime, model: agent.model, effort: agent.effort || "default", mention: agent.mention.override,
+        auditEnabled: agent.inboxAudit.override.enabled,
+        auditIntervalInherited: agent.inboxAudit.override.intervalMs === "inherit",
+        auditGapMinutes: formatAuditGapMinutes(intervalMs),
+      };
       setResponse(next);
       setServerDraft(values);
       if (!preserveDraft || !dirty) setDraft(values);
@@ -341,6 +391,12 @@ function AgentConfiguration({ agentId, readiness, onDirtyChange, refreshKey }: {
     : [{ id: model, label: unavailableLabel }];
   const efforts = directoryReady && model !== "default" ? models.find((item) => item.id === model)?.supportedReasoningEfforts || [] : [];
   const runtimeDirty = draft.runtime !== serverDraft.runtime || draft.model !== serverDraft.model || draft.effort !== serverDraft.effort;
+  const auditEnabled = draft.auditEnabled === "on" || draft.auditEnabled === "off" ? draft.auditEnabled : "inherit";
+  const auditIntervalInherited = draft.auditIntervalInherited === true;
+  const auditGapMinutes = String(draft.auditGapMinutes || "");
+  const auditDirty = draft.auditEnabled !== serverDraft.auditEnabled
+    || draft.auditIntervalInherited !== serverDraft.auditIntervalInherited
+    || draft.auditGapMinutes !== serverDraft.auditGapMinutes;
 
   const requestApply = () => jsonFetch<{ agentId: string; applyState: string }>("/api/config/apply", {
     method: "POST",
@@ -350,6 +406,11 @@ function AgentConfiguration({ agentId, readiness, onDirtyChange, refreshKey }: {
 
   const save = async () => {
     if (!config) return;
+    const auditIntervalMs = auditGapFromMinutes(draft.auditGapMinutes);
+    if (auditDirty && !auditIntervalInherited && auditIntervalMs === null) {
+      setFeedback("巡检间隔必须在 1 到 1440 分钟之间；草稿已保留。");
+      return;
+    }
     setLoading(true);
     try {
       const operations: Array<Record<string, unknown>> = [];
@@ -357,6 +418,12 @@ function AgentConfiguration({ agentId, readiness, onDirtyChange, refreshKey }: {
       else if (draft.model !== serverDraft.model) operations.push({ operation: "set-agent-model", agentId, model: draft.model });
       if (draft.effort !== serverDraft.effort) operations.push({ operation: "set-agent-effort", agentId, effort: draft.effort });
       if (draft.mention !== serverDraft.mention) operations.push({ operation: "set-agent-mention", agentId, value: draft.mention });
+      if (auditDirty) operations.push({
+        operation: "set-agent-inbox-audit", agentId,
+        ...(draft.auditEnabled !== serverDraft.auditEnabled ? { enabled: auditEnabled === "inherit" ? "inherit" : auditEnabled === "on" } : {}),
+        ...(draft.auditIntervalInherited !== serverDraft.auditIntervalInherited || draft.auditGapMinutes !== serverDraft.auditGapMinutes
+          ? { intervalMs: auditIntervalInherited ? "inherit" : auditIntervalMs! } : {}),
+      });
       let latest: { revision: string; applyState: string } | null = null;
       for (const operation of operations) latest = await mutateConfig(operation);
       if (runtimeDirty) {
@@ -394,6 +461,9 @@ function AgentConfiguration({ agentId, readiness, onDirtyChange, refreshKey }: {
 
   if (!config && loading) return <EmptyState title="加载 Agent 配置…" />;
   if (!config) return <EmptyState title="配置不可用" detail={feedback || "请重试"} />;
+  const auditEffective = config.inboxAudit.effective;
+  const auditSource = config.inboxAudit.source;
+  const auditStateDescription = `${auditSource.enabled === "agent" ? "当前 Agent 已单独设置" : auditSource.enabled === "global" ? "当前使用全局设置" : "当前使用默认设置"}：${auditEffective.enabled ? "已开启" : "已关闭"}，每 ${formatAuditGapMinutes(auditEffective.intervalMs)} 分钟`;
   const applyStateLabel = config.apply.applyState === "pending" ? "待应用" : config.apply.applyState === "applied" ? "已应用" : "状态未知";
   return <div className="configuration-page">
     <section className="config-section"><div className="section-heading"><div><h3>Agent 配置</h3><p>只作用于 {agentId}；运行配置会在安全时机自动应用，Agent 正忙时会保留待处理。</p></div><Badge className={config.apply.applyState === "pending" ? "warning" : "success"}>{applyStateLabel}</Badge></div>
@@ -404,6 +474,15 @@ function AgentConfiguration({ agentId, readiness, onDirtyChange, refreshKey }: {
         <label><span>Model</span><select value={model} disabled={loading || !directoryReady} onChange={(event) => { update("model", event.target.value); if (event.target.value === "default") update("effort", "default"); }}>{visibleModels.map((item) => <option value={item.id} key={item.id}>{item.label || item.id}</option>)}</select></label>
         <label><span>Effort</span><select value={String(draft.effort || "default")} disabled={loading || !directoryReady || model === "default" || !efforts.length} onChange={(event) => update("effort", event.target.value)}><option value="default">default · 不指定</option>{efforts.map((value) => <option value={value} key={value}>{value}</option>)}</select></label>
         <label><span>群消息策略</span><select value={String(draft.mention || "inherit")} disabled={loading} onChange={(event) => update("mention", event.target.value)}><option value="inherit">跟随全局设置</option><option value="require">需要 @</option><option value="free">无需 @</option></select></label>
+      </div>
+      <div className="audit-controls" aria-labelledby="agent-inbox-audit-title">
+        <div className="audit-heading"><div><h3 id="agent-inbox-audit-title">Inbox 巡检</h3><p>{auditStateDescription}。</p></div></div>
+        <div className="config-grid audit-grid">
+          <label><span>巡检设置</span><select aria-label="Inbox 巡检设置" value={auditEnabled} disabled={loading} onChange={(event) => update("auditEnabled", event.target.value)}><option value="inherit">跟随全局设置</option><option value="on">为此 Agent 开启</option><option value="off">为此 Agent 关闭</option></select></label>
+          <label><span>巡检间隔（分钟）</span><input aria-label="Agent 巡检间隔（分钟）" type="number" min={MIN_AUDIT_GAP_MINUTES} max={MAX_AUDIT_GAP_MINUTES} step="any" inputMode="decimal" value={auditGapMinutes} disabled={loading} onChange={(event) => setDraft((current) => ({ ...current, auditGapMinutes: event.target.value, auditIntervalInherited: false }))} /></label>
+        </div>
+        <div className="audit-inline-actions"><span>{auditIntervalInherited ? "间隔跟随全局设置；编辑数字后会仅作用于此 Agent。" : "此 Agent 使用单独的巡检间隔。"}</span>{!auditIntervalInherited ? <Button disabled={loading} onClick={() => setDraft((current) => ({ ...current, auditIntervalInherited: true, auditGapMinutes: formatAuditGapMinutes(auditEffective.intervalMs) }))}>间隔跟随全局设置</Button> : null}</div>
+        <p className="field-help">即使关闭巡检，也可保存间隔；间隔修改不会开启巡检。</p>
       </div>
       {dirty || config.apply.applyState === "pending" ? <div className="form-actions">
         {dirty ? <Button disabled={loading} onClick={() => setDraft(serverDraft)}>放弃草稿</Button> : null}

--- a/src/dashboard/web/styles.css
+++ b/src/dashboard/web/styles.css
@@ -168,8 +168,23 @@ button:disabled, select:disabled, input:disabled { cursor: not-allowed; opacity:
 .cli-guidance code { color: var(--ink); font: 600 10.5px ui-monospace, monospace; overflow-wrap: anywhere; }
 .config-grid { display: grid; grid-template-columns: repeat(4, minmax(120px, 1fr)); gap: 12px; }
 .config-grid label, .settings-form label, .chat-add label { min-width: 0; display: grid; gap: 5px; color: var(--subtle); font-size: 11px; font-weight: 600; }
-.config-grid select, .config-grid input, .settings-form select, .chat-add select, .chat-add input, .policy-table select { min-width: 0; width: 100%; min-height: 37px; border: 1px solid var(--line); border-radius: 8px; padding: 7px 9px; background: var(--paper); color: var(--ink); font-size: 12px; }
+.config-grid select, .config-grid input, .settings-form select, .settings-form input, .chat-add select, .chat-add input, .policy-table select { min-width: 0; width: 100%; min-height: 37px; border: 1px solid var(--line); border-radius: 8px; padding: 7px 9px; background: var(--paper); color: var(--ink); font-size: 12px; }
 .config-grid input:disabled { color: var(--subtle); }
+.audit-controls { display: grid; gap: 12px; margin-top: 18px; border-top: 1px solid var(--line); padding-top: 16px; }
+.audit-heading { display: flex; align-items: flex-start; justify-content: space-between; gap: 16px; }
+.audit-heading h3 { margin: 0; font: 600 15px Georgia, serif; }
+.audit-heading p, .audit-inline-actions { margin: 3px 0 0; color: var(--subtle); font-size: 11px; line-height: 1.5; }
+.audit-switch { display: inline-flex; flex: 0 0 auto; align-items: center; gap: 7px; color: var(--ink); font-size: 11px; font-weight: 600; white-space: nowrap; }
+.audit-switch input { position: absolute; width: 1px; height: 1px; overflow: hidden; clip: rect(0 0 0 0); }
+.audit-switch > span { width: 32px; height: 18px; border: 1px solid var(--line); border-radius: 999px; background: var(--panel); transition: background-color .18s ease, border-color .18s ease; }
+.audit-switch > span::after { display: block; width: 12px; height: 12px; margin: 2px; border-radius: 50%; background: var(--subtle); content: ""; transition: transform .18s ease, background-color .18s ease; }
+.audit-switch input:checked + span { border-color: var(--accent); background: var(--accent); }
+.audit-switch input:checked + span::after { transform: translateX(14px); background: var(--paper); }
+.audit-switch input:focus-visible + span { outline: 2px solid var(--accent); outline-offset: 3px; }
+.audit-switch input:disabled + span { opacity: .55; }
+.audit-grid { grid-template-columns: repeat(2, minmax(0, 1fr)); }
+.audit-inline-actions { display: flex; align-items: center; justify-content: space-between; gap: 12px; }
+.audit-inline-actions .ui-button { flex: 0 0 auto; }
 .form-actions { display: flex; flex-wrap: wrap; justify-content: flex-end; gap: 8px; margin-top: 16px; }
 .feedback { margin: 10px 0 0; color: var(--subtle); font-size: 11px; }
 .table-search { min-width: min(300px, 42vw); padding: 7px 9px; }
@@ -248,6 +263,9 @@ button:disabled, select:disabled, input:disabled { cursor: not-allowed; opacity:
   .metric-stat:nth-last-child(-n+1) { border-bottom: 0; }
   .overview-sections { grid-template-columns: 1fr; gap: 22px; }
   .config-grid { grid-template-columns: 1fr; }
+  .audit-grid { grid-template-columns: 1fr; }
+  .audit-heading, .audit-inline-actions { display: grid; }
+  .audit-switch { justify-self: start; }
   .section-heading { display: block; }
   .section-heading > .ui-badge, .section-heading > .table-search { margin-top: 9px; }
   .table-search { width: 100%; min-width: 0; }

--- a/src/dashboard/web/types.ts
+++ b/src/dashboard/web/types.ts
@@ -107,6 +107,11 @@ export interface ConfigAgent {
   model: string;
   effort: string | null;
   mention: { override: "inherit" | "require" | "free"; effective: "require" | "free"; source: "global" | "agent" };
+  inboxAudit: {
+    override: { enabled: "inherit" | "on" | "off"; intervalMs: "inherit" | number };
+    effective: { enabled: boolean; intervalMs: number };
+    source: { enabled: "default" | "global" | "agent"; intervalMs: "default" | "global" | "agent" };
+  };
   knownChats: KnownChat[];
   apply: { applyState?: "unknown" | "pending" | "applied" };
 }
@@ -121,6 +126,7 @@ export interface RuntimeModel {
 export interface ConfigResponse {
   version: 4;
   mentionPolicy: "require" | "free";
+  inboxAudit: { enabled: boolean; intervalMs: number };
   persistedRevision: string;
   agents: ConfigAgent[];
   runtimeModels: Record<string, RuntimeModel[]>;

--- a/src/feishu/host-shell.ts
+++ b/src/feishu/host-shell.ts
@@ -20,7 +20,7 @@ import { ProcessingEyeOrchestrator } from "./host-processing-eye.js";
 import { projectInboxEnvelope, targetKeyOfInboxEnvelope } from "../agent/inbox-projection.js";
 import { HostReminderOrchestrator } from "../agent/host-reminder-orchestrator.js";
 import { boundedInboxAuditDiagnostic, InboxAuditHeartbeat, INBOX_AUDIT_CADENCE_MS } from "../agent/inbox-audit-heartbeat.js";
-import { hasPendingInboxAuditTargets, inboxAuditRegistryFile, observeInboxAuditTarget } from "../agent/missed-outbound-scan.js";
+import { discardInboxAuditTargetRetry, enqueueInboxAuditTargetRetry, hasPendingInboxAuditTargets, inboxAuditRegistryFile, inboxAuditRetryFile, observeInboxAuditTarget, reconcileInboxAuditTargetRetries } from "../agent/missed-outbound-scan.js";
 import { HostChannelBusiness } from "./host-channel-business.js";
 import { HostInteractionOrchestrator } from "./interaction-orchestrator.js";
 import { targetFor, type FeishuInboundEvent } from "./message-policy.js";
@@ -517,6 +517,23 @@ export function createHostShell({
   for (const agent of agents) prepareAgentState(agent);
   const reminder = new HostReminderOrchestrator({ agents, stateStore, envelopeProjector, deliveryTarget: runtimeHost, log });
   const auditRegistry = inboxAuditRegistryFile(larkinHome);
+  const auditRetryJournal = inboxAuditRetryFile(larkinHome);
+  let auditRetryTimer: NodeJS.Timeout | null = null;
+  let auditRetryAttempt = 0;
+  const reconcileAuditRetries = (): number => {
+    try { return reconcileInboxAuditTargetRetries(auditRegistry, auditRetryJournal).remaining; }
+    catch (error) { log(`inbox audit retry 读取失败: ${boundedInboxAuditDiagnostic(error)}`); return 1; }
+  };
+  const scheduleAuditRetry = (): void => {
+    if (auditRetryTimer || auditRetryAttempt >= 5) return;
+    const delay = [100, 250, 1_000, 3_000, 10_000][auditRetryAttempt++]!;
+    auditRetryTimer = setTimeout(() => {
+      auditRetryTimer = null;
+      if (reconcileAuditRetries() > 0) scheduleAuditRetry();
+      else auditRetryAttempt = 0;
+    }, delay);
+    auditRetryTimer.unref?.();
+  };
   const inboxAudit = new InboxAuditHeartbeat({
     agents,
     stateStore,
@@ -574,8 +591,13 @@ export function createHostShell({
         if (event.event_id) seenEventIds.add(eventKey);
         try {
           observeInboxAuditTarget(auditRegistry, agent.agentId, { ...event, wake });
+          discardInboxAuditTargetRetry(auditRetryJournal, agent.agentId, event);
         } catch (error) {
-          log(`inbox audit target 未持久化: ${boundedInboxAuditDiagnostic(error)}`);
+          try {
+            enqueueInboxAuditTargetRetry(auditRetryJournal, agent.agentId, { ...event, wake });
+            scheduleAuditRetry();
+            log(`inbox audit target 延后重试: ${boundedInboxAuditDiagnostic(error)}`);
+          } catch (retryError) { log(`inbox audit target 未持久化: ${boundedInboxAuditDiagnostic(retryError)}`); }
         }
         if (append.status === "duplicate_consumed") return null;
         const inboxEnvelope = append.envelope;
@@ -1455,6 +1477,8 @@ export function createHostShell({
       eventSourceStartTimer = null;
       await Promise.resolve(eventSourceStop());
       reminder.stopSync();
+      if (auditRetryTimer) clearTimeout(auditRetryTimer);
+      auditRetryTimer = null;
       inboxAudit.stop();
       interaction.stopSync();
       await runtimeHost.shutdown(reason);
@@ -1662,6 +1686,7 @@ export function createHostShell({
           previousSession: agentStates.get(agent.agentId)?.state.previousSessions?.[agent.runtime] ?? null,
         })));
         reminder.startSync();
+        if (reconcileAuditRetries() > 0) scheduleAuditRetry();
         inboxAudit.start();
         interaction.startSync();
         eventSourceStartTimer = setTimeout(() => { eventSourceStartTimer = null; startEventSource(); }, eventSourceStartDelayMs);

--- a/src/feishu/host-shell.ts
+++ b/src/feishu/host-shell.ts
@@ -522,6 +522,7 @@ export function createHostShell({
     stateStore,
     runtimeHost,
     log,
+    configFile: path.join(larkinHome, "config.json"),
     schedule(agent) {
       try { return resolveInboxAuditSchedule(loadConfig(env).config, agent.agentId); }
       catch (error) {

--- a/src/feishu/host-shell.ts
+++ b/src/feishu/host-shell.ts
@@ -19,7 +19,7 @@ import {
 import { ProcessingEyeOrchestrator } from "./host-processing-eye.js";
 import { projectInboxEnvelope, targetKeyOfInboxEnvelope } from "../agent/inbox-projection.js";
 import { HostReminderOrchestrator } from "../agent/host-reminder-orchestrator.js";
-import { InboxAuditHeartbeat, INBOX_AUDIT_CADENCE_MS } from "../agent/inbox-audit-heartbeat.js";
+import { boundedInboxAuditDiagnostic, InboxAuditHeartbeat, INBOX_AUDIT_CADENCE_MS } from "../agent/inbox-audit-heartbeat.js";
 import { hasPendingInboxAuditTargets, inboxAuditRegistryFile, observeInboxAuditTarget } from "../agent/missed-outbound-scan.js";
 import { HostChannelBusiness } from "./host-channel-business.js";
 import { HostInteractionOrchestrator } from "./interaction-orchestrator.js";
@@ -574,7 +574,7 @@ export function createHostShell({
         try {
           observeInboxAuditTarget(auditRegistry, agent.agentId, { ...event, wake });
         } catch (error) {
-          log(`inbox audit target 未持久化: ${(error as Error).message}`);
+          log(`inbox audit target 未持久化: ${boundedInboxAuditDiagnostic(error)}`);
         }
         if (append.status === "duplicate_consumed") return null;
         const inboxEnvelope = append.envelope;

--- a/src/feishu/host-shell.ts
+++ b/src/feishu/host-shell.ts
@@ -589,7 +589,8 @@ export function createHostShell({
         // An event becomes permanently transport-seen only after the canonical
         // append/dedupe decision is durable. Agent model-seen state is untouched.
         if (event.event_id) seenEventIds.add(eventKey);
-        const auditSourceSeq = Number((append.envelope as { seq?: unknown }).seq);
+        if (append.status === "duplicate_consumed") return null;
+        const auditSourceSeq = Number((append.envelope as { target_seq?: unknown }).target_seq);
         try {
           observeInboxAuditTarget(auditRegistry, agent.agentId, { ...event, wake, source_seq: auditSourceSeq });
           discardInboxAuditTargetRetry(auditRetryJournal, agent.agentId, { ...event, source_seq: auditSourceSeq });
@@ -600,7 +601,6 @@ export function createHostShell({
             log(`inbox audit target 延后重试: ${boundedInboxAuditDiagnostic(error)}`);
           } catch (retryError) { log(`inbox audit target 未持久化: ${boundedInboxAuditDiagnostic(retryError)}`); }
         }
-        if (append.status === "duplicate_consumed") return null;
         const inboxEnvelope = append.envelope;
         if (append.status === "appended") hostState.appendConversation(agent, {
           direction: "in", from: inboxEnvelope.sender_name, senderType: inboxEnvelope.sender_type,

--- a/src/feishu/host-shell.ts
+++ b/src/feishu/host-shell.ts
@@ -19,8 +19,8 @@ import {
 import { ProcessingEyeOrchestrator } from "./host-processing-eye.js";
 import { projectInboxEnvelope, targetKeyOfInboxEnvelope } from "../agent/inbox-projection.js";
 import { HostReminderOrchestrator } from "../agent/host-reminder-orchestrator.js";
-import { InboxAuditHeartbeat } from "../agent/inbox-audit-heartbeat.js";
-import { inboxAuditRegistryFile, observeInboxAuditTarget } from "../agent/missed-outbound-scan.js";
+import { InboxAuditHeartbeat, INBOX_AUDIT_CADENCE_MS } from "../agent/inbox-audit-heartbeat.js";
+import { hasPendingInboxAuditTargets, inboxAuditRegistryFile, observeInboxAuditTarget } from "../agent/missed-outbound-scan.js";
 import { HostChannelBusiness } from "./host-channel-business.js";
 import { HostInteractionOrchestrator } from "./interaction-orchestrator.js";
 import { targetFor, type FeishuInboundEvent } from "./message-policy.js";
@@ -36,7 +36,7 @@ import {
 } from "../runtime/runtime-readiness.js";
 import { safeProviderDiagnostic } from "../runtime/provider-error-classifier.js";
 import { readDocumentCommentSubscription, verifyCallbackProbe, type EffectiveDocumentCommentSubscription } from "../platform/callback-capability.js";
-import { loadConfig, resolveMentionPolicy } from "../platform/config.js";
+import { loadConfig, resolveInboxAuditSchedule, resolveMentionPolicy } from "../platform/config.js";
 import { processCommandToken } from "../app/internal-command.js";
 import { managedOfficialLarkCli } from "../app/agent-lark-cli-workspace.js";
 import { isChannelReconnecting, isRuntimeReadinessCurrent } from "../app/agent-readiness.js";
@@ -516,13 +516,27 @@ export function createHostShell({
   };
   for (const agent of agents) prepareAgentState(agent);
   const reminder = new HostReminderOrchestrator({ agents, stateStore, envelopeProjector, deliveryTarget: runtimeHost, log });
+  const auditRegistry = inboxAuditRegistryFile(larkinHome);
   const inboxAudit = new InboxAuditHeartbeat({
     agents,
     stateStore,
     runtimeHost,
     log,
+    schedule(agent) {
+      try { return resolveInboxAuditSchedule(loadConfig(env).config, agent.agentId); }
+      catch (error) {
+        log(`inbox audit schedule 读取失败 agent=${agent.agentId}: ${errorMessage(error)}`);
+        return { enabled: false, intervalMs: INBOX_AUDIT_CADENCE_MS };
+      }
+    },
+    shouldDispatch(agent) {
+      try { return hasPendingInboxAuditTargets(auditRegistry, agent.agentId); }
+      catch (error) {
+        log(`inbox audit pending 读取失败 agent=${agent.agentId}: ${errorMessage(error)}`);
+        return false;
+      }
+    },
   });
-  const auditRegistry = inboxAuditRegistryFile(larkinHome);
   const seenEventIds = new Set<string>();
   const inFlightEventIds = new Set<string>();
   const onFeishuMessage = async (agent: ConfiguredAgent, event: FeishuInboundEvent, options?: { wake?: boolean }): Promise<void> => {
@@ -558,7 +572,7 @@ export function createHostShell({
         // append/dedupe decision is durable. Agent model-seen state is untouched.
         if (event.event_id) seenEventIds.add(eventKey);
         try {
-          observeInboxAuditTarget(auditRegistry, agent.agentId, event);
+          observeInboxAuditTarget(auditRegistry, agent.agentId, { ...event, wake });
         } catch (error) {
           log(`inbox audit target 未持久化: ${(error as Error).message}`);
         }

--- a/src/feishu/host-shell.ts
+++ b/src/feishu/host-shell.ts
@@ -589,12 +589,13 @@ export function createHostShell({
         // An event becomes permanently transport-seen only after the canonical
         // append/dedupe decision is durable. Agent model-seen state is untouched.
         if (event.event_id) seenEventIds.add(eventKey);
+        const auditSourceSeq = Number((append.envelope as { seq?: unknown }).seq);
         try {
-          observeInboxAuditTarget(auditRegistry, agent.agentId, { ...event, wake });
-          discardInboxAuditTargetRetry(auditRetryJournal, agent.agentId, event);
+          observeInboxAuditTarget(auditRegistry, agent.agentId, { ...event, wake, source_seq: auditSourceSeq });
+          discardInboxAuditTargetRetry(auditRetryJournal, agent.agentId, { ...event, source_seq: auditSourceSeq });
         } catch (error) {
           try {
-            enqueueInboxAuditTargetRetry(auditRetryJournal, agent.agentId, { ...event, wake });
+            enqueueInboxAuditTargetRetry(auditRetryJournal, agent.agentId, { ...event, wake, source_seq: auditSourceSeq });
             scheduleAuditRetry();
             log(`inbox audit target 延后重试: ${boundedInboxAuditDiagnostic(error)}`);
           } catch (retryError) { log(`inbox audit target 未持久化: ${boundedInboxAuditDiagnostic(retryError)}`); }

--- a/src/platform/config.ts
+++ b/src/platform/config.ts
@@ -16,6 +16,21 @@ export {
 } from "../runtime/user-runtime.js";
 export type MentionPolicy = "require" | "free";
 export type MentionPolicyOverride = MentionPolicy | "inherit";
+export type InboxAuditEnabledOverride = boolean | "inherit";
+export type InboxAuditIntervalOverride = number | "inherit";
+
+export interface InboxAuditSettings {
+  enabled?: boolean;
+  intervalMs?: number;
+}
+export interface InboxAuditResolved {
+  enabled: boolean;
+  intervalMs: number;
+}
+
+export const DEFAULT_INBOX_AUDIT_INTERVAL_MS = 15 * 60_000;
+export const MIN_INBOX_AUDIT_INTERVAL_MS = 60_000;
+export const MAX_INBOX_AUDIT_INTERVAL_MS = 24 * 60 * 60_000;
 
 export interface StoredAgent {
   runtime: string;
@@ -23,6 +38,7 @@ export interface StoredAgent {
   effort?: string;
   mentionPolicy?: MentionPolicy;
   chatMentionPolicies?: Record<string, MentionPolicy>;
+  inboxAudit?: InboxAuditSettings;
   createdAt?: string;
 }
 
@@ -43,6 +59,7 @@ export interface HydratedConfig {
   version: 4;
   serverId: string | null;
   mentionPolicy: MentionPolicy;
+  inboxAudit?: InboxAuditResolved;
   configDir: string;
   larkinHome: string;
   larkConfigDir: string;
@@ -55,6 +72,8 @@ export type ConfigMutation =
   | { kind: "set-global-mention"; value: MentionPolicy }
   | { kind: "set-agent-mention"; agentId: string; value: MentionPolicyOverride }
   | { kind: "set-chat-mention"; agentId: string; chatId: string; value: MentionPolicyOverride }
+  | { kind: "set-global-inbox-audit"; enabled?: boolean; intervalMs?: number }
+  | { kind: "set-agent-inbox-audit"; agentId: string; enabled?: InboxAuditEnabledOverride; intervalMs?: InboxAuditIntervalOverride }
   | { kind: "set-agent-runtime"; agentId: string; runtime: string; model?: string }
   | { kind: "set-agent-model"; agentId: string; model: string }
   | { kind: "set-agent-effort"; agentId: string; effort: string | null };
@@ -75,9 +94,11 @@ interface ConfigApplyFile { version: 1; persistedRevision: string; agents: Recor
 
 const TOP_FIELDS_V3 = new Set(["version", "serverId", "activeAgent", "agents"]);
 const TOP_FIELDS_V4 = new Set(["version", "serverId", "mentionPolicy", "activeAgent", "agents"]);
+const OPTIONAL_TOP_FIELDS_V4 = new Set(["inboxAudit"]);
 const AGENT_FIELDS_V3 = new Set(["runtime", "model", "effort", "noMentionChats", "createdAt"]);
-const AGENT_FIELDS_V4 = new Set(["runtime", "model", "effort", "mentionPolicy", "chatMentionPolicies", "createdAt"]);
+const AGENT_FIELDS_V4 = new Set(["runtime", "model", "effort", "mentionPolicy", "chatMentionPolicies", "inboxAudit", "createdAt"]);
 const LEGACY_AGENT_FIELDS = new Set(["piDistribution", "runtimeOption"]);
+const INBOX_AUDIT_FIELDS = new Set(["enabled", "intervalMs"]);
 const APP_ID = /^cli_[A-Za-z0-9]+$/;
 const CHAT_ID = /^oc_[A-Za-z0-9_-]+$/;
 const PI_EFFORTS = new Set(["off", "minimal", "low", "medium", "high", "xhigh", "max"]);
@@ -144,6 +165,88 @@ function assertPolicy(value: unknown, label: string): asserts value is MentionPo
   if (value !== "require" && value !== "free") throw new Error(`${label} 只允许 require/free`);
 }
 
+export function assertInboxAuditInterval(value: unknown, label = "inbox-audit interval"): asserts value is number {
+  if (typeof value !== "number" || !Number.isSafeInteger(value) || value < MIN_INBOX_AUDIT_INTERVAL_MS || value > MAX_INBOX_AUDIT_INTERVAL_MS) {
+    throw new Error(`${label} 必须是 ${MIN_INBOX_AUDIT_INTERVAL_MS}–${MAX_INBOX_AUDIT_INTERVAL_MS} 毫秒`);
+  }
+}
+
+export function parseInboxAuditInterval(value: string): number {
+  if (typeof value !== "string" || !value) throw new Error("inbox-audit interval 不能为空");
+  let milliseconds: number;
+  if (/^[1-9]\d*$/.test(value)) milliseconds = Number(value);
+  else {
+    const match = /^([1-9]\d*)(m|h)$/.exec(value);
+    if (!match) throw new Error("inbox-audit interval 只允许 15m/1h 或 60000–86400000 毫秒");
+    milliseconds = Number(match[1]) * (match[2] === "h" ? 3_600_000 : 60_000);
+  }
+  assertInboxAuditInterval(milliseconds);
+  return milliseconds;
+}
+
+export function formatInboxAuditInterval(intervalMs: number): string {
+  if (intervalMs % 3_600_000 === 0) return `${intervalMs / 3_600_000}h`;
+  if (intervalMs % 60_000 === 0) return `${intervalMs / 60_000}m`;
+  return `${intervalMs}ms`;
+}
+
+function parseStoredInboxAudit(value: unknown, label: string): InboxAuditSettings {
+  if (!isPlainObject(value)) throw new Error(`${label} 必须是普通 object`);
+  assertAllowedFields(value, INBOX_AUDIT_FIELDS, label);
+  const settings: InboxAuditSettings = {};
+  if (Object.hasOwn(value, "enabled")) {
+    if (typeof value.enabled !== "boolean") throw new Error(`${label}.enabled 必须是 boolean`);
+    settings.enabled = value.enabled;
+  }
+  if (Object.hasOwn(value, "intervalMs")) {
+    assertInboxAuditInterval(value.intervalMs, `${label}.intervalMs`);
+    settings.intervalMs = value.intervalMs;
+  }
+  return settings;
+}
+
+function resolvedInboxAudit(settings: InboxAuditSettings | undefined): InboxAuditResolved {
+  return {
+    enabled: settings?.enabled ?? false,
+    intervalMs: settings?.intervalMs ?? DEFAULT_INBOX_AUDIT_INTERVAL_MS,
+  };
+}
+
+export function inboxAuditMutationFromCli(input: {
+  scope: string;
+  enabled: string | undefined;
+  interval: string | undefined;
+  agentId: string;
+}): ConfigMutation {
+  if (input.scope === "global") {
+    if (input.enabled !== "on" && input.enabled !== "off") {
+      throw new Error("用法: larkin config inbox-audit global <on|off> [--interval <15m|1h>]");
+    }
+    const mutation: Extract<ConfigMutation, { kind: "set-global-inbox-audit" }> = {
+      kind: "set-global-inbox-audit", enabled: input.enabled === "on",
+    };
+    if (input.interval !== undefined) {
+      if (input.interval === "inherit") throw new Error("全局 inbox-audit 不支持 interval=inherit");
+      mutation.intervalMs = parseInboxAuditInterval(input.interval);
+    }
+    return mutation;
+  }
+  if (input.scope === "agent") {
+    if (input.enabled !== "on" && input.enabled !== "off" && input.enabled !== "inherit") {
+      throw new Error("用法: larkin config inbox-audit agent <inherit|on|off> [--agent <App ID>] [--interval <15m|inherit>]");
+    }
+    const mutation: Extract<ConfigMutation, { kind: "set-agent-inbox-audit" }> = {
+      kind: "set-agent-inbox-audit", agentId: input.agentId,
+      enabled: input.enabled === "inherit" ? "inherit" : input.enabled === "on",
+    };
+    if (input.interval !== undefined) {
+      mutation.intervalMs = input.interval === "inherit" ? "inherit" : parseInboxAuditInterval(input.interval);
+    }
+    return mutation;
+  }
+  throw new Error("inbox-audit scope 只支持 global/agent");
+}
+
 function assertModel(runtime: string, model: string): void {
   if (model === "default") return;
   const safe = runtime === "pi" ? PI_MODEL.test(model)
@@ -201,6 +304,7 @@ function validateStoredAgent(key: string, agent: unknown, version: 3 | 4): asser
     }
   }
   if (version === 4 && Object.hasOwn(agent, "mentionPolicy")) assertPolicy(agent.mentionPolicy, `Agent ${key}.mentionPolicy`);
+  if (version === 4 && Object.hasOwn(agent, "inboxAudit")) parseStoredInboxAudit(agent.inboxAudit, `Agent ${key}.inboxAudit`);
   if (version === 4 && Object.hasOwn(agent, "chatMentionPolicies")) {
     if (!isPlainObject(agent.chatMentionPolicies)) throw new Error(`Agent ${key}.chatMentionPolicies 必须是普通 object`);
     for (const [chatId, policy] of Object.entries(agent.chatMentionPolicies)) {
@@ -225,6 +329,7 @@ function hydratedStoredAgent(key: string, agent: Obj, version: 3 | 4): StoredAge
     model: agent.model as string,
     ...(typeof agent.effort === "string" ? { effort: agent.effort } : {}),
     ...(version === 4 && (agent.mentionPolicy === "require" || agent.mentionPolicy === "free") ? { mentionPolicy: agent.mentionPolicy } : {}),
+    ...(version === 4 && Object.hasOwn(agent, "inboxAudit") ? { inboxAudit: parseStoredInboxAudit(agent.inboxAudit, `Agent ${key}.inboxAudit`) } : {}),
     ...(Object.keys(chatMentionPolicies).length ? { chatMentionPolicies, noMentionChats: Object.entries(chatMentionPolicies).filter(([, policy]) => policy === "free").map(([chatId]) => chatId) } : {}),
     ...(typeof agent.createdAt === "string" ? { createdAt: agent.createdAt } : {}),
   };
@@ -239,6 +344,7 @@ export function hydrateAgent(key: string, agent: StoredAgent & { noMentionChats?
     larkConfigDir: path.join(layout.agentStateDir(key), "lark-cli-config"),
     ...(agent.effort ? { effort: agent.effort } : {}),
     ...(agent.mentionPolicy ? { mentionPolicy: agent.mentionPolicy } : {}),
+    ...(agent.inboxAudit ? { inboxAudit: { ...agent.inboxAudit } } : {}),
     ...(agent.chatMentionPolicies ? { chatMentionPolicies: { ...agent.chatMentionPolicies } } : {}),
     ...(agent.noMentionChats ? { noMentionChats: [...agent.noMentionChats] } : {}),
     ...(agent.createdAt ? { createdAt: agent.createdAt } : {}),
@@ -255,7 +361,7 @@ export function normalizeConfig(raw: unknown, configDir: string, { mint }: { min
   const version = raw.version;
   if (version !== 3 && version !== 4) throw new Error("不支持该配置格式：larkin 只接受 version=3/4");
   const topFields = version === 3 ? TOP_FIELDS_V3 : TOP_FIELDS_V4;
-  assertAllowedFields(raw, topFields, "config");
+  assertAllowedFields(raw, version === 4 ? new Set([...TOP_FIELDS_V4, ...OPTIONAL_TOP_FIELDS_V4]) : topFields, "config");
   for (const field of topFields) if (!Object.hasOwn(raw, field)) throw new Error(`config 缺少必需字段 ${field}`);
   if (typeof raw.serverId !== "string" || !raw.serverId) throw new Error("config.serverId 必须是非空字符串");
   if (version === 4) assertPolicy(raw.mentionPolicy, "config.mentionPolicy");
@@ -265,8 +371,12 @@ export function normalizeConfig(raw: unknown, configDir: string, { mint }: { min
   if (raw.activeAgent !== null && !Object.hasOwn(raw.agents, raw.activeAgent)) throw new Error(`config.activeAgent 指向不存在的 Agent：${raw.activeAgent}`);
   const agents: Record<string, HydratedAgent> = {};
   for (const [key, agent] of Object.entries(raw.agents)) agents[key] = hydrateAgent(key, hydratedStoredAgent(key, agent as Obj, version), layout.root);
+  const inboxAudit = version === 4 && Object.hasOwn(raw, "inboxAudit")
+    ? resolvedInboxAudit(parseStoredInboxAudit(raw.inboxAudit, "config.inboxAudit"))
+    : undefined;
   return {
     version: 4, serverId: raw.serverId, mentionPolicy: version === 4 ? raw.mentionPolicy as MentionPolicy : "require",
+    ...(inboxAudit ? { inboxAudit } : {}),
     configDir: layout.configDir, larkinHome: layout.larkinHome, larkConfigDir: resolveLarkConfigDir({}, layout.root), activeAgent: raw.activeAgent as string | null, agents,
   };
 }
@@ -455,13 +565,22 @@ export function selectAgent(config: HydratedConfig, env: Env = process.env): Hyd
   return agents[config.activeAgent];
 }
 
-export function toStored(config: HydratedConfig): { version: 4; serverId: string | null; mentionPolicy: MentionPolicy; activeAgent: string | null; agents: Record<string, StoredAgent> } {
-  const out = { version: 4 as const, serverId: config.serverId, mentionPolicy: config.mentionPolicy, activeAgent: config.activeAgent, agents: {} as Record<string, StoredAgent> };
+export function toStored(config: HydratedConfig): {
+  version: 4; serverId: string | null; mentionPolicy: MentionPolicy; inboxAudit?: InboxAuditResolved;
+  activeAgent: string | null; agents: Record<string, StoredAgent>;
+} {
+  const out: ReturnType<typeof toStored> = {
+    version: 4, serverId: config.serverId, mentionPolicy: config.mentionPolicy, activeAgent: config.activeAgent, agents: {},
+  };
+  if (config.inboxAudit) out.inboxAudit = { enabled: config.inboxAudit.enabled, intervalMs: config.inboxAudit.intervalMs };
   for (const [key, agent] of Object.entries(config.agents || {})) {
     const stored: StoredAgent = { runtime: agent.runtime, model: agent.model };
     if (typeof agent.effort === "string" && agent.effort) stored.effort = agent.effort;
     if (agent.mentionPolicy) stored.mentionPolicy = agent.mentionPolicy;
     if (agent.chatMentionPolicies && Object.keys(agent.chatMentionPolicies).length) stored.chatMentionPolicies = { ...agent.chatMentionPolicies };
+    if (agent.inboxAudit && (agent.inboxAudit.enabled !== undefined || agent.inboxAudit.intervalMs !== undefined)) {
+      stored.inboxAudit = { ...agent.inboxAudit };
+    }
     if (typeof agent.createdAt === "string" && agent.createdAt) stored.createdAt = agent.createdAt;
     out.agents[key] = stored;
   }
@@ -488,6 +607,23 @@ export function resolveAgentGlobalMentionPolicy(config: HydratedConfig, agentId:
   return { effective: config.mentionPolicy, source: "global" };
 }
 
+export function resolveInboxAuditSchedule(config: HydratedConfig, agentId: string): InboxAuditResolved & {
+  enabledSource: "agent" | "global" | "default";
+  intervalSource: "agent" | "global" | "default";
+} {
+  const agent = config.agents[agentId];
+  if (!agent) throw new Error(`Agent 不存在：${agentId}`);
+  const enabled = agent.inboxAudit?.enabled ?? config.inboxAudit?.enabled ?? false;
+  const intervalMs = agent.inboxAudit?.intervalMs ?? config.inboxAudit?.intervalMs ?? DEFAULT_INBOX_AUDIT_INTERVAL_MS;
+  assertInboxAuditInterval(intervalMs);
+  return {
+    enabled,
+    intervalMs,
+    enabledSource: agent.inboxAudit?.enabled !== undefined ? "agent" : config.inboxAudit ? "global" : "default",
+    intervalSource: agent.inboxAudit?.intervalMs !== undefined ? "agent" : config.inboxAudit?.intervalMs !== undefined ? "global" : "default",
+  };
+}
+
 function revision(bytes: Buffer | string): string {
   return `sha256:${crypto.createHash("sha256").update(bytes).digest("hex")}`;
 }
@@ -500,6 +636,7 @@ function agentSignature(config: HydratedConfig, agentId: string): string {
     schema: 2,
     runtime: agent.runtime, model: agent.model, effort: agent.effort ?? null,
     globalMentionPolicy: config.mentionPolicy, agentMentionPolicy: agent.mentionPolicy ?? null, chatMentionPolicies: chats,
+    globalInboxAudit: config.inboxAudit ?? null, agentInboxAudit: agent.inboxAudit ?? null,
   }));
 }
 
@@ -630,11 +767,36 @@ function applyMutation(config: HydratedConfig, mutation: ConfigMutation): { scop
     config.mentionPolicy = mutation.value;
     return { scope: "global", runtimeChange: false, affectedAgentIds: Object.keys(config.agents) };
   }
+  if (mutation.kind === "set-global-inbox-audit") {
+    if (mutation.enabled === undefined && mutation.intervalMs === undefined) throw new Error("inbox-audit 全局变更必须包含 enabled 或 interval");
+    const current = resolvedInboxAudit(config.inboxAudit);
+    if (mutation.enabled !== undefined) current.enabled = mutation.enabled;
+    if (mutation.intervalMs !== undefined) {
+      assertInboxAuditInterval(mutation.intervalMs, "全局 inbox-audit interval");
+      current.intervalMs = mutation.intervalMs;
+    }
+    config.inboxAudit = current;
+    return { scope: "global", runtimeChange: false, affectedAgentIds: Object.keys(config.agents) };
+  }
   if (!APP_ID.test(mutation.agentId) || !config.agents[mutation.agentId]) throw new Error(`Agent 不存在：${mutation.agentId}`);
   const agent = config.agents[mutation.agentId];
   if (mutation.kind === "set-agent-mention") {
     if (mutation.value === "inherit") delete agent.mentionPolicy;
     else { assertPolicy(mutation.value, "Agent mention policy"); agent.mentionPolicy = mutation.value; }
+    return { scope: "agent", agentId: mutation.agentId, runtimeChange: false, affectedAgentIds: [mutation.agentId] };
+  }
+  if (mutation.kind === "set-agent-inbox-audit") {
+    if (mutation.enabled === undefined && mutation.intervalMs === undefined) throw new Error("inbox-audit Agent 变更必须包含 enabled 或 interval");
+    const current: InboxAuditSettings = { ...(agent.inboxAudit || {}) };
+    if (mutation.enabled === "inherit") delete current.enabled;
+    else if (mutation.enabled !== undefined) current.enabled = mutation.enabled;
+    if (mutation.intervalMs === "inherit") delete current.intervalMs;
+    else if (mutation.intervalMs !== undefined) {
+      assertInboxAuditInterval(mutation.intervalMs, "Agent inbox-audit interval");
+      current.intervalMs = mutation.intervalMs;
+    }
+    if (current.enabled === undefined && current.intervalMs === undefined) delete agent.inboxAudit;
+    else agent.inboxAudit = current;
     return { scope: "agent", agentId: mutation.agentId, runtimeChange: false, affectedAgentIds: [mutation.agentId] };
   }
   if (mutation.kind === "set-chat-mention") {
@@ -1030,8 +1192,24 @@ export function safeConfigView(config: HydratedConfig, onlyAgentId?: string, cha
       source: agent.mentionPolicy ? "agent" : "global",
       ...(chatId ? { chat: { chatId, override: agent.chatMentionPolicies?.[chatId] ?? "inherit", ...resolveMentionPolicy(config, agentId, chatId) } } : {}),
     },
+    inboxAudit: (() => {
+      const resolved = resolveInboxAuditSchedule(config, agentId);
+      return {
+        override: {
+          enabled: agent.inboxAudit?.enabled === undefined ? "inherit" : agent.inboxAudit.enabled ? "on" : "off",
+          intervalMs: agent.inboxAudit?.intervalMs ?? "inherit",
+        },
+        effective: { enabled: resolved.enabled, intervalMs: resolved.intervalMs },
+        source: { enabled: resolved.enabledSource, intervalMs: resolved.intervalSource },
+      };
+    })(),
     chatMentionPolicies: { ...(agent.chatMentionPolicies || {}) },
     apply: (applyState?.agents as Record<string, unknown> | undefined)?.[agentId] ?? { applyState: "unknown" },
   }));
-  return { version: 4, mentionPolicy: config.mentionPolicy, persistedRevision: applyState?.persistedRevision ?? "unknown", agents };
+  const inboxAudit = resolvedInboxAudit(config.inboxAudit);
+  return {
+    version: 4, mentionPolicy: config.mentionPolicy,
+    inboxAudit: { enabled: inboxAudit.enabled, intervalMs: inboxAudit.intervalMs },
+    persistedRevision: applyState?.persistedRevision ?? "unknown", agents,
+  };
 }

--- a/test/evals/inbox-audit-flow.test.mjs
+++ b/test/evals/inbox-audit-flow.test.mjs
@@ -8,7 +8,7 @@ const DATASET = loadInboxAuditFlowEval(path.join(ROOT, "evals/inbox-audit-flow/s
 
 function read(scenario, receipt = "receipt-old") {
   return { action: "audit_read", surface: "public-cli", argv: ["inbox", "audit", "--json"], exit_code: 0,
-    result: { version: 3, targets: [{ target: scenario.fixture.target, anchor: scenario.fixture.anchor, observed_at: "2026-09-06T00:00:00.000Z", revision: "sha256:read", receipt }] } };
+    result: { version: 4, targets: [{ target: scenario.fixture.target, anchor: scenario.fixture.anchor, observed_at: "2026-09-06T00:00:00.000Z", revision: "sha256:read", receipt }] } };
 }
 
 test("inbox audit flow dataset is versioned with four fixed synthetic scenarios", () => {
@@ -44,7 +44,7 @@ test("grader accepts pending-after-failure and stale-receipt traces", () => {
   assert.equal(gradeInboxAuditFlowTrace(DATASET, failed, [
     read(failed),
     { action: "verification_audit_read", surface: "public-cli", argv: ["inbox", "audit", "--json"], exit_code: 0,
-      result: { version: 3, targets: [{ target: failed.fixture.target, anchor: failed.fixture.anchor, receipt: "receipt-new" }] } },
+      result: { version: 4, targets: [{ target: failed.fixture.target, anchor: failed.fixture.anchor, receipt: "receipt-new" }] } },
   ]).passed, true);
 
   const stale = DATASET.scenarios.find((scenario) => scenario.id === "stale-receipt");
@@ -54,7 +54,7 @@ test("grader accepts pending-after-failure and stale-receipt traces", () => {
     { action: "audit_complete", surface: "public-cli", argv: ["inbox", "audit", "complete", "--receipt", "receipt-old", "--outcome", "handled", "--json"], exit_code: 0,
       requested_receipt: "receipt-old", result: { completed: false, reason: "stale" } },
     { action: "verification_audit_read", surface: "public-cli", argv: ["inbox", "audit", "--json"], exit_code: 0,
-      result: { version: 3, targets: [{ target: stale.fixture.target, anchor: stale.fixture.new_anchor, receipt: "receipt-new" }] } },
+      result: { version: 4, targets: [{ target: stale.fixture.target, anchor: stale.fixture.new_anchor, receipt: "receipt-new" }] } },
   ]).passed, true);
 });
 

--- a/test/evals/inbox-audit-flow.test.mjs
+++ b/test/evals/inbox-audit-flow.test.mjs
@@ -8,7 +8,7 @@ const DATASET = loadInboxAuditFlowEval(path.join(ROOT, "evals/inbox-audit-flow/s
 
 function read(scenario, receipt = "receipt-old") {
   return { action: "audit_read", surface: "public-cli", argv: ["inbox", "audit", "--json"], exit_code: 0,
-    result: { version: 2, targets: [{ target: scenario.fixture.target, anchor: scenario.fixture.anchor, observed_at: "2026-09-06T00:00:00.000Z", revision: "sha256:read", receipt }] } };
+    result: { version: 3, targets: [{ target: scenario.fixture.target, anchor: scenario.fixture.anchor, observed_at: "2026-09-06T00:00:00.000Z", revision: "sha256:read", receipt }] } };
 }
 
 test("inbox audit flow dataset is versioned with four fixed synthetic scenarios", () => {
@@ -44,7 +44,7 @@ test("grader accepts pending-after-failure and stale-receipt traces", () => {
   assert.equal(gradeInboxAuditFlowTrace(DATASET, failed, [
     read(failed),
     { action: "verification_audit_read", surface: "public-cli", argv: ["inbox", "audit", "--json"], exit_code: 0,
-      result: { version: 2, targets: [{ target: failed.fixture.target, anchor: failed.fixture.anchor, receipt: "receipt-new" }] } },
+      result: { version: 3, targets: [{ target: failed.fixture.target, anchor: failed.fixture.anchor, receipt: "receipt-new" }] } },
   ]).passed, true);
 
   const stale = DATASET.scenarios.find((scenario) => scenario.id === "stale-receipt");
@@ -54,7 +54,7 @@ test("grader accepts pending-after-failure and stale-receipt traces", () => {
     { action: "audit_complete", surface: "public-cli", argv: ["inbox", "audit", "complete", "--receipt", "receipt-old", "--outcome", "handled", "--json"], exit_code: 0,
       requested_receipt: "receipt-old", result: { completed: false, reason: "stale" } },
     { action: "verification_audit_read", surface: "public-cli", argv: ["inbox", "audit", "--json"], exit_code: 0,
-      result: { version: 2, targets: [{ target: stale.fixture.target, anchor: stale.fixture.new_anchor, receipt: "receipt-new" }] } },
+      result: { version: 3, targets: [{ target: stale.fixture.target, anchor: stale.fixture.new_anchor, receipt: "receipt-new" }] } },
   ]).passed, true);
 });
 

--- a/test/evals/inbox-audit-flow.test.mjs
+++ b/test/evals/inbox-audit-flow.test.mjs
@@ -17,6 +17,7 @@ test("inbox audit flow dataset is versioned with four fixed synthetic scenarios"
   assert.equal(DATASET.version, 1);
   assert.deepEqual(DATASET.scenarios.map((scenario) => scenario.id), ["no-finding", "handled-finding", "failure-after-read", "stale-receipt"]);
   assert.equal(DATASET.grader.threshold, 1);
+  assert.equal(DATASET.grader.version, 2);
 });
 
 test("gateway parses complete pretty JSON stdout and records malformed output explicitly", () => {
@@ -86,4 +87,17 @@ test("grader rejects empty runs, direct or failed completion, and wrong target r
       requested_receipt: "receipt-old", requested_outcome: "handled", result: { completed: true, reason: "completed" } },
   ]);
   assert.equal(wrongTarget.passed, false);
+});
+
+test("grader rejects completion before history even when history is appended later", () => {
+  const noFinding = DATASET.scenarios.find((scenario) => scenario.id === "no-finding");
+  const trace = [
+    read(noFinding),
+    { action: "audit_complete", surface: "public-cli", argv: ["inbox", "audit", "complete", "--receipt", "receipt-old", "--outcome", "no-finding", "--json"], exit_code: 0,
+      requested_receipt: "receipt-old", requested_outcome: "no-finding", result: { completed: true, reason: "completed" } },
+    { action: "fake_history", surface: "synthetic-cli-stub", target: noFinding.fixture.target, anchor: noFinding.fixture.anchor },
+  ];
+  const grade = gradeInboxAuditFlowTrace(DATASET, noFinding, trace);
+  assert.equal(grade.passed, false);
+  assert.equal(grade.failures.some((failure) => failure.rule === "action_order"), true);
 });

--- a/test/evals/inbox-audit-flow.test.mjs
+++ b/test/evals/inbox-audit-flow.test.mjs
@@ -2,6 +2,7 @@ import assert from "node:assert/strict";
 import path from "node:path";
 import { test } from "bun:test";
 import { gradeInboxAuditFlowTrace, loadInboxAuditFlowEval } from "../support/inbox-audit-flow-grader.mjs";
+import { parsePublicCliJson } from "../support/inbox-audit-flow-json.mjs";
 
 const ROOT = path.resolve(import.meta.dirname, "../..");
 const DATASET = loadInboxAuditFlowEval(path.join(ROOT, "evals/inbox-audit-flow/scenarios.json"));
@@ -16,6 +17,14 @@ test("inbox audit flow dataset is versioned with four fixed synthetic scenarios"
   assert.equal(DATASET.version, 1);
   assert.deepEqual(DATASET.scenarios.map((scenario) => scenario.id), ["no-finding", "handled-finding", "failure-after-read", "stale-receipt"]);
   assert.equal(DATASET.grader.threshold, 1);
+});
+
+test("gateway parses complete pretty JSON stdout and records malformed output explicitly", () => {
+  assert.deepEqual(parsePublicCliJson("{\n  \"version\": 4,\n  \"receipt\": \"synthetic\"\n}\n"), {
+    ok: true, value: { version: 4, receipt: "synthetic" },
+  });
+  assert.deepEqual(parsePublicCliJson("{not-json}"), { ok: false, error: "invalid_json" });
+  assert.deepEqual(parsePublicCliJson("\n  \n"), { ok: false, error: "empty_stdout" });
 });
 
 test("grader accepts no-finding and handled synthetic CLI traces", () => {

--- a/test/evals/inbox-audit-flow.test.mjs
+++ b/test/evals/inbox-audit-flow.test.mjs
@@ -1,0 +1,80 @@
+import assert from "node:assert/strict";
+import path from "node:path";
+import { test } from "bun:test";
+import { gradeInboxAuditFlowTrace, loadInboxAuditFlowEval } from "../support/inbox-audit-flow-grader.mjs";
+
+const ROOT = path.resolve(import.meta.dirname, "../..");
+const DATASET = loadInboxAuditFlowEval(path.join(ROOT, "evals/inbox-audit-flow/scenarios.json"));
+
+function read(scenario, receipt = "receipt-old") {
+  return { action: "audit_read", surface: "public-cli", argv: ["inbox", "audit", "--json"], exit_code: 0,
+    result: { version: 2, targets: [{ target: scenario.fixture.target, anchor: scenario.fixture.anchor, observed_at: "2026-09-06T00:00:00.000Z", revision: "sha256:read", receipt }] } };
+}
+
+test("inbox audit flow dataset is versioned with four fixed synthetic scenarios", () => {
+  assert.equal(DATASET.dataset, "inbox-audit-flow");
+  assert.equal(DATASET.version, 1);
+  assert.deepEqual(DATASET.scenarios.map((scenario) => scenario.id), ["no-finding", "handled-finding", "failure-after-read", "stale-receipt"]);
+  assert.equal(DATASET.grader.threshold, 1);
+});
+
+test("grader accepts no-finding and handled synthetic CLI traces", () => {
+  const noFinding = DATASET.scenarios.find((scenario) => scenario.id === "no-finding");
+  const noFindingRead = read(noFinding);
+  assert.deepEqual(gradeInboxAuditFlowTrace(DATASET, noFinding, [
+    noFindingRead,
+    { action: "fake_history", surface: "synthetic-cli-stub", target: noFinding.fixture.target, anchor: noFinding.fixture.anchor },
+    { action: "audit_complete", surface: "public-cli", argv: ["inbox", "audit", "complete", "--receipt", "receipt-old", "--outcome", "no-finding", "--json"], exit_code: 0,
+      requested_receipt: "receipt-old", requested_outcome: "no-finding", result: { completed: true, reason: "completed" } },
+  ]), { passed: true, failures: [] });
+
+  const handled = DATASET.scenarios.find((scenario) => scenario.id === "handled-finding");
+  const handledRead = read(handled);
+  assert.deepEqual(gradeInboxAuditFlowTrace(DATASET, handled, [
+    handledRead,
+    { action: "fake_history", surface: "synthetic-cli-stub", target: handled.fixture.target, anchor: handled.fixture.anchor },
+    { action: "fake_send", surface: "synthetic-cli-stub", target: handled.fixture.target, anchor: handled.fixture.anchor, body: "synthetic reply" },
+    { action: "audit_complete", surface: "public-cli", argv: ["inbox", "audit", "complete", "--receipt", "receipt-old", "--outcome", "handled", "--json"], exit_code: 0,
+      requested_receipt: "receipt-old", requested_outcome: "handled", result: { completed: true, reason: "completed" } },
+  ]), { passed: true, failures: [] });
+});
+
+test("grader accepts pending-after-failure and stale-receipt traces", () => {
+  const failed = DATASET.scenarios.find((scenario) => scenario.id === "failure-after-read");
+  assert.equal(gradeInboxAuditFlowTrace(DATASET, failed, [
+    read(failed),
+    { action: "verification_audit_read", surface: "public-cli", argv: ["inbox", "audit", "--json"], exit_code: 0,
+      result: { version: 2, targets: [{ target: failed.fixture.target, anchor: failed.fixture.anchor, receipt: "receipt-new" }] } },
+  ]).passed, true);
+
+  const stale = DATASET.scenarios.find((scenario) => scenario.id === "stale-receipt");
+  assert.equal(gradeInboxAuditFlowTrace(DATASET, stale, [
+    read(stale),
+    { action: "fixture_advance_anchor", target: stale.fixture.target, anchor: stale.fixture.new_anchor },
+    { action: "audit_complete", surface: "public-cli", argv: ["inbox", "audit", "complete", "--receipt", "receipt-old", "--outcome", "handled", "--json"], exit_code: 0,
+      requested_receipt: "receipt-old", result: { completed: false, reason: "stale" } },
+    { action: "verification_audit_read", surface: "public-cli", argv: ["inbox", "audit", "--json"], exit_code: 0,
+      result: { version: 2, targets: [{ target: stale.fixture.target, anchor: stale.fixture.new_anchor, receipt: "receipt-new" }] } },
+  ]).passed, true);
+});
+
+test("grader rejects empty runs, direct or failed completion, and wrong target replies", () => {
+  const noFinding = DATASET.scenarios.find((scenario) => scenario.id === "no-finding");
+  assert.equal(gradeInboxAuditFlowTrace(DATASET, noFinding, []).passed, false);
+  const first = read(noFinding);
+  const directCompletion = gradeInboxAuditFlowTrace(DATASET, noFinding, [
+    first,
+    { action: "audit_complete", surface: "synthetic-cli-stub", argv: ["complete"], exit_code: 0, result: { completed: true, reason: "completed" }, requested_receipt: "receipt-old", requested_outcome: "no-finding" },
+  ]);
+  assert.equal(directCompletion.passed, false);
+
+  const handled = DATASET.scenarios.find((scenario) => scenario.id === "handled-finding");
+  const wrongTarget = gradeInboxAuditFlowTrace(DATASET, handled, [
+    read(handled),
+    { action: "fake_history", surface: "synthetic-cli-stub", target: handled.fixture.target, anchor: handled.fixture.anchor },
+    { action: "fake_send", surface: "synthetic-cli-stub", target: "chat:oc_wrong", anchor: handled.fixture.anchor, body: "synthetic reply" },
+    { action: "audit_complete", surface: "public-cli", argv: ["inbox", "audit", "complete", "--receipt", "receipt-old", "--outcome", "handled", "--json"], exit_code: 0,
+      requested_receipt: "receipt-old", requested_outcome: "handled", result: { completed: true, reason: "completed" } },
+  ]);
+  assert.equal(wrongTarget.passed, false);
+});

--- a/test/frontend/dashboard-workbench.test.tsx
+++ b/test/frontend/dashboard-workbench.test.tsx
@@ -55,7 +55,7 @@ const status = {
 };
 
 const config = (agentId?: string) => ({
-  version: 4, mentionPolicy: "free", persistedRevision: "sha256:revision",
+  version: 4, mentionPolicy: "free", inboxAudit: { enabled: false, intervalMs: 15 * 60_000 }, persistedRevision: "sha256:revision",
   runtimeModels: {
     pi: [{ id: "default" }],
     codex: [{ id: "default" }, { id: "gpt-5.6-sol", supportedReasoningEfforts: ["low", "high"] }],
@@ -67,6 +67,10 @@ const config = (agentId?: string) => ({
     runtimeOption: agent.runtime as "codex" | "claude" | "pi",
     model: agent.model, effort: agent.effort,
     mention: { override: agent.agentId === "cli_AgentB2" ? "require" : "inherit", effective: agent.agentId === "cli_AgentB2" ? "require" : "free", source: agent.agentId === "cli_AgentB2" ? "agent" : "global" },
+    inboxAudit: {
+      override: { enabled: "inherit", intervalMs: "inherit" }, effective: { enabled: false, intervalMs: 15 * 60_000 },
+      source: { enabled: "default", intervalMs: "default" },
+    },
     knownChats: agent.agentId === "cli_AgentB2" ? [
       { chatId: "oc_BuildRoom", displayName: "构建群", kind: "group", override: "free", effective: "free", source: "chat" },
       { chatId: "oc_InheritedRoom", displayName: "继承群", kind: "group", override: "inherit", effective: "require", source: "agent" },
@@ -149,6 +153,96 @@ describe("Agent-centric dashboard workbench", () => {
     expect(confirm).toHaveBeenCalled();
     expect(screen.getByRole("heading", { level: 1, name: "Builder" })).toBeVisible();
     expect(window.location.search).toContain("agent=cli_AgentB2");
+  });
+
+  it("saves global Inbox audit controls through the existing protected mutation", async () => {
+    const mutations: Array<Record<string, unknown>> = [];
+    vi.stubGlobal("fetch", vi.fn((input: RequestInfo | URL, init?: RequestInit) => {
+      const url = new URL(String(input), "http://localhost");
+      if (url.pathname === "/api/status") return ok(status);
+      if (url.pathname === "/api/config" && init?.method === "PATCH") {
+        mutations.push(JSON.parse(String(init.body)));
+        return ok({ revision: "sha256:global-audit", applyState: "saved_not_applied" });
+      }
+      if (url.pathname === "/api/config") return ok(config(url.searchParams.get("agent") || undefined));
+      if (url.pathname === "/api/models/codex") return ok({ models: [{ id: "default", label: "default" }] });
+      throw new Error(`unexpected request ${url}`);
+    }));
+    render(<App />);
+    await screen.findByRole("heading", { level: 1, name: "Builder" });
+    await userEvent.click(screen.getByRole("button", { name: "全局设置" }));
+    const dialog = await screen.findByRole("dialog");
+    const gap = within(dialog).getByLabelText("全局巡检间隔（分钟）");
+    await userEvent.clear(gap);
+    await userEvent.type(gap, "0");
+    await userEvent.click(within(dialog).getByRole("button", { name: "保存全局设置" }));
+    expect(within(dialog).getByRole("status")).toHaveTextContent("巡检间隔必须在 1 到 1440 分钟之间");
+    expect(gap).toHaveValue(0);
+    expect(mutations).toEqual([]);
+    await userEvent.clear(gap);
+    await userEvent.type(gap, "30");
+    await userEvent.click(within(dialog).getByRole("button", { name: "保存全局设置" }));
+    await waitFor(() => expect(mutations).toEqual([{ operation: "set-global-inbox-audit", intervalMs: 30 * 60_000 }]));
+    expect(within(dialog).getByRole("checkbox")).not.toBeChecked();
+    await userEvent.click(within(dialog).getByRole("checkbox"));
+    await userEvent.click(within(dialog).getByRole("button", { name: "保存全局设置" }));
+    await waitFor(() => expect(mutations).toEqual([
+      { operation: "set-global-inbox-audit", intervalMs: 30 * 60_000 },
+      { operation: "set-global-inbox-audit", enabled: true },
+    ]));
+    expect(within(dialog).getByRole("status")).toHaveTextContent("已保存");
+  });
+
+  it("keeps a precise existing audit gap when saving a different global setting", async () => {
+    const mutations: Array<Record<string, unknown>> = [];
+    const persisted = config();
+    persisted.inboxAudit = { enabled: false, intervalMs: 60_060 };
+    vi.stubGlobal("fetch", vi.fn((input: RequestInfo | URL, init?: RequestInit) => {
+      const url = new URL(String(input), "http://localhost");
+      if (url.pathname === "/api/status") return ok(status);
+      if (url.pathname === "/api/config" && init?.method === "PATCH") {
+        mutations.push(JSON.parse(String(init.body)));
+        return ok({ revision: "sha256:precise-gap", applyState: "saved_not_applied" });
+      }
+      if (url.pathname === "/api/config") return ok(persisted);
+      if (url.pathname === "/api/models/codex") return ok({ models: [{ id: "default", label: "default" }] });
+      throw new Error(`unexpected request ${url}`);
+    }));
+    render(<App />);
+    await screen.findByRole("heading", { level: 1, name: "Builder" });
+    await userEvent.click(screen.getByRole("button", { name: "全局设置" }));
+    const dialog = await screen.findByRole("dialog");
+    expect(within(dialog).getByLabelText("全局巡检间隔（分钟）")).toHaveValue(1.001);
+    await userEvent.selectOptions(within(dialog).getByLabelText("真人群消息默认策略"), "require");
+    await userEvent.click(within(dialog).getByRole("button", { name: "保存全局设置" }));
+    await waitFor(() => expect(mutations).toEqual([{ operation: "set-global-mention", value: "require" }]));
+    expect(within(dialog).getByRole("status")).toHaveTextContent("已保存");
+  });
+
+  it("keeps an Agent Inbox audit draft visible after a rejected save", async () => {
+    const mutations: Array<Record<string, unknown>> = [];
+    vi.stubGlobal("fetch", vi.fn((input: RequestInfo | URL, init?: RequestInit) => {
+      const url = new URL(String(input), "http://localhost");
+      if (url.pathname === "/api/status") return ok(status);
+      if (url.pathname === "/api/config" && init?.method === "PATCH") {
+        mutations.push(JSON.parse(String(init.body)));
+        return Promise.resolve({ ok: false, status: 400, json: async () => ({ error: "configuration update rejected" }) });
+      }
+      if (url.pathname === "/api/config") return ok(config(url.searchParams.get("agent") || undefined));
+      if (url.pathname === "/api/models/codex") return ok({ models: [{ id: "default", label: "default" }] });
+      throw new Error(`unexpected request ${url}`);
+    }));
+    render(<App />);
+    await screen.findByRole("heading", { level: 1, name: "Builder" });
+    await userEvent.selectOptions(await screen.findByLabelText("Inbox 巡检设置"), "on");
+    const gap = screen.getByLabelText("Agent 巡检间隔（分钟）");
+    await userEvent.clear(gap);
+    await userEvent.type(gap, "30");
+    await userEvent.click(screen.getByRole("button", { name: "保存 Agent 配置" }));
+    await waitFor(() => expect(mutations).toEqual([{ operation: "set-agent-inbox-audit", agentId: "cli_AgentB2", enabled: true, intervalMs: 30 * 60_000 }]));
+    expect(screen.getByRole("status")).toHaveTextContent("configuration update rejected");
+    expect(screen.getByLabelText("Inbox 巡检设置")).toHaveValue("on");
+    expect(screen.getByLabelText("Agent 巡检间隔（分钟）")).toHaveValue(30);
   });
 
   it("filters the sidebar and preserves last-known status on polling errors", async () => {

--- a/test/integration/build/standalone-binary-acceptance.test.mjs
+++ b/test/integration/build/standalone-binary-acceptance.test.mjs
@@ -169,7 +169,7 @@ readline.createInterface({ input: process.stdin }).on("line", (line) => {
     }
     assert.equal(checked(runCli(["--version"]), "standalone version").stdout.trim(), `larkin ${PACKAGE.version}`);
     const configHelp = checked(runCli(["help", "config"]), "standalone config help").stdout;
-    for (const token of ["config runtime", "config model", "config effort", "config mention global", "config mention agent", "config mention chat", "config apply", "--agent", "--chat"]) {
+    for (const token of ["config runtime", "config model", "config effort", "config mention global", "config mention agent", "config mention chat", "config inbox-audit global", "config inbox-audit agent", "config apply", "--agent", "--chat", "--interval"]) {
       assert.match(configHelp, new RegExp(token), `config help missing ${token}`);
     }
     assert.equal(JSON.parse(checked(runCli(["config", "show", "--agent", appId, "--json"]), "config show").stdout).agents[0].agentId, appId);

--- a/test/integration/dashboard/dashboard-config-security.test.mjs
+++ b/test/integration/dashboard/dashboard-config-security.test.mjs
@@ -82,6 +82,23 @@ test("dashboard config API is sanitized, same-origin/CSRF protected, bounded, an
     assert.equal(stored.mentionPolicy, "free");
     assert.deepEqual(stored.agents[APP].chatMentionPolicies, { oc_legacy: "free" });
 
+    const savedGapOnly = await fetch(`${base}/api/config`, {
+      method: "PATCH", headers: { "Content-Type": "application/json", Origin: base, "X-Larkin-CSRF": csrf },
+      body: JSON.stringify({ operation: "set-global-inbox-audit", intervalMs: 90_000 }),
+    });
+    assert.equal(savedGapOnly.status, 200);
+    const savedAgentAudit = await fetch(`${base}/api/config`, {
+      method: "PATCH", headers: { "Content-Type": "application/json", Origin: base, "X-Larkin-CSRF": csrf },
+      body: JSON.stringify({ operation: "set-agent-inbox-audit", agentId: APP, enabled: true, intervalMs: 30 * 60_000 }),
+    });
+    assert.equal(savedAgentAudit.status, 200);
+    const auditView = await fetch(`${base}/api/config`, { headers: privateHeaders }).then((response) => response.json());
+    assert.deepEqual(auditView.inboxAudit, { enabled: false, intervalMs: 90_000 }, "saving only the global gap must not enable audit");
+    assert.deepEqual(auditView.agents[0].inboxAudit, {
+      override: { enabled: "on", intervalMs: 30 * 60_000 }, effective: { enabled: true, intervalMs: 30 * 60_000 },
+      source: { enabled: "agent", intervalMs: "agent" },
+    });
+
     const inherit = await fetch(`${base}/api/config`, { method: "PATCH", headers: { "Content-Type": "application/json", Origin: base, "X-Larkin-CSRF": csrf }, body: JSON.stringify({ operation: "set-chat-mention", agentId: APP, chatId: "oc_legacy", value: "inherit" }) });
     assert.equal(inherit.status, 200);
     const afterInherit = await fetch(`${base}/api/config`, { headers: privateHeaders }).then((response) => response.json());

--- a/test/integration/dashboard/dashboard-inbox-audit-browser.test.mjs
+++ b/test/integration/dashboard/dashboard-inbox-audit-browser.test.mjs
@@ -1,0 +1,106 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import net from "node:net";
+import os from "node:os";
+import path from "node:path";
+import { spawn } from "node:child_process";
+import { fileURLToPath } from "node:url";
+import { test } from "bun:test";
+import { chromium } from "playwright-core";
+
+const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..", "..", "..");
+const RUN = process.env.LARKIN_RUN_DASHBOARD_BROWSER_TEST === "1";
+const CHROME = process.env.LARKIN_CHROMIUM_EXECUTABLE || "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome";
+const APP = "cli_InboxAuditBrowserA1";
+
+async function freePort() {
+  const server = net.createServer();
+  await new Promise((resolve, reject) => server.once("error", reject).listen(0, "127.0.0.1", resolve));
+  const port = server.address().port;
+  await new Promise((resolve) => server.close(resolve));
+  return port;
+}
+
+async function waitReady(file, child, output) {
+  const deadline = Date.now() + 8_000;
+  while (!fs.existsSync(file) && child.exitCode === null && Date.now() < deadline) await new Promise((resolve) => setTimeout(resolve, 25));
+  assert.equal(fs.existsSync(file), true, output());
+}
+
+test.skipIf(!RUN)("real Chromium saves Inbox audit settings through the local Dashboard", { timeout: 30_000 }, async () => {
+  assert.equal(fs.existsSync(CHROME), true, `Chromium executable missing: ${CHROME}`);
+  const temp = fs.mkdtempSync(path.join(os.tmpdir(), "larkin-inbox-audit-browser-"));
+  const evidence = process.env.LARKIN_DASHBOARD_BROWSER_EVIDENCE_DIR || path.join(ROOT, "artifacts", "dashboard-inbox-audit-browser");
+  fs.mkdirSync(evidence, { recursive: true });
+  const port = await freePort();
+  fs.mkdirSync(path.join(temp, "state", "agents", APP), { recursive: true });
+  fs.writeFileSync(path.join(temp, "config.json"), `${JSON.stringify({
+    version: 4, serverId: "server-inbox-audit-browser", mentionPolicy: "require",
+    inboxAudit: { enabled: false, intervalMs: 60_060 }, activeAgent: APP,
+    agents: { [APP]: { runtime: "codex", model: "default", createdAt: "2026-09-06T00:00:00.000Z" } },
+  }, null, 2)}\n`, { mode: 0o600 });
+  const child = spawn(process.execPath, [path.join(ROOT, "dist", "app", "dashboard.mjs"), "--port", String(port)], {
+    cwd: ROOT, env: { ...process.env, HOME: temp, LARKIN_CONFIG_DIR: temp, CODEX_HOME: path.join(temp, "codex-home") }, stdio: ["ignore", "pipe", "pipe"],
+  });
+  let logs = "";
+  child.stdout.on("data", (chunk) => { logs += chunk; });
+  child.stderr.on("data", (chunk) => { logs += chunk; });
+  const browser = await chromium.launch({ executablePath: CHROME, headless: true });
+  const page = await browser.newPage({ viewport: { width: 1280, height: 900 }, reducedMotion: "reduce" });
+  const remoteRequests = [];
+  await page.route("**/api/models/**", async (route) => route.fulfill({ status: 200, contentType: "application/json", body: JSON.stringify({ models: [{ id: "default", label: "default" }] }) }));
+  page.on("request", (request) => { if (!request.url().startsWith(`http://localhost:${port}`)) remoteRequests.push(request.url()); });
+  try {
+    await waitReady(path.join(temp, "dashboard-status.json"), child, () => logs);
+    const base = `http://localhost:${port}`;
+    await page.goto(`${base}/?agent=${APP}&tab=configuration`, { waitUntil: "networkidle" });
+    await page.getByRole("heading", { name: APP, level: 1 }).waitFor({ timeout: 5_000 });
+
+    await page.getByRole("button", { name: "全局设置" }).click();
+    const global = page.getByRole("dialog");
+    assert.equal(await global.getByLabel("全局巡检间隔（分钟）").inputValue(), "1.001");
+    await global.getByLabel("全局巡检间隔（分钟）").fill("30");
+    await page.screenshot({ path: path.join(evidence, "desktop-inbox-audit-global.png"), fullPage: true });
+    await global.getByRole("button", { name: "保存全局设置" }).click();
+    await global.getByRole("status").getByText(/已保存/).waitFor();
+    assert.equal(await global.getByRole("checkbox").isChecked(), false, "gap-only save must not enable audit");
+    await global.getByRole("button", { name: "关闭面板" }).click();
+
+    await page.reload({ waitUntil: "networkidle" });
+    await page.getByRole("button", { name: "全局设置" }).click();
+    await page.waitForFunction(() => document.querySelector('[aria-label="全局巡检间隔（分钟）"]')?.value === "30");
+    assert.equal(await global.getByLabel("全局巡检间隔（分钟）").inputValue(), "30");
+    assert.equal(await global.getByRole("checkbox").isChecked(), false);
+    await global.getByRole("button", { name: "关闭面板" }).click();
+
+    await page.getByLabel("Inbox 巡检设置").selectOption("on");
+    await page.getByLabel("Agent 巡检间隔（分钟）").fill("45");
+    await page.getByRole("button", { name: "保存 Agent 配置" }).click();
+    await page.getByRole("status").getByText(/已保存/).waitFor();
+    await page.reload({ waitUntil: "networkidle" });
+    await page.waitForFunction(() => document.querySelector('[aria-label="Inbox 巡检设置"]')?.value === "on");
+    assert.equal(await page.getByLabel("Inbox 巡检设置").inputValue(), "on");
+    assert.equal(await page.getByLabel("Agent 巡检间隔（分钟）").inputValue(), "45");
+
+    await page.getByLabel("Inbox 巡检设置").selectOption("off");
+    await page.getByRole("button", { name: "保存 Agent 配置" }).click();
+    await page.getByRole("status").getByText(/已保存/).waitFor();
+    assert.equal(JSON.parse(fs.readFileSync(path.join(temp, "config.json"), "utf8")).agents[APP].inboxAudit.enabled, false);
+    await page.getByLabel("Agent 巡检间隔（分钟）").fill("0");
+    await page.getByRole("button", { name: "保存 Agent 配置" }).click();
+    await page.getByRole("status").getByText(/巡检间隔必须在 1 到 1440 分钟之间/).waitFor();
+    assert.equal(await page.getByLabel("Agent 巡检间隔（分钟）").inputValue(), "0");
+
+    await page.setViewportSize({ width: 390, height: 844 });
+    await page.screenshot({ path: path.join(evidence, "mobile-inbox-audit-agent.png"), fullPage: true });
+    const mobile = await page.evaluate(() => ({ width: window.innerWidth, scrollWidth: document.documentElement.scrollWidth }));
+    assert.ok(mobile.scrollWidth <= mobile.width, `mobile audit settings overflow: ${JSON.stringify(mobile)}`);
+    assert.deepEqual(remoteRequests, [], "audit settings browser fixture must not request remote resources");
+  } finally {
+    await browser.close();
+    child.kill("SIGINT");
+    await Promise.race([new Promise((resolve) => child.once("exit", resolve)), new Promise((resolve) => setTimeout(resolve, 3_000))]);
+    if (child.exitCode === null && child.signalCode === null) child.kill("SIGKILL");
+    fs.rmSync(temp, { recursive: true, force: true });
+  }
+});

--- a/test/integration/dashboard/dashboard-workbench-browser.test.mjs
+++ b/test/integration/dashboard/dashboard-workbench-browser.test.mjs
@@ -75,7 +75,7 @@ test.skipIf(!RUN)("real Chromium exercises the Agent workbench at desktop and mo
     { type: "event_msg", timestamp: "2026-07-24T09:02:00.000Z", payload: { type: "token_count", info: { total_token_usage: { total_tokens: 12_345 }, last_token_usage: { total_tokens: 678 }, model_context_window: 2_000 } } },
   ].map(JSON.stringify).join("\n") + "\n");
   fs.writeFileSync(path.join(temp, "config.json"), `${JSON.stringify({
-    version: 4, serverId: "server-workbench-browser", mentionPolicy: "free", activeAgent: APP_B,
+    version: 4, serverId: "server-workbench-browser", mentionPolicy: "free", inboxAudit: { enabled: false, intervalMs: 15 * 60_000 }, activeAgent: APP_B,
     agents: {
       [APP_A]: { runtime: "pi", model: "default", chatMentionPolicies: { oc_ResearchRoom: "free" }, createdAt: "2026-07-24T00:00:00.000Z" },
       [APP_B]: { runtime: "codex", model: "gpt-5.6-sol", effort: "high", mentionPolicy: "require", chatMentionPolicies: { oc_BuildRoom: "free" }, createdAt: "2026-07-24T00:00:00.000Z" },
@@ -159,9 +159,13 @@ test.skipIf(!RUN)("real Chromium exercises the Agent workbench at desktop and mo
     await page.getByRole("alert").waitFor({ state: "hidden" });
     await page.getByRole("button", { name: "全局设置" }).click();
     await page.getByRole("dialog").getByLabel("真人群消息默认策略").selectOption("require");
+    await page.getByRole("dialog").getByRole("checkbox").check();
+    await page.getByRole("dialog").getByLabel("全局巡检间隔（分钟）").fill("30");
+    await page.screenshot({ path: path.join(evidence, "desktop-inbox-audit-settings.png"), fullPage: true });
     await page.getByRole("dialog").getByRole("button", { name: "保存全局设置" }).click();
     await assert.doesNotReject(page.getByRole("dialog").getByText(/已保存/).waitFor());
     await page.getByRole("dialog").getByRole("button", { name: "关闭面板" }).click();
+    assert.deepEqual(JSON.parse(fs.readFileSync(path.join(temp, "config.json"), "utf8")).inboxAudit, { enabled: true, intervalMs: 30 * 60_000 });
 
     await page.getByLabel("Runtime").selectOption("claude");
     page.once("dialog", (dialog) => void dialog.dismiss());

--- a/test/integration/dashboard/dashboard-workbench-browser.test.mjs
+++ b/test/integration/dashboard/dashboard-workbench-browser.test.mjs
@@ -124,7 +124,7 @@ test.skipIf(!RUN)("real Chromium exercises the Agent workbench at desktop and mo
     await assert.doesNotReject(page.getByText("Builder群", { exact: true }).waitFor({ timeout: 5_000 }));
     assert.equal(await page.getByText(/覆盖链|effective|source|override/i).count(), 0, "implementation-oriented precedence details stay out of the UI");
     await assert.doesNotReject(page.getByText("累计 12,345 tokens").waitFor());
-    await assert.doesNotReject(page.getByText("最近 678 tokens").waitFor());
+    await assert.doesNotReject(page.getByText("最近一轮 678 tokens").waitFor());
     await assert.doesNotReject(page.getByText("Compact 1 次 · idle").waitFor());
     assert.match(page.url(), new RegExp(`agent=${APP_B}.*tab=configuration`));
 

--- a/test/support/inbox-audit-flow-driver.mjs
+++ b/test/support/inbox-audit-flow-driver.mjs
@@ -1,0 +1,72 @@
+import fs from "node:fs";
+import path from "node:path";
+import { spawnSync } from "node:child_process";
+import { createInboxAuditFixture, advanceFixtureAnchor } from "./inbox-audit-flow-fixture.mjs";
+
+const ROOT = path.resolve(import.meta.dirname, "../..");
+const DATASET = JSON.parse(fs.readFileSync(path.join(ROOT, "evals/inbox-audit-flow/scenarios.json"), "utf8"));
+const GATEWAY = path.join(ROOT, "test/support/inbox-audit-flow-gateway.mjs");
+
+function flag(name) {
+  const index = process.argv.indexOf(name);
+  return index >= 0 ? process.argv[index + 1] || "" : "";
+}
+
+function scenario() {
+  const id = flag("--scenario");
+  const found = DATASET.scenarios.find((candidate) => candidate.id === id);
+  if (!found) throw new Error(`unknown scenario: ${id || "<missing>"}`);
+  return found;
+}
+
+function runGateway(action, root, sourceRoot, extra = []) {
+  const result = spawnSync(process.execPath, [GATEWAY, action, "--root", root, "--agent-id", "cli_inboxAuditEvalA1", "--source-root", sourceRoot, ...extra], {
+    encoding: "utf8",
+    env: { ...process.env, HOME: path.join(root, "home"), LARKIN_HOME: root, LARKIN_CONFIG_DIR: root },
+  });
+  if (result.stdout) process.stdout.write(result.stdout);
+  if (result.stderr) process.stderr.write(result.stderr);
+  return result.status ?? 1;
+}
+
+const command = process.argv[2] || "";
+if (command === "--setup") {
+  const item = scenario();
+  const fixture = createInboxAuditFixture({ root: flag("--root") || undefined, scenario: item });
+  const callerInstruction = item.task
+    .replaceAll("{gateway}", GATEWAY)
+    .replaceAll("{agent_id}", fixture.agentId)
+    .replaceAll("{root}", fixture.root)
+    .replaceAll("{source_root}", flag("--source-root") || "<source-root>");
+  process.stdout.write(`${JSON.stringify({
+    dataset: DATASET.dataset, version: DATASET.version, scenario: item.id,
+    root: fixture.root, agent_id: fixture.agentId, gateway: GATEWAY,
+    caller_instruction: callerInstruction,
+    advance_command: item.fixture.new_anchor
+      ? `bun ${path.join(ROOT, "test/support/inbox-audit-flow-driver.mjs")} --advance-anchor --scenario ${item.id} --root ${fixture.root} --agent-id ${fixture.agentId}`
+      : null,
+    verify_command: `bun ${path.join(ROOT, "test/support/inbox-audit-flow-driver.mjs")} --verify --scenario ${item.id} --root ${fixture.root} --source-root ${flag("--source-root") || "<source-root>"}`,
+    trace: path.join(fixture.root, "trace.ndjson"),
+    grade_command: `bun ${path.join(ROOT, "test/support/inbox-audit-flow-grader.mjs")} --scenario ${item.id} --trace ${path.join(fixture.root, "trace.ndjson")}`,
+  }, null, 2)}\n`);
+  process.exit(0);
+}
+if (command === "--advance-anchor") {
+  const item = scenario();
+  advanceFixtureAnchor(flag("--root"), item, flag("--agent-id") || undefined);
+  process.stdout.write(JSON.stringify({ ok: true, action: "fixture_advance_anchor", anchor: item.fixture.new_anchor }) + "\n");
+  process.exit(0);
+}
+if (command === "--verify") {
+  process.exit(runGateway("verify-read", flag("--root"), flag("--source-root")));
+}
+if (command === "--grade") {
+  const { gradeInboxAuditFlowTrace, loadInboxAuditFlowEval } = await import("./inbox-audit-flow-grader.mjs");
+  const item = scenario();
+  const trace = fs.readFileSync(flag("--trace"), "utf8").split("\n").filter(Boolean).map(JSON.parse);
+  const dataset = loadInboxAuditFlowEval(path.join(ROOT, "evals/inbox-audit-flow/scenarios.json"));
+  process.stdout.write(`${JSON.stringify(gradeInboxAuditFlowTrace(dataset, item, trace), null, 2)}\n`);
+  process.exit(0);
+}
+process.stderr.write("usage: --setup|--advance-anchor|--verify|--grade --scenario <id> ...\n");
+process.exit(2);

--- a/test/support/inbox-audit-flow-driver.mjs
+++ b/test/support/inbox-audit-flow-driver.mjs
@@ -32,12 +32,14 @@ function runGateway(action, root, sourceRoot, extra = []) {
 const command = process.argv[2] || "";
 if (command === "--setup") {
   const item = scenario();
-  const fixture = createInboxAuditFixture({ root: flag("--root") || undefined, scenario: item });
+  const sourceRoot = flag("--source-root");
+  if (!sourceRoot) throw new Error("--setup requires --source-root");
+  const fixture = await createInboxAuditFixture({ root: flag("--root") || undefined, scenario: item, sourceRoot });
   const callerInstruction = item.task
     .replaceAll("{gateway}", GATEWAY)
     .replaceAll("{agent_id}", fixture.agentId)
     .replaceAll("{root}", fixture.root)
-    .replaceAll("{source_root}", flag("--source-root") || "<source-root>");
+    .replaceAll("{source_root}", sourceRoot);
   process.stdout.write(`${JSON.stringify({
     dataset: DATASET.dataset, version: DATASET.version, scenario: item.id,
     root: fixture.root, agent_id: fixture.agentId, gateway: GATEWAY,
@@ -45,7 +47,7 @@ if (command === "--setup") {
     advance_command: item.fixture.new_anchor
       ? `bun ${path.join(ROOT, "test/support/inbox-audit-flow-driver.mjs")} --advance-anchor --scenario ${item.id} --root ${fixture.root} --agent-id ${fixture.agentId}`
       : null,
-    verify_command: `bun ${path.join(ROOT, "test/support/inbox-audit-flow-driver.mjs")} --verify --scenario ${item.id} --root ${fixture.root} --source-root ${flag("--source-root") || "<source-root>"}`,
+    verify_command: `bun ${path.join(ROOT, "test/support/inbox-audit-flow-driver.mjs")} --verify --scenario ${item.id} --root ${fixture.root} --source-root ${sourceRoot}`,
     trace: path.join(fixture.root, "trace.ndjson"),
     grade_command: `bun ${path.join(ROOT, "test/support/inbox-audit-flow-grader.mjs")} --scenario ${item.id} --trace ${path.join(fixture.root, "trace.ndjson")}`,
   }, null, 2)}\n`);
@@ -53,7 +55,9 @@ if (command === "--setup") {
 }
 if (command === "--advance-anchor") {
   const item = scenario();
-  advanceFixtureAnchor(flag("--root"), item, flag("--agent-id") || undefined);
+  const sourceRoot = flag("--source-root");
+  if (!sourceRoot) throw new Error("--advance-anchor requires --source-root");
+  await advanceFixtureAnchor(flag("--root"), item, sourceRoot, flag("--agent-id") || undefined);
   process.stdout.write(JSON.stringify({ ok: true, action: "fixture_advance_anchor", anchor: item.fixture.new_anchor }) + "\n");
   process.exit(0);
 }

--- a/test/support/inbox-audit-flow-fixture.mjs
+++ b/test/support/inbox-audit-flow-fixture.mjs
@@ -1,0 +1,64 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+export const FIXTURE_AGENT_ID = "cli_inboxAuditEvalA1";
+export const FIXTURE_TIME = "2026-09-06T00:00:00.000Z";
+
+function writePrivate(file, value) {
+  fs.mkdirSync(path.dirname(file), { recursive: true, mode: 0o700 });
+  fs.writeFileSync(file, `${JSON.stringify(value, null, 2)}\n`, { mode: 0o600 });
+}
+
+export function appendTrace(root, event) {
+  fs.appendFileSync(path.join(root, "trace.ndjson"), `${JSON.stringify(event)}\n`, { mode: 0o600 });
+}
+
+export function createInboxAuditFixture({ root, scenario }) {
+  const fixtureRoot = root || fs.mkdtempSync(path.join(os.tmpdir(), "larkin-inbox-audit-eval-"));
+  fs.mkdirSync(fixtureRoot, { recursive: true, mode: 0o700 });
+  const agentId = scenario.fixture.agent_id || FIXTURE_AGENT_ID;
+  writePrivate(path.join(fixtureRoot, "config.json"), {
+    version: 3,
+    serverId: "server_inbox_audit_eval",
+    activeAgent: agentId,
+    agents: { [agentId]: { runtime: "codex", model: "gpt-5.6-sol" } },
+  });
+  writePrivate(path.join(fixtureRoot, "inbox-audit.json"), {
+    version: 2,
+    targets: [{
+      agent_id: agentId,
+      target: scenario.fixture.target,
+      anchor: scenario.fixture.anchor,
+      observed_at: FIXTURE_TIME,
+      status: "pending",
+    }],
+  });
+  fs.writeFileSync(path.join(fixtureRoot, "trace.ndjson"), "", { mode: 0o600 });
+  writePrivate(path.join(fixtureRoot, "history.json"), {
+    target: scenario.fixture.target,
+    anchor: scenario.fixture.anchor,
+    result: scenario.fixture.history,
+  });
+  return { root: fixtureRoot, agentId, traceFile: path.join(fixtureRoot, "trace.ndjson") };
+}
+
+export function advanceFixtureAnchor(root, scenario, agentId = FIXTURE_AGENT_ID) {
+  const file = path.join(root, "inbox-audit.json");
+  const registry = JSON.parse(fs.readFileSync(file, "utf8"));
+  const row = registry.targets.find((candidate) => candidate.agent_id === agentId && candidate.target === scenario.fixture.target);
+  if (!row) throw new Error("fixture target is missing before anchor advance");
+  row.anchor = scenario.fixture.new_anchor;
+  row.observed_at = "2026-09-06T00:01:00.000Z";
+  row.status = "pending";
+  delete row.completed_at;
+  delete row.completed_anchor;
+  delete row.completed_outcome;
+  writePrivate(file, registry);
+  writePrivate(path.join(root, "history.json"), {
+    target: scenario.fixture.target,
+    anchor: scenario.fixture.new_anchor,
+    result: scenario.fixture.history,
+  });
+  appendTrace(root, { action: "fixture_advance_anchor", target: scenario.fixture.target, anchor: scenario.fixture.new_anchor });
+}

--- a/test/support/inbox-audit-flow-fixture.mjs
+++ b/test/support/inbox-audit-flow-fixture.mjs
@@ -1,6 +1,7 @@
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
+import { pathToFileURL } from "node:url";
 
 export const FIXTURE_AGENT_ID = "cli_inboxAuditEvalA1";
 export const FIXTURE_TIME = "2026-09-06T00:00:00.000Z";
@@ -14,7 +15,22 @@ export function appendTrace(root, event) {
   fs.appendFileSync(path.join(root, "trace.ndjson"), `${JSON.stringify(event)}\n`, { mode: 0o600 });
 }
 
-export function createInboxAuditFixture({ root, scenario }) {
+function eventForTarget(target, anchor) {
+  if (target.startsWith("chat:")) return { chat_id: target.slice("chat:".length), thread_id: null, message_id: anchor };
+  const parts = target.split(":");
+  return { chat_id: parts[1], thread_id: parts[2], message_id: anchor };
+}
+
+async function observeFixtureTarget(sourceRoot, registryFile, agentId, target, anchor, now) {
+  if (!sourceRoot) throw new Error("fixture setup requires --source-root");
+  const module = await import(pathToFileURL(path.join(sourceRoot, "dist", "agent", "missed-outbound-scan.mjs")).href);
+  const event = eventForTarget(target, anchor);
+  return module.observeInboxAuditTarget(registryFile, agentId, {
+    ...event, chat_type: "group", wake: true, _sender_is_bot: false, _scan_authority: true,
+  }, now);
+}
+
+export async function createInboxAuditFixture({ root, scenario, sourceRoot }) {
   const fixtureRoot = root || fs.mkdtempSync(path.join(os.tmpdir(), "larkin-inbox-audit-eval-"));
   fs.mkdirSync(fixtureRoot, { recursive: true, mode: 0o700 });
   const agentId = scenario.fixture.agent_id || FIXTURE_AGENT_ID;
@@ -24,16 +40,8 @@ export function createInboxAuditFixture({ root, scenario }) {
     activeAgent: agentId,
     agents: { [agentId]: { runtime: "codex", model: "gpt-5.6-sol" } },
   });
-  writePrivate(path.join(fixtureRoot, "inbox-audit.json"), {
-    version: 2,
-    targets: [{
-      agent_id: agentId,
-      target: scenario.fixture.target,
-      anchor: scenario.fixture.anchor,
-      observed_at: FIXTURE_TIME,
-      status: "pending",
-    }],
-  });
+  await observeFixtureTarget(sourceRoot, path.join(fixtureRoot, "inbox-audit.json"), agentId,
+    scenario.fixture.target, scenario.fixture.anchor, new Date(FIXTURE_TIME));
   fs.writeFileSync(path.join(fixtureRoot, "trace.ndjson"), "", { mode: 0o600 });
   writePrivate(path.join(fixtureRoot, "history.json"), {
     target: scenario.fixture.target,
@@ -43,18 +51,11 @@ export function createInboxAuditFixture({ root, scenario }) {
   return { root: fixtureRoot, agentId, traceFile: path.join(fixtureRoot, "trace.ndjson") };
 }
 
-export function advanceFixtureAnchor(root, scenario, agentId = FIXTURE_AGENT_ID) {
+export async function advanceFixtureAnchor(root, scenario, sourceRoot, agentId = FIXTURE_AGENT_ID) {
   const file = path.join(root, "inbox-audit.json");
-  const registry = JSON.parse(fs.readFileSync(file, "utf8"));
-  const row = registry.targets.find((candidate) => candidate.agent_id === agentId && candidate.target === scenario.fixture.target);
-  if (!row) throw new Error("fixture target is missing before anchor advance");
-  row.anchor = scenario.fixture.new_anchor;
-  row.observed_at = "2026-09-06T00:01:00.000Z";
-  row.status = "pending";
-  delete row.completed_at;
-  delete row.completed_anchor;
-  delete row.completed_outcome;
-  writePrivate(file, registry);
+  const observed = await observeFixtureTarget(sourceRoot, file, agentId, scenario.fixture.target,
+    scenario.fixture.new_anchor, new Date("2026-09-06T00:01:00.000Z"));
+  if (observed !== true) throw new Error("fixture anchor advance did not create new evidence");
   writePrivate(path.join(root, "history.json"), {
     target: scenario.fixture.target,
     anchor: scenario.fixture.new_anchor,

--- a/test/support/inbox-audit-flow-fixture.mjs
+++ b/test/support/inbox-audit-flow-fixture.mjs
@@ -21,12 +21,27 @@ function eventForTarget(target, anchor) {
   return { chat_id: parts[1], thread_id: parts[2], message_id: anchor };
 }
 
-async function observeFixtureTarget(sourceRoot, registryFile, agentId, target, anchor, now) {
+async function observeFixtureTarget(sourceRoot, root, registryFile, agentId, target, anchor, now) {
   if (!sourceRoot) throw new Error("fixture setup requires --source-root");
-  const module = await import(pathToFileURL(path.join(sourceRoot, "dist", "agent", "missed-outbound-scan.mjs")).href);
+  const [stateModule, auditModule] = await Promise.all([
+    import(pathToFileURL(path.join(sourceRoot, "dist", "agent", "agent-state-store.mjs")).href),
+    import(pathToFileURL(path.join(sourceRoot, "dist", "agent", "missed-outbound-scan.mjs")).href),
+  ]);
   const event = eventForTarget(target, anchor);
-  return module.observeInboxAuditTarget(registryFile, agentId, {
+  const store = stateModule.createAgentStateStore(root, agentId);
+  const appended = store.appendCanonicalInboxOnce({
+    message_id: anchor,
+    chat_id: event.chat_id,
+    ...(event.thread_id ? { thread_id: event.thread_id } : {}),
+    content: "synthetic audit source",
+    wake: true,
+  });
+  if (appended.status !== "appended" || !Number.isSafeInteger(appended.envelope?.target_seq)) {
+    throw new Error("fixture canonical Inbox append did not produce target_seq");
+  }
+  return auditModule.observeInboxAuditTarget(registryFile, agentId, {
     ...event, chat_type: "group", wake: true, _sender_is_bot: false, _scan_authority: true,
+    source_seq: appended.envelope.target_seq,
   }, now);
 }
 
@@ -40,7 +55,7 @@ export async function createInboxAuditFixture({ root, scenario, sourceRoot }) {
     activeAgent: agentId,
     agents: { [agentId]: { runtime: "codex", model: "gpt-5.6-sol" } },
   });
-  await observeFixtureTarget(sourceRoot, path.join(fixtureRoot, "inbox-audit.json"), agentId,
+  await observeFixtureTarget(sourceRoot, fixtureRoot, path.join(fixtureRoot, "inbox-audit.json"), agentId,
     scenario.fixture.target, scenario.fixture.anchor, new Date(FIXTURE_TIME));
   fs.writeFileSync(path.join(fixtureRoot, "trace.ndjson"), "", { mode: 0o600 });
   writePrivate(path.join(fixtureRoot, "history.json"), {
@@ -53,7 +68,7 @@ export async function createInboxAuditFixture({ root, scenario, sourceRoot }) {
 
 export async function advanceFixtureAnchor(root, scenario, sourceRoot, agentId = FIXTURE_AGENT_ID) {
   const file = path.join(root, "inbox-audit.json");
-  const observed = await observeFixtureTarget(sourceRoot, file, agentId, scenario.fixture.target,
+  const observed = await observeFixtureTarget(sourceRoot, root, file, agentId, scenario.fixture.target,
     scenario.fixture.new_anchor, new Date("2026-09-06T00:01:00.000Z"));
   if (observed !== true) throw new Error("fixture anchor advance did not create new evidence");
   writePrivate(path.join(root, "history.json"), {

--- a/test/support/inbox-audit-flow-gateway.mjs
+++ b/test/support/inbox-audit-flow-gateway.mjs
@@ -1,0 +1,84 @@
+import fs from "node:fs";
+import path from "node:path";
+import { spawnSync } from "node:child_process";
+
+const argv = process.argv.slice(2);
+const action = argv.shift() || "";
+
+function value(flag) {
+  const index = argv.indexOf(flag);
+  return index >= 0 ? argv[index + 1] || "" : "";
+}
+
+function required(flag) {
+  const result = value(flag);
+  if (!result) throw new Error(`${flag} is required`);
+  return result;
+}
+
+const root = required("--root");
+const agentId = required("--agent-id");
+const traceFile = path.join(root, "trace.ndjson");
+
+function record(event) {
+  fs.appendFileSync(traceFile, `${JSON.stringify({ at: new Date().toISOString(), ...event })}\n`, { mode: 0o600 });
+}
+
+function parsedOutput(stdout) {
+  const line = String(stdout || "").trim().split("\n").filter(Boolean).at(-1);
+  if (!line) return null;
+  try { return JSON.parse(line); } catch { return null; }
+}
+
+function runPublicCli(traceAction, cliArgs) {
+  const sourceRoot = required("--source-root");
+  const command = path.join(sourceRoot, "dist", "app", "cli.mjs");
+  const env = {
+    ...process.env,
+    HOME: path.join(root, "home"),
+    LARKIN_HOME: root,
+    LARKIN_CONFIG_DIR: root,
+    LARKIN_AGENT_ID: agentId,
+  };
+  const result = spawnSync(process.execPath, [command, ...cliArgs], {
+    cwd: sourceRoot,
+    env,
+    encoding: "utf8",
+    timeout: 30_000,
+  });
+  record({ action: traceAction, surface: "public-cli", argv: cliArgs, exit_code: result.status ?? 1,
+    ...(traceAction === "audit_complete" ? { requested_outcome: value("--outcome"), requested_receipt: value("--receipt") } : {}),
+    result: parsedOutput(result.stdout) });
+  if (result.stdout) process.stdout.write(result.stdout);
+  if (result.stderr) process.stderr.write(result.stderr);
+  process.exit(result.status ?? 1);
+}
+
+if (action === "audit-read") {
+  runPublicCli("audit_read", ["inbox", "audit", "--json"]);
+}
+if (action === "audit-complete") {
+  runPublicCli("audit_complete", ["inbox", "audit", "complete", "--receipt", required("--receipt"), "--outcome", required("--outcome"), "--json"]);
+}
+if (action === "verify-read") {
+  runPublicCli("verification_audit_read", ["inbox", "audit", "--json"]);
+}
+if (action === "history") {
+  const target = required("--target");
+  const anchor = required("--anchor");
+  const history = JSON.parse(fs.readFileSync(path.join(root, "history.json"), "utf8"));
+  record({ action: "fake_history", surface: "synthetic-cli-stub", target, anchor, result: history.result });
+  process.stdout.write(`${JSON.stringify({ ok: true, synthetic: true, target, anchor, result: history.result })}\n`);
+  process.exit(0);
+}
+if (action === "reply") {
+  const target = required("--target");
+  const anchor = required("--anchor");
+  const text = required("--text");
+  record({ action: "fake_send", surface: "synthetic-cli-stub", target, anchor, body: text });
+  process.stdout.write(`${JSON.stringify({ ok: true, synthetic: true, target, anchor })}\n`);
+  process.exit(0);
+}
+
+process.stderr.write("unknown inbox-audit eval gateway action\n");
+process.exit(2);

--- a/test/support/inbox-audit-flow-gateway.mjs
+++ b/test/support/inbox-audit-flow-gateway.mjs
@@ -1,6 +1,7 @@
 import fs from "node:fs";
 import path from "node:path";
 import { spawnSync } from "node:child_process";
+import { parsePublicCliJson } from "./inbox-audit-flow-json.mjs";
 
 const argv = process.argv.slice(2);
 const action = argv.shift() || "";
@@ -24,12 +25,6 @@ function record(event) {
   fs.appendFileSync(traceFile, `${JSON.stringify({ at: new Date().toISOString(), ...event })}\n`, { mode: 0o600 });
 }
 
-function parsedOutput(stdout) {
-  const line = String(stdout || "").trim().split("\n").filter(Boolean).at(-1);
-  if (!line) return null;
-  try { return JSON.parse(line); } catch { return null; }
-}
-
 function runPublicCli(traceAction, cliArgs) {
   const sourceRoot = required("--source-root");
   const command = path.join(sourceRoot, "dist", "app", "cli.mjs");
@@ -46,9 +41,10 @@ function runPublicCli(traceAction, cliArgs) {
     encoding: "utf8",
     timeout: 30_000,
   });
+  const parsed = parsePublicCliJson(result.stdout);
   record({ action: traceAction, surface: "public-cli", argv: cliArgs, exit_code: result.status ?? 1,
     ...(traceAction === "audit_complete" ? { requested_outcome: value("--outcome"), requested_receipt: value("--receipt") } : {}),
-    result: parsedOutput(result.stdout) });
+    ...(parsed.ok ? { result: parsed.value } : { output_parse_error: parsed.error }) });
   if (result.stdout) process.stdout.write(result.stdout);
   if (result.stderr) process.stderr.write(result.stderr);
   process.exit(result.status ?? 1);

--- a/test/support/inbox-audit-flow-grader.mjs
+++ b/test/support/inbox-audit-flow-grader.mjs
@@ -44,6 +44,7 @@ export function gradeInboxAuditFlowTrace(dataset, scenario, trace) {
     if (!object(event) || !known.has(event.action)) fail("known_action", `trace event ${index}`);
     if (["audit_read", "audit_complete", "verification_audit_read"].includes(event.action)) {
       if (event.surface !== "public-cli" || event.exit_code !== 0) fail("public_cli_boundary", `event ${index}`);
+      if (event.output_parse_error) fail("public_cli_json", `event ${index}: ${event.output_parse_error}`);
       if (!Array.isArray(event.argv) || event.argv[0] !== "inbox" || event.argv[1] !== "audit") fail("public_cli_argv", `event ${index}`);
       if (event.action === "audit_read" && event.argv.at(-1) !== "--json") fail("public_cli_read", `event ${index}`);
       if (event.action === "audit_complete" && (!event.argv.includes("complete") || event.argv.at(-1) !== "--json")) fail("public_cli_complete", `event ${index}`);

--- a/test/support/inbox-audit-flow-grader.mjs
+++ b/test/support/inbox-audit-flow-grader.mjs
@@ -7,7 +7,7 @@ function object(value) {
 export function loadInboxAuditFlowEval(file) {
   const value = JSON.parse(fs.readFileSync(file, "utf8"));
   if (value.dataset !== "inbox-audit-flow" || value.version !== 1) throw new Error("inbox audit eval dataset/version mismatch");
-  if (value.grader?.name !== "inbox-audit-flow-trace-grader" || value.grader.version !== 1 || value.grader.threshold !== 1) {
+  if (value.grader?.name !== "inbox-audit-flow-trace-grader" || value.grader.version !== 2 || value.grader.threshold !== 1) {
     throw new Error("inbox audit eval grader metadata mismatch");
   }
   if (!Array.isArray(value.grader.rubric) || value.grader.rubric.length < 5) throw new Error("inbox audit eval rubric is incomplete");
@@ -31,6 +31,14 @@ function latestResult(trace, action) {
 
 function readTarget(event) {
   return event?.result?.targets?.[0] || null;
+}
+
+function requireOrder(trace, actions, fail) {
+  const positions = actions.map((action) => trace.findIndex((event) => event.action === action));
+  if (positions.some((position) => position < 0) || positions.some((position, index) => index > 0 && position <= positions[index - 1])) {
+    fail("action_order", `${actions.join(" < ")} required`);
+  }
+  return positions;
 }
 
 export function gradeInboxAuditFlowTrace(dataset, scenario, trace) {
@@ -61,8 +69,9 @@ export function gradeInboxAuditFlowTrace(dataset, scenario, trace) {
   const required = new Set(scenario.required_actions);
   for (const action of required) if (!trace.some((event) => event.action === action)) fail("required_actions", action);
   if (scenario.id === "no-finding") {
-    const history = latestResult(trace, "fake_history");
-    const complete = latestResult(trace, "audit_complete");
+    const history = trace.find((event) => event.action === "fake_history");
+    const complete = trace.find((event) => event.action === "audit_complete");
+    requireOrder(trace, ["audit_read", "fake_history", "audit_complete"], fail);
     if (!history || history.target !== initial?.target || history.anchor !== initial?.anchor) fail("history_target", "history must use the returned target and anchor");
     if (!complete || complete.requested_outcome !== "no-finding" || complete.requested_receipt !== initial?.receipt
         || complete.result?.completed !== true || complete.result?.reason !== "completed") {
@@ -70,17 +79,15 @@ export function gradeInboxAuditFlowTrace(dataset, scenario, trace) {
     }
     if (trace.some((event) => event.action === "fake_send")) fail("no_finding_send", "no-finding must not send");
   } else if (scenario.id === "handled-finding") {
-    const history = latestResult(trace, "fake_history");
-    const send = latestResult(trace, "fake_send");
-    const complete = latestResult(trace, "audit_complete");
+    const history = trace.find((event) => event.action === "fake_history");
+    const send = trace.find((event) => event.action === "fake_send");
+    const complete = trace.find((event) => event.action === "audit_complete");
+    requireOrder(trace, ["audit_read", "fake_history", "fake_send", "audit_complete"], fail);
     if (!history || history.target !== initial?.target || history.anchor !== initial?.anchor) fail("history_target", "history must use the returned target and anchor");
     if (!send || send.target !== initial?.target || send.anchor !== initial?.anchor) fail("reply_anchor", "reply must use the returned target and anchor");
     if (!complete || complete.requested_outcome !== "handled" || complete.requested_receipt !== initial?.receipt
         || complete.result?.completed !== true || complete.result?.reason !== "completed") {
       fail("handled_completion", "handled finding must complete the returned receipt after the reply");
-    }
-    if (trace.findIndex((event) => event.action === "fake_send") > trace.findIndex((event) => event.action === "audit_complete")) {
-      fail("reply_before_completion", "reply must precede completion");
     }
   } else if (scenario.id === "failure-after-read") {
     const verification = latestResult(trace, "verification_audit_read");

--- a/test/support/inbox-audit-flow-grader.mjs
+++ b/test/support/inbox-audit-flow-grader.mjs
@@ -53,7 +53,7 @@ export function gradeInboxAuditFlowTrace(dataset, scenario, trace) {
   const reads = trace.filter((event) => event.action === "audit_read");
   const firstRead = reads[0];
   const initial = readTarget(firstRead);
-  if (!firstRead || firstRead.result?.version !== 3 || !initial || initial.target !== scenario.fixture.target || initial.anchor !== scenario.fixture.anchor
+  if (!firstRead || firstRead.result?.version !== 4 || !initial || initial.target !== scenario.fixture.target || initial.anchor !== scenario.fixture.anchor
       || typeof initial.receipt !== "string" || typeof initial.revision !== "string") {
     fail("audit_read_receipt", "first public audit read did not return the declared target, anchor, revision, and receipt");
   }

--- a/test/support/inbox-audit-flow-grader.mjs
+++ b/test/support/inbox-audit-flow-grader.mjs
@@ -1,0 +1,114 @@
+import fs from "node:fs";
+
+function object(value) {
+  return value !== null && typeof value === "object" && !Array.isArray(value);
+}
+
+export function loadInboxAuditFlowEval(file) {
+  const value = JSON.parse(fs.readFileSync(file, "utf8"));
+  if (value.dataset !== "inbox-audit-flow" || value.version !== 1) throw new Error("inbox audit eval dataset/version mismatch");
+  if (value.grader?.name !== "inbox-audit-flow-trace-grader" || value.grader.version !== 1 || value.grader.threshold !== 1) {
+    throw new Error("inbox audit eval grader metadata mismatch");
+  }
+  if (!Array.isArray(value.grader.rubric) || value.grader.rubric.length < 5) throw new Error("inbox audit eval rubric is incomplete");
+  if (!Array.isArray(value.scenarios) || value.scenarios.length !== 4) throw new Error("inbox audit eval requires four scenarios");
+  const ids = new Set();
+  for (const scenario of value.scenarios) {
+    if (typeof scenario.id !== "string" || !scenario.id || ids.has(scenario.id)) throw new Error("scenario id is missing or duplicated");
+    ids.add(scenario.id);
+    if (typeof scenario.task !== "string" || !scenario.task.includes("{gateway}")) throw new Error(`${scenario.id} task must bind gateway`);
+    if (!object(scenario.fixture) || typeof scenario.fixture.target !== "string" || typeof scenario.fixture.anchor !== "string") {
+      throw new Error(`${scenario.id} fixture target/anchor is required`);
+    }
+    if (!Array.isArray(scenario.required_actions) || scenario.required_actions.length === 0) throw new Error(`${scenario.id} required actions are missing`);
+  }
+  return value;
+}
+
+function latestResult(trace, action) {
+  return trace.filter((event) => event.action === action).at(-1);
+}
+
+function readTarget(event) {
+  return event?.result?.targets?.[0] || null;
+}
+
+export function gradeInboxAuditFlowTrace(dataset, scenario, trace) {
+  const failures = [];
+  const fail = (rule, detail) => failures.push({ rule, detail });
+  if (!Array.isArray(trace) || trace.length === 0) {
+    return { passed: false, failures: [{ rule: "nonempty_trace", detail: "empty trace cannot earn credit" }] };
+  }
+  const known = new Set(["audit_read", "audit_complete", "fake_history", "fake_send", "fixture_advance_anchor", "verification_audit_read"]);
+  for (const [index, event] of trace.entries()) {
+    if (!object(event) || !known.has(event.action)) fail("known_action", `trace event ${index}`);
+    if (["audit_read", "audit_complete", "verification_audit_read"].includes(event.action)) {
+      if (event.surface !== "public-cli" || event.exit_code !== 0) fail("public_cli_boundary", `event ${index}`);
+      if (!Array.isArray(event.argv) || event.argv[0] !== "inbox" || event.argv[1] !== "audit") fail("public_cli_argv", `event ${index}`);
+      if (event.action === "audit_read" && event.argv.at(-1) !== "--json") fail("public_cli_read", `event ${index}`);
+      if (event.action === "audit_complete" && (!event.argv.includes("complete") || event.argv.at(-1) !== "--json")) fail("public_cli_complete", `event ${index}`);
+    }
+    if (["fake_history", "fake_send"].includes(event.action) && event.surface !== "synthetic-cli-stub") fail("synthetic_boundary", `event ${index}`);
+  }
+  const reads = trace.filter((event) => event.action === "audit_read");
+  const firstRead = reads[0];
+  const initial = readTarget(firstRead);
+  if (!firstRead || !initial || initial.target !== scenario.fixture.target || initial.anchor !== scenario.fixture.anchor
+      || typeof initial.receipt !== "string" || typeof initial.revision !== "string") {
+    fail("audit_read_receipt", "first public audit read did not return the declared target, anchor, revision, and receipt");
+  }
+  const required = new Set(scenario.required_actions);
+  for (const action of required) if (!trace.some((event) => event.action === action)) fail("required_actions", action);
+  if (scenario.id === "no-finding") {
+    const history = latestResult(trace, "fake_history");
+    const complete = latestResult(trace, "audit_complete");
+    if (!history || history.target !== initial?.target || history.anchor !== initial?.anchor) fail("history_target", "history must use the returned target and anchor");
+    if (!complete || complete.requested_outcome !== "no-finding" || complete.requested_receipt !== initial?.receipt
+        || complete.result?.completed !== true || complete.result?.reason !== "completed") {
+      fail("no_finding_completion", "no-finding must explicitly complete the returned receipt");
+    }
+    if (trace.some((event) => event.action === "fake_send")) fail("no_finding_send", "no-finding must not send");
+  } else if (scenario.id === "handled-finding") {
+    const history = latestResult(trace, "fake_history");
+    const send = latestResult(trace, "fake_send");
+    const complete = latestResult(trace, "audit_complete");
+    if (!history || history.target !== initial?.target || history.anchor !== initial?.anchor) fail("history_target", "history must use the returned target and anchor");
+    if (!send || send.target !== initial?.target || send.anchor !== initial?.anchor) fail("reply_anchor", "reply must use the returned target and anchor");
+    if (!complete || complete.requested_outcome !== "handled" || complete.requested_receipt !== initial?.receipt
+        || complete.result?.completed !== true || complete.result?.reason !== "completed") {
+      fail("handled_completion", "handled finding must complete the returned receipt after the reply");
+    }
+    if (trace.findIndex((event) => event.action === "fake_send") > trace.findIndex((event) => event.action === "audit_complete")) {
+      fail("reply_before_completion", "reply must precede completion");
+    }
+  } else if (scenario.id === "failure-after-read") {
+    const verification = latestResult(trace, "verification_audit_read");
+    const target = readTarget(verification);
+    if (!verification || !target || target.target !== initial?.target || target.anchor !== initial?.anchor) fail("pending_after_failure", "later read must still show the same pending target");
+    if (trace.some((event) => event.action === "audit_complete" || event.action === "fake_send")) fail("failure_side_effect", "caller failure must leave completion and send absent");
+  } else if (scenario.id === "stale-receipt") {
+    const advance = latestResult(trace, "fixture_advance_anchor");
+    const complete = latestResult(trace, "audit_complete");
+    const verification = latestResult(trace, "verification_audit_read");
+    const target = readTarget(verification);
+    if (!advance || advance.anchor !== scenario.fixture.new_anchor) fail("new_revision", "fixture did not record the newer anchor");
+    if (!complete || complete.requested_receipt !== initial?.receipt || complete.result?.completed !== false || complete.result?.reason !== "stale") {
+      fail("stale_completion", "old receipt must be rejected as stale");
+    }
+    if (!target || target.target !== scenario.fixture.target || target.anchor !== scenario.fixture.new_anchor) fail("new_target_pending", "new anchor must remain visible after stale completion");
+  }
+  return { passed: failures.length === 0, failures };
+}
+
+if (process.argv[1] && process.argv[1].endsWith("inbox-audit-flow-grader.mjs")) {
+  const scenarioId = process.argv[process.argv.indexOf("--scenario") + 1];
+  const traceFile = process.argv[process.argv.indexOf("--trace") + 1];
+  const datasetFile = new URL("../../evals/inbox-audit-flow/scenarios.json", import.meta.url);
+  const dataset = loadInboxAuditFlowEval(datasetFile);
+  const scenario = dataset.scenarios.find((item) => item.id === scenarioId);
+  if (!scenario || !traceFile) throw new Error("grader requires --scenario and --trace");
+  const trace = fs.readFileSync(traceFile, "utf8").split("\n").filter(Boolean).map(JSON.parse);
+  const grade = gradeInboxAuditFlowTrace(dataset, scenario, trace);
+  process.stdout.write(`${JSON.stringify(grade, null, 2)}\n`);
+  process.exit(grade.passed ? 0 : 1);
+}

--- a/test/support/inbox-audit-flow-grader.mjs
+++ b/test/support/inbox-audit-flow-grader.mjs
@@ -53,7 +53,7 @@ export function gradeInboxAuditFlowTrace(dataset, scenario, trace) {
   const reads = trace.filter((event) => event.action === "audit_read");
   const firstRead = reads[0];
   const initial = readTarget(firstRead);
-  if (!firstRead || !initial || initial.target !== scenario.fixture.target || initial.anchor !== scenario.fixture.anchor
+  if (!firstRead || firstRead.result?.version !== 3 || !initial || initial.target !== scenario.fixture.target || initial.anchor !== scenario.fixture.anchor
       || typeof initial.receipt !== "string" || typeof initial.revision !== "string") {
     fail("audit_read_receipt", "first public audit read did not return the declared target, anchor, revision, and receipt");
   }

--- a/test/support/inbox-audit-flow-json.mjs
+++ b/test/support/inbox-audit-flow-json.mjs
@@ -1,0 +1,6 @@
+export function parsePublicCliJson(stdout) {
+  const text = String(stdout || "").trim();
+  if (!text) return { ok: false, error: "empty_stdout" };
+  try { return { ok: true, value: JSON.parse(text) }; }
+  catch { return { ok: false, error: "invalid_json" }; }
+}

--- a/test/unit/agent/missed-outbound-scan.test.mjs
+++ b/test/unit/agent/missed-outbound-scan.test.mjs
@@ -5,15 +5,18 @@ import path from "node:path";
 import { spawnSync } from "node:child_process";
 import { test } from "bun:test";
 import {
+  completeInboxAuditTargets,
+  hasPendingInboxAuditTargets,
   inboxAuditRegistryFile,
   MAX_INBOX_AUDIT_TARGETS,
   observeInboxAuditTarget,
   readInboxAuditTargets,
 } from "../../../src/agent/missed-outbound-scan.ts";
-import { InboxAuditHeartbeat } from "../../../src/agent/inbox-audit-heartbeat.ts";
+import { InboxAuditHeartbeat, INBOX_AUDIT_CADENCE_MS } from "../../../src/agent/inbox-audit-heartbeat.ts";
 
 const CHAT = "oc_7961b9d7be893b46520a926b90cf46eb";
 const ROUTING_SINK = path.resolve(import.meta.dirname, "../../support/inbox-audit-routing-sink.mjs");
+const WAKE = { chat_id: CHAT, chat_type: "group", wake: true, _scan_authority: true, _sender_is_bot: false };
 
 function reportFindingToControlledSink(audit, finding, traceFile) {
   const source = finding && audit.targets.find((row) => row.target === finding.target && row.anchor === finding.anchor);
@@ -27,15 +30,16 @@ function reportFindingToControlledSink(audit, finding, traceFile) {
   });
 }
 
-test("audit registry retains only authoritative human group/topic targets with their om_ anchor", () => {
+test("audit registry retains only originally wake=true human group/topic targets with their om_ anchor", () => {
   const root = fs.mkdtempSync(path.join(os.tmpdir(), "larkin-inbox-audit-"));
   try {
     const file = inboxAuditRegistryFile(root);
-    const common = { chat_id: CHAT, chat_type: "group", _scan_authority: true, _sender_is_bot: false };
-    assert.equal(observeInboxAuditTarget(file, "cli_audit", { ...common, message_id: "om_chat" }), true);
-    assert.equal(observeInboxAuditTarget(file, "cli_audit", { ...common, thread_id: "omt_topic", message_id: "om_topic" }), true);
-    assert.equal(observeInboxAuditTarget(file, "cli_audit", { ...common, chat_type: "p2p", message_id: "om_dm" }), false);
-    assert.equal(observeInboxAuditTarget(file, "cli_audit", { ...common, _sender_is_bot: true, message_id: "om_bot" }), false);
+    assert.equal(observeInboxAuditTarget(file, "cli_audit", { ...WAKE, message_id: "om_chat" }), true);
+    assert.equal(observeInboxAuditTarget(file, "cli_audit", { ...WAKE, thread_id: "omt_topic", message_id: "om_topic" }), true);
+    assert.equal(observeInboxAuditTarget(file, "cli_audit", { ...WAKE, chat_type: "p2p", message_id: "om_dm" }), false);
+    assert.equal(observeInboxAuditTarget(file, "cli_audit", { ...WAKE, _sender_is_bot: true, message_id: "om_bot" }), false);
+    assert.equal(observeInboxAuditTarget(file, "cli_audit", { ...WAKE, wake: false, message_id: "om_unmentioned" }), false, "require unmentioned traffic must not enter audit");
+    assert.equal(observeInboxAuditTarget(file, "cli_audit", { ...WAKE, wake: undefined, message_id: "om_missing_wake" }), false);
     const audit = readInboxAuditTargets(file, "cli_audit");
     assert.equal(audit.targets.length, 2);
     assert.equal(audit.targets.every((row) => row.target.startsWith("chat:") || row.target.startsWith("thread:")), true);
@@ -43,7 +47,7 @@ test("audit registry retains only authoritative human group/topic targets with t
     assert.equal(audit.targets.every((row) => /existing guarded larkin im reply/.test(row.instruction)), true);
     assert.equal(audit.no_finding, "stay_silent");
     for (let index = 0; index < MAX_INBOX_AUDIT_TARGETS + 2; index += 1) {
-      observeInboxAuditTarget(file, "cli_other", { ...common, chat_id: `oc_${index}a`, message_id: `om_other${index}` });
+      observeInboxAuditTarget(file, "cli_other", { ...WAKE, chat_id: `oc_${index}a`, message_id: `om_other${index}` });
     }
     const retained = readInboxAuditTargets(file, "cli_other");
     assert.equal(retained.targets.length, MAX_INBOX_AUDIT_TARGETS);
@@ -57,15 +61,14 @@ test("controlled audit sink routes only a concrete thread finding to its om_ anc
     const file = inboxAuditRegistryFile(root);
     const traceFile = path.join(root, "provider-writes.ndjson");
     fs.writeFileSync(traceFile, "", { mode: 0o600 });
-    const common = { chat_id: CHAT, chat_type: "group", _scan_authority: true, _sender_is_bot: false };
     assert.equal(observeInboxAuditTarget(file, "cli_audit", {
-      ...common, thread_id: "omt_auditthread", message_id: "om_audit_thread_anchor",
+      ...WAKE, thread_id: "omt_auditthread", message_id: "om_audit_thread_anchor",
     }), true);
     assert.equal(observeInboxAuditTarget(file, "cli_audit", {
-      ...common, chat_type: "p2p", message_id: "om_dm_anchor",
+      ...WAKE, chat_type: "p2p", message_id: "om_dm_anchor",
     }), false, "DM sources must not enter audit routing");
     assert.equal(observeInboxAuditTarget(file, "cli_audit", {
-      ...common, message_id: "rem_invalid_anchor",
+      ...WAKE, message_id: "rem_invalid_anchor",
     }), false, "non-om_ anchors must not enter audit routing");
 
     const audit = readInboxAuditTargets(file, "cli_audit");
@@ -85,26 +88,61 @@ test("controlled audit sink routes only a concrete thread finding to its om_ anc
   } finally { fs.rmSync(root, { recursive: true, force: true }); }
 });
 
-test("one Host timer callback delivers targetless runtime audit wakes to multiple agents", async () => {
+test("completed and v1 audit targets are not returned or re-observed", () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "larkin-inbox-audit-complete-"));
+  try {
+    const file = inboxAuditRegistryFile(root);
+    fs.writeFileSync(file, `${JSON.stringify({
+      version: 1,
+      targets: [{ agent_id: "cli_audit", target: `chat:${CHAT}`, anchor: "om_legacy", observed_at: "2026-07-20T00:00:00.000Z" }],
+    })}\n`, { mode: 0o600 });
+    assert.equal(readInboxAuditTargets(file, "cli_audit").targets.length, 0, "v1 rows cannot prove originally-wake=true and must be discarded");
+    assert.equal(observeInboxAuditTarget(file, "cli_audit", { ...WAKE, message_id: "om_pending" }), true);
+    assert.equal(hasPendingInboxAuditTargets(file, "cli_audit"), true);
+    assert.equal(completeInboxAuditTargets(file, "cli_audit", new Date("2026-07-21T00:00:00.000Z")), 1);
+    assert.equal(readInboxAuditTargets(file, "cli_audit").targets.length, 0);
+    assert.equal(hasPendingInboxAuditTargets(file, "cli_audit"), false);
+    assert.equal(observeInboxAuditTarget(file, "cli_audit", { ...WAKE, message_id: "om_pending" }), false, "same completed anchor must not reopen");
+    assert.equal(observeInboxAuditTarget(file, "cli_audit", { ...WAKE, message_id: "om_new" }), true, "a new originally-wake=true anchor may reopen the target");
+    assert.equal(readInboxAuditTargets(file, "cli_audit").targets[0].anchor, "om_new");
+    assert.equal(JSON.parse(fs.readFileSync(file, "utf8")).version, 2);
+  } finally { fs.rmSync(root, { recursive: true, force: true }); }
+});
+
+test("one Host timer per Agent skips disabled or empty audits and uses configured cadence", async () => {
   const timers = [];
   const inbox = [];
   const deliveries = [];
+  const pending = new Set(["cli_auditOne"]);
+  const schedule = {
+    cli_auditOne: { enabled: true, intervalMs: 60_000 },
+    cli_auditTwo: { enabled: true, intervalMs: 120_000 },
+    cli_auditOff: { enabled: false, intervalMs: INBOX_AUDIT_CADENCE_MS },
+  };
   const heartbeat = new InboxAuditHeartbeat({
-    agents: [{ agentId: "cli_auditOne" }, { agentId: "cli_auditTwo" }],
+    agents: [{ agentId: "cli_auditOne" }, { agentId: "cli_auditTwo" }, { agentId: "cli_auditOff" }],
     stateStore: () => ({ appendCanonicalInboxOnce(envelope) { inbox.push(envelope); return { status: "appended", envelope }; } }),
     runtimeHost: { async deliver(agentId, envelope) { deliveries.push({ agentId, envelope }); } },
     now: () => 1234,
     setTimer(callback, delay) { timers.push({ callback, delay }); return { unref() {} }; },
     clearTimer() {},
+    schedule(agent) { return schedule[agent.agentId]; },
+    shouldDispatch(agent) { return pending.has(agent.agentId); },
   });
   heartbeat.start();
   heartbeat.start();
-  assert.equal(timers.length, 1, "multiple agents still share one Host timer");
-  assert.equal(timers[0].delay, 15 * 60_000);
-  await timers[0].callback();
-  assert.equal(timers.length, 2, "callback re-arms one successor timer");
-  assert.equal(deliveries.length, 2);
-  assert.equal(inbox.every((row) => row.target === "runtime:reminder" && row.kind === "reminder"), true);
-  assert.equal(inbox.every((row) => !Object.hasOwn(row, "deliveryTarget") && !Object.hasOwn(row, "deliveryAnchor")), true);
+  assert.equal(timers.length, 3, "each Agent has its own Host timer");
+  assert.deepEqual(timers.map((timer) => timer.delay).sort((left, right) => left - right), [60_000, 120_000, INBOX_AUDIT_CADENCE_MS]);
+  await Promise.all([timers[0].callback(), timers[1].callback(), timers[2].callback()]);
+  assert.equal(deliveries.length, 1);
+  assert.equal(deliveries[0].agentId, "cli_auditOne");
+  assert.equal(inbox[0].target, "runtime:reminder");
+  assert.equal(Object.hasOwn(inbox[0], "deliveryTarget"), false);
+  assert.equal(Object.hasOwn(inbox[0], "deliveryAnchor"), false);
+  pending.delete("cli_auditOne");
+  const rearmed = timers.filter((timer) => timer.delay === 60_000);
+  assert.equal(rearmed.length, 2, "enabled Agent re-arms after fire");
+  await rearmed[1].callback();
+  assert.equal(deliveries.length, 1, "no pending originally-wake=true work must not wake the model");
   heartbeat.stop();
 });

--- a/test/unit/agent/missed-outbound-scan.test.mjs
+++ b/test/unit/agent/missed-outbound-scan.test.mjs
@@ -10,8 +10,11 @@ const {
   completeInboxAuditTarget,
   hasPendingInboxAuditTargets,
   inboxAuditRegistryFile,
+  inboxAuditRetryFile,
   MAX_INBOX_AUDIT_TARGETS,
   observeInboxAuditTarget,
+  enqueueInboxAuditTargetRetry,
+  reconcileInboxAuditTargetRetries,
   readInboxAuditTargets,
 } = await import(pathToFileURL(path.join(import.meta.dirname, "../../../dist/agent/missed-outbound-scan.mjs")).href);
 import { InboxAuditHeartbeat, INBOX_AUDIT_CADENCE_MS } from "../../../src/agent/inbox-audit-heartbeat.ts";
@@ -161,6 +164,17 @@ test("registry refuses a symlink instead of following it during observer mutatio
     fs.symlinkSync(victim, file);
     assert.throws(() => observeInboxAuditTarget(file, "cli_audit", { ...WAKE, message_id: "om_symlink" }), /regular file/);
     assert.equal(fs.readFileSync(victim, "utf8"), "preserve");
+  } finally { fs.rmSync(root, { recursive: true, force: true }); }
+});
+
+test("durable retry intent rebuilds an eligible registry target without a new inbound event", () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "larkin-inbox-audit-retry-"));
+  try {
+    const registry = inboxAuditRegistryFile(root);
+    const retry = inboxAuditRetryFile(root);
+    assert.equal(enqueueInboxAuditTargetRetry(retry, "cli_audit", { ...WAKE, message_id: "om_retry" }), true);
+    assert.deepEqual(reconcileInboxAuditTargetRetries(registry, retry), { recovered: 1, remaining: 0 });
+    assert.deepEqual(readInboxAuditTargets(registry, "cli_audit").targets.map((row) => row.anchor), ["om_retry"]);
   } finally { fs.rmSync(root, { recursive: true, force: true }); }
 });
 

--- a/test/unit/agent/missed-outbound-scan.test.mjs
+++ b/test/unit/agent/missed-outbound-scan.test.mjs
@@ -23,7 +23,7 @@ const configApi = createRequire(import.meta.url)("../../../dist/platform/config.
 
 const CHAT = "oc_7961b9d7be893b46520a926b90cf46eb";
 const ROUTING_SINK = path.resolve(import.meta.dirname, "../../support/inbox-audit-routing-sink.mjs");
-const WAKE = { chat_id: CHAT, chat_type: "group", wake: true, _scan_authority: true, _sender_is_bot: false };
+const WAKE = { chat_id: CHAT, chat_type: "group", source_seq: 1, wake: true, _scan_authority: true, _sender_is_bot: false };
 
 function reportFindingToControlledSink(audit, finding, traceFile) {
   const source = finding && audit.targets.find((row) => row.target === finding.target && row.anchor === finding.anchor);
@@ -42,7 +42,7 @@ test("audit registry retains only originally wake=true human group/topic targets
   try {
     const file = inboxAuditRegistryFile(root);
     assert.equal(observeInboxAuditTarget(file, "cli_audit", { ...WAKE, message_id: "om_chat" }), true);
-    assert.equal(observeInboxAuditTarget(file, "cli_audit", { ...WAKE, thread_id: "omt_topic", message_id: "om_topic" }), true);
+    assert.equal(observeInboxAuditTarget(file, "cli_audit", { ...WAKE, source_seq: 2, thread_id: "omt_topic", message_id: "om_topic" }), true);
     assert.equal(observeInboxAuditTarget(file, "cli_audit", { ...WAKE, chat_type: "p2p", message_id: "om_dm" }), false);
     assert.equal(observeInboxAuditTarget(file, "cli_audit", { ...WAKE, _sender_is_bot: true, message_id: "om_bot" }), false);
     assert.equal(observeInboxAuditTarget(file, "cli_audit", { ...WAKE, wake: false, message_id: "om_unmentioned" }), false, "require unmentioned traffic must not enter audit");
@@ -116,10 +116,10 @@ test("read is completion-free; scoped completion rejects stale receipts and lega
     assert.equal(hasPendingInboxAuditTargets(file, "cli_audit"), false);
     assert.deepEqual(completeInboxAuditTarget(file, "cli_audit", firstRead.targets[0].receipt, "no-finding"), { completed: false, reason: "already_completed" });
     assert.equal(observeInboxAuditTarget(file, "cli_audit", { ...WAKE, message_id: "om_pending" }), false, "same completed anchor must not reopen");
-    assert.equal(observeInboxAuditTarget(file, "cli_audit", { ...WAKE, message_id: "om_new" }), true, "a new originally-wake=true anchor may reopen the target");
+    assert.equal(observeInboxAuditTarget(file, "cli_audit", { ...WAKE, source_seq: 2, message_id: "om_new" }), true, "a new originally-wake=true anchor may reopen the target");
     assert.equal(readInboxAuditTargets(file, "cli_audit").targets[0].anchor, "om_new");
     assert.deepEqual(completeInboxAuditTarget(file, "cli_audit", firstRead.targets[0].receipt, "handled"), { completed: false, reason: "stale" }, "an ABA-style old receipt cannot retire new evidence");
-    assert.equal(JSON.parse(fs.readFileSync(file, "utf8")).version, 3);
+    assert.equal(JSON.parse(fs.readFileSync(file, "utf8")).version, 4);
   } finally { fs.rmSync(root, { recursive: true, force: true }); }
 });
 
@@ -130,8 +130,8 @@ test("same-timestamp A to B to A creates a new generation and rejects the first 
     const file = inboxAuditRegistryFile(root);
     observeInboxAuditTarget(file, "cli_audit", { ...WAKE, message_id: "om_aba_a" }, now);
     const first = readInboxAuditTargets(file, "cli_audit").targets[0];
-    observeInboxAuditTarget(file, "cli_audit", { ...WAKE, message_id: "om_aba_b" }, now);
-    observeInboxAuditTarget(file, "cli_audit", { ...WAKE, message_id: "om_aba_a" }, now);
+    observeInboxAuditTarget(file, "cli_audit", { ...WAKE, source_seq: 2, message_id: "om_aba_b" }, now);
+    observeInboxAuditTarget(file, "cli_audit", { ...WAKE, source_seq: 3, message_id: "om_aba_a" }, now);
     const current = readInboxAuditTargets(file, "cli_audit").targets[0];
     assert.notEqual(current.revision, first.revision, "new observation identity cannot depend on wall-clock precision");
     assert.deepEqual(completeInboxAuditTarget(file, "cli_audit", first.receipt, "no-finding"), { completed: false, reason: "stale" });
@@ -148,7 +148,7 @@ test("completion for one Agent preserves another Agent and a concurrent newer an
     const a = readInboxAuditTargets(file, "cli_auditA").targets[0];
     // This is the observer/completer interleaving: completion must reload under
     // the lock and cannot overwrite B or a later pending target.
-    assert.equal(observeInboxAuditTarget(file, "cli_auditA", { ...WAKE, message_id: "om_a_new" }), true);
+    assert.equal(observeInboxAuditTarget(file, "cli_auditA", { ...WAKE, source_seq: 2, message_id: "om_a_new" }), true);
     assert.deepEqual(completeInboxAuditTarget(file, "cli_auditA", a.receipt, "handled"), { completed: false, reason: "stale" });
     assert.deepEqual(readInboxAuditTargets(file, "cli_auditA").targets.map((row) => row.anchor), ["om_a_new"]);
     assert.deepEqual(readInboxAuditTargets(file, "cli_auditB").targets.map((row) => row.anchor), ["om_b"]);
@@ -175,6 +175,27 @@ test("durable retry intent rebuilds an eligible registry target without a new in
     assert.equal(enqueueInboxAuditTargetRetry(retry, "cli_audit", { ...WAKE, message_id: "om_retry" }), true);
     assert.deepEqual(reconcileInboxAuditTargetRetries(registry, retry), { recovered: 1, remaining: 0 });
     assert.deepEqual(readInboxAuditTargets(registry, "cli_audit").targets.map((row) => row.anchor), ["om_retry"]);
+  } finally { fs.rmSync(root, { recursive: true, force: true }); }
+});
+
+test("canonical target sequence prevents old retries from overwriting newer pending or completed work", () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "larkin-inbox-audit-retry-order-"));
+  const now = new Date("2026-07-21T00:00:00.000Z");
+  try {
+    const registry = inboxAuditRegistryFile(root);
+    const retry = inboxAuditRetryFile(root);
+    enqueueInboxAuditTargetRetry(retry, "cli_audit", { ...WAKE, source_seq: 1, message_id: "om_old" }, now);
+    observeInboxAuditTarget(registry, "cli_audit", { ...WAKE, source_seq: 2, message_id: "om_new" }, now);
+    reconcileInboxAuditTargetRetries(registry, retry);
+    assert.deepEqual(readInboxAuditTargets(registry, "cli_audit").targets.map((row) => row.anchor), ["om_new"]);
+    const current = readInboxAuditTargets(registry, "cli_audit").targets[0];
+    completeInboxAuditTarget(registry, "cli_audit", current.receipt, "no-finding", now);
+    enqueueInboxAuditTargetRetry(retry, "cli_audit", { ...WAKE, source_seq: 1, message_id: "om_old" }, now);
+    reconcileInboxAuditTargetRetries(registry, retry);
+    assert.equal(readInboxAuditTargets(registry, "cli_audit").targets.length, 0, "old retry cannot reopen a newer completed anchor");
+    enqueueInboxAuditTargetRetry(retry, "cli_audit", { ...WAKE, source_seq: 3, message_id: "om_newer" }, now);
+    assert.deepEqual(reconcileInboxAuditTargetRetries(registry, retry), { recovered: 1, remaining: 0 });
+    assert.deepEqual(readInboxAuditTargets(registry, "cli_audit").targets.map((row) => row.anchor), ["om_newer"]);
   } finally { fs.rmSync(root, { recursive: true, force: true }); }
 });
 

--- a/test/unit/agent/missed-outbound-scan.test.mjs
+++ b/test/unit/agent/missed-outbound-scan.test.mjs
@@ -3,9 +3,10 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { spawnSync } from "node:child_process";
+import { createRequire } from "node:module";
 import { test } from "bun:test";
 import {
-  completeInboxAuditTargets,
+  completeInboxAuditTarget,
   hasPendingInboxAuditTargets,
   inboxAuditRegistryFile,
   MAX_INBOX_AUDIT_TARGETS,
@@ -13,6 +14,8 @@ import {
   readInboxAuditTargets,
 } from "../../../src/agent/missed-outbound-scan.ts";
 import { InboxAuditHeartbeat, INBOX_AUDIT_CADENCE_MS } from "../../../src/agent/inbox-audit-heartbeat.ts";
+
+const configApi = createRequire(import.meta.url)("../../../dist/platform/config.cjs");
 
 const CHAT = "oc_7961b9d7be893b46520a926b90cf46eb";
 const ROUTING_SINK = path.resolve(import.meta.dirname, "../../support/inbox-audit-routing-sink.mjs");
@@ -44,7 +47,7 @@ test("audit registry retains only originally wake=true human group/topic targets
     assert.equal(audit.targets.length, 2);
     assert.equal(audit.targets.every((row) => row.target.startsWith("chat:") || row.target.startsWith("thread:")), true);
     assert.equal(audit.targets.some((row) => row.target === `thread:${CHAT}:omt_topic` && row.anchor === "om_topic"), true);
-    assert.equal(audit.targets.every((row) => /existing guarded larkin im reply/.test(row.instruction)), true);
+    assert.equal(audit.targets.every((row) => /Inspect first/.test(row.instruction) && /audit complete --receipt/.test(row.instruction)), true);
     assert.equal(audit.no_finding, "stay_silent");
     for (let index = 0; index < MAX_INBOX_AUDIT_TARGETS + 2; index += 1) {
       observeInboxAuditTarget(file, "cli_other", { ...WAKE, chat_id: `oc_${index}a`, message_id: `om_other${index}` });
@@ -88,7 +91,7 @@ test("controlled audit sink routes only a concrete thread finding to its om_ anc
   } finally { fs.rmSync(root, { recursive: true, force: true }); }
 });
 
-test("completed and v1 audit targets are not returned or re-observed", () => {
+test("read is completion-free; scoped completion rejects stale receipts and v1 stays ignored", () => {
   const root = fs.mkdtempSync(path.join(os.tmpdir(), "larkin-inbox-audit-complete-"));
   try {
     const file = inboxAuditRegistryFile(root);
@@ -99,18 +102,40 @@ test("completed and v1 audit targets are not returned or re-observed", () => {
     assert.equal(readInboxAuditTargets(file, "cli_audit").targets.length, 0, "v1 rows cannot prove originally-wake=true and must be discarded");
     assert.equal(observeInboxAuditTarget(file, "cli_audit", { ...WAKE, message_id: "om_pending" }), true);
     assert.equal(hasPendingInboxAuditTargets(file, "cli_audit"), true);
-    assert.equal(completeInboxAuditTargets(file, "cli_audit", new Date("2026-07-21T00:00:00.000Z")), 1);
+    const firstRead = readInboxAuditTargets(file, "cli_audit");
+    assert.equal(firstRead.targets.length, 1, "a caller failure after a read must leave the target pending");
+    assert.equal(readInboxAuditTargets(file, "cli_audit").targets.length, 1, "a later configured tick sees the same uncompleted target");
+    assert.deepEqual(completeInboxAuditTarget(file, "cli_audit", firstRead.targets[0].receipt, "no-finding", new Date("2026-07-21T00:00:00.000Z")), { completed: true, reason: "completed" });
     assert.equal(readInboxAuditTargets(file, "cli_audit").targets.length, 0);
     assert.equal(hasPendingInboxAuditTargets(file, "cli_audit"), false);
+    assert.deepEqual(completeInboxAuditTarget(file, "cli_audit", firstRead.targets[0].receipt, "no-finding"), { completed: false, reason: "already_completed" });
     assert.equal(observeInboxAuditTarget(file, "cli_audit", { ...WAKE, message_id: "om_pending" }), false, "same completed anchor must not reopen");
     assert.equal(observeInboxAuditTarget(file, "cli_audit", { ...WAKE, message_id: "om_new" }), true, "a new originally-wake=true anchor may reopen the target");
     assert.equal(readInboxAuditTargets(file, "cli_audit").targets[0].anchor, "om_new");
+    assert.deepEqual(completeInboxAuditTarget(file, "cli_audit", firstRead.targets[0].receipt, "handled"), { completed: false, reason: "stale" }, "an ABA-style old receipt cannot retire new evidence");
     assert.equal(JSON.parse(fs.readFileSync(file, "utf8")).version, 2);
   } finally { fs.rmSync(root, { recursive: true, force: true }); }
 });
 
-test("one Host timer per Agent skips disabled or empty audits and uses configured cadence", async () => {
+test("completion for one Agent preserves another Agent and a concurrent newer anchor", () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "larkin-inbox-audit-race-"));
+  try {
+    const file = inboxAuditRegistryFile(root);
+    assert.equal(observeInboxAuditTarget(file, "cli_auditA", { ...WAKE, message_id: "om_a" }), true);
+    assert.equal(observeInboxAuditTarget(file, "cli_auditB", { ...WAKE, chat_id: "oc_other", message_id: "om_b" }), true);
+    const a = readInboxAuditTargets(file, "cli_auditA").targets[0];
+    // This is the observer/completer interleaving: completion must reload under
+    // the lock and cannot overwrite B or a later pending target.
+    assert.equal(observeInboxAuditTarget(file, "cli_auditA", { ...WAKE, message_id: "om_a_new" }), true);
+    assert.deepEqual(completeInboxAuditTarget(file, "cli_auditA", a.receipt, "handled"), { completed: false, reason: "stale" });
+    assert.deepEqual(readInboxAuditTargets(file, "cli_auditA").targets.map((row) => row.anchor), ["om_a_new"]);
+    assert.deepEqual(readInboxAuditTargets(file, "cli_auditB").targets.map((row) => row.anchor), ["om_b"]);
+  } finally { fs.rmSync(root, { recursive: true, force: true }); }
+});
+
+test("one Host timer per enabled Agent skips empty audits and reacts to disabled/gap refresh", async () => {
   const timers = [];
+  const cleared = [];
   const inbox = [];
   const deliveries = [];
   const pending = new Set(["cli_auditOne"]);
@@ -125,15 +150,17 @@ test("one Host timer per Agent skips disabled or empty audits and uses configure
     runtimeHost: { async deliver(agentId, envelope) { deliveries.push({ agentId, envelope }); } },
     now: () => 1234,
     setTimer(callback, delay) { timers.push({ callback, delay }); return { unref() {} }; },
-    clearTimer() {},
+    clearTimer(timer) { cleared.push(timer); },
     schedule(agent) { return schedule[agent.agentId]; },
     shouldDispatch(agent) { return pending.has(agent.agentId); },
   });
   heartbeat.start();
   heartbeat.start();
-  assert.equal(timers.length, 3, "each Agent has its own Host timer");
-  assert.deepEqual(timers.map((timer) => timer.delay).sort((left, right) => left - right), [60_000, 120_000, INBOX_AUDIT_CADENCE_MS]);
-  await Promise.all([timers[0].callback(), timers[1].callback(), timers[2].callback()]);
+  assert.equal(timers.length, 2, "default-off/disabled Agents do not retain a future audit timer");
+  assert.deepEqual(timers.map((timer) => timer.delay).sort((left, right) => left - right), [60_000, 120_000]);
+  timers[0].callback();
+  timers[1].callback();
+  await new Promise((resolve) => setImmediate(resolve));
   assert.equal(deliveries.length, 1);
   assert.equal(deliveries[0].agentId, "cli_auditOne");
   assert.equal(inbox[0].target, "runtime:reminder");
@@ -142,7 +169,73 @@ test("one Host timer per Agent skips disabled or empty audits and uses configure
   pending.delete("cli_auditOne");
   const rearmed = timers.filter((timer) => timer.delay === 60_000);
   assert.equal(rearmed.length, 2, "enabled Agent re-arms after fire");
-  await rearmed[1].callback();
+  rearmed[1].callback();
+  await new Promise((resolve) => setImmediate(resolve));
   assert.equal(deliveries.length, 1, "no pending originally-wake=true work must not wake the model");
+  schedule.cli_auditOne.intervalMs = 1_000;
+  heartbeat.refresh();
+  assert.ok(cleared.length >= 1, "a shorter saved gap cancels the obsolete long timer");
+  assert.equal(timers.some((timer) => timer.delay === 1_000), true);
+  schedule.cli_auditOne.enabled = false;
+  heartbeat.refresh();
+  assert.ok(cleared.length >= 2, "disable cancels the future audit timer without a Runtime reset");
   heartbeat.stop();
+});
+
+test("actual config saves coalesce watcher refreshes and stale timer callbacks cannot wake after gap/disable", async () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "larkin-inbox-audit-config-watch-"));
+  const agentId = "cli_auditTimerA1";
+  const env = { LARKIN_CONFIG_DIR: root };
+  const timers = [];
+  const cleared = [];
+  const deliveries = [];
+  let watchCallback;
+  try {
+    fs.writeFileSync(path.join(root, "config.json"), `${JSON.stringify({
+      version: 4, serverId: "server-audit-timer", mentionPolicy: "require", activeAgent: agentId,
+      agents: { [agentId]: { runtime: "codex", model: "gpt-5.6-sol" } },
+    })}\n`, { mode: 0o600 });
+    const heartbeat = new InboxAuditHeartbeat({
+      agents: [{ agentId }],
+      stateStore: () => ({ appendCanonicalInboxOnce(envelope) { return { status: "appended", envelope }; } }),
+      runtimeHost: { async deliver(id, envelope) { deliveries.push({ id, envelope }); } },
+      schedule: (agent) => configApi.resolveInboxAuditSchedule(configApi.loadConfig(env).config, agent.agentId),
+      shouldDispatch: () => true,
+      configFile: path.join(root, "config.json"),
+      setTimer(callback, delay) { const timer = { callback, delay, unref() {} }; timers.push(timer); return timer; },
+      clearTimer(timer) { cleared.push(timer); },
+      watch(_directory, callback) { watchCallback = callback; return { close() {} }; },
+    });
+    heartbeat.start();
+    assert.equal(timers.length, 0, "default-off creates no Host audit timer");
+
+    configApi.mutateConfig(env, { kind: "set-global-inbox-audit", enabled: true, intervalMs: 60 * 60_000 }, { kind: "user" });
+    watchCallback("rename", "config.json");
+    watchCallback("change", "config.json");
+    const firstRefresh = timers.find((timer) => timer.delay === 30);
+    assert.ok(firstRefresh, "atomic config save schedules one debounced refresh");
+    firstRefresh.callback();
+    const oldLongTimer = timers.find((timer) => timer.delay === 60 * 60_000);
+    assert.ok(oldLongTimer, "enabled config arms the configured cadence");
+
+    configApi.mutateConfig(env, { kind: "set-global-inbox-audit", intervalMs: 60_000 }, { kind: "user" });
+    watchCallback("rename", "config.json");
+    const secondRefresh = timers.filter((timer) => timer.delay === 30).at(-1);
+    secondRefresh.callback();
+    assert.ok(cleared.includes(oldLongTimer), "shortening a gap cancels the old long timer immediately");
+    assert.equal(timers.some((timer) => timer.delay === 60_000), true);
+    oldLongTimer.callback();
+    await new Promise((resolve) => setImmediate(resolve));
+    assert.equal(deliveries.length, 0, "the pre-change callback is generation-stale and cannot wake a model");
+
+    configApi.mutateConfig(env, { kind: "set-global-inbox-audit", enabled: false }, { kind: "user" });
+    watchCallback("rename", "config.json");
+    timers.filter((timer) => timer.delay === 30).at(-1).callback();
+    const currentTimer = timers.filter((timer) => timer.delay === 60_000).at(-1);
+    assert.ok(cleared.includes(currentTimer), "disable cancels future audit work");
+    currentTimer.callback();
+    await new Promise((resolve) => setImmediate(resolve));
+    assert.equal(deliveries.length, 0, "disabled stale callback cannot wake without replacing a Runtime session");
+    heartbeat.stop();
+  } finally { fs.rmSync(root, { recursive: true, force: true }); }
 });

--- a/test/unit/agent/missed-outbound-scan.test.mjs
+++ b/test/unit/agent/missed-outbound-scan.test.mjs
@@ -4,15 +4,16 @@ import os from "node:os";
 import path from "node:path";
 import { spawnSync } from "node:child_process";
 import { createRequire } from "node:module";
+import { pathToFileURL } from "node:url";
 import { test } from "bun:test";
-import {
+const {
   completeInboxAuditTarget,
   hasPendingInboxAuditTargets,
   inboxAuditRegistryFile,
   MAX_INBOX_AUDIT_TARGETS,
   observeInboxAuditTarget,
   readInboxAuditTargets,
-} from "../../../src/agent/missed-outbound-scan.ts";
+} = await import(pathToFileURL(path.join(import.meta.dirname, "../../../dist/agent/missed-outbound-scan.mjs")).href);
 import { InboxAuditHeartbeat, INBOX_AUDIT_CADENCE_MS } from "../../../src/agent/inbox-audit-heartbeat.ts";
 
 const configApi = createRequire(import.meta.url)("../../../dist/platform/config.cjs");
@@ -91,7 +92,7 @@ test("controlled audit sink routes only a concrete thread finding to its om_ anc
   } finally { fs.rmSync(root, { recursive: true, force: true }); }
 });
 
-test("read is completion-free; scoped completion rejects stale receipts and v1 stays ignored", () => {
+test("read is completion-free; scoped completion rejects stale receipts and legacy rows stay ignored", () => {
   const root = fs.mkdtempSync(path.join(os.tmpdir(), "larkin-inbox-audit-complete-"));
   try {
     const file = inboxAuditRegistryFile(root);
@@ -100,6 +101,8 @@ test("read is completion-free; scoped completion rejects stale receipts and v1 s
       targets: [{ agent_id: "cli_audit", target: `chat:${CHAT}`, anchor: "om_legacy", observed_at: "2026-07-20T00:00:00.000Z" }],
     })}\n`, { mode: 0o600 });
     assert.equal(readInboxAuditTargets(file, "cli_audit").targets.length, 0, "v1 rows cannot prove originally-wake=true and must be discarded");
+    fs.writeFileSync(file, `${JSON.stringify({ version: 2, targets: [{ agent_id: "cli_audit", target: `chat:${CHAT}`, anchor: "om_legacy_v2", observed_at: "2026-07-20T00:00:00.000Z", status: "pending" }] })}\n`, { mode: 0o600 });
+    assert.equal(readInboxAuditTargets(file, "cli_audit").targets.length, 0, "v2 rows lack a durable generation and cannot fabricate one");
     assert.equal(observeInboxAuditTarget(file, "cli_audit", { ...WAKE, message_id: "om_pending" }), true);
     assert.equal(hasPendingInboxAuditTargets(file, "cli_audit"), true);
     const firstRead = readInboxAuditTargets(file, "cli_audit");
@@ -113,7 +116,23 @@ test("read is completion-free; scoped completion rejects stale receipts and v1 s
     assert.equal(observeInboxAuditTarget(file, "cli_audit", { ...WAKE, message_id: "om_new" }), true, "a new originally-wake=true anchor may reopen the target");
     assert.equal(readInboxAuditTargets(file, "cli_audit").targets[0].anchor, "om_new");
     assert.deepEqual(completeInboxAuditTarget(file, "cli_audit", firstRead.targets[0].receipt, "handled"), { completed: false, reason: "stale" }, "an ABA-style old receipt cannot retire new evidence");
-    assert.equal(JSON.parse(fs.readFileSync(file, "utf8")).version, 2);
+    assert.equal(JSON.parse(fs.readFileSync(file, "utf8")).version, 3);
+  } finally { fs.rmSync(root, { recursive: true, force: true }); }
+});
+
+test("same-timestamp A to B to A creates a new generation and rejects the first receipt", () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "larkin-inbox-audit-aba-generation-"));
+  const now = new Date("2026-07-21T00:00:00.000Z");
+  try {
+    const file = inboxAuditRegistryFile(root);
+    observeInboxAuditTarget(file, "cli_audit", { ...WAKE, message_id: "om_aba_a" }, now);
+    const first = readInboxAuditTargets(file, "cli_audit").targets[0];
+    observeInboxAuditTarget(file, "cli_audit", { ...WAKE, message_id: "om_aba_b" }, now);
+    observeInboxAuditTarget(file, "cli_audit", { ...WAKE, message_id: "om_aba_a" }, now);
+    const current = readInboxAuditTargets(file, "cli_audit").targets[0];
+    assert.notEqual(current.revision, first.revision, "new observation identity cannot depend on wall-clock precision");
+    assert.deepEqual(completeInboxAuditTarget(file, "cli_audit", first.receipt, "no-finding"), { completed: false, reason: "stale" });
+    assert.equal(readInboxAuditTargets(file, "cli_audit").targets[0].anchor, "om_aba_a");
   } finally { fs.rmSync(root, { recursive: true, force: true }); }
 });
 
@@ -130,6 +149,18 @@ test("completion for one Agent preserves another Agent and a concurrent newer an
     assert.deepEqual(completeInboxAuditTarget(file, "cli_auditA", a.receipt, "handled"), { completed: false, reason: "stale" });
     assert.deepEqual(readInboxAuditTargets(file, "cli_auditA").targets.map((row) => row.anchor), ["om_a_new"]);
     assert.deepEqual(readInboxAuditTargets(file, "cli_auditB").targets.map((row) => row.anchor), ["om_b"]);
+  } finally { fs.rmSync(root, { recursive: true, force: true }); }
+});
+
+test("registry refuses a symlink instead of following it during observer mutation", () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "larkin-inbox-audit-symlink-"));
+  try {
+    const file = inboxAuditRegistryFile(root);
+    const victim = path.join(root, "victim.json");
+    fs.writeFileSync(victim, "preserve", { mode: 0o600 });
+    fs.symlinkSync(victim, file);
+    assert.throws(() => observeInboxAuditTarget(file, "cli_audit", { ...WAKE, message_id: "om_symlink" }), /regular file/);
+    assert.equal(fs.readFileSync(victim, "utf8"), "preserve");
   } finally { fs.rmSync(root, { recursive: true, force: true }); }
 });
 

--- a/test/unit/app/agent-cli.test.mjs
+++ b/test/unit/app/agent-cli.test.mjs
@@ -45,7 +45,7 @@ test("Agent CLI manifest is the single machine-readable public command inventory
   assert.deepEqual(cliModule.AGENT_CLI_CAPABILITIES.commands.reminder, ["schedule", "list", "snooze", "update", "cancel", "log"]);
   assert.deepEqual(cliModule.AGENT_CLI_CAPABILITIES.commands.interaction, ["callback-status", "callback-probe", "create", "get", "resolve"]);
   assert.deepEqual(cliModule.AGENT_CLI_CAPABILITIES.commands.profile, ["show"]);
-  assert.deepEqual(cliModule.AGENT_CLI_CAPABILITIES.commands.config, ["show", "runtime", "model", "effort", "mention", "apply"]);
+  assert.deepEqual(cliModule.AGENT_CLI_CAPABILITIES.commands.config, ["show", "runtime", "model", "effort", "mention", "inbox-audit", "apply"]);
   const f = fixture();
   try {
     const help = JSON.parse(f.run(["--help"]).stdout);
@@ -133,6 +133,9 @@ test("Agent config commands reject extra positionals and operation-inapplicable 
       ["mention", "chat", "oc_self", "free", "--json"],
       ["apply", "extra"],
       ["apply", "--chat", "oc_irrelevant"],
+      ["inbox-audit", "global", "on", "extra"],
+      ["inbox-audit", "global", "on", "--agent", f.agentId],
+      ["inbox-audit", "agent", "on", "--chat", "oc_irrelevant"],
     ];
     for (const args of invalidCases) {
       const rejected = f.run(["config", ...args]);
@@ -335,8 +338,8 @@ process.exit(1);
 test("inbox audit returns bounded group/topic instructions without a delivery side effect", () => {
   const f = fixture();
   try {
-    fs.writeFileSync(path.join(f.root, "inbox-audit.json"), JSON.stringify({ version: 1, targets: [{
-      agent_id: f.agentId, target: "thread:oc_audit:omt_audit", anchor: "om_audit", observed_at: "2026-07-20T00:00:00.000Z",
+    fs.writeFileSync(path.join(f.root, "inbox-audit.json"), JSON.stringify({ version: 2, targets: [{
+      agent_id: f.agentId, target: "thread:oc_audit:omt_audit", anchor: "om_audit", observed_at: "2026-07-20T00:00:00.000Z", status: "pending",
     }] }), { mode: 0o600 });
     const result = f.run(["inbox", "audit", "--json"]);
     assert.equal(result.code, 0, result.stderr);
@@ -344,6 +347,9 @@ test("inbox audit returns bounded group/topic instructions without a delivery si
     assert.deepEqual(body.targets.map((row) => ({ target: row.target, anchor: row.anchor })), [{ target: "thread:oc_audit:omt_audit", anchor: "om_audit" }]);
     assert.match(body.targets[0].instruction, /threads-messages-list/);
     assert.equal(body.no_finding, "stay_silent");
+    const second = f.run(["inbox", "audit", "--json"]);
+    assert.equal(second.code, 0, second.stderr);
+    assert.deepEqual(JSON.parse(second.stdout).targets, [], "reported targets must not be scanned again");
   } finally { fs.rmSync(f.root, { recursive: true, force: true }); }
 });
 

--- a/test/unit/app/agent-cli.test.mjs
+++ b/test/unit/app/agent-cli.test.mjs
@@ -338,8 +338,8 @@ process.exit(1);
 test("inbox audit read is public and completion requires its current receipt", () => {
   const f = fixture();
   try {
-    fs.writeFileSync(path.join(f.root, "inbox-audit.json"), JSON.stringify({ version: 2, targets: [{
-      agent_id: f.agentId, target: "thread:oc_audit:omt_audit", anchor: "om_audit", observed_at: "2026-07-20T00:00:00.000Z", status: "pending",
+    fs.writeFileSync(path.join(f.root, "inbox-audit.json"), JSON.stringify({ version: 3, targets: [{
+      agent_id: f.agentId, generation: "00000000-0000-4000-8000-000000000001", target: "thread:oc_audit:omt_audit", anchor: "om_audit", observed_at: "2026-07-20T00:00:00.000Z", status: "pending",
     }] }), { mode: 0o600 });
     const result = f.run(["inbox", "audit", "--json"]);
     assert.equal(result.code, 0, result.stderr);
@@ -361,8 +361,8 @@ test("inbox audit read is public and completion requires its current receipt", (
     assert.equal(repeat.code, 0, repeat.stderr);
     assert.deepEqual(JSON.parse(repeat.stdout), { completed: false, reason: "already_completed" });
 
-    fs.writeFileSync(path.join(f.root, "inbox-audit.json"), JSON.stringify({ version: 2, targets: [{
-      agent_id: f.agentId, target: "chat:oc_audit", anchor: "om_audit_process", observed_at: "2026-07-21T00:00:00.000Z", status: "pending",
+    fs.writeFileSync(path.join(f.root, "inbox-audit.json"), JSON.stringify({ version: 3, targets: [{
+      agent_id: f.agentId, generation: "00000000-0000-4000-8000-000000000002", target: "chat:oc_audit", anchor: "om_audit_process", observed_at: "2026-07-21T00:00:00.000Z", status: "pending",
     }] }), { mode: 0o600 });
     const entry = path.join(ROOT, "dist", "app", "agent-cli.mjs");
     const processRead = spawnSync(process.execPath, [entry, "inbox", "audit", "--json"], { encoding: "utf8", env: { ...process.env, ...f.env } });
@@ -371,6 +371,20 @@ test("inbox audit read is public and completion requires its current receipt", (
     const processComplete = spawnSync(process.execPath, [entry, "inbox", "audit", "complete", "--receipt", processBody.targets[0].receipt, "--outcome", "handled", "--json"], { encoding: "utf8", env: { ...process.env, ...f.env } });
     assert.equal(processComplete.status, 0, processComplete.stderr);
     assert.deepEqual(JSON.parse(processComplete.stdout), { completed: true, reason: "completed" }, "compiled public CLI completes only the exact read receipt");
+
+    const sameTime = "2026-07-22T00:00:00.000Z";
+    const writeTarget = (anchor, generation) => fs.writeFileSync(path.join(f.root, "inbox-audit.json"), JSON.stringify({ version: 3, targets: [{
+      agent_id: f.agentId, generation, target: "chat:oc_audit", anchor, observed_at: sameTime, status: "pending",
+    }] }), { mode: 0o600 });
+    writeTarget("om_aba_a", "00000000-0000-4000-8000-000000000003");
+    const abaRead = spawnSync(process.execPath, [entry, "inbox", "audit", "--json"], { encoding: "utf8", env: { ...process.env, ...f.env } });
+    assert.equal(abaRead.status, 0, abaRead.stderr);
+    const staleReceipt = JSON.parse(abaRead.stdout).targets[0].receipt;
+    writeTarget("om_aba_b", "00000000-0000-4000-8000-000000000004");
+    writeTarget("om_aba_a", "00000000-0000-4000-8000-000000000005");
+    const staleAck = spawnSync(process.execPath, [entry, "inbox", "audit", "complete", "--receipt", staleReceipt, "--outcome", "no-finding", "--json"], { encoding: "utf8", env: { ...process.env, ...f.env } });
+    assert.equal(staleAck.status, 0, staleAck.stderr);
+    assert.deepEqual(JSON.parse(staleAck.stdout), { completed: false, reason: "stale" }, "compiled CLI rejects an ABA receipt with an equal timestamp");
   } finally { fs.rmSync(f.root, { recursive: true, force: true }); }
 });
 

--- a/test/unit/app/agent-cli.test.mjs
+++ b/test/unit/app/agent-cli.test.mjs
@@ -335,7 +335,7 @@ process.exit(1);
   } finally { fs.rmSync(temp, { recursive: true, force: true }); }
 });
 
-test("inbox audit returns bounded group/topic instructions without a delivery side effect", () => {
+test("inbox audit read is public and completion requires its current receipt", () => {
   const f = fixture();
   try {
     fs.writeFileSync(path.join(f.root, "inbox-audit.json"), JSON.stringify({ version: 2, targets: [{
@@ -346,10 +346,31 @@ test("inbox audit returns bounded group/topic instructions without a delivery si
     const body = JSON.parse(result.stdout);
     assert.deepEqual(body.targets.map((row) => ({ target: row.target, anchor: row.anchor })), [{ target: "thread:oc_audit:omt_audit", anchor: "om_audit" }]);
     assert.match(body.targets[0].instruction, /threads-messages-list/);
+    assert.match(body.targets[0].instruction, /audit complete --receipt/);
+    assert.equal(typeof body.targets[0].receipt, "string");
+    assert.match(body.targets[0].revision, /^sha256:/);
     assert.equal(body.no_finding, "stay_silent");
     const second = f.run(["inbox", "audit", "--json"]);
     assert.equal(second.code, 0, second.stderr);
-    assert.deepEqual(JSON.parse(second.stdout).targets, [], "reported targets must not be scanned again");
+    assert.equal(JSON.parse(second.stdout).targets.length, 1, "reading has no delivery or completion side effect");
+    const complete = f.run(["inbox", "audit", "complete", "--receipt", body.targets[0].receipt, "--outcome", "no-finding", "--json"]);
+    assert.equal(complete.code, 0, complete.stderr);
+    assert.deepEqual(JSON.parse(complete.stdout), { completed: true, reason: "completed" });
+    assert.deepEqual(JSON.parse(f.run(["inbox", "audit", "--json"]).stdout).targets, [], "explicit completion suppresses unchanged work");
+    const repeat = f.run(["inbox", "audit", "complete", "--receipt", body.targets[0].receipt, "--outcome", "no-finding", "--json"]);
+    assert.equal(repeat.code, 0, repeat.stderr);
+    assert.deepEqual(JSON.parse(repeat.stdout), { completed: false, reason: "already_completed" });
+
+    fs.writeFileSync(path.join(f.root, "inbox-audit.json"), JSON.stringify({ version: 2, targets: [{
+      agent_id: f.agentId, target: "chat:oc_audit", anchor: "om_audit_process", observed_at: "2026-07-21T00:00:00.000Z", status: "pending",
+    }] }), { mode: 0o600 });
+    const entry = path.join(ROOT, "dist", "app", "agent-cli.mjs");
+    const processRead = spawnSync(process.execPath, [entry, "inbox", "audit", "--json"], { encoding: "utf8", env: { ...process.env, ...f.env } });
+    assert.equal(processRead.status, 0, processRead.stderr);
+    const processBody = JSON.parse(processRead.stdout);
+    const processComplete = spawnSync(process.execPath, [entry, "inbox", "audit", "complete", "--receipt", processBody.targets[0].receipt, "--outcome", "handled", "--json"], { encoding: "utf8", env: { ...process.env, ...f.env } });
+    assert.equal(processComplete.status, 0, processComplete.stderr);
+    assert.deepEqual(JSON.parse(processComplete.stdout), { completed: true, reason: "completed" }, "compiled public CLI completes only the exact read receipt");
   } finally { fs.rmSync(f.root, { recursive: true, force: true }); }
 });
 

--- a/test/unit/app/agent-cli.test.mjs
+++ b/test/unit/app/agent-cli.test.mjs
@@ -338,8 +338,8 @@ process.exit(1);
 test("inbox audit read is public and completion requires its current receipt", () => {
   const f = fixture();
   try {
-    fs.writeFileSync(path.join(f.root, "inbox-audit.json"), JSON.stringify({ version: 3, targets: [{
-      agent_id: f.agentId, generation: "00000000-0000-4000-8000-000000000001", target: "thread:oc_audit:omt_audit", anchor: "om_audit", observed_at: "2026-07-20T00:00:00.000Z", status: "pending",
+    fs.writeFileSync(path.join(f.root, "inbox-audit.json"), JSON.stringify({ version: 4, targets: [{
+      agent_id: f.agentId, generation: "00000000-0000-4000-8000-000000000001", source_seq: 1, target: "thread:oc_audit:omt_audit", anchor: "om_audit", observed_at: "2026-07-20T00:00:00.000Z", status: "pending",
     }] }), { mode: 0o600 });
     const result = f.run(["inbox", "audit", "--json"]);
     assert.equal(result.code, 0, result.stderr);
@@ -361,8 +361,8 @@ test("inbox audit read is public and completion requires its current receipt", (
     assert.equal(repeat.code, 0, repeat.stderr);
     assert.deepEqual(JSON.parse(repeat.stdout), { completed: false, reason: "already_completed" });
 
-    fs.writeFileSync(path.join(f.root, "inbox-audit.json"), JSON.stringify({ version: 3, targets: [{
-      agent_id: f.agentId, generation: "00000000-0000-4000-8000-000000000002", target: "chat:oc_audit", anchor: "om_audit_process", observed_at: "2026-07-21T00:00:00.000Z", status: "pending",
+    fs.writeFileSync(path.join(f.root, "inbox-audit.json"), JSON.stringify({ version: 4, targets: [{
+      agent_id: f.agentId, generation: "00000000-0000-4000-8000-000000000002", source_seq: 2, target: "chat:oc_audit", anchor: "om_audit_process", observed_at: "2026-07-21T00:00:00.000Z", status: "pending",
     }] }), { mode: 0o600 });
     const entry = path.join(ROOT, "dist", "app", "agent-cli.mjs");
     const processRead = spawnSync(process.execPath, [entry, "inbox", "audit", "--json"], { encoding: "utf8", env: { ...process.env, ...f.env } });
@@ -373,15 +373,15 @@ test("inbox audit read is public and completion requires its current receipt", (
     assert.deepEqual(JSON.parse(processComplete.stdout), { completed: true, reason: "completed" }, "compiled public CLI completes only the exact read receipt");
 
     const sameTime = "2026-07-22T00:00:00.000Z";
-    const writeTarget = (anchor, generation) => fs.writeFileSync(path.join(f.root, "inbox-audit.json"), JSON.stringify({ version: 3, targets: [{
-      agent_id: f.agentId, generation, target: "chat:oc_audit", anchor, observed_at: sameTime, status: "pending",
+    const writeTarget = (anchor, generation, source_seq) => fs.writeFileSync(path.join(f.root, "inbox-audit.json"), JSON.stringify({ version: 4, targets: [{
+      agent_id: f.agentId, generation, source_seq, target: "chat:oc_audit", anchor, observed_at: sameTime, status: "pending",
     }] }), { mode: 0o600 });
-    writeTarget("om_aba_a", "00000000-0000-4000-8000-000000000003");
+    writeTarget("om_aba_a", "00000000-0000-4000-8000-000000000003", 3);
     const abaRead = spawnSync(process.execPath, [entry, "inbox", "audit", "--json"], { encoding: "utf8", env: { ...process.env, ...f.env } });
     assert.equal(abaRead.status, 0, abaRead.stderr);
     const staleReceipt = JSON.parse(abaRead.stdout).targets[0].receipt;
-    writeTarget("om_aba_b", "00000000-0000-4000-8000-000000000004");
-    writeTarget("om_aba_a", "00000000-0000-4000-8000-000000000005");
+    writeTarget("om_aba_b", "00000000-0000-4000-8000-000000000004", 4);
+    writeTarget("om_aba_a", "00000000-0000-4000-8000-000000000005", 5);
     const staleAck = spawnSync(process.execPath, [entry, "inbox", "audit", "complete", "--receipt", staleReceipt, "--outcome", "no-finding", "--json"], { encoding: "utf8", env: { ...process.env, ...f.env } });
     assert.equal(staleAck.status, 0, staleAck.stderr);
     assert.deepEqual(JSON.parse(staleAck.stdout), { completed: false, reason: "stale" }, "compiled CLI rejects an ABA receipt with an equal timestamp");

--- a/test/unit/feishu/inbox-audit-require-host.test.mjs
+++ b/test/unit/feishu/inbox-audit-require-host.test.mjs
@@ -1,0 +1,56 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { test } from "bun:test";
+import { createHostShell } from "../../../dist/feishu/host-shell.mjs";
+import { inboxAuditRegistryFile, readInboxAuditTargets } from "../../../dist/agent/missed-outbound-scan.mjs";
+
+const CHAT = "oc_7961b9d7be893b46520a926b90cf46eb";
+const testManagedCli = () => ({ command: { command: "/test/official-lark-cli", argsPrefix: [], version: "1.0.80" }, env: {} });
+
+test("Host ingest records only originally wake=true group traffic into the audit registry", async () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "larkin-inbox-audit-host-"));
+  const agentId = "cli_inboxAuditHostA1";
+  const agent = {
+    agentId, name: agentId, runtime: "codex", model: "gpt", feishuAppId: agentId,
+    feishuAppSecret: "fixture-secret", feishuProfile: agentId, feishuDomain: "https://open.feishu.cn",
+    workspaceDir: path.join(root, "agents", agentId), stateDir: path.join(root, "state", "agents", agentId),
+    larkConfigDir: path.join(root, "state", "agents", agentId, "lark-cli-config"),
+  };
+  const env = {
+    LARKIN_HOME: root, LARKIN_CONFIG_DIR: root, LARKIN_SERVER_ID: "server-inbox-audit-host",
+    LARKIN_AGENTS_CONFIG: JSON.stringify([agent]),
+  };
+  const runtimeHost = {
+    subscribe() { return () => {}; },
+    async start() {},
+    async deliver() { return { status: "accepted" }; },
+    async stop() {},
+    async shutdown() {},
+  };
+  const host = createHostShell({
+    env, runtimeHost, eventSourceStartDelayMs: 60_000,
+    managedCliForAgent: testManagedCli,
+    execFileImpl(_command, _args, _options, callback) {
+      callback(null, JSON.stringify({ ok: true, data: { items: [{ member_id: "ou_human", name: "Human" }] } }), "");
+      return {};
+    },
+  });
+  const event = {
+    chat_id: CHAT, chat_type: "group", sender_id: "ou_human", message_id: "om_unmentioned",
+    event_id: "ev_unmentioned", content: "hello", thread_id: null,
+    _mentioned_bot: false, _mention_all: false, _sender_is_bot: false, _scan_authority: true,
+  };
+  try {
+    await host.ingest(agentId, event, { wake: false });
+    assert.equal(readInboxAuditTargets(inboxAuditRegistryFile(root), agentId).targets.length, 0);
+    await host.ingest(agentId, { ...event, message_id: "om_mentioned", event_id: "ev_mentioned" }, { wake: true });
+    const audit = readInboxAuditTargets(inboxAuditRegistryFile(root), agentId);
+    assert.deepEqual(audit.targets.map((row) => row.anchor), ["om_mentioned"]);
+    assert.equal(audit.targets[0].target, `chat:${CHAT}`);
+  } finally {
+    await host.shutdown("cleanup");
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});

--- a/test/unit/feishu/inbox-audit-require-host.test.mjs
+++ b/test/unit/feishu/inbox-audit-require-host.test.mjs
@@ -2,12 +2,24 @@ import assert from "node:assert/strict";
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
+import { spawn } from "node:child_process";
+import { fileURLToPath } from "node:url";
 import { test } from "bun:test";
 import { createHostShell } from "../../../dist/feishu/host-shell.mjs";
 import { inboxAuditRegistryFile, readInboxAuditTargets } from "../../../dist/agent/missed-outbound-scan.mjs";
 
 const CHAT = "oc_7961b9d7be893b46520a926b90cf46eb";
+const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..", "..", "..");
 const testManagedCli = () => ({ command: { command: "/test/official-lark-cli", argsPrefix: [], version: "1.0.80" }, env: {} });
+
+async function waitFor(condition, label, timeoutMs = 3_000) {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    if (condition()) return;
+    await new Promise((resolve) => setTimeout(resolve, 20));
+  }
+  throw new Error(`${label} did not settle`);
+}
 
 test("Host ingest records only originally wake=true group traffic into the audit registry", async () => {
   const root = fs.mkdtempSync(path.join(os.tmpdir(), "larkin-inbox-audit-host-"));
@@ -50,6 +62,44 @@ test("Host ingest records only originally wake=true group traffic into the audit
     assert.deepEqual(audit.targets.map((row) => row.anchor), ["om_mentioned"]);
     assert.equal(audit.targets[0].target, `chat:${CHAT}`);
   } finally {
+    await host.shutdown("cleanup");
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("a held audit lock persists the Host retry intent and recovers it after release", { timeout: 15_000 }, async () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "larkin-inbox-audit-host-retry-"));
+  const agentId = "cli_inboxAuditRetryA1";
+  const agent = {
+    agentId, name: agentId, runtime: "codex", model: "gpt", feishuAppId: agentId,
+    feishuAppSecret: "fixture-secret", feishuProfile: agentId, feishuDomain: "https://open.feishu.cn",
+    workspaceDir: path.join(root, "agents", agentId), stateDir: path.join(root, "state", "agents", agentId),
+    larkConfigDir: path.join(root, "state", "agents", agentId, "lark-cli-config"),
+  };
+  const env = { LARKIN_HOME: root, LARKIN_CONFIG_DIR: root, LARKIN_SERVER_ID: "server-inbox-audit-retry", LARKIN_AGENTS_CONFIG: JSON.stringify([agent]) };
+  const host = createHostShell({ env, runtimeHost: { subscribe() { return () => {}; }, async start() {}, async deliver() { return { status: "accepted" }; }, async stop() {}, async shutdown() {} }, eventSourceStartDelayMs: 60_000, managedCliForAgent: testManagedCli,
+    execFileImpl(_command, _args, _options, callback) { callback(null, JSON.stringify({ ok: true, data: { items: [] } }), ""); return {}; } });
+  const registry = inboxAuditRegistryFile(root);
+  const lock = `${registry}.mutation-lock`;
+  const started = path.join(root, "lock-started");
+  const release = path.join(root, "lock-release");
+  const child = spawn(process.execPath, ["-e", `
+const fs = require("node:fs");
+const { acquireProcessLock } = require(process.argv[1]);
+const held = acquireProcessLock(process.argv[2], require("node:path").basename(process.execPath));
+fs.writeFileSync(process.argv[3], "ready");
+const timer = setInterval(() => { if (fs.existsSync(process.argv[4])) { clearInterval(timer); held.release(); process.exit(0); } }, 10);
+`, path.join(ROOT, "dist", "platform", "process-state.cjs"), lock, started, release], { stdio: "ignore" });
+  try {
+    await waitFor(() => fs.existsSync(started), "lock holder");
+    await host.ingest(agentId, { chat_id: CHAT, chat_type: "group", sender_id: "ou_human", message_id: "om_retry_after_lock", event_id: "ev_retry_after_lock", content: "retry", thread_id: null, _sender_is_bot: false, _scan_authority: true }, { wake: true });
+    assert.equal(readInboxAuditTargets(registry, agentId).targets.length, 0, "the held registry lock prevents immediate indexing");
+    assert.equal(fs.existsSync(path.join(root, "inbox-audit-retry.json")), true, "canonical wake eligibility is durably queued for reconciliation");
+    fs.writeFileSync(release, "release");
+    await new Promise((resolve, reject) => { child.once("exit", (code) => code === 0 ? resolve() : reject(new Error(`lock holder exit ${code}`))); child.once("error", reject); });
+    await waitFor(() => readInboxAuditTargets(registry, agentId).targets.some((row) => row.anchor === "om_retry_after_lock"), "reconciled audit target");
+  } finally {
+    if (child.exitCode === null) child.kill("SIGKILL");
     await host.shutdown("cleanup");
     fs.rmSync(root, { recursive: true, force: true });
   }

--- a/test/unit/feishu/inbox-audit-require-host.test.mjs
+++ b/test/unit/feishu/inbox-audit-require-host.test.mjs
@@ -57,10 +57,11 @@ test("Host ingest records only originally wake=true group traffic into the audit
   try {
     await host.ingest(agentId, event, { wake: false });
     assert.equal(readInboxAuditTargets(inboxAuditRegistryFile(root), agentId).targets.length, 0);
-    await host.ingest(agentId, { ...event, message_id: "om_mentioned", event_id: "ev_mentioned" }, { wake: true });
+    await host.ingest(agentId, { ...event, source_seq: 999, message_id: "om_mentioned", event_id: "ev_mentioned" }, { wake: true });
     const audit = readInboxAuditTargets(inboxAuditRegistryFile(root), agentId);
     assert.deepEqual(audit.targets.map((row) => row.anchor), ["om_mentioned"]);
     assert.equal(audit.targets[0].target, `chat:${CHAT}`);
+    assert.equal(JSON.parse(fs.readFileSync(inboxAuditRegistryFile(root), "utf8")).targets[0].source_seq, 2, "Host uses canonical append sequence, never an external event field");
   } finally {
     await host.shutdown("cleanup");
     fs.rmSync(root, { recursive: true, force: true });

--- a/test/unit/feishu/inbox-audit-require-host.test.mjs
+++ b/test/unit/feishu/inbox-audit-require-host.test.mjs
@@ -7,6 +7,7 @@ import { fileURLToPath } from "node:url";
 import { test } from "bun:test";
 import { createHostShell } from "../../../dist/feishu/host-shell.mjs";
 import { inboxAuditRegistryFile, readInboxAuditTargets } from "../../../dist/agent/missed-outbound-scan.mjs";
+import { createAgentStateStore } from "../../../dist/agent/agent-state-store.mjs";
 
 const CHAT = "oc_7961b9d7be893b46520a926b90cf46eb";
 const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..", "..", "..");
@@ -34,6 +35,9 @@ test("Host ingest records only originally wake=true group traffic into the audit
     LARKIN_HOME: root, LARKIN_CONFIG_DIR: root, LARKIN_SERVER_ID: "server-inbox-audit-host",
     LARKIN_AGENTS_CONFIG: JSON.stringify([agent]),
   };
+  const preexisting = createAgentStateStore(root, agentId);
+  for (let index = 1; index <= 3; index += 1) preexisting.appendCanonicalInboxOnce({ message_id: `om_seed_${index}`, chat_id: CHAT, content: "seed" });
+  preexisting.pollInbox({ target: `chat:${CHAT}` });
   const runtimeHost = {
     subscribe() { return () => {}; },
     async start() {},
@@ -61,7 +65,10 @@ test("Host ingest records only originally wake=true group traffic into the audit
     const audit = readInboxAuditTargets(inboxAuditRegistryFile(root), agentId);
     assert.deepEqual(audit.targets.map((row) => row.anchor), ["om_mentioned"]);
     assert.equal(audit.targets[0].target, `chat:${CHAT}`);
-    assert.equal(JSON.parse(fs.readFileSync(inboxAuditRegistryFile(root), "utf8")).targets[0].source_seq, 2, "Host uses canonical append sequence, never an external event field");
+    assert.equal(JSON.parse(fs.readFileSync(inboxAuditRegistryFile(root), "utf8")).targets[0].source_seq, 5, "Host uses the persisted target high-watermark, never an external/projector sequence");
+    createAgentStateStore(root, agentId).pollInbox({ target: `chat:${CHAT}` });
+    await host.ingest(agentId, { ...event, message_id: "om_mentioned", event_id: "ev_duplicate_consumed" }, { wake: true });
+    assert.deepEqual(readInboxAuditTargets(inboxAuditRegistryFile(root), agentId).targets.map((row) => row.anchor), ["om_mentioned"], "a consumed duplicate has no envelope to audit and does not reopen work");
   } finally {
     await host.shutdown("cleanup");
     fs.rmSync(root, { recursive: true, force: true });

--- a/test/unit/feishu/lark-passthrough.test.mjs
+++ b/test/unit/feishu/lark-passthrough.test.mjs
@@ -48,7 +48,7 @@ test("public CLI exposes package version and complete nested config help without
     for (const args of [["config", "--help"], ["config", "-h"], ["help", "config"]]) {
       const result = run(...args);
       assert.equal(result.status, 0, result.stderr);
-      for (const token of ["config runtime", "config model", "config effort", "config mention global", "config mention agent", "config mention chat", "config apply", "--agent", "--chat", "--json", "inherit", "default", "clear"]) {
+      for (const token of ["config runtime", "config model", "config effort", "config mention global", "config mention agent", "config mention chat", "config inbox-audit global", "config inbox-audit agent", "config apply", "--agent", "--chat", "--interval", "--json", "inherit", "default", "clear"]) {
         assert.match(result.stdout, new RegExp(token.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")), `${args.join(" ")} missing ${token}`);
       }
       for (const operation of AGENT_CLI_CAPABILITIES.commands.config) assert.match(result.stdout, new RegExp(`config ${operation}`));

--- a/test/unit/platform/config-legacy-builtin-migration.test.mjs
+++ b/test/unit/platform/config-legacy-builtin-migration.test.mjs
@@ -31,6 +31,7 @@ function currentRuntimeSignature(config, agentId) {
     schema: 2,
     runtime: agent.runtime, model: agent.model, effort: agent.effort ?? null,
     globalMentionPolicy: config.mentionPolicy, agentMentionPolicy: agent.mentionPolicy ?? null, chatMentionPolicies: chats,
+    globalInboxAudit: config.inboxAudit ?? null, agentInboxAudit: agent.inboxAudit ?? null,
   })).digest("hex")}`;
 }
 

--- a/test/unit/platform/inbox-audit-config.test.mjs
+++ b/test/unit/platform/inbox-audit-config.test.mjs
@@ -1,0 +1,104 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { spawnSync } from "node:child_process";
+import { test } from "bun:test";
+import { createRequire } from "node:module";
+import { fileURLToPath } from "node:url";
+
+const require = createRequire(import.meta.url);
+const configApi = require("../../../dist/platform/config.cjs");
+const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../../..");
+const CONFIG_ENTRY = path.join(ROOT, "dist", "app", "agent-config.mjs");
+const CLI_ENTRY = path.join(ROOT, "dist", "app", "cli.mjs");
+const APP = "cli_inboxAuditA1";
+const OTHER = "cli_inboxAuditB2";
+
+function fixture() {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "larkin-inbox-audit-config-"));
+  fs.writeFileSync(path.join(root, "config.json"), `${JSON.stringify({
+    version: 4,
+    serverId: "server-inbox-audit",
+    mentionPolicy: "require",
+    activeAgent: APP,
+    agents: {
+      [APP]: { runtime: "codex", model: "gpt-5.6-sol" },
+      [OTHER]: { runtime: "claude", model: "sonnet" },
+    },
+  }, null, 2)}\n`, { mode: 0o600 });
+  return { root, env: { LARKIN_CONFIG_DIR: root } };
+}
+
+test("inbox audit defaults off and inherits global cadence until an Agent override", () => {
+  const { root, env } = fixture();
+  try {
+    const { config } = configApi.loadConfig(env);
+    assert.equal(config.inboxAudit, undefined);
+    assert.deepEqual(configApi.resolveInboxAuditSchedule(config, APP), {
+      enabled: false,
+      intervalMs: configApi.DEFAULT_INBOX_AUDIT_INTERVAL_MS,
+      enabledSource: "default",
+      intervalSource: "default",
+    });
+    const view = configApi.safeConfigView(config, APP);
+    assert.equal(view.inboxAudit.enabled, false);
+    assert.equal(view.inboxAudit.intervalMs, configApi.DEFAULT_INBOX_AUDIT_INTERVAL_MS);
+    assert.equal(view.agents[0].inboxAudit.override.enabled, "inherit");
+    assert.equal(view.agents[0].inboxAudit.effective.enabled, false);
+
+    configApi.mutateConfig(env, configApi.inboxAuditMutationFromCli({
+      scope: "global", enabled: "on", interval: "30m", agentId: APP,
+    }), { kind: "user" });
+    let stored = JSON.parse(fs.readFileSync(path.join(root, "config.json"), "utf8"));
+    assert.deepEqual(stored.inboxAudit, { enabled: true, intervalMs: 30 * 60_000 });
+    assert.equal("inboxAudit" in stored.agents[APP], false);
+
+    configApi.mutateConfig(env, configApi.inboxAuditMutationFromCli({
+      scope: "agent", enabled: "off", interval: "1h", agentId: APP,
+    }), { kind: "user" });
+    const after = configApi.loadConfig(env).config;
+    assert.deepEqual(configApi.resolveInboxAuditSchedule(after, APP), {
+      enabled: false, intervalMs: 60 * 60_000, enabledSource: "agent", intervalSource: "agent",
+    });
+    assert.deepEqual(configApi.resolveInboxAuditSchedule(after, OTHER), {
+      enabled: true, intervalMs: 30 * 60_000, enabledSource: "global", intervalSource: "global",
+    });
+
+    configApi.mutateConfig(env, configApi.inboxAuditMutationFromCli({
+      scope: "agent", enabled: "inherit", interval: "inherit", agentId: APP,
+    }), { kind: "user" });
+    stored = JSON.parse(fs.readFileSync(path.join(root, "config.json"), "utf8"));
+    assert.equal("inboxAudit" in stored.agents[APP], false);
+    assert.equal(configApi.parseInboxAuditInterval("15m"), configApi.DEFAULT_INBOX_AUDIT_INTERVAL_MS);
+    assert.throws(() => configApi.parseInboxAuditInterval("1s"), /15m\/1h|毫秒/);
+    assert.throws(() => configApi.inboxAuditMutationFromCli({
+      scope: "global", enabled: "on", interval: "inherit", agentId: APP,
+    }), /不支持 interval=inherit/);
+  } finally { fs.rmSync(root, { recursive: true, force: true }); }
+});
+
+test("larkin config inbox-audit CLI persists per-Agent cadence without editing config.json by hand", () => {
+  const { root, env } = fixture();
+  try {
+    const help = spawnSync(process.execPath, [CLI_ENTRY, "help", "config"], { encoding: "utf8" });
+    assert.equal(help.status, 0, help.stderr);
+    assert.match(help.stdout, /config inbox-audit global/);
+    assert.match(help.stdout, /config inbox-audit agent/);
+    assert.match(help.stdout, /--interval/);
+    const run = (...args) => {
+      const spawnEnv = { ...process.env, ...env };
+      delete spawnEnv.LARKIN_AGENT_ID;
+      return spawnSync(process.execPath, [CONFIG_ENTRY, "config", ...args], { encoding: "utf8", env: spawnEnv });
+    };
+    const enabled = run("inbox-audit", "global", "on", "--interval", "15m");
+    assert.equal(enabled.status, 0, enabled.stderr);
+    const stored = JSON.parse(fs.readFileSync(path.join(root, "config.json"), "utf8"));
+    assert.deepEqual(stored.inboxAudit, { enabled: true, intervalMs: 15 * 60_000 });
+    const agentOff = run("inbox-audit", "agent", "off", "--agent", APP, "--interval", "1h");
+    assert.equal(agentOff.status, 0, agentOff.stderr);
+    const after = JSON.parse(fs.readFileSync(path.join(root, "config.json"), "utf8"));
+    assert.deepEqual(after.agents[APP].inboxAudit, { enabled: false, intervalMs: 60 * 60_000 });
+    assert.equal("inboxAudit" in after.agents[OTHER], false);
+  } finally { fs.rmSync(root, { recursive: true, force: true }); }
+});


### PR DESCRIPTION
Inbox Audit previously ran implicitly and could revisit unmentioned group traffic or repeatedly scan retained targets. The old proposal also completed targets as soon as the audit CLI returned, losing retry opportunities when the caller stopped before checking.

This consolidated fix makes audit off by default and adds Dashboard/CLI global and per-Agent switches and inspection gaps. Gap-only edits do not enable it; saves update scheduling without replacing Runtime sessions. Audit registration uses canonical wake eligibility and durable target sequence ordering, with bounded registry I/O and persisted recovery after lock contention. Reads stay read-only; callers explicitly complete a scoped observation receipt after checking, and stale receipts/retries cannot retire newer work. Unproven legacy audit indices are ignored while ordinary Inbox and conversation history remain intact.

Fixes #186. Supersedes the overlapping implementation proposals in #187 and #195. Version: 0.5.4.

Validation:
- Independent executor/evaluator loop resolved same-timestamp receipt ABA, lock FIFO blocking, and stale/deferred registration ordering; final targeted production review reported no issue.
- Full local suite: frontend 30; unit 958 with 1 platform skip; integration 206 with 17 opt-in skips; E2E 22. Types/build passed.
- Standalone binary acceptance passed. Real Chromium Dashboard save/reload/precision/invalid-draft/mobile workflow passed.
- Versioned caller-flow grader tests passed. Two independent GPT-5.6 Luna API subagents exercised actual public audit read/complete with synthetic history/reply, and two deterministic CLI scenarios verified read-failure retry and stale-receipt rejection. All four scored pass. These are isolated fixtures, not real Feishu delivery or a production managed-Codex session claim.
- License/publication/diff checks passed. No production configuration, credentials, Inbox, daemon, or local installation was changed for validation.
