### PR TITLE
fix(runtime): surface catalog spawn failures and stop misreporting resolved executables

### DIFF
--- a/src/runtime/claude-model-catalog.ts
+++ b/src/runtime/claude-model-catalog.ts
@@ -48,7 +48,7 @@ async function runClaudeControl(call: ClaudeControlCall): Promise<unknown> {
     };
     const timer = setTimeout(() => finish(new Error("Claude model catalog timed out")), call.timeout);
     timer.unref?.();
-    child.on("error", () => finish(new Error("Claude model catalog command failed")));
+    child.on("error", (error) => finish(new Error(`Claude model catalog command failed: ${error.message}`)));
     child.on("exit", () => finish(new Error("Claude model catalog control channel exited before response")));
     child.stderr.resume();
     child.stdout.on("data", (chunk: Buffer) => {

--- a/src/runtime/codex-model-catalog.ts
+++ b/src/runtime/codex-model-catalog.ts
@@ -58,7 +58,7 @@ async function runCodexAppServer(call: CodexCall): Promise<unknown> {
     };
     const timer = setTimeout(() => finish(new Error("Codex model catalog timed out")), call.timeout);
     timer.unref?.();
-    child.on("error", () => finish(new Error("Codex model catalog command failed")));
+    child.on("error", (error) => finish(new Error(`Codex model catalog command failed: ${error.message}`)));
     child.on("exit", () => finish(new Error("Codex model catalog app-server exited before response")));
     child.stderr.resume();
     child.stdout.on("data", (chunk: Buffer) => {

--- a/src/runtime/runtime-readiness.ts
+++ b/src/runtime/runtime-readiness.ts
@@ -164,11 +164,21 @@ export function resolveRuntimeExecutable(command: string, env: NodeJS.ProcessEnv
 export function classifyRuntimePrerequisite(runtime: RuntimeReadiness["runtime"], error: unknown,
   executable?: string): RuntimeReadiness {
   const reason = (error instanceof Error ? error.message : String(error)).replace(/[\r\n]+/g, " ").slice(0, 500);
-  if (/ENOENT|not found|no such file|spawn .* failed/i.test(reason)) return {
-    runtime, state: "missing", ...(executable ? { executable } : {}),
-    reason: `${runtime} is not installed`,
-    nextAction: runtimeInstallNextAction(runtime),
-  };
+  if (/ENOENT|not found|no such file|spawn .* failed/i.test(reason)) {
+    // A resolved executable that still exists on disk is not a missing install:
+    // the spawn failure comes from the launch environment (working directory,
+    // interpreter, permissions). Keep the raw reason instead of sending the
+    // user to reinstall the runtime.
+    if (executable && fs.existsSync(executable)) return {
+      runtime, state: "unavailable", executable, reason,
+      nextAction: `Verify the ${runtime} launch environment (working directory, interpreter, permissions), then retry.`,
+    };
+    return {
+      runtime, state: "missing", ...(executable ? { executable } : {}),
+      reason: `${runtime} is not installed`,
+      nextAction: runtimeInstallNextAction(runtime),
+    };
+  }
   if (/no authenticated available models|login|credential|unauthenticated|unauthorized|oauth/i.test(reason)) return {
     runtime, state: "unauthenticated", ...(executable ? { executable } : {}), reason,
     nextAction: runtimeLoginNextAction(runtime),

--- a/test/unit/runtime/claude-model-catalog.test.mjs
+++ b/test/unit/runtime/claude-model-catalog.test.mjs
@@ -39,3 +39,15 @@ test("Claude catalog fails closed without a valid default and visible model list
     await assert.rejects(discoverClaudeModelCatalog({ async runClaudeControl() { return response; } }), /Claude model catalog|Claude 模型目录/i);
   }
 });
+
+test("Claude catalog surfaces the underlying spawn failure instead of a generic message", async () => {
+  const { discoverClaudeModelCatalog } = await import(MODULE);
+  await assert.rejects(
+    discoverClaudeModelCatalog({ command: "/definitely/missing/larkin-claude-spawn-probe" }),
+    (error) => {
+      assert.match(error.message, /Claude model catalog command failed/);
+      assert.match(error.message, /ENOENT/);
+      return true;
+    },
+  );
+});

--- a/test/unit/runtime/codex-model-catalog.test.mjs
+++ b/test/unit/runtime/codex-model-catalog.test.mjs
@@ -52,3 +52,15 @@ test("Codex catalog fails closed on malformed, empty, or unbounded catalog shape
     );
   }
 });
+
+test("Codex catalog surfaces the underlying spawn failure instead of a generic message", async () => {
+  const { discoverCodexModelCatalog } = await import(MODULE);
+  await assert.rejects(
+    discoverCodexModelCatalog({ command: "/definitely/missing/larkin-codex-spawn-probe" }),
+    (error) => {
+      assert.match(error.message, /Codex model catalog command failed/);
+      assert.match(error.message, /ENOENT/);
+      return true;
+    },
+  );
+});

--- a/test/unit/runtime/runtime-readiness.test.mjs
+++ b/test/unit/runtime/runtime-readiness.test.mjs
@@ -226,3 +226,22 @@ test("Pi readiness does not require Agent identity or an owned provider director
     fs.rmSync(root, { recursive: true, force: true });
   }
 });
+
+for (const runtime of ["codex", "claude", "pi"]) {
+  test(`${runtime} readiness keeps a resolved executable out of the not-installed diagnosis`, () => {
+    // Pi already surfaces the spawn errno as "Pi RPC process failed: ..."; the
+    // claude/codex catalogs append it after their own prefix. Either way a
+    // still-existing resolved executable must keep the raw reason.
+    const message = runtime === "pi"
+      ? `Pi RPC process failed: spawn ${process.execPath} ENOENT`
+      : `spawn ${process.execPath} ENOENT`;
+    const readiness = classifyRuntimePrerequisite(runtime, new Error(message), process.execPath);
+    assert.equal(readiness.state, "unavailable");
+    assert.match(readiness.reason || "", /ENOENT/);
+    assert.doesNotMatch(readiness.nextAction || "", /install/i);
+    assert.doesNotMatch(readiness.nextAction || "", FORBIDDEN);
+    const missing = classifyRuntimePrerequisite(runtime, new Error(`spawn ${runtime} ENOENT`));
+    assert.equal(missing.state, "missing");
+    assert.equal(missing.reason, `${runtime} is not installed`);
+  });
+}


### PR DESCRIPTION
## What

The runtime model-catalog probes (claude / codex) discard the underlying spawn error (`child.on("error", () => finish(new Error("... model catalog command failed")))`), so the real cause is lost. And `classifyRuntimePrerequisite`'s ENOENT branch reports `not installed` even when the caller already resolved an absolute, existing executable — a launch-environment failure (bad working directory, interpreter, permissions) then reads as "reinstall the runtime". The pi runtime already surfaces the spawn errno through `PiRpcClient` (`Pi RPC process failed: ... ENOENT`), but its resolved-executable case was misclassified the same way.

## Change

- `src/runtime/claude-model-catalog.ts` / `src/runtime/codex-model-catalog.ts`: include the underlying `error.message` (carries the errno, e.g. `spawn <path> ENOENT`) in the wrapped failure.
- `src/runtime/runtime-readiness.ts` (`classifyRuntimePrerequisite`): keep the `not installed` diagnosis only when no executable was resolved or the resolved file no longer exists; a still-existing resolved executable preserves the raw spawn reason and gets a nextAction pointing at the launch environment (working directory, interpreter, permissions).
- Tests: spawn-failure coverage in `test/unit/runtime/{claude,codex}-model-catalog.test.mjs` and classification coverage for all three runtimes — including pi's `Pi RPC process failed: ... ENOENT` shape — in `test/unit/runtime/runtime-readiness.test.mjs`.

## Validation

- `bun run build` ✅
- `bun run typecheck` ✅
- `bun test test/unit/runtime/claude-model-catalog.test.mjs test/unit/runtime/codex-model-catalog.test.mjs test/unit/runtime/runtime-readiness.test.mjs` → 28 pass / 0 fail
- `bun run test:unit` → 882 pass / 16 skip / 2 fail. Both failures (`shared tmux session lists windows by recorded owner`, `three-Agent live acceptance is opt-in, hermetic by default, and fixture-verifiable`) reproduce identically on unmodified `main` in this environment (`tmux` is not installed here) and are unrelated to this change.

Fixes #213

🤖 Generated with [Claude Code](https://claude.com/claude-code)
