### PR TITLE
fix(runtime): load Pi extensions in the isolated context-window probe

### DIFF
--- a/src/runtime/runtime-adapters.ts
+++ b/src/runtime/runtime-adapters.ts
@@ -937,7 +937,14 @@ async function discoverEffectivePiContextWindow(input: RuntimeSessionCreate, com
   commandPrefix: readonly string[], requestedModel: string | undefined,
   env: NodeJS.ProcessEnv, spawn: (command: string, args: readonly string[], options: Record<string, unknown>) => ProcessLike,
   rpcOptions?: PiRpcClientOptions): Promise<PiProbeResult> {
-  const probeArgs = [...commandPrefix, "--mode", "rpc", "--no-session", "--no-extensions",
+  // The isolated context-window probe must load the same extensions as the real
+  // session handshake. Pi packages can register additional model providers, so a
+  // configured `--model <provider>/<id>` only resolves once extensions load.
+  // Probing with `--no-extensions` makes any extension-provided model fail with a
+  // spurious "model not found", which createPiRpcBackend then classifies as a
+  // missing prerequisite ("pi is not installed") even though pi is installed,
+  // authenticated, and the model works in a real session.
+  const probeArgs = [...commandPrefix, "--mode", "rpc", "--no-session",
     ...(requestedModel ? ["--model", requestedModel] : [])];
   const probe = spawn(command, probeArgs, {
     cwd: input.workspaceDir,

--- a/test/integration/setup/external-pi-setup-hot-attach.test.mjs
+++ b/test/integration/setup/external-pi-setup-hot-attach.test.mjs
@@ -214,8 +214,12 @@ test("rerunning external-pi setup repairs model=default and hot-attach uses the 
     try {
       const launches = readLaunches(fake.marker);
       assert.equal(launches.some((row) => row.args.includes("--version")), true, JSON.stringify(launches));
-      const isolated = launches.find((row) => row.args.includes("--no-session") && row.args.includes("--no-extensions"));
+      const isolated = launches.find((row) => row.args.includes("--no-session") && row.args.includes("--model") && !row.args.includes("--session-dir"));
       assert.ok(isolated, JSON.stringify(launches));
+      // Regression: the isolated context-window probe must not disable extensions,
+      // otherwise models from a Pi package provider fail to resolve and the runtime
+      // is misclassified as not installed.
+      assert.equal(isolated.args.includes("--no-extensions"), false, JSON.stringify(launches));
       assert.equal(isolated.args.includes("--model"), true);
       assert.equal(isolated.args[isolated.args.indexOf("--model") + 1], "fixture/pi-fixture");
       const sessionLaunch = launches.find((row) => row.args.includes("--session-dir"));

--- a/test/unit/runtime/runtime-adapters.test.mjs
+++ b/test/unit/runtime/runtime-adapters.test.mjs
@@ -105,7 +105,7 @@ process.stdin.on("data", (chunk) => {
     const line = buffer.slice(0, newline); buffer = buffer.slice(newline + 1);
     const request = JSON.parse(line); record({ kind: "request", probe, type: request.type });
     if (request.type === "get_state") {
-      if (!(${JSON.stringify(mode)} === "probe-timeout" && args.includes("--no-extensions"))) respond(request, state());
+      if (!(${JSON.stringify(mode)} === "probe-timeout" && args.includes("--no-session") && args.includes("--model"))) respond(request, state());
     } else if (request.type === "get_available_models") respond(request, {
       models: process.env.PI_CODING_AGENT_DIR ? [] : [{ provider: "test-provider", id: "test-model" }],
     });
@@ -896,7 +896,10 @@ test("production Pi probe uses isolated get_state only and preserves the verifie
     const runtimeArgs = rows.find((row) => row.kind === "argv" && !row.probe && !row.args.includes("--version"));
     assert.ok(probeArgs);
     assert.ok(probeArgs.args.includes("--no-session"), JSON.stringify(probeArgs));
-    assert.ok(probeArgs.args.includes("--no-extensions"), JSON.stringify(rows));
+    // The isolated context-window probe must not pass --no-extensions: models
+    // registered by a Pi package provider only exist when extensions load, so
+    // probing with --no-extensions would spuriously fail model resolution.
+    assert.equal(probeArgs.args.includes("--no-extensions"), false, JSON.stringify(rows));
     assert.equal(probeArgs.args.includes("-e"), false);
     assert.deepEqual(probeRequests, ["get_state"]);
     assert.ok(runtimeArgs.args.includes("-e"));


### PR DESCRIPTION
## Problem

Switching an Agent to the external Pi runtime with a model that comes from a **Pi package provider** (a package that calls `pi.registerProvider(...)`, e.g. an OpenAI-compatible or third-party provider installed via `pi install npm:...`) makes the daemon crash-loop with a misleading `pi is not installed`, even though `pi` is installed, on `PATH`/`LARKIN_PI_COMMAND`, authenticated, and the model starts fine in a real interactive session.

## Root cause

Before creating a session, `createPiRpcBackend` resolves the model's context window with an isolated probe in `discoverEffectivePiContextWindow`:

```
pi --mode rpc --no-session --no-extensions --model <model>
```

Pi packages register their model providers as **extensions**, so a configured `--model <provider>/<id>` only resolves once extensions load. Under `--no-extensions` the provider is absent and the probe exits with `Model "<provider>/<id>" not found`. `createPiRpcBackend` runs that error through `classifyRuntimePrerequisite`, which matches the process-exit branch and returns `state: "missing"` → surfaced as **"pi is not installed"**, and the Runtime Host crash-loops.

The readiness probe (`probeNativeRuntimeReadiness` → `discoverPiModelCatalog`) lists models *without* `--model`, so it reports `ready`; the misclassification only appears at session start, which makes it look like an install/PATH problem when it is not.

## Fix

Drop `--no-extensions` from the isolated context-window probe so it loads the same extensions as the real session handshake. The surrounding code already documents that the isolated probe "must share the same prerequisite contract as the session handshake" — this aligns the probe with that intent. The real session already loads extensions (`--approve`, `-e <bundle>`), so this only affects the lightweight isolated probe.

The context-window probe is now distinguished from the lighter catalog-discovery probe by its `--model` argument (the catalog probe passes no `--model`); the two tests that pinned `--no-extensions` on the isolated probe are updated accordingly.

## Tests

- `test/unit/runtime/runtime-adapters.test.mjs`: asserts the isolated probe does **not** pass `--no-extensions`; the `probe-timeout` fixture now identifies the context-window probe by `--no-session` + `--model`.
- `test/integration/setup/external-pi-setup-hot-attach.test.mjs`: regression assertion that the isolated probe loads extensions.
- Both suites pass (`bun test` on the two files: 76 pass / 0 fail).

## Impact

Restores the external-Pi → package-provider path for any model provided by a Pi package, which is otherwise blocked at session start. No behavior change for models on Pi's built-in providers, and no change to the real session spawn.