### PR TITLE
chore(release): bump version to 0.5.6

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "larkin",
-  "version": "0.5.5",
+  "version": "0.5.6",
   "private": false,
   "larkinPackageRole": "npm-published",
   "files": [


### PR DESCRIPTION
Bump package.json 0.5.5 to 0.5.6 from main 94d2409 using bun run version:bump 0.5.6. One-line diff. release:check-version and publication:check:tree passed. No other changes. Does not merge, release, or deploy.