### PR TITLE
fix(runtime): settle Pi RPC shutdown on close when the spawn itself failed

### DIFF
--- a/src/runtime/pi-rpc-client.ts
+++ b/src/runtime/pi-rpc-client.ts
@@ -11,6 +11,7 @@ export interface PiRpcProcess {
   stdout: PiRpcReadable | null;
   stderr: PiRpcReadable | null;
   once(event: "exit", listener: (code: number | null, signal: NodeJS.Signals | null) => void): unknown;
+  once(event: "close", listener: (code: number | null, signal: NodeJS.Signals | null) => void): unknown;
   once(event: "error", listener: (error: Error) => void): unknown;
   kill(signal?: NodeJS.Signals): boolean;
 }
@@ -78,11 +79,15 @@ export class PiRpcClient {
       this.stderrBuffer = Buffer.concat([this.stderrBuffer, value.subarray(0, this.maxStderrBytes - this.stderrBuffer.length)]);
     });
     process.once("error", (error) => this.fail(new Error(`Pi RPC process failed: ${error.message}`), true));
-    process.once("exit", (code, signal) => {
+    const settle = (code: number | null, signal: NodeJS.Signals | null) => {
       this.exited = true;
       const stderr = this.stderrBuffer.toString("utf8").trim().slice(0, 2_000);
       this.fail(new Error(`Pi RPC process exited (${code ?? signal ?? "unknown"})${stderr ? `: ${stderr}` : ""}`), false);
-    });
+    };
+    process.once("exit", settle);
+    // A spawn that never started emits "error" + "close" and never "exit", so
+    // "close" is the only terminal event Node guarantees for failed spawns.
+    process.once("close", settle);
   }
 
   subscribe(listener: (event: RpcObject) => void): () => void {
@@ -255,6 +260,9 @@ export class PiRpcClient {
         resolve();
       };
       this.process.once("exit", finish);
+      // A failed spawn never emits "exit": settle on "close" instead of waiting
+      // out the grace timers (or never, when nothing else keeps the loop alive).
+      this.process.once("close", finish);
       this.process.kill("SIGTERM");
       forceTimer = setTimeout(() => {
         if (this.exited) { finish(); return; }

--- a/src/runtime/runtime-adapters.ts
+++ b/src/runtime/runtime-adapters.ts
@@ -65,6 +65,7 @@ interface ProcessLike {
   stdout: ReadableLike | null;
   stderr: ReadableLike | null;
   once(event: "exit", listener: (code: number | null, signal: NodeJS.Signals | null) => void): unknown;
+  once(event: "close", listener: (code: number | null, signal: NodeJS.Signals | null) => void): unknown;
   once(event: "error", listener: (error: Error) => void): unknown;
   kill(signal?: NodeJS.Signals): boolean;
 }

--- a/test/unit/runtime/pi-rpc-client.test.mjs
+++ b/test/unit/runtime/pi-rpc-client.test.mjs
@@ -149,3 +149,23 @@ test("Pi RPC failure and close share one shutdown promise that escalates a stubb
   await first;
   assert.deepEqual(child.killed, ["SIGTERM", "SIGKILL"]);
 });
+
+class FailedSpawnProcess extends FakeProcess {
+  kill(signal) {
+    // A spawn that never started has no process to signal; Node returns false.
+    this.killed.push(signal);
+    return false;
+  }
+}
+
+test("Pi RPC shutdown settles on close when the spawn itself failed", async () => {
+  const child = new FailedSpawnProcess();
+  const client = new PiRpcClient(child, { requestTimeoutMs: 100, shutdownGraceMs: 5_000 });
+  const pending = client.request("get_state");
+  child.emit("error", Object.assign(new Error("spawn pi ENOENT"), { code: "ENOENT" }));
+  child.emit("close", -2, null);
+  await assert.rejects(pending, /spawn pi ENOENT/);
+  const startedAt = Date.now();
+  await client.close();
+  assert.ok(Date.now() - startedAt < 1_000, "shutdown must settle on close, not on the grace timers");
+});


### PR DESCRIPTION
## What

`PiRpcClient.beginShutdown()` waits on the child's `exit` event. Node emits **`error` + `close` and never `exit`** when the spawn itself fails, so a failed pi spawn made `close()` take ~4 seconds (two `shutdownGraceMs` timers, since `kill()` on a failed spawn returns `false`) — and with nothing else keeping the event loop alive, the promise never settled at all. `this.exited` was also only set in the `exit` handler, so the existing fast-path (`if (this.exited) return Promise.resolve()`) could not trigger.

## Change

- `src/runtime/pi-rpc-client.ts`: treat `close` as a terminal event alongside `exit` — both in the constructor's termination handler (`this.exited` + fail-closed) and in `beginShutdown()` (`finish` on either event). Normal `exit` → `close` sequences and the SIGTERM→SIGKILL escalation for stubborn children are unchanged.
- `src/runtime/runtime-adapters.ts`: the local `ProcessLike` child-process contract gains the matching `close` overload.
- `test/unit/runtime/pi-rpc-client.test.mjs`: `FailedSpawnProcess` double (emits `error` + `close`, no `exit`, `kill()` returns `false`) asserting shutdown settles in under a second instead of waiting out the grace timers.

## Validation

- Repro before the change (real pi binary, nonexistent cwd, live event loop): `t=3ms request rejected: Pi RPC process failed: spawn <path> ENOENT` → `t=9ms child close code=-2` → **`t=4003ms close resolved`**. After the change, the catalog call fails in **50ms** with the same error.
- `bun run build` ✅
- `bun run typecheck` ✅
- `bun run licenses:check` ✅ · `bun run publication:check:tree` ✅
- `bun test test/unit/runtime/pi-rpc-client.test.mjs test/unit/runtime/pi-model-catalog.test.mjs` → 21 pass / 0 fail
- `bun test test/unit/runtime/` → 232 pass / 0 fail
- `bun run test:unit` → 896 pass / 1 skip / 1 fail. The remaining failure, `three-Agent live acceptance is opt-in, hermetic by default, and fixture-verifiable`, reproduces on unmodified `main` in this environment and is unrelated to this change; a one-off `real dashboard … SIGINT` timeout in an earlier run did not recur and passes standalone in ~320 ms.

Fixes #218

🤖 Generated with [Claude Code](https://claude.com/claude-code)
