### PR TITLE
fix(setup): reconcile Lark grants and preserve same-app recovery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.5.8
+
+Lark setup now reconciles requested tenant permissions with actual grants and links missing scopes to the same application in the developer console. Required permissions still block setup until granted; optional permissions and event/callback verification are reported separately. Existing-application authorization preserves and checks its App ID before recording any capability state.
+
 ## 0.5.5
 
 Pi uses a small Larkin-owned tmux Bash extension when tmux is available on macOS/Linux. Commands preserve their working directory, including non-Git paths with spaces; a foreground wait can return while the same command continues. The returned task ID supports inspection and cancellation, and background completion resumes the Agent. Native Windows and environments without tmux retain Pi's native Bash.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "larkin",
-  "version": "0.5.7",
+  "version": "0.5.8",
   "private": false,
   "larkinPackageRole": "npm-published",
   "files": [

--- a/src/setup/bot-register.ts
+++ b/src/setup/bot-register.ts
@@ -747,7 +747,7 @@ try {
   if (!verified) throw new Error("Bot identity verification failed");
   const scopeResult = await runIdentityProcess(
     official.command,
-    [...official.argsPrefix, "api", "GET", "/open-apis/application/v6/scopes"],
+    [...official.argsPrefix, "api", "GET", "/open-apis/application/v6/scopes", "--as", "bot"],
     cliEnv,
   );
   let scopePayload: unknown;
@@ -757,8 +757,10 @@ try {
   say(grants.verified
     ? `Tenant scopes 对账：必需未授予=${grants.missingRequired.join(", ") || "无"}；可选未授予=${grants.missingOptional.join(", ") || "无"}`
     : "Tenant scopes 对账未验证：权威 API 失败或响应无效，不能确认任何申请项已授予。");
+  if (!grants.verified) say("请检查所选 Agent 的受管 bot CLI 与网络后重跑原 larkin setup 命令，保留 --tenant/--runtime 参数；不要重建 Agent，也不要据此修改应用权限。");
+  if (grants.verified && !grants.missingRequired.length && grants.missingOptional.length) say("! 可选权限未授予，setup 可继续；相关能力仍不可用或未验证。");
   if (missing.length) say(tenantScopeRecoveryMessage(tenant, id, missing));
-  if (grants.missingRequired.length > 0) {
+  if (!grants.verified || grants.missingRequired.length > 0) {
     const reason = scopeResult.status !== 0
       ? `scopes API 失败 status=${scopeResult.status}`
       : !grants.verified ? "scopes API 响应无效" : `缺 ${grants.missingRequired.join(", ")}`;

--- a/src/setup/bot-register.ts
+++ b/src/setup/bot-register.ts
@@ -28,7 +28,7 @@ import {
   type LarkinTenant,
 } from "../feishu/platform-hosts.js";
 import { authorizationUrlFailureMessage, presentAuthorizationUrl } from "./setup-authorization-url.js";
-import { missingGrantedTenantScopes } from "./tenant-scope-grant.js";
+import { reconcileTenantScopes, tenantScopeRecoveryMessage } from "./tenant-scope-grant.js";
 // qrcode-terminal does not publish TypeScript declarations.
 // @ts-expect-error bundled CommonJS dependency
 import qrcodePackage from "qrcode-terminal";
@@ -752,14 +752,17 @@ try {
   );
   let scopePayload: unknown;
   try { scopePayload = JSON.parse(scopeResult.stdout || ""); } catch { scopePayload = null; }
-  const missing = missingGrantedTenantScopes(scopePayload);
-  if (scopeResult.status !== 0 || missing.length > 0) {
+  const grants = reconcileTenantScopes(scopeResult.status === 0 ? scopePayload : null, TENANT_SCOPES);
+  const missing = [...grants.missingRequired, ...grants.missingOptional];
+  say(grants.verified
+    ? `Tenant scopes 对账：必需未授予=${grants.missingRequired.join(", ") || "无"}；可选未授予=${grants.missingOptional.join(", ") || "无"}`
+    : "Tenant scopes 对账未验证：权威 API 失败或响应无效，不能确认任何申请项已授予。");
+  if (missing.length) say(tenantScopeRecoveryMessage(tenant, id, missing));
+  if (grants.missingRequired.length > 0) {
     const reason = scopeResult.status !== 0
       ? `scopes API 失败 status=${scopeResult.status}`
-      : `缺 ${missing.join(", ")}`;
-    throw new Error(
-      `Bot tenant scope 未就绪，${reason}；+chat-list 成功不能当作可发群消息。请在开发者后台开通后重跑 setup，不要重建 Agent。`,
-    );
+      : !grants.verified ? "scopes API 响应无效" : `缺 ${grants.missingRequired.join(", ")}`;
+    throw new Error(`Bot tenant scope 未就绪，${reason}；+chat-list 成功不能当作可发群消息。`);
   }
   if (commentSubscription !== "preserve") {
     const reconciled = await applyDocumentCommentSubscription({

--- a/src/setup/grant-scopes.ts
+++ b/src/setup/grant-scopes.ts
@@ -180,7 +180,7 @@ export async function main(): Promise<void> {
   }
   const managed = resolveManagedOfficialCli(selected, process.env);
   const response = spawnSync(managed.command.command,
-    [...managed.command.argsPrefix, "api", "GET", "/open-apis/application/v6/scopes"],
+    [...managed.command.argsPrefix, "api", "GET", "/open-apis/application/v6/scopes", "--as", "bot"],
     { encoding: "utf8", env: managed.env, timeout: 30_000 });
   let payload: unknown;
   try { payload = JSON.parse(response.stdout || ""); } catch { payload = null; }
@@ -189,9 +189,10 @@ export async function main(): Promise<void> {
     ? `Tenant scopes 对账：必需未授予=${grants.missingRequired.join(", ") || "无"}；可选未授予=${grants.missingOptional.join(", ") || "无"}`
     : "Tenant scopes 对账未验证：权威 API 失败或响应无效。");
   const missing = [...grants.missingRequired, ...grants.missingOptional];
+  if (!grants.verified) throw new Error("Bot tenant scope 未验证；请检查所选 Agent 的受管 bot CLI 与网络，再重跑原 setup 命令并保留 --tenant/--runtime；不要据此修改应用权限。");
+  if (!grants.missingRequired.length && grants.missingOptional.length) log("! 可选权限未授予，setup 可继续；相关能力仍不可用或未验证。");
   if (missing.length) log(tenantScopeRecoveryMessage(TENANT, APP_ID, missing));
   if (grants.missingRequired.length) throw new Error(`Bot tenant scope 未就绪，缺 ${grants.missingRequired.join(", ")}`);
-  if (!missing.length) console.log(`GRANTED_APP_ID=${APP_ID}`);
 }
 
 if (path.resolve(process.argv[1] || "") === path.resolve(fileURLToPath(import.meta.url))) {

--- a/src/setup/grant-scopes.ts
+++ b/src/setup/grant-scopes.ts
@@ -12,6 +12,7 @@ import { managedOfficialLarkCli } from "../app/agent-lark-cli-workspace.js";
 import { loadValidatedBotCredential } from "./run-credential-preflight.js";
 import { parseLarkinTenant, registerAppAccountsHost, type LarkinTenant } from "../feishu/platform-hosts.js";
 import { presentAuthorizationUrl } from "./setup-authorization-url.js";
+import { reconcileTenantScopes, tenantScopeRecoveryMessage } from "./tenant-scope-grant.js";
 // qrcode-terminal does not publish TypeScript declarations.
 // @ts-expect-error bundled CommonJS dependency
 import qrcodePackage from "qrcode-terminal";
@@ -138,6 +139,7 @@ export async function main(): Promise<void> {
       const presented = presentAuthorizationUrl(info.url, {
         tenant: TENANT,
         larkCliVersion: official.command.version,
+        expectedAppId: APP_ID,
       });
       if (TENANT === "lark" && /\/page\/launcher(?:\?|$)/.test(presented)) {
         throw new Error("Lark 租户拒绝把 /page/launcher 交给浏览器");
@@ -163,11 +165,12 @@ export async function main(): Promise<void> {
     process.exit(1);
   }
   clearTimeout(timeout);
-  log(`\n✓ 权限增补已确认，appId=${result?.client_id || APP_ID}`);
+  if (result?.client_id !== APP_ID) throw new Error("授权回传 App ID 与既有应用不匹配；未记录权限或能力状态");
+  log(`\n✓ 既有应用授权凭证已回传，appId=${APP_ID}；实际权限仍需核验`);
   log(`  已请求增补: ${TENANT_SCOPES.join(", ")}`);
   log(`  已请求事件: ${TENANT_EVENTS.join(", ")}（仍需发布并用真实文档 @Bot 验证）`);
   try {
-    markSetupCapabilitiesRequested(config.larkinHome, result?.client_id || APP_ID);
+    markSetupCapabilitiesRequested(config.larkinHome, APP_ID);
     log("  card.action.trigger 仍是 requested-unverified；请确认发布后执行 interaction callback-probe 并真实点击，验证前不会创建业务交互卡片。");
     log("  document comment capability=publish_or_event_unverified reason=publication_and_real_event_unverified；配置发布与真实事件到达均未验证，不声明生效。");
     log("  document comment reply scope=docs:document.comment:create requested-unverified；同时覆盖 in-thread reply 与 whole-document create_v2 fallback。");
@@ -175,7 +178,20 @@ export async function main(): Promise<void> {
     if ((error as NodeJS.ErrnoException).code !== "ENOENT") throw error;
     log("  本机没有该 App 的 bot credential，无法记录 callback readiness；能力保持 missing，请先运行 larkin setup 后再执行 callback-probe。");
   }
-  console.log(`GRANTED_APP_ID=${result?.client_id || APP_ID}`);
+  const managed = resolveManagedOfficialCli(selected, process.env);
+  const response = spawnSync(managed.command.command,
+    [...managed.command.argsPrefix, "api", "GET", "/open-apis/application/v6/scopes"],
+    { encoding: "utf8", env: managed.env, timeout: 30_000 });
+  let payload: unknown;
+  try { payload = JSON.parse(response.stdout || ""); } catch { payload = null; }
+  const grants = reconcileTenantScopes(response.status === 0 ? payload : null, TENANT_SCOPES);
+  log(grants.verified
+    ? `Tenant scopes 对账：必需未授予=${grants.missingRequired.join(", ") || "无"}；可选未授予=${grants.missingOptional.join(", ") || "无"}`
+    : "Tenant scopes 对账未验证：权威 API 失败或响应无效。");
+  const missing = [...grants.missingRequired, ...grants.missingOptional];
+  if (missing.length) log(tenantScopeRecoveryMessage(TENANT, APP_ID, missing));
+  if (grants.missingRequired.length) throw new Error(`Bot tenant scope 未就绪，缺 ${grants.missingRequired.join(", ")}`);
+  if (!missing.length) console.log(`GRANTED_APP_ID=${APP_ID}`);
 }
 
 if (path.resolve(process.argv[1] || "") === path.resolve(fileURLToPath(import.meta.url))) {

--- a/src/setup/setup-authorization-url.ts
+++ b/src/setup/setup-authorization-url.ts
@@ -23,10 +23,13 @@ export function officialCliSetupUrl(input: OfficialCliSetupUrlInput): string {
 
 export function presentAuthorizationUrl(
   rawUrl: string,
-  input: { tenant: LarkinTenant; larkCliVersion: string },
+  input: { tenant: LarkinTenant; larkCliVersion: string; expectedAppId?: string },
 ): string {
   let parsed: URL;
   try { parsed = new URL(rawUrl); } catch { throw new Error("授权 URL 非法"); }
+  if (input.expectedAppId && parsed.searchParams.get("clientID") !== input.expectedAppId) {
+    throw new Error("既有应用授权 URL 的 clientID 与目标 App ID 不匹配；未继续授权");
+  }
   const userCode = parsed.searchParams.get("user_code") || "";
   // Feishu China still authorizes on /page/launcher. Only International Lark
   // must leave launcher (open.larksuite.com ack 10074 / 链接已失效).
@@ -38,6 +41,8 @@ export function presentAuthorizationUrl(
     // still requests the same Larkin addons Feishu already sends.
     const addons = parsed.searchParams.get("addons");
     if (addons) presented.searchParams.set("addons", addons);
+    const clientID = parsed.searchParams.get("clientID");
+    if (clientID) presented.searchParams.set("clientID", clientID);
     return presented.toString();
   }
   return parsed.toString();

--- a/src/setup/tenant-scope-grant.ts
+++ b/src/setup/tenant-scope-grant.ts
@@ -6,6 +6,7 @@ export const FRESHNESS_REQUIRED_TENANT_SCOPES = ["im:message.group_msg"] as cons
 interface ScopeRow {
   scope_name?: unknown;
   grant_status?: unknown;
+  scope_type?: unknown;
 }
 
 function asRows(payload: unknown): ScopeRow[] {
@@ -20,22 +21,23 @@ function asRows(payload: unknown): ScopeRow[] {
 /** grant_status 1 is granted on GET /open-apis/application/v6/scopes. */
 export function missingGrantedTenantScopes(payload: unknown, required: readonly string[] = FRESHNESS_REQUIRED_TENANT_SCOPES): string[] {
   const rows = asRows(payload);
-  return required.filter((name) => !rows.some((row) => row.scope_name === name && row.grant_status === 1));
+  return required.filter((name) => !rows.some((row) => row.scope_name === name && row.grant_status === 1 && (row.scope_type === undefined || row.scope_type === "tenant")));
 }
 
 /** Reconcile intent with the authoritative bot scopes response, never credential return. */
 export function reconcileTenantScopes(payload: unknown, requested: readonly string[]) {
   const root = payload && typeof payload === "object"
-    ? payload as { code?: unknown; ok?: unknown; data?: { scopes?: unknown }; scopes?: unknown }
+    ? payload as { code?: unknown; ok?: unknown; identity?: unknown; data?: { scopes?: unknown }; scopes?: unknown }
     : null;
-  const verified = !!root && (root.code === undefined || root.code === 0) && root.ok !== false
+  const verified = !!root && (root.code === undefined || root.code === 0) && (root.ok === undefined || root.ok === true)
+    && (root.identity === undefined || root.identity === "bot")
     && (Array.isArray(root.data?.scopes) || Array.isArray(root.scopes));
   const required: readonly string[] = FRESHNESS_REQUIRED_TENANT_SCOPES;
   const optional = requested.filter((name) => !required.includes(name));
   return {
     verified,
-    missingRequired: missingGrantedTenantScopes(verified ? payload : null, required),
-    missingOptional: missingGrantedTenantScopes(verified ? payload : null, optional),
+    missingRequired: verified ? missingGrantedTenantScopes(payload, required) : [],
+    missingOptional: verified ? missingGrantedTenantScopes(payload, optional) : [],
   };
 }
 
@@ -47,6 +49,6 @@ export function tenantScopeRecoveryMessage(tenant: LarkinTenant, appId: string, 
   url.searchParams.set("token_type", "tenant");
   return `保留同一个 App ID ${appId}，由应用 owner 打开开发者后台权限管理：${url.toString()}\n`
     + "完成平台要求的权限确认、管理员审批或版本发布，再重新核验实际授予状态。\n"
-    + `运行 larkin setup --tenant ${tenant} --no-start，在网页选择同一个已有机器人并保留原 Runtime 配置，不要重建 Agent；核验通过后再启动。\n`
+    + `完成后重跑原 larkin setup 命令，保留 --tenant ${tenant} 和 --runtime 参数（可加 --no-start），在网页选择同一个已有机器人并保留原 Runtime 配置，不要重建 Agent。\n`
     + "凭证回传不代表附加权限已授予；平台可能未应用 addons，不能仅靠重新扫码或重建应用修复。事件与 callbacks 仍需各自验证。";
 }

--- a/src/setup/tenant-scope-grant.ts
+++ b/src/setup/tenant-scope-grant.ts
@@ -1,3 +1,5 @@
+import { openPlatformHost, type LarkinTenant } from "../feishu/platform-hosts.js";
+
 /** Tenant scopes the freshness gate needs on the Bot application. */
 export const FRESHNESS_REQUIRED_TENANT_SCOPES = ["im:message.group_msg"] as const;
 
@@ -19,4 +21,32 @@ function asRows(payload: unknown): ScopeRow[] {
 export function missingGrantedTenantScopes(payload: unknown, required: readonly string[] = FRESHNESS_REQUIRED_TENANT_SCOPES): string[] {
   const rows = asRows(payload);
   return required.filter((name) => !rows.some((row) => row.scope_name === name && row.grant_status === 1));
+}
+
+/** Reconcile intent with the authoritative bot scopes response, never credential return. */
+export function reconcileTenantScopes(payload: unknown, requested: readonly string[]) {
+  const root = payload && typeof payload === "object"
+    ? payload as { code?: unknown; ok?: unknown; data?: { scopes?: unknown }; scopes?: unknown }
+    : null;
+  const verified = !!root && (root.code === undefined || root.code === 0) && root.ok !== false
+    && (Array.isArray(root.data?.scopes) || Array.isArray(root.scopes));
+  const required: readonly string[] = FRESHNESS_REQUIRED_TENANT_SCOPES;
+  const optional = requested.filter((name) => !required.includes(name));
+  return {
+    verified,
+    missingRequired: missingGrantedTenantScopes(verified ? payload : null, required),
+    missingOptional: missingGrantedTenantScopes(verified ? payload : null, optional),
+  };
+}
+
+/** Official console recovery form used by lark-cli; scopes are tenant permissions. */
+export function tenantScopeRecoveryMessage(tenant: LarkinTenant, appId: string, scopes: readonly string[]): string {
+  const url = new URL(`${openPlatformHost(tenant)}/app/${encodeURIComponent(appId)}/auth`);
+  url.searchParams.set("q", scopes.join(","));
+  url.searchParams.set("op_from", "openapi");
+  url.searchParams.set("token_type", "tenant");
+  return `保留同一个 App ID ${appId}，由应用 owner 打开开发者后台权限管理：${url.toString()}\n`
+    + "完成平台要求的权限确认、管理员审批或版本发布，再重新核验实际授予状态。\n"
+    + `运行 larkin setup --tenant ${tenant} --no-start，在网页选择同一个已有机器人并保留原 Runtime 配置，不要重建 Agent；核验通过后再启动。\n`
+    + "凭证回传不代表附加权限已授予；平台可能未应用 addons，不能仅靠重新扫码或重建应用修复。事件与 callbacks 仍需各自验证。";
 }

--- a/test/integration/app/strict-production-cutover.test.mjs
+++ b/test/integration/app/strict-production-cutover.test.mjs
@@ -332,7 +332,8 @@ for (const [mode, needle] of [
       const text = `${result.stderr || ""}\n${result.stdout || ""}`;
       assert.notEqual(result.status, 0, text);
       assert.match(text, needle);
-      assert.match(text, /开发者后台/);
+      if (mode === "scope-denied") assert.match(text, /开发者后台/);
+      else assert.doesNotMatch(text, /\/auth\?q=/);
       assert.match(text, /不要重建 Agent/);
       assert.doesNotMatch(text, /身份授权\/评论订阅核验失败/);
       assert.doesNotMatch(text, /canary-secret/);

--- a/test/integration/app/strict-production-cutover.test.mjs
+++ b/test/integration/app/strict-production-cutover.test.mjs
@@ -303,7 +303,7 @@ for (const [mode, expectedCalls, expectedStatus] of [["sync-network", 2, 0], ["s
 for (const [mode, needle] of [
   ["scope-denied", /缺 im:message\.group_msg/],
   ["scope-network", /scopes API 失败/],
-  ["scope-malformed", /缺 im:message\.group_msg/],
+  ["scope-malformed", /scopes API 响应无效/],
 ]) {
   test(`bot-register fail-closes ${mode} and keeps the actionable scope diagnostic`, { timeout: TRANSIENT_VERIFY_TEST_TIMEOUT_MS }, () => {
     const temp = fs.mkdtempSync(path.join(os.tmpdir(), `larkin-strict-register-${mode}-`));

--- a/test/integration/build/production-boundary.test.mjs
+++ b/test/integration/build/production-boundary.test.mjs
@@ -62,10 +62,10 @@ test("grant-scopes selects only explicit App ID, explicit --agent App ID, or act
     const spawnMarker = path.join(temp, "spawn.ndjson");
     const preload = path.join(temp, "preload.cjs");
     fs.writeFileSync(preload, `module.exports={
-  registerApp:async(opts)=>{require("node:fs").writeFileSync(process.env.REGISTER_MARKER,JSON.stringify(opts));opts.onQRCodeReady({url:"https://mock.invalid/grant",expireIn:60});return {client_id:opts.appId}},
+  registerApp:async(opts)=>{require("node:fs").writeFileSync(process.env.REGISTER_MARKER,JSON.stringify(opts));opts.onQRCodeReady({url:"https://mock.invalid/grant?clientID="+opts.appId,expireIn:60});return {client_id:opts.appId}},
   qrcode:{generate(){}},
   managedOfficialCli:()=>({command:{command:"/verified/official-lark-cli",argsPrefix:[],version:"1.0.80"},env:{}}),
-  spawnSync(command,args){require("node:fs").appendFileSync(process.env.SPAWN_MARKER,JSON.stringify({command,args})+"\\n");return {status:0,stdout:"{}",stderr:""}}
+  spawnSync(command,args){if(args.includes("/open-apis/application/v6/scopes"))return {status:0,stdout:JSON.stringify({data:{scopes:[{scope_name:"im:message.group_msg",grant_status:1}]}}),stderr:""};require("node:fs").appendFileSync(process.env.SPAWN_MARKER,JSON.stringify({command,args})+"\\n");return {status:0,stdout:"{}",stderr:""}}
 };`);
     const run = (args = [], extra = {}) => spawnSync(process.execPath, [path.join(ROOT, "dist/setup/grant-scopes.mjs"), "--wait-min", "1", ...args], {
       cwd: ROOT, encoding: "utf8", env: { ...process.env, HOME: path.join(temp, "home"), LARKIN_HOME: root, LARKIN_CONFIG_DIR: root, LARKSUITE_CLI_CONFIG_DIR: path.join(temp, "lark-cli"), LARKIN_TEST_GRANT_SCOPES_MODULE: preload, REGISTER_MARKER: marker, SPAWN_MARKER: spawnMarker, ...extra },

--- a/test/integration/setup/bot-register-scope-pi-transaction.test.mjs
+++ b/test/integration/setup/bot-register-scope-pi-transaction.test.mjs
@@ -41,7 +41,7 @@ function writePiOriginal(root) {
   fs.writeFileSync(path.join(dir, "models-store.json"), "{}\n", { mode: 0o600 });
 }
 
-function writeFixture(temp, scopesStdout, scopesStatus = 0) {
+function writeFixture(temp, scopesStdout, scopesStatus = 0, tenant = "feishu") {
   const fixture = path.join(temp, "fixture.cjs");
   fs.writeFileSync(fixture, `const fs = require("node:fs");
 const path = require("node:path");
@@ -69,13 +69,16 @@ function writeBoundConfig() {
   }) + "\\n", { mode: 0o600 });
 }
 module.exports = {
-  registerApp: async () => ({ client_id: ${JSON.stringify(APP)}, client_secret: "canary-secret", user_info: { tenant_brand: "feishu", open_id: "ou_owner" } }),
+  registerApp: async () => ({ client_id: ${JSON.stringify(APP)}, client_secret: "canary-secret", user_info: { tenant_brand: ${JSON.stringify(tenant)}, open_id: "ou_owner" } }),
   qrcode: { generate() {} },
   resolveOfficialLarkCli: () => ({ command: "lark-cli", argsPrefix: [], version: "1.0.80" }),
   wait: async () => {},
-  spawn(command, args) {
+  spawn(command, args, options) {
     if (args.includes("+chat-list")) return fakeChild(0, JSON.stringify({ ok: true, identity: "bot" }));
-    if (args.some((a) => String(a).includes("application/v6/scopes"))) return fakeChild(${scopesStatus}, ${JSON.stringify(scopesStdout)});
+    if (args.some((a) => String(a).includes("application/v6/scopes"))) {
+      if (!options.env.LARKSUITE_CLI_CONFIG_DIR.includes(${JSON.stringify(APP)})) throw new Error("scope read lost selected agent environment");
+      return fakeChild(${scopesStatus}, ${JSON.stringify(scopesStdout)});
+    }
     if (args.includes("setup-bind")) { writeBoundConfig(); return fakeChild(0, ""); }
     return fakeChild(0, "");
   },
@@ -103,8 +106,8 @@ module.exports = {
   return fixture;
 }
 
-function runRegister(root, temp, fixture, resultFile) {
-  return spawnSync(process.execPath, [path.join(ROOT, "dist/setup/bot-register.mjs"), "--auto", "--result-file", resultFile], {
+function runRegister(root, temp, fixture, resultFile, tenant = "feishu") {
+  return spawnSync(process.execPath, [path.join(ROOT, "dist/setup/bot-register.mjs"), "--auto", "--tenant", tenant, "--result-file", resultFile], {
     cwd: ROOT,
     encoding: "utf8",
     timeout: 15_000,
@@ -176,3 +179,39 @@ test("injected agent-choice retries after grant and keeps Pi setup credential", 
     fs.rmSync(temp, { recursive: true, force: true });
   }
 });
+
+for (const [scenario, payload, status] of [
+  ["absent", '{"data":{"scopes":[]}}', 0],
+  ["pending", DENIED_SCOPES, 0],
+  ["malformed", "not-json", 0],
+  ["api-failure", GRANTED_SCOPES, 1],
+  ["api-error-envelope", '{"code":999,"data":{"scopes":[{"scope_name":"im:message.group_msg","grant_status":1}]}}', 0],
+]) {
+  test(`Lark setup ${scenario} preserves same-app recovery and retry accepts required grant with optional warnings`, { timeout: 20_000 }, () => {
+    const temp = fs.mkdtempSync(path.join(os.tmpdir(), "larkin-lark-scope-"));
+    const root = path.join(temp, "root");
+    fs.mkdirSync(root, { recursive: true, mode: 0o700 });
+    const resultFile = path.join(root, ".setup-result-210.json");
+    try {
+      const first = runRegister(root, temp, writeFixture(temp, payload, status, "lark"), resultFile, "lark");
+      const text = first.stdout + first.stderr;
+      assert.notEqual(first.status, 0, text);
+      assert.equal(fs.existsSync(resultFile), false);
+      assert.match(text, /https:\/\/open\.larksuite\.com\/app\//, text);
+      const recovery = new URL(text.match(/https:\/\/open\.larksuite\.com\/app\/[^\s]+/)[0]);
+      assert.equal(recovery.pathname, `/app/${APP}/auth`);
+      assert.equal(recovery.searchParams.get("token_type"), "tenant");
+      assert.ok(recovery.searchParams.get("q").split(",").includes("im:message.group_msg"));
+      assert.match(text, /larkin setup --tenant lark --no-start/);
+      assert.match(text, /同一个已有机器人/);
+      assert.doesNotMatch(text, /canary-secret|GRANTED_APP_ID/);
+      const state = path.join(root, "agents", APP, "keep-state.txt");
+      fs.writeFileSync(state, "retain existing state");
+      const second = runRegister(root, temp, writeFixture(temp, GRANTED_SCOPES, 0, "lark"), resultFile, "lark");
+      assert.equal(second.status, 0, second.stderr);
+      assert.match(second.stdout + second.stderr, /必需未授予=无；可选未授予=.*search:message/);
+      assert.equal(JSON.parse(fs.readFileSync(resultFile, "utf8")).agentId, APP);
+      assert.equal(fs.readFileSync(state, "utf8"), "retain existing state");
+    } finally { fs.rmSync(temp, { recursive: true, force: true }); }
+  });
+}

--- a/test/integration/setup/bot-register-scope-pi-transaction.test.mjs
+++ b/test/integration/setup/bot-register-scope-pi-transaction.test.mjs
@@ -76,6 +76,7 @@ module.exports = {
   spawn(command, args, options) {
     if (args.includes("+chat-list")) return fakeChild(0, JSON.stringify({ ok: true, identity: "bot" }));
     if (args.some((a) => String(a).includes("application/v6/scopes"))) {
+      if (args.at(-2) !== "--as" || args.at(-1) !== "bot") throw new Error("explicit bot identity missing");
       if (!options.env.LARKSUITE_CLI_CONFIG_DIR.includes(${JSON.stringify(APP)})) throw new Error("scope read lost selected agent environment");
       return fakeChild(${scopesStatus}, ${JSON.stringify(scopesStdout)});
     }
@@ -182,9 +183,6 @@ test("injected agent-choice retries after grant and keeps Pi setup credential", 
 
 for (const [scenario, payload, status] of [
   ["absent", '{"data":{"scopes":[]}}', 0],
-  ["pending", DENIED_SCOPES, 0],
-  ["malformed", "not-json", 0],
-  ["api-failure", GRANTED_SCOPES, 1],
   ["api-error-envelope", '{"code":999,"data":{"scopes":[{"scope_name":"im:message.group_msg","grant_status":1}]}}', 0],
 ]) {
   test(`Lark setup ${scenario} preserves same-app recovery and retry accepts required grant with optional warnings`, { timeout: 20_000 }, () => {
@@ -197,12 +195,17 @@ for (const [scenario, payload, status] of [
       const text = first.stdout + first.stderr;
       assert.notEqual(first.status, 0, text);
       assert.equal(fs.existsSync(resultFile), false);
+      if (scenario === "api-error-envelope") {
+        assert.match(text, /未验证/);
+        assert.doesNotMatch(text, /\/auth\?q=/);
+        return;
+      }
       assert.match(text, /https:\/\/open\.larksuite\.com\/app\//, text);
       const recovery = new URL(text.match(/https:\/\/open\.larksuite\.com\/app\/[^\s]+/)[0]);
       assert.equal(recovery.pathname, `/app/${APP}/auth`);
       assert.equal(recovery.searchParams.get("token_type"), "tenant");
       assert.ok(recovery.searchParams.get("q").split(",").includes("im:message.group_msg"));
-      assert.match(text, /larkin setup --tenant lark --no-start/);
+      assert.match(text, /保留 --tenant lark 和 --runtime 参数/);
       assert.match(text, /同一个已有机器人/);
       assert.doesNotMatch(text, /canary-secret|GRANTED_APP_ID/);
       const state = path.join(root, "agents", APP, "keep-state.txt");
@@ -210,6 +213,7 @@ for (const [scenario, payload, status] of [
       const second = runRegister(root, temp, writeFixture(temp, GRANTED_SCOPES, 0, "lark"), resultFile, "lark");
       assert.equal(second.status, 0, second.stderr);
       assert.match(second.stdout + second.stderr, /必需未授予=无；可选未授予=.*search:message/);
+      assert.match(second.stdout + second.stderr, /setup 可继续/);
       assert.equal(JSON.parse(fs.readFileSync(resultFile, "utf8")).agentId, APP);
       assert.equal(fs.readFileSync(state, "utf8"), "retain existing state");
     } finally { fs.rmSync(temp, { recursive: true, force: true }); }

--- a/test/live/lark-setup-scope-grants-live.test.mjs
+++ b/test/live/lark-setup-scope-grants-live.test.mjs
@@ -17,7 +17,7 @@ test.skipIf(!enabled)("real selected Lark bot has authoritative required tenant 
   assert.equal(loadValidatedBotCredential(path.join(config.larkinHome, "bots"), agent.feishuAppId).tenant, "lark");
   const managed = managedOfficialLarkCli(agent, process.env);
   const result = spawnSync(managed.command.command,
-    [...managed.command.argsPrefix, "api", "GET", "/open-apis/application/v6/scopes"],
+    [...managed.command.argsPrefix, "api", "GET", "/open-apis/application/v6/scopes", "--as", "bot"],
     { env: managed.env, encoding: "utf8", timeout: 30_000 });
   assert.equal(result.status, 0, "managed bot scope API request failed; inspect privately");
   const grants = reconcileTenantScopes(JSON.parse(result.stdout), ["im:message.group_msg"]);

--- a/test/live/lark-setup-scope-grants-live.test.mjs
+++ b/test/live/lark-setup-scope-grants-live.test.mjs
@@ -1,0 +1,27 @@
+// Opt-in, read-only grant verification. Does not authorize apps or send messages.
+// LARKIN_RUN_LARK_SETUP_SCOPE_GRANTS=1 LARKIN_AGENT_ID=<existing-app-id> bun test test/live/lark-setup-scope-grants-live.test.mjs
+import path from "node:path";
+import { loadValidatedBotCredential } from "../../dist/setup/run-credential-preflight.mjs";
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import { test } from "bun:test";
+import { loadConfig, selectAgent } from "../../dist/platform/config.mjs";
+import { managedOfficialLarkCli } from "../../dist/app/agent-lark-cli-workspace.mjs";
+import { reconcileTenantScopes } from "../../src/setup/tenant-scope-grant.ts";
+
+const enabled = process.env.LARKIN_RUN_LARK_SETUP_SCOPE_GRANTS === "1";
+test.skipIf(!enabled)("real selected Lark bot has authoritative required tenant grant", { timeout: 40_000 }, () => {
+  assert.ok(process.env.LARKIN_AGENT_ID, "explicit existing LARKIN_AGENT_ID is required");
+  const { config } = loadConfig(process.env);
+  const agent = selectAgent(config, process.env);
+  assert.equal(loadValidatedBotCredential(path.join(config.larkinHome, "bots"), agent.feishuAppId).tenant, "lark");
+  const managed = managedOfficialLarkCli(agent, process.env);
+  const result = spawnSync(managed.command.command,
+    [...managed.command.argsPrefix, "api", "GET", "/open-apis/application/v6/scopes"],
+    { env: managed.env, encoding: "utf8", timeout: 30_000 });
+  assert.equal(result.status, 0, "managed bot scope API request failed; inspect privately");
+  const grants = reconcileTenantScopes(JSON.parse(result.stdout), ["im:message.group_msg"]);
+  assert.equal(grants.verified, true, "invalid authoritative grant response");
+  assert.deepEqual(grants.missingRequired, []);
+  // Passing proves this grant only, not addons application, callbacks or message delivery.
+});

--- a/test/unit/setup/grant-scopes-tenant-urls.test.mjs
+++ b/test/unit/setup/grant-scopes-tenant-urls.test.mjs
@@ -32,12 +32,19 @@ module.exports = {
       domain: opts.domain,
       addons: opts.addons ?? null,
     }));
-    opts.onQRCodeReady({ url: process.env.GRANT_READY_URL || ("https://" + opts.domain + "/oauth/grant"), expireIn: 60 });
-    return { client_id: opts.appId };
+    opts.onQRCodeReady({ url: process.env.GRANT_READY_URL || ("https://" + opts.domain + "/oauth/grant?clientID=" + opts.appId), expireIn: 60 });
+    return { client_id: process.env.GRANT_RETURN_APP_ID ?? opts.appId };
   },
   qrcode: { generate() {} },
-  managedOfficialCli: () => ({ command: { command: "/verified/official-lark-cli", argsPrefix: [], version: "1.0.80" }, env: {} }),
-  spawnSync() { return { status: 0, stdout: "{}", stderr: "" }; },
+  managedOfficialCli: () => ({ command: { command: "/verified/official-lark-cli", argsPrefix: [], version: "1.0.80" }, env: { GRANT_BOT_ONLY: "1" } }),
+  spawnSync(command, args, options) {
+    if (args.includes("/open-apis/application/v6/scopes")) {
+      if (options.env.GRANT_BOT_ONLY !== "1") throw new Error("managed identity lost");
+      fs.writeFileSync(process.env.REGISTER_MARKER + ".scope-read", JSON.stringify(args));
+      return { status: Number(process.env.GRANT_SCOPE_STATUS || 0), stdout: process.env.GRANT_SCOPES || JSON.stringify({ data: { scopes: [{ scope_name: "im:message.group_msg", grant_status: 1 }] } }), stderr: "" };
+    }
+    return { status: 0, stdout: "{}", stderr: "" };
+  },
 };
 `);
   const result = spawnSync(process.execPath, [ENTRY, "--wait-min", "1", ...extraArgs], {
@@ -86,7 +93,7 @@ test("--tenant lark rewrites launcher to /page/cli and keeps addons", () => {
     tenant: "lark",
     extraArgs: ["--tenant", "lark", "--url-file", urlFile],
     extraEnv: {
-      GRANT_READY_URL: "https://open.larksuite.com/page/launcher?user_code=YKDY-TZ7Q&from=sdk&addons=H4sI",
+      GRANT_READY_URL: "https://open.larksuite.com/page/launcher?user_code=YKDY-TZ7Q&from=sdk&addons=H4sI&clientID=cli_grantTenantA1",
     },
   });
   try {
@@ -95,6 +102,7 @@ test("--tenant lark rewrites launcher to /page/cli and keeps addons", () => {
     assert.match(presented, /^https:\/\/open\.larksuite\.com\/page\/cli\?/);
     assert.match(presented, /user_code=YKDY-TZ7Q/);
     assert.match(presented, /[?&]addons=H4sI/);
+    assert.equal(new URL(presented).searchParams.get("clientID"), "cli_grantTenantA1");
     assert.doesNotMatch(presented, /\/page\/launcher/);
   } finally {
     fs.rmSync(temp, { recursive: true, force: true });
@@ -118,5 +126,30 @@ test("grant-scopes tenant scopes include search:message", () => {
     assert.equal(result.status, 0, result.stderr);
     const opts = JSON.parse(fs.readFileSync(marker, "utf8"));
     assert.equal(opts.addons.scopes.tenant.includes("search:message"), true);
+  } finally { fs.rmSync(temp, { recursive: true, force: true }); }
+});
+
+for (const appId of ["cli_other", ""]) {
+  test(`existing-app update rejects returned target ${appId || "missing"}`, () => {
+    const { temp, marker, result } = runGrant({ extraEnv: { GRANT_RETURN_APP_ID: appId } });
+    try {
+      assert.notEqual(result.status, 0);
+      assert.match(result.stderr, /App ID.*不匹配/);
+      assert.doesNotMatch(result.stdout, /GRANTED_APP_ID/);
+      assert.equal(fs.existsSync(marker + ".scope-read"), false);
+      const credential = JSON.parse(fs.readFileSync(path.join(temp, "root/bots/cli_grantTenantA1.json"), "utf8"));
+      assert.equal(credential.capabilities, undefined);
+    } finally { fs.rmSync(temp, { recursive: true, force: true }); }
+  });
+}
+
+test("existing-app credential return is not a grant; missing required scope fails with same-app recovery", () => {
+  const { temp, marker, result } = runGrant({ tenant: "lark", extraEnv: { GRANT_SCOPES: '{"data":{"scopes":[]}}' } });
+  try {
+    assert.notEqual(result.status, 0);
+    assert.equal(fs.existsSync(marker + ".scope-read"), true);
+    assert.match(result.stderr, /缺 im:message.group_msg/);
+    assert.match(result.stderr, /open.larksuite.com\/app\/cli_grantTenantA1\/auth/);
+    assert.doesNotMatch(result.stdout, /GRANTED_APP_ID/);
   } finally { fs.rmSync(temp, { recursive: true, force: true }); }
 });

--- a/test/unit/setup/grant-scopes-tenant-urls.test.mjs
+++ b/test/unit/setup/grant-scopes-tenant-urls.test.mjs
@@ -39,6 +39,7 @@ module.exports = {
   managedOfficialCli: () => ({ command: { command: "/verified/official-lark-cli", argsPrefix: [], version: "1.0.80" }, env: { GRANT_BOT_ONLY: "1" } }),
   spawnSync(command, args, options) {
     if (args.includes("/open-apis/application/v6/scopes")) {
+      if (args.at(-2) !== "--as" || args.at(-1) !== "bot") throw new Error("explicit bot identity missing");
       if (options.env.GRANT_BOT_ONLY !== "1") throw new Error("managed identity lost");
       fs.writeFileSync(process.env.REGISTER_MARKER + ".scope-read", JSON.stringify(args));
       return { status: Number(process.env.GRANT_SCOPE_STATUS || 0), stdout: process.env.GRANT_SCOPES || JSON.stringify({ data: { scopes: [{ scope_name: "im:message.group_msg", grant_status: 1 }] } }), stderr: "" };
@@ -151,5 +152,14 @@ test("existing-app credential return is not a grant; missing required scope fail
     assert.match(result.stderr, /缺 im:message.group_msg/);
     assert.match(result.stderr, /open.larksuite.com\/app\/cli_grantTenantA1\/auth/);
     assert.doesNotMatch(result.stdout, /GRANTED_APP_ID/);
+  } finally { fs.rmSync(temp, { recursive: true, force: true }); }
+});
+
+test("failed authoritative read does not prescribe permission changes", () => {
+  const { temp, result } = runGrant({ extraEnv: { GRANT_SCOPE_STATUS: "1" } });
+  try {
+    assert.notEqual(result.status, 0);
+    assert.match(result.stderr, /未验证/);
+    assert.doesNotMatch(result.stderr, /\/auth\?q=/);
   } finally { fs.rmSync(temp, { recursive: true, force: true }); }
 });

--- a/test/unit/setup/setup-authorization-url.test.mjs
+++ b/test/unit/setup/setup-authorization-url.test.mjs
@@ -94,3 +94,16 @@ test("bot-register wires Lark to /page/cli QR and keeps Feishu on launcher regis
   assert.match(feishuBranch, /presentUrl\(url, expireIn\)/);
   assert.doesNotMatch(feishuBranch, /presentAuthorizationUrl|page\/cli/);
 });
+
+test("existing-app authorization retains its target and addons and rejects a different target", () => {
+  for (const tenant of ["lark", "feishu"]) {
+    const host = tenant === "lark" ? "open.larksuite.com" : "open.feishu.cn";
+    const raw = `https://${host}/page/launcher?user_code=AB12-CD34&clientID=cli_fixture123&addons=H4sI%2B%2F%3D`;
+    const input = { tenant, larkCliVersion: "1.0.94", expectedAppId: "cli_fixture123" };
+    const presented = new URL(mod.presentAuthorizationUrl(raw, input));
+    assert.equal(presented.searchParams.get("clientID"), "cli_fixture123");
+    assert.equal(presented.searchParams.get("addons"), "H4sI+/=");
+    assert.throws(() => mod.presentAuthorizationUrl(raw.replace("clientID=cli_fixture123", "clientID=cli_other"), input), /clientID/);
+    assert.throws(() => mod.presentAuthorizationUrl(raw.replace("&clientID=cli_fixture123", ""), input), /clientID/);
+  }
+});

--- a/test/unit/setup/tenant-scope-grant.test.mjs
+++ b/test/unit/setup/tenant-scope-grant.test.mjs
@@ -31,9 +31,17 @@ test("grant reconciliation distinguishes required and optional while rejecting i
   assert.deepEqual(reconcileTenantScopes(payload, requested), {
     verified: true, missingRequired: [], missingOptional: ["search:message", "drive:drive"],
   });
-  for (const invalid of [null, {}, { ...payload, code: 999 }, { ...payload, ok: false }]) {
+  for (const invalid of [null, {}, { ...payload, code: 999 }, { ...payload, ok: false }, { ...payload, ok: "false" }, { ...payload, identity: "user" }]) {
     assert.deepEqual(reconcileTenantScopes(invalid, requested), {
-      verified: false, missingRequired: ["im:message.group_msg"], missingOptional: ["search:message", "drive:drive"],
+      verified: false, missingRequired: [], missingOptional: [],
     });
   }
+});
+
+test("explicit user and unknown scope types never satisfy tenant readiness", () => {
+  for (const scope_type of ["user", "unknown", null]) {
+    const payload = { code: 0, data: { scopes: [{ scope_name: "im:message.group_msg", grant_status: 1, scope_type }] } };
+    assert.deepEqual(reconcileTenantScopes(payload, ["im:message.group_msg"]).missingRequired, ["im:message.group_msg"]);
+  }
+  assert.deepEqual(reconcileTenantScopes({ code: 0, data: { scopes: [{ scope_name: "im:message.group_msg", grant_status: 1, scope_type: "tenant" }] } }, []).missingRequired, []);
 });

--- a/test/unit/setup/tenant-scope-grant.test.mjs
+++ b/test/unit/setup/tenant-scope-grant.test.mjs
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict";
 import { test } from "bun:test";
-import { missingGrantedTenantScopes } from "../../../src/setup/tenant-scope-grant.ts";
+import { missingGrantedTenantScopes, reconcileTenantScopes } from "../../../src/setup/tenant-scope-grant.ts";
 
 test("missingGrantedTenantScopes requires grant_status 1 for group_msg", () => {
   assert.deepEqual(missingGrantedTenantScopes({ data: { scopes: [] } }), ["im:message.group_msg"]);
@@ -19,4 +19,21 @@ test("missingGrantedTenantScopes requires grant_status 1 for group_msg", () => {
   assert.deepEqual(missingGrantedTenantScopes({
     data: { scopes: [{ grant_status: 1 }] },
   }), ["im:message.group_msg"]);
+});
+
+test("grant reconciliation distinguishes required and optional while rejecting invalid API envelopes", () => {
+  const requested = ["im:message.group_msg", "search:message", "drive:drive"];
+  const payload = { code: 0, data: { scopes: [
+    { scope_name: "im:message.group_msg", grant_status: 1 },
+    { scope_name: "search:message", grant_status: "1" },
+    { scope_name: "drive:drive", grant_status: 0 },
+  ] } };
+  assert.deepEqual(reconcileTenantScopes(payload, requested), {
+    verified: true, missingRequired: [], missingOptional: ["search:message", "drive:drive"],
+  });
+  for (const invalid of [null, {}, { ...payload, code: 999 }, { ...payload, ok: false }]) {
+    assert.deepEqual(reconcileTenantScopes(invalid, requested), {
+      verified: false, missingRequired: ["im:message.group_msg"], missingOptional: ["search:message", "drive:drive"],
+    });
+  }
 });


### PR DESCRIPTION
## Summary

Lark setup could return credentials while requested permissions remained ungranted, and the existing-app authorization URL lost its `clientID`. Setup now reports required versus optional grant gaps and links directly to the same application in the tenant-specific developer console. Users complete any platform-required confirmation, approval or publication, then rerun setup selecting that existing bot.

The existing `im:message.group_msg` gate still requires numeric `grant_status=1`. Credential return, a successful URL rewrite and requested events/callbacks do not count as effective permissions or message delivery.

- `src/setup/setup-authorization-url.ts` preserves `clientID` alongside addons; internal existing-app updates reject missing/mismatched URL and returned App IDs before recording capabilities.
- `src/setup/tenant-scope-grant.ts` extends the existing grant module with response validation, required/optional reconciliation and official same-app console recovery. Unreadable or invalid API responses fail with retry guidance without prescribing permission changes; explicit user scope rows cannot satisfy tenant readiness. `bot-register.ts` and `grant-scopes.ts` use it with the selected Agent's managed bot-only CLI environment and explicit `--as bot`.
- Regression workflows cover absent/pending/malformed/error responses, state-preserving same-app retry, optional-only warnings and identity mismatch. A read-only live Lark grant check is opt-in and skipped by default.
- Patch version: 0.5.7 → 0.5.8.

## Related issue

Closes #210

## Scope

- In scope: setup grant diagnostics and existing-app authorization/recovery correctness.
- Out of scope: automatic approval/publication, user OAuth fallback, new startup gates, remote deployment and live messages.
- Compatibility: required permission policy and existing setup command remain unchanged; optional gaps are nonfatal. The unused internal `GRANTED_APP_ID` marker was removed; the internal update flow reports credential return and actual grant evidence separately.

## Validation

- [x] Final focused setup/URL/grant tests: 24 passed, 1 opt-in live check skipped.
- [x] `bun run build` and strict typecheck passed.
- [x] Final `bun run test`: frontend 30 passed; unit 897 passed; integration 208 passed / 17 skipped; Mock E2E 22 passed. No failures.
- [x] Final-head GitHub CI passed: source-checks, Windows x64 standalone build, and native Windows core/standalone gate ([run 34501434161](https://github.com/eddiearc/larkin/actions/runs/34501434161)).
- [x] `bun run licenses:check` — 97 runtime package versions.
- [x] `bun run publication:check:tree` and `bun run publication:check` passed.
- [x] `git diff --check` passed.

These are controlled workflow and local checks. The real Lark post-repair grant, addon application, approval branch and message delivery remain unverified. The opt-in entry is `LARKIN_RUN_LARK_SETUP_SCOPE_GRANTS=1 LARKIN_AGENT_ID=<existing-app-id> bun test test/live/lark-setup-scope-grants-live.test.mjs`; it reads only the selected managed bot's scope API.

Independent Codex Sol/high review completed with no remaining findings after counterexample probes. Simplification removed an unused success sentinel and redundant same-agent retry repetitions; existing-App-ID checks, one reconciler and one recovery formatter remain necessary. The implementation adds no state store, startup mechanism or recovery command.

A Linux x64 candidate also built successfully from the clean final source; binary/runtime-notices publication scan passed. Native Linux deployment and real Lark acceptance are separate from this code review.

## Safety and publication

- [x] No credentials, private messages, user data, private filesystem paths, generated dist or release artifacts are included.
- [x] No permission checks were bypassed and no real app permissions or messages were changed during validation.
- [x] No release tag was created, moved or replaced.
