### PR TITLE
fix(setup): request search:message for bot IM search

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "larkin",
-  "version": "0.5.6",
+  "version": "0.5.7",
   "private": false,
   "larkinPackageRole": "npm-published",
   "files": [

--- a/src/setup/bot-register.ts
+++ b/src/setup/bot-register.ts
@@ -529,6 +529,7 @@ const TENANT_SCOPES = [
   "im:message.group_at_msg:readonly",
   "im:message.group_msg",
   "im:message:send_as_bot",
+  "search:message",
   "im:chat:readonly",
   "im:chat:create",
   "im:chat:update",

--- a/src/setup/grant-scopes.ts
+++ b/src/setup/grant-scopes.ts
@@ -88,6 +88,7 @@ const TENANT_SCOPES = [
   "im:message.group_at_msg:readonly",
   "im:message.group_msg",
   "im:message:send_as_bot",
+  "search:message",
   "im:chat:readonly",
   "im:chat",
   "im:chat:create",

--- a/test/unit/setup/bot-register-tenant-urls.test.mjs
+++ b/test/unit/setup/bot-register-tenant-urls.test.mjs
@@ -15,7 +15,7 @@ function assertLarkinRegisterAddons(addons) {
   assert.equal(addons == null, false);
   assert.deepEqual(addons.events.items.tenant, EXPECTED_TENANT_EVENTS);
   assert.deepEqual(addons.callbacks.items, EXPECTED_CALLBACKS);
-  for (const scope of ["im:message", "im:message:send_as_bot", "im:message.group_msg", "drive:drive", "docs:document.comment:create", "docs:document.comment:read"]) {
+  for (const scope of ["im:message", "im:message:send_as_bot", "im:message.group_msg", "search:message", "drive:drive", "docs:document.comment:create", "docs:document.comment:read"]) {
     assert.equal(addons.scopes.tenant.includes(scope), true, `missing tenant scope ${scope}`);
   }
 }

--- a/test/unit/setup/grant-scopes-tenant-urls.test.mjs
+++ b/test/unit/setup/grant-scopes-tenant-urls.test.mjs
@@ -30,6 +30,7 @@ module.exports = {
     fs.writeFileSync(process.env.REGISTER_MARKER, JSON.stringify({
       appId: opts.appId,
       domain: opts.domain,
+      addons: opts.addons ?? null,
     }));
     opts.onQRCodeReady({ url: process.env.GRANT_READY_URL || ("https://" + opts.domain + "/oauth/grant"), expireIn: 60 });
     return { client_id: opts.appId };
@@ -108,5 +109,14 @@ test("Feishu credential / default still uses accounts.feishu.cn", () => {
     const opts = JSON.parse(fs.readFileSync(marker, "utf8"));
     assert.equal(opts.domain, "accounts.feishu.cn");
     assert.doesNotMatch(JSON.stringify(opts), /larksuite\.com/);
+  } finally { fs.rmSync(temp, { recursive: true, force: true }); }
+});
+
+test("grant-scopes tenant scopes include search:message", () => {
+  const { temp, marker, result } = runGrant({ tenant: "feishu" });
+  try {
+    assert.equal(result.status, 0, result.stderr);
+    const opts = JSON.parse(fs.readFileSync(marker, "utf8"));
+    assert.equal(opts.addons.scopes.tenant.includes("search:message"), true);
   } finally { fs.rmSync(temp, { recursive: true, force: true }); }
 });


### PR DESCRIPTION
Issue 175: managed Bot +messages-search fails because tenant scopes omit search:message. This PR only adds search:message to bot-register and grant-scopes tenant lists, covers both paths with tests, and bumps 0.5.6 to 0.5.7. No passthrough, token-cache, or platform authorization changes. Live Bot still returns 99991672 missing search:message until the app owner grants the scope. Does not merge or release.